### PR TITLE
Renamed _ColorXXX properties in Unlit to _UnlitColor to avoid conflic…

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
@@ -422,7 +422,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             // Commented out for now because unfortunately we used the hard coded property names used by the GI system for our own parameters
             // So we need a way to work around that before we activate this.
-            //SetupMainTexForAlphaTestGI("_EmissiveColorMap", "_EmissiveColor", material);
+            SetupMainTexForAlphaTestGI("_EmissiveColorMap", "_EmissiveColor", material);
 
             // DoubleSidedGI has to be synced with our double sided toggle
             var serializedObject = new SerializedObject(material);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/UnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/UnlitUI.cs
@@ -16,9 +16,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         protected MaterialProperty color = null;
-        protected const string kColor = "_Color";
+        protected const string kColor = "_UnlitColor";
         protected MaterialProperty colorMap = null;
-        protected const string kColorMap = "_ColorMap";
+        protected const string kColorMap = "_UnlitColorMap";
         protected MaterialProperty emissiveColor = null;
         protected const string kEmissiveColor = "_EmissiveColor";
         protected MaterialProperty emissiveColorMap = null;

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
@@ -2,8 +2,9 @@ Shader "HDRenderPipeline/Unlit"
 {
     Properties
     {
-        _Color("Color", Color) = (1,1,1,1)
-        _ColorMap("ColorMap", 2D) = "white" {}
+        // Be careful, do not change the name here to _Color. It will conflict with the "fake" parameters (see end of properties) required for GI.
+        _UnlitColor("Color", Color) = (1,1,1,1)
+        _UnlitColorMap("ColorMap", 2D) = "white" {}
 
         _EmissiveColor("EmissiveColor", Color) = (0, 0, 0)
         _EmissiveColorMap("EmissiveColorMap", 2D) = "white" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitData.hlsl
@@ -4,8 +4,8 @@
 
 void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
 {
-    surfaceData.color = SAMPLE_TEXTURE2D(_ColorMap, sampler_ColorMap, input.texCoord0).rgb * _Color.rgb;
-    float alpha = SAMPLE_TEXTURE2D(_ColorMap, sampler_ColorMap, input.texCoord0).a * _Color.a;
+    surfaceData.color = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, input.texCoord0).rgb * _UnlitColor.rgb;
+    float alpha = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, input.texCoord0).a * _UnlitColor.a;
 
 #ifdef _ALPHATEST_ON
     DoAlphaTest(alpha, _AlphaCutoff);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitProperties.hlsl
@@ -1,6 +1,6 @@
-﻿float4  _Color;
-TEXTURE2D(_ColorMap);
-SAMPLER2D(sampler_ColorMap);
+﻿float4  _UnlitColor;
+TEXTURE2D(_UnlitColorMap);
+SAMPLER2D(sampler_UnlitColorMap);
 
 TEXTURE2D(_DistortionVectorMap);
 SAMPLER2D(sampler_DistortionVectorMap);


### PR DESCRIPTION
…t with legacy Unity names which are required for Alpha test to work with GI.