### PR TITLE
Hack for GI to handle Alpha Test correctly: Filled the hard-coded pro…

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -292,6 +292,11 @@ Shader "HDRenderPipeline/LayeredLit"
 
         // Transparency
         [ToggleOff] _PreRefractionPass("PreRefractionPass", Float) = 0.0
+
+        // HACK: GI Baking system relies on some properties existing in the shader ("_MainTex", "_Cutoff" and "_Color") for opacity handling, so we need to store our version of those parameters in the hard-coded name the GI baking system recognizes.
+        _MainTex("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (1,1,1,1)
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
     }
 
     HLSLINCLUDE

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -301,6 +301,11 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
 
         // Transparency
         [ToggleOff] _PreRefractionPass("PreRefractionPass", Float) = 0.0
+
+        // HACK: GI Baking system relies on some properties existing in the shader ("_MainTex", "_Cutoff" and "_Color") for opacity handling, so we need to store our version of those parameters in the hard-coded name the GI baking system recognizes.
+        _MainTex("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (1,1,1,1)
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
     }
 
     HLSLINCLUDE

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/BaseLitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/BaseLitUI.cs
@@ -349,6 +349,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 TessellationMode tessMode = (TessellationMode)material.GetFloat(kTessellationMode);
                 SetKeyword(material, "_TESSELLATION_PHONG", tessMode == TessellationMode.Phong);
             }
+
+            SetupMainTexForAlphaTestGI("_BaseColorMap", "_BaseColor", material);
         }
 
         static public void SetupBaseLitMaterialPass(Material material)

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -142,6 +142,11 @@ Shader "HDRenderPipeline/Lit"
         // In our case we don't use such a mechanism but need to keep the code quiet. We declare the value and always enable it.
         // TODO: Fix the code in legacy unity so we can customize the beahvior for GI
         _EmissionColor("Color", Color) = (1, 1, 1)
+
+        // HACK: GI Baking system relies on some properties existing in the shader ("_MainTex", "_Cutoff" and "_Color") for opacity handling, so we need to store our version of those parameters in the hard-coded name the GI baking system recognizes.
+        _MainTex("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (1,1,1,1)
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
     }
 
     HLSLINCLUDE

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -153,6 +153,11 @@ Shader "HDRenderPipeline/LitTessellation"
         _TessellationShapeFactor("Tessellation shape factor", Range(0.0, 1.0)) = 0.75 // Only use with Phong
         _TessellationBackFaceCullEpsilon("Tessellation back face epsilon", Range(-1.0, 0.0)) = -0.25
          // TODO: Handle culling mode for backface culling
+
+        // HACK: GI Baking system relies on some properties existing in the shader ("_MainTex", "_Cutoff" and "_Color") for opacity handling, so we need to store our version of those parameters in the hard-coded name the GI baking system recognizes.
+        _MainTex("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (1,1,1,1)
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
     }
 
     HLSLINCLUDE

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
@@ -420,11 +420,38 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // The fixup routine makes sure that the material is in the correct state if/when changes are made to the mode or color.
             MaterialEditor.FixupEmissiveFlag(material);
 
+            // Commented out for now because unfortunately we used the hard coded property names used by the GI system for our own parameters
+            // So we need a way to work around that before we activate this.
+            //SetupMainTexForAlphaTestGI("_EmissiveColorMap", "_EmissiveColor", material);
+
             // DoubleSidedGI has to be synced with our double sided toggle
             var serializedObject = new SerializedObject(material);
             var doubleSidedGIppt = serializedObject.FindProperty("m_DoubleSidedGI");
             doubleSidedGIppt.boolValue = doubleSidedEnable;
             serializedObject.ApplyModifiedProperties();
+        }
+
+        // This is a hack for GI. PVR looks in the shader for a texture named "_MainTex" to extract the opacity of the material for baking. In the same manner, "_Cutoff" and "_Color" are also necessary.
+        // Since we don't have those parameters in our shaders we need to provide a "fake" useless version of them with the right values for the GI to work.
+        protected static void SetupMainTexForAlphaTestGI(string colorMapPropertyName, string colorPropertyName, Material material)
+        {
+            if(material.HasProperty(colorMapPropertyName))
+            {
+                var mainTex = material.GetTexture(colorMapPropertyName);
+                material.SetTexture("_MainTex", mainTex);
+            }
+
+            if(material.HasProperty(colorPropertyName))
+            {
+                var color = material.GetColor(colorPropertyName);
+                material.SetColor("_Color", color);
+            }
+
+            if(material.HasProperty("_AlphaCutoff")) // Same for all our materials
+            {
+                var cutoff = material.GetFloat("_AlphaCutoff");
+                material.SetFloat("_Cutoff", cutoff);
+            }
         }
 
         static public void SetupBaseUnlitMaterialPass(Material material)

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
@@ -47,6 +47,11 @@ Shader "HDRenderPipeline/Unlit"
         // In our case we don't use such a mechanism but need to keep the code quiet. We declare the value and always enable it.
         // TODO: Fix the code in legacy unity so we can customize the beahvior for GI
         _EmissionColor("Color", Color) = (1, 1, 1)
+        
+        // HACK: GI Baking system relies on some properties existing in the shader ("_MainTex", "_Cutoff" and "_Color") for opacity handling, so we need to store our version of those parameters in the hard-coded name the GI baking system recognizes.
+        _MainTex("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (1,1,1,1)
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
     }
 
     HLSLINCLUDE


### PR DESCRIPTION
Hack for GI to handle Alpha Test correctly: Filled the hard-coded property used by the GI system to resolve opacity with our own equivalent so that GI works correctly with alpha-test. Disabled for now for Unlit because of a name conflict.
