### PR TITLE
Branch Fix Layered Wind

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -966,10 +966,22 @@ float4 GetBlendMask(LayerTexCoord layerTexCoord, float4 vertexColor, bool useLod
     // Settings this specific Main layer blend mask in alpha allow to be transparent in case we don't use it and 1 is provide by default.
     float4 blendMasks = useLodSampling ? SAMPLE_UVMAPPING_TEXTURE2D_LOD(_LayerMaskMap, sampler_LayerMaskMap, layerTexCoord.blendMask, lod) : SAMPLE_UVMAPPING_TEXTURE2D(_LayerMaskMap, sampler_LayerMaskMap, layerTexCoord.blendMask);
 
+    // Wind uses vertex alpha as an intensity parameter.
+    // So in case Layered shader uses wind, we need to hardcode the alpha here so that the main layer can be visible without affecting wind intensity.
+    // It also means that when using wind, users can't use vertex color to modulate the effect of influence from the main layer.
+    float4 maskVertexColor = vertexColor;
 #if defined(_LAYER_MASK_VERTEX_COLOR_MUL)
-    blendMasks *= vertexColor;
+    #if defined(_VERTEX_WIND)
+        // For multiplicative vertex color blend mask. 1.0f is the neutral value
+        maskVertexColor.a = 1.0f;
+        blendMasks *= maskVertexColor;
+    #endif
 #elif defined(_LAYER_MASK_VERTEX_COLOR_ADD)
-    blendMasks = saturate(blendMasks + vertexColor * 2.0 - 1.0);
+    #if defined(_VERTEX_WIND)
+        // For additive vertex color blend mask. 0.5f is the neutral value (0.5 * 2.0 - 1.0 = 0.0)
+        maskVertexColor.a = 0.5f;
+    #endif
+    blendMasks = saturate(blendMasks + maskVertexColor * 2.0 - 1.0);
 #endif
 
     return blendMasks;

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -972,14 +972,14 @@ float4 GetBlendMask(LayerTexCoord layerTexCoord, float4 vertexColor, bool useLod
     float4 maskVertexColor = vertexColor;
 #if defined(_LAYER_MASK_VERTEX_COLOR_MUL)
     #if defined(_VERTEX_WIND)
-        // For multiplicative vertex color blend mask. 1.0f is the neutral value
-        maskVertexColor.a = 1.0f;
-        blendMasks *= maskVertexColor;
+    // For multiplicative vertex color blend mask. 1.0f is the neutral value
+    maskVertexColor.a = 1.0f;
     #endif
+    blendMasks *= maskVertexColor;
 #elif defined(_LAYER_MASK_VERTEX_COLOR_ADD)
     #if defined(_VERTEX_WIND)
-        // For additive vertex color blend mask. 0.5f is the neutral value (0.5 * 2.0 - 1.0 = 0.0)
-        maskVertexColor.a = 0.5f;
+    // For additive vertex color blend mask. 0.5f is the neutral value (0.5 * 2.0 - 1.0 = 0.0)
+    maskVertexColor.a = 0.5f;
     #endif
     blendMasks = saturate(blendMasks + maskVertexColor * 2.0 - 1.0);
 #endif


### PR DESCRIPTION
Hardcoded vertex color alpha values for layered shader vertex blend mask when using wind so that main layer is visible without affecting wind behavior for the object.
