### PR TITLE
Fix position of material previews in Unlit scene.

### DIFF
--- a/Tests/GraphicsTests/RenderPipeline/HDRenderPipeline/Scenes/1xxx_Materials/1101_Unlit.unity
+++ b/Tests/GraphicsTests/RenderPipeline/HDRenderPipeline/Scenes/1xxx_Materials/1101_Unlit.unity
@@ -1768,27 +1768,27 @@ Prefab:
     m_Modifications:
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalPosition.x
-      value: -9.590492
+      value: -17
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 1.3619998
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalPosition.z
-      value: 6.2851562
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.w
@@ -10852,8 +10852,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 416243467}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.90950775, y: 2.3619227, z: -2.7148438}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15.5, y: 8, z: 9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 641123203}
@@ -12648,27 +12648,27 @@ Prefab:
     m_Modifications:
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalPosition.x
-      value: -9.590492
+      value: -17
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 7.3639226
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalPosition.z
-      value: 6.2851562
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 4998153201766196, guid: 047164696a3569e47bc62a2a5b4742a8, type: 2}
       propertyPath: m_LocalRotation.w
@@ -17771,7 +17771,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 780367057}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -7.4095078, y: 0.6380774, z: 2.7148438}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 61111092}
@@ -30142,8 +30142,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1372922176}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.90950775, y: -3.6399999, z: -2.7148438}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15.5, y: 2, z: 9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 131578286}
@@ -41122,8 +41122,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1938033848}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.90950775, y: -5.14, z: -2.7148438}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15.5, y: 0.5, z: 9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 356687269}
@@ -43751,8 +43751,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2040780205}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.90950775, y: 0.8619226, z: -2.7148438}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15.5, y: 6.5, z: 9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1901425998}
@@ -45251,7 +45251,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2111839919}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -7.4095078, y: 0.6380774, z: 2.7148438}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 518216940}


### PR DESCRIPTION
Moved objects that were broken after unlit fix to match previous graphic test template.