### PR TITLE
Feature/refraction cubemap

### DIFF
--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Refraction.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Refraction.hlsl
@@ -1,0 +1,70 @@
+﻿#ifndef UNITY_REFRACTION_INCLUDED
+#define UNITY_REFRACTION_INCLUDED
+
+//-----------------------------------------------------------------------------
+// Util refraction
+//-----------------------------------------------------------------------------
+
+struct RefractionModelResult
+{
+    float       opticalDepth;
+    float3      positionWS;     // out ray position
+    float3      rayWS;          // out ray direction
+};
+
+RefractionModelResult RefractionModel_Sphere(float3 V, float3 positionWS, float3 normalWS, float ior, float thickness)
+{
+    // Sphere shape model:
+    //  We approximate locally the shape of the object as sphere, that is tangent to the shape.
+    //  The sphere has a diameter of {thickness}
+    //  The center of the sphere is at {positionWS} - {normalWS} * {thickness}
+    //
+    //  So the light is refracted twice: in and out of the tangent sphere
+
+    // First refraction (tangent sphere in)
+    // Refracted ray
+    float3 R1 = refract(-V, normalWS, 1.0 / ior);
+    // Center of the tangent sphere
+    float3 C = positionWS - normalWS * thickness * 0.5;
+
+    // Second refraction (tangent sphere out)
+    float NoR1 = dot(normalWS, R1);
+    // Optical depth within the sphere
+    float opticalDepth = -NoR1 * thickness;
+    // Out hit point in the tangent sphere
+    float3 P1 = positionWS + R1 * opticalDepth;
+    // Out normal
+    float3 N1 = normalize(C - P1);
+    // Out refracted ray
+    float3 R2 = refract(R1, N1, ior);
+    float N1oR2 = dot(N1, R2);
+    float VoR1 = dot(V, R1);
+
+    RefractionModelResult result;
+    result.opticalDepth = opticalDepth;
+    result.positionWS = P1;
+    result.rayWS = R2;
+
+    return result;
+}
+
+RefractionModelResult RefractionModel_Plane(float3 V, float3 positionWS, float3 normalWS, float ior, float thickness)
+{
+    // Plane shape model:
+    //  We approximate locally the shape of the object as a plane with normal {normalWS} at {positionWS}
+    //  with a thickness {thickness}
+
+    // Refracted ray
+    float3 R = refract(-V, normalWS, 1.0 / ior);
+
+    // Optical depth within the thin plane
+    float opticalDepth = thickness / dot(R, -normalWS);
+
+    RefractionModelResult result;
+    result.opticalDepth = opticalDepth;
+    result.positionWS = positionWS + R * opticalDepth;
+    result.rayWS = -V;
+
+    return result;
+}
+#endif

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Refraction.hlsl.meta
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Refraction.hlsl.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 61125f624d229884d8cff04fc0fceab7
+timeCreated: 1509090550
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
@@ -1675,7 +1675,7 @@ IndirectLighting EvaluateBSDF_SSReflection(LightLoopContext lightLoopContext,
 }
 
 IndirectLighting EvaluateBSDF_SSRefraction(LightLoopContext lightLoopContext,
-                                            float3 V, PositionInputs posInputs,
+                                            float3 V, PositionInputs posInput,
                                             PreLightData preLightData, BSDFData bsdfData,
                                             inout float hierarchyWeight)
 {
@@ -1690,7 +1690,7 @@ IndirectLighting EvaluateBSDF_SSRefraction(LightLoopContext lightLoopContext,
     //    a. Get the corresponding color depending on the roughness from the gaussian pyramid of the color buffer
     //    b. Multiply by the transmittance for absorption (depends on the optical depth)
 
-    float3 refractedBackPointWS = EstimateRaycast(V, posInputs, preLightData.transmissionPositionWS, preLightData.transmissionRefractV);
+    float3 refractedBackPointWS = EstimateRaycast(V, posInput, preLightData.transmissionPositionWS, preLightData.transmissionRefractV);
 
     // Calculate screen space coordinates of refracted point in back plane
     float4 refractedBackPointCS = mul(_ViewProjMatrix, float4(refractedBackPointWS, 1.0));
@@ -1700,7 +1700,7 @@ IndirectLighting EvaluateBSDF_SSRefraction(LightLoopContext lightLoopContext,
 
     // Exit if texel is out of color buffer
     // Or if the texel is from an object in front of the object
-    if (refractedBackPointDepth < posInputs.depthVS
+    if (refractedBackPointDepth < posInput.depthVS
         || any(refractedBackPointSS < 0.0)
         || any(refractedBackPointSS > 1.0))
     {
@@ -1776,13 +1776,11 @@ IndirectLighting EvaluateBSDF_Env(  LightLoopContext lightLoopContext,
     float3 R = preLightData.iblDirWS;
     float3 coatR = preLightData.coatIblDirWS;
 
-#if defined(HAS_REFRACTION)
     if (GPUImageBasedLightingType == GPUIMAGEBASEDLIGHTINGTYPE_REFRACTION)
     {
         positionWS = preLightData.transmissionPositionWS;
         R = preLightData.transmissionRefractV;
     }
-#endif
 
     // In Unity the cubemaps are capture with the localToWorld transform of the component.
     // This mean that location and orientation matter. So after intersection of proxy volume we need to convert back to world.


### PR DESCRIPTION
Refactored code of cubemap support for refraction

 - Added new file Refraction.hlsl with refraction models
 - Moved refraction and transmission properties into preLightData
 - Updated screen space refraction and environment lighting code

NB: There is still an issue with roughness: 
![2017-10-27_11-56-56](https://user-images.githubusercontent.com/1635937/32098736-f873669e-bb0d-11e7-8672-930c3e17dc94.png)
Roughness is not properly synchronized between screen space rough refraction and cubemap rough refraction
