### PR TITLE
Improve subsurface scattering

### DIFF
--- a/ScriptableRenderPipeline/Core/ShaderLibrary/API/PSSL.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/API/PSSL.hlsl
@@ -1,7 +1,9 @@
 // This file assume SHADER_API_D3D11 is defined
 
 #define INTRINSIC_BITFIELD_EXTRACT
+#define INTRINSIC_WAVEREADFIRSTLANE
 #define INTRINSIC_MAD24
+#define WaveReadFirstLane ReadFirstLane
 #define Mad24 mad24
 #define INTRINSIC_MED3
 #define INTRINSIC_MINMAX3

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/API/PSSL.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/API/PSSL.hlsl
@@ -2,10 +2,9 @@
 
 #define INTRINSIC_BITFIELD_EXTRACT
 #define INTRINSIC_WAVEREADFIRSTLANE
-#define INTRINSIC_MAD24
 #define WaveReadFirstLane ReadFirstLane
+#define INTRINSIC_MAD24
 #define Mad24 mad24
-#define INTRINSIC_MED3
 #define INTRINSIC_MINMAX3
 #define Min3 min3
 #define Max3 max3

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
@@ -123,12 +123,6 @@ uint WaveReadFirstLane(uint scalarValue)
 }
 #endif
 
-#ifndef INTRINSIC_CLAMP
-// TODO: should we force all clamp to be intrinsic by default ?
-// Some platform have one instruction clamp
-#define Clamp clamp
-#endif // INTRINSIC_CLAMP
-
 #ifndef INTRINSIC_MUL24
 int Mul24(int a, int b)
 {
@@ -152,13 +146,6 @@ uint Mad24(uint a, uint b, uint c)
     return a * b + c;
 }
 #endif // INTRINSIC_MAD24
-
-#ifndef INTRINSIC_MED3
-float Med3(float a, float b, float c)
-{
-    return Clamp(a, b, c);
-}
-#endif // INTRINSIC_MED3
 
 #ifndef INTRINSIC_MINMAX3
 float Min3(float a, float b, float c)

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
@@ -115,6 +115,14 @@ bool IsBitSet(uint data, uint bitPos)
     return BitFieldExtract(data, 1u, bitPos) != 0;
 }
 
+#ifndef INTRINSIC_WAVEREADFIRSTLANE
+// Warning: for correctness, the value you pass to the function must be constant across the wave!
+uint WaveReadFirstLane(uint scalarValue)
+{
+    return scalarValue;
+}
+#endif
+
 #ifndef INTRINSIC_CLAMP
 // TODO: should we force all clamp to be intrinsic by default ?
 // Some platform have one instruction clamp

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/CommonMaterial.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/CommonMaterial.hlsl
@@ -156,6 +156,22 @@ float ComputeWrappedDiffuseLighting(float NdotL, float w)
     return saturate((NdotL + w) / ((1 + w) * (1 + w)));
 }
 
+// In order to support subsurface scattering, we need to know which pixels have an SSS material.
+// It can be accomplished by reading the stencil buffer.
+// A faster solution (which avoids an extra texture fetch) is to simply make sure that
+// all pixels which belong to an SSS material are not black (those that don't always are).
+float3 TagLightingForSSS(float3 subsurfaceLighting)
+{
+    subsurfaceLighting.r = max(subsurfaceLighting.r, HFLT_MIN);
+    return subsurfaceLighting;
+}
+
+// See TagLightingForSSS() for details.
+bool TestLightingForSSS(float3 subsurfaceLighting)
+{
+    return subsurfaceLighting.r > 0;
+}
+
 // MACRO from Legacy Untiy
 // Transforms 2D UV by scale/bias property
 #define TRANSFORM_TEX(tex, name) ((tex.xy) * name##_ST.xy + name##_ST.zw)

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/EntityLighting.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/EntityLighting.hlsl
@@ -69,7 +69,7 @@ float3 SampleProbeVolumeSH4(TEXTURE3D_ARGS(SHVolumeTexture, SHVolumeSampler), fl
     // but last one is not used.
     // Clamp to edge of the "internal" texture, as R is from half texel to size of R texture minus half texel.
     // This avoid leaking
-    texCoord.x = Clamp(texCoord.x * 0.25, 0.5 * texelSizeX, 0.25 - 0.5 * texelSizeX);
+    texCoord.x = clamp(texCoord.x * 0.25, 0.5 * texelSizeX, 0.25 - 0.5 * texelSizeX);
 
     float4 shAr = SAMPLE_TEXTURE3D(SHVolumeTexture, SHVolumeSampler, texCoord);
     texCoord.x += 0.25;

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Shadow/Resources/ShadowBlurMoments.compute
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Shadow/Resources/ShadowBlurMoments.compute
@@ -191,7 +191,7 @@ void KERNEL_MAIN( uint3 dispatchId : SV_DispatchThreadID, uint3 groupThreadId : 
 #if MAX_MSAA > 1
 	uint width, height, sampleCnt;
 	depthTex.GetDimensions( width, height, sampleCnt );
-	sampleCnt = Clamp( sampleCnt, 2, MAX_MSAA );
+	sampleCnt = clamp( sampleCnt, 2, MAX_MSAA );
 	float sampleCntRcp = 1.0 / sampleCnt;
 
 	// calculate weights based on sample positions
@@ -241,7 +241,7 @@ void KERNEL_MAIN( uint3 dispatchId : SV_DispatchThreadID, uint3 groupThreadId : 
 						  // We're pancaking triangles to znear in the depth pass so depth and subsequently all moments can end up being zero.
 						  // The solver ShadowMoments_SolveMSM then ends up calculating infinities and nands, which produces different results
 						  // on different vendors' GPUs. So we're adding a small safety margin here.
-						  depth = Clamp( depth, 0.001, 0.999 );
+						  depth = clamp( depth, 0.001, 0.999 );
 #   endif
 					avgMoments += sampleWeights[is] * DepthToMoments( depth );
 				}
@@ -255,7 +255,7 @@ void KERNEL_MAIN( uint3 dispatchId : SV_DispatchThreadID, uint3 groupThreadId : 
 					  // We're pancaking triangles to znear in the depth pass so depth and subsequently all moments can end up being zero.
 					  // The solver ShadowMoments_SolveMSM then ends up calculating infinities and nands, which produces different results
 					  // on different vendors' GPUs. So we're adding a small safety margin here.
-					  depth = Clamp( depth, 0.001, 0.999 );
+					  depth = clamp( depth, 0.001, 0.999 );
 #   endif
 				writeToShared( DepthToMoments( depth ), int2( ldsIdx.x, groupThreadId.y ), LDS_STRIDE );
 #endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -1225,7 +1225,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture2,  m_GbufferManager.GetGBuffers()[2]);
                     cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture3,  m_GbufferManager.GetGBuffers()[3]);
                     cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._DepthTexture,     GetDepthTexture());
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._StencilTexture,   GetStencilTexture());
                     cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._HTile,            GetHTile());
                     cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._IrradianceSource, m_CameraSssDiffuseLightingBufferRT);
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -568,7 +568,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         bool NeedDepthBufferCopy()
         {
-            // For now we consider only PS4 to be able to read from a bound depth buffer. Need to test/implement for other platforms.
+            // For now we consider only PS4 to be able to read from a bound depth buffer.
+            // TODO: test/implement for other platforms.
             return SystemInfo.graphicsDeviceType != GraphicsDeviceType.PlayStation4;
         }
 
@@ -583,7 +584,18 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             // Currently, Unity does not offer a way to access the GCN HTile even on PS4 and Xbox One.
             // Therefore, it's computed in a pixel shader, and optimized to only contain the SSS bit.
-            return m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission;
+            return m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission && sssSettings.useDisneySSS;
+        }
+
+        bool NeedTemporarySubsurfaceBuffer()
+        {
+            // Typed UAV loads from FORMAT_R16G16B16A16_FLOAT is an optional feature of Direct3D 11.
+            // Most modern GPUs support it. We can avoid performing a costly copy in this case.
+            // TODO: test/implement for other platforms.
+            return m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission && (!sssSettings.useDisneySSS || (
+            SystemInfo.graphicsDeviceType != GraphicsDeviceType.PlayStation4 &&
+            SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOne &&
+            SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOneD3D12));
         }
 
         RenderTargetIdentifier GetDepthTexture()
@@ -1208,24 +1220,34 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._FilterKernels,      sssParameters.filterKernels);
                     cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._ShapeParams,        sssParameters.shapeParams);
 
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture0,       m_GbufferManager.GetGBuffers()[0]);
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture1,       m_GbufferManager.GetGBuffers()[1]);
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture2,       m_GbufferManager.GetGBuffers()[2]);
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture3,       m_GbufferManager.GetGBuffers()[3]);
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._DepthTexture,          GetDepthTexture());
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._StencilTexture,        GetStencilTexture());
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._HTile,                 GetHTile());
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._IrradianceSource,      m_CameraSssDiffuseLightingBufferRT);
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._CameraColorTexture,    m_CameraColorBufferRT);
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._CameraFilteringBuffer, m_CameraFilteringBufferRT);
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture0,  m_GbufferManager.GetGBuffers()[0]);
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture1,  m_GbufferManager.GetGBuffers()[1]);
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture2,  m_GbufferManager.GetGBuffers()[2]);
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._GBufferTexture3,  m_GbufferManager.GetGBuffers()[3]);
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._DepthTexture,     GetDepthTexture());
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._StencilTexture,   GetStencilTexture());
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._HTile,            GetHTile());
+                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._IrradianceSource, m_CameraSssDiffuseLightingBufferRT);
 
-                    // Perform the SSS filtering pass which fills 'm_CameraFilteringBufferRT'.
-                    cmd.DispatchCompute(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, ((int)hdCamera.screenSize.x + 15) / 16, ((int)hdCamera.screenSize.y + 15) / 16, 1);
+                    if (NeedTemporarySubsurfaceBuffer())
+                    {
+                        cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._CameraFilteringBuffer, m_CameraFilteringBufferRT);
 
-                    cmd.SetGlobalTexture(HDShaderIDs._IrradianceSource, m_CameraFilteringBufferRT);  // Cannot set a RT on a material
+                        // Perform the SSS filtering pass which fills 'm_CameraFilteringBufferRT'.
+                        cmd.DispatchCompute(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, ((int)hdCamera.screenSize.x + 15) / 16, ((int)hdCamera.screenSize.y + 15) / 16, 1);
 
-                    // Combine diffuse and specular lighting into 'm_CameraColorBufferRT'.
-                    CoreUtils.DrawFullScreen(cmd, m_CombineLightingPass, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT);
+                        cmd.SetGlobalTexture(HDShaderIDs._IrradianceSource, m_CameraFilteringBufferRT);  // Cannot set a RT on a material
+
+                        // Additively blend diffuse and specular lighting into 'm_CameraColorBufferRT'.
+                        CoreUtils.DrawFullScreen(cmd, m_CombineLightingPass, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT);
+                    }
+                    else
+                    {
+                        cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._CameraColorTexture, m_CameraColorBufferRT);
+
+                        // Perform the SSS filtering pass which performs an in-place update of 'm_CameraColorBufferRT'.
+                        cmd.DispatchCompute(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, ((int)hdCamera.screenSize.x + 15) / 16, ((int)hdCamera.screenSize.y + 15) / 16, 1);
+                    }
                 }
                 else
                 {
@@ -1615,7 +1637,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                     cmd.GetTemporaryRT(m_CameraColorBuffer,              w, h, 0, FilterMode.Point, RenderTextureFormat.ARGBHalf,       RenderTextureReadWrite.Linear, 1, true); // Enable UAV
                     cmd.GetTemporaryRT(m_CameraSssDiffuseLightingBuffer, w, h, 0, FilterMode.Point, RenderTextureFormat.RGB111110Float, RenderTextureReadWrite.Linear, 1, true); // Enable UAV
-                    cmd.GetTemporaryRT(m_CameraFilteringBuffer,          w, h, 0, FilterMode.Point, RenderTextureFormat.RGB111110Float, RenderTextureReadWrite.Linear, 1, true); // Enable UAV
+                    if (NeedTemporarySubsurfaceBuffer())
+                    {
+                        cmd.GetTemporaryRT(m_CameraFilteringBuffer,      w, h, 0, FilterMode.Point, RenderTextureFormat.RGB111110Float, RenderTextureReadWrite.Linear, 1, true); // Enable UAV
+                    }
 
                     // Color and depth pyramids
                     int s = CalculatePyramidSize(w, h);
@@ -1641,7 +1666,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
 
                 // Old SSS Model >>>
-                if (!sssSettings.useDisneySSS)
+                if (NeedTemporarySubsurfaceBuffer())
                 {
                     // Clear the SSS filtering target
                     using (new ProfilingSample(cmd, "Clear SSS filtering target"))

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
@@ -114,12 +114,7 @@ Shader "Hidden/HDRenderPipeline/Deferred"
                 Outputs outputs;
             #ifdef OUTPUT_SPLIT_LIGHTING
                 outputs.specularLighting = float4(specularLighting, 1.0);
-                outputs.diffuseLighting  = diffuseLighting;
-                // We SSSSS is enabled with use split lighting.
-                // SSSSS algorithm need to know which pixels contribute to SSS and which doesn't. We could use the stencil for that but it mean that it will increase the cost of SSSSS
-                // A simpler solution is to add a slight contribution here that isn't visible (here we chose fp16 min (which is also fp11 and fp10 min).
-                // The SSSSS algorithm will check if diffuse lighting is black and discard the pixel if it is the case
-                outputs.diffuseLighting.r = max(outputs.diffuseLighting.r, HFLT_MIN);
+                outputs.diffuseLighting  = TagLightingForSSS(diffuseLighting);
             #else
                 outputs.combinedLighting = float4(diffuseLighting + specularLighting, 1.0);
             #endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
@@ -146,14 +146,8 @@ void SHADE_OPAQUE_ENTRY(uint2 dispatchThreadId : SV_DispatchThreadID, uint2 grou
 
     if (_EnableSSSAndTransmission != 0 && bsdfData.materialId == MATERIALID_LIT_SSS && HasMaterialFeatureFlag(MATERIALFEATUREFLAGS_LIT_SSS))
     {
-        // We SSSSS is enabled with use split lighting.
-        // SSSSS algorithm need to know which pixels contribute to SSS and which doesn't. We could use the stencil for that but it mean that it will increase the cost of SSSSS
-        // A simpler solution is to add a slight contribution here that isn't visible (here we chose fp16 min (which is also fp11 and fp10 min).
-        // The SSSSS algorithm will check if diffuse lighting is black and discard the pixel if it is the case
-        diffuseLighting.r = max(diffuseLighting.r, HFLT_MIN);
-
         specularLightingUAV[pixelCoord] = float4(specularLighting, 1.0);
-        diffuseLightingUAV[pixelCoord]  = diffuseLighting;
+        diffuseLightingUAV[pixelCoord]  = TagLightingForSSS(diffuseLighting);
     }
     else
     {

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
@@ -25,7 +25,7 @@
 #define GBufferType1 uint4
 
 // TODO: How to abstract that ? We would like to avoid this PS4 test here
-#ifdef SHADER_API_PS4
+#ifdef SHADER_API_PSSL
 // On PS4 we need to specify manually the format of the output render target, output type is not enough
 #pragma PSSL_target_output_format(target 0 FMT_UINT16_ABGR)
 #pragma PSSL_target_output_format(target 1 FMT_UINT16_ABGR)

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
@@ -26,9 +26,10 @@
 #define TEXTURE_CACHE_BORDER  2
 #define TEXTURE_CACHE_SIZE_1D (GROUP_SIZE_1D + 2 * TEXTURE_CACHE_BORDER)
 
+// Check for support of typed UAV loads from FORMAT_R16G16B16A16_FLOAT.
 // TODO: query the format support more precisely.
-#if defined(SHADER_API_PSSL) || defined(SHADER_API_XBOXONE)
-#define TYPED_UAV_LOAD_FORMAT_R16G16B16A16_FLOAT
+#if !(defined(SHADER_API_PSSL) || defined(SHADER_API_XBOXONE))
+#define USE_INTERMEDIATE_BUFFER
 #endif
 
 //--------------------------------------------------------------------------------------------------
@@ -54,10 +55,10 @@ TEXTURE2D(_DepthTexture);                           // Z-buffer
 TEXTURE2D(_HTile);                                  // DXGI_FORMAT_R8_UINT is not supported by Unity
 TEXTURE2D(_IrradianceSource);                       // Includes transmitted light
 
-#ifdef TYPED_UAV_LOAD_FORMAT_R16G16B16A16_FLOAT
-    RW_TEXTURE2D(float4, _CameraColorTexture);      // Target texture
-#else
+#ifdef USE_INTERMEDIATE_BUFFER
     RW_TEXTURE2D(float4, _CameraFilteringTexture);  // Target texture
+#else
+    RW_TEXTURE2D(float4, _CameraColorTexture);      // Target texture
 #endif
 
 //--------------------------------------------------------------------------------------------------
@@ -223,10 +224,10 @@ void EvaluateSample(uint i, uint n, uint profileID, uint iR, uint iP, float2 cen
 
 void WriteResult(uint2 pixelCoord, float3 irradiance)
 {
-#ifdef TYPED_UAV_LOAD_FORMAT_R16G16B16A16_FLOAT
-    _CameraColorTexture[pixelCoord]    += float4(irradiance, 0);
-#else
+#ifdef USE_INTERMEDIATE_BUFFER
     _CameraFilteringTexture[pixelCoord] = float4(irradiance, 1);
+#else
+    _CameraColorTexture[pixelCoord]    += float4(irradiance, 0);
 #endif
 }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
@@ -51,7 +51,6 @@ float4 _FilterKernels[SSS_N_PROFILES][SSS_N_SAMPLES_NEAR_FIELD]; // XY = near fi
 
 DECLARE_GBUFFER_TEXTURE(_GBufferTexture);           // Contains the albedo and SSS parameters
 TEXTURE2D(_DepthTexture);                           // Z-buffer
-TEXTURE2D(_StencilTexture);                         // DXGI_FORMAT_R8_UINT is not supported by Unity
 TEXTURE2D(_HTile);                                  // DXGI_FORMAT_R8_UINT is not supported by Unity
 TEXTURE2D(_IrradianceSource);                       // Includes transmitted light
 
@@ -76,7 +75,7 @@ bool StencilTest(int2 pixelCoord, float stencilRef)
     bool passedStencilTest;
 
 #if SSS_SAMPLE_TEST_HTILE
-    int2 tileCoord = pixelCoord >> 3; // Divide by 8
+    int2 tileCoord = pixelCoord / 8;
 
     // Perform the stencil test (reject at the tile rate).
     passedStencilTest = stencilRef == LOAD_TEXTURE2D(_HTile, tileCoord).r;
@@ -90,7 +89,8 @@ bool StencilTest(int2 pixelCoord, float stencilRef)
     {
         // Unfortunately, our copy of HTile does not allow to accept at the tile rate.
         // Therefore, we have to additionally perform the stencil test at the pixel rate.
-        passedStencilTest = (uint)stencilRef == UnpackByte(LOAD_TEXTURE2D(_StencilTexture, pixelCoord).r);
+        // We check the tagged irradiance buffer to avoid an extra stencil texture fetch.
+        passedStencilTest = TestLightingForSSS(LOAD_TEXTURE2D(_IrradianceSource, pixelCoord).rgb);
     }
 
     return passedStencilTest;
@@ -197,18 +197,27 @@ void EvaluateSample(uint i, uint n, uint profileID, uint iR, uint iP, float2 cen
 
     float4 textureSample = LoadSample(position, cacheAnchor);
     float3 irradiance    = textureSample.rgb;
-    float  linearDepth   = textureSample.a;
 
     // Check the results of the stencil test.
-    if (linearDepth > 0)
+    if (TestLightingForSSS(irradiance))
     {
         // Apply bilateral weighting.
+        float  linearDepth = textureSample.a;
         float  z = linearDepth - centerPosVS.z;
         float  p = _FilterKernels[profileID][i][iP];
         float3 w = ComputeBilateralWeight(xy2, z, mmPerUnit, shapeParam, p);
 
         totalIrradiance += w * irradiance;
         totalWeight     += w;
+    }
+    else
+    {
+        // The irradiance is 0. This could happen for 2 reasons.
+        // Most likely, the surface fragment does not have an SSS material.
+        // Alternatively, our sample comes from a region without any geometry.
+        // Our blur is energy-preserving, so 'centerWeight' should be set to 0.
+        // We do not terminate the loop since we want to gather the contribution
+        // of the remaining samples (e.g. in case of hair covering skin).
     }
 }
 
@@ -260,7 +269,7 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
 
     float3 centerIrradiance = 0;
     float  centerDepth      = 0;
-    float4 cachedValue      = float4(0, 0, 0, 0);
+    float4 cachedValue      = 0;
 
     bool passedStencilTest = StencilTest((int2)pixelCoord, stencilRef);
 
@@ -310,7 +319,7 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
 
         uint2  cacheCoord2  = 2 * (startQuad + quadCoord) + uint2(laneIndex & 1, (laneIndex >> 1) & 1);
         int2   pixelCoord2  = (int2)(tileAnchor + cacheCoord2) - TEXTURE_CACHE_BORDER;
-        float4 cachedValue2 = float4(0, 0, 0, 0);
+        float4 cachedValue2 = 0;
 
         [branch] if (StencilTest(pixelCoord2, stencilRef))
         {

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
@@ -9,10 +9,10 @@
 // Tweak parameters.
 #define SSS_BILATERAL_FILTER  1
 #define SSS_USE_LDS_CACHE     1
-#define SSS_ENABLE_NEAR_FIELD 0
-#define SSS_SAMPLE_TEST_HTILE 0
-#define SSS_USE_TANGENT_PLANE 0
-#define SSS_CLAMP_ARTIFACT    0
+#define SSS_ENABLE_NEAR_FIELD 0 // Greatly increases the number of samples. Comes at a high cost.
+#define SSS_SAMPLE_TEST_HTILE 0 // Potential optimization. YMMV.
+#define SSS_USE_TANGENT_PLANE 0 // Improves the accuracy of the approximation(0 -> 1st order). High cost. Does not work with back-facing normals.
+#define SSS_CLAMP_ARTIFACT    0 // Reduces bleeding. Use with SSS_USE_TANGENT_PLANE.
 #define SSS_DEBUG_LOD         0
 #define SSS_DEBUG_NORMAL_VS   0
 
@@ -368,8 +368,9 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
     float3 tangentY = GetLocalFrame(normalVS)[1] * unitsPerMm;
 
 #if SSS_DEBUG_NORMAL_VS
-    // We expect the view-space normal to be front-facing.
-    if (normalVS.z >= 0)
+    // We expect the normal to be front-facing.
+    float3 viewDirVS = normalize(centerPosVS);
+    if (dot(normalVS, viewDirVS) >= 0)
     {
         _CameraFilteringTexture[pixelCoord] = float4(1, 1, 1, 1);
         return;

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
@@ -228,7 +228,7 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
                           uint  groupThreadId : SV_GroupThreadID)
 {
     // Note: any factor of 64 is a suitable wave size for our algorithm.
-    uint waveIndex = groupThreadId / 64;
+    uint waveIndex = WaveReadFirstLane(groupThreadId / 64);
     uint laneIndex = groupThreadId % 64;
     uint quadIndex = laneIndex / 4;
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.compute
@@ -26,6 +26,11 @@
 #define TEXTURE_CACHE_BORDER  2
 #define TEXTURE_CACHE_SIZE_1D (GROUP_SIZE_1D + 2 * TEXTURE_CACHE_BORDER)
 
+// TODO: query the format support more precisely.
+#if defined(SHADER_API_PSSL) || defined(SHADER_API_XBOXONE)
+#define TYPED_UAV_LOAD_FORMAT_R16G16B16A16_FLOAT
+#endif
+
 //--------------------------------------------------------------------------------------------------
 // Included headers
 //--------------------------------------------------------------------------------------------------
@@ -44,12 +49,17 @@
 float4 _WorldScales[SSS_N_PROFILES];                             // Size of the world unit in meters (only the X component is used)
 float4 _FilterKernels[SSS_N_PROFILES][SSS_N_SAMPLES_NEAR_FIELD]; // XY = near field, ZW = far field; 0 = radius, 1 = reciprocal of the PDF
 
-DECLARE_GBUFFER_TEXTURE(_GBufferTexture);      // Contains the albedo and SSS parameters
-TEXTURE2D(_DepthTexture);                      // Z-buffer
-TEXTURE2D(_StencilTexture);                    // DXGI_FORMAT_R8_UINT is not supported by Unity
-TEXTURE2D(_HTile);                             // DXGI_FORMAT_R8_UINT is not supported by Unity
-TEXTURE2D(_IrradianceSource);                  // Includes transmitted light
-RW_TEXTURE2D(float4, _CameraFilteringTexture); // Target texture
+DECLARE_GBUFFER_TEXTURE(_GBufferTexture);           // Contains the albedo and SSS parameters
+TEXTURE2D(_DepthTexture);                           // Z-buffer
+TEXTURE2D(_StencilTexture);                         // DXGI_FORMAT_R8_UINT is not supported by Unity
+TEXTURE2D(_HTile);                                  // DXGI_FORMAT_R8_UINT is not supported by Unity
+TEXTURE2D(_IrradianceSource);                       // Includes transmitted light
+
+#ifdef TYPED_UAV_LOAD_FORMAT_R16G16B16A16_FLOAT
+    RW_TEXTURE2D(float4, _CameraColorTexture);      // Target texture
+#else
+    RW_TEXTURE2D(float4, _CameraFilteringTexture);  // Target texture
+#endif
 
 //--------------------------------------------------------------------------------------------------
 // Implementation
@@ -202,6 +212,15 @@ void EvaluateSample(uint i, uint n, uint profileID, uint iR, uint iP, float2 cen
     }
 }
 
+void WriteResult(uint2 pixelCoord, float3 irradiance)
+{
+#ifdef TYPED_UAV_LOAD_FORMAT_R16G16B16A16_FLOAT
+    _CameraColorTexture[pixelCoord]    += float4(irradiance, 0);
+#else
+    _CameraFilteringTexture[pixelCoord] = float4(irradiance, 1);
+#endif
+}
+
 #pragma kernel SubsurfaceScattering
 
 [numthreads(GROUP_SIZE_2D, 1, 1)]
@@ -352,9 +371,9 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
     [branch] if (distScale == 0 || maxDistInPixels < 1)
     {
         #if SSS_DEBUG_LOD
-            _CameraFilteringTexture[pixelCoord] = float4(0, 0, 1, 1);
+            WriteResult(pixelCoord, float3(0, 0, 1));
         #else
-            _CameraFilteringTexture[pixelCoord] = float4(albedo * centerIrradiance, 1);
+            WriteResult(pixelCoord, albedo * centerIrradiance);
         #endif
             return;
     }
@@ -372,7 +391,7 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
     float3 viewDirVS = normalize(centerPosVS);
     if (dot(normalVS, viewDirVS) >= 0)
     {
-        _CameraFilteringTexture[pixelCoord] = float4(1, 1, 1, 1);
+        WriteResult(pixelCoord, float3(1, 1, 1));
         return;
     }
 #endif
@@ -381,7 +400,7 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
     bool useNearFieldKernel = SSS_ENABLE_NEAR_FIELD && maxDistInPixels > SSS_LOD_THRESHOLD;
 
 #if SSS_DEBUG_LOD
-    _CameraFilteringTexture[pixelCoord] = useNearFieldKernel ? float4(1, 0, 0, 1) : float4(0.5, 0.5, 0, 1);
+    WriteResult(pixelCoord, useNearFieldKernel ? float3(1, 0, 0) : float3(0.5, 0.5, 0);
     return;
 #endif
 
@@ -411,7 +430,7 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
 
     [branch] if (!useNearFieldKernel)
     {
-         _CameraFilteringTexture[pixelCoord] = float4(albedo * totalIrradiance / totalWeight, 1);
+         WriteResult(pixelCoord, albedo * totalIrradiance / totalWeight);
          return;
     }
 
@@ -425,5 +444,5 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
                        totalIrradiance, totalWeight);
     }
 
-    _CameraFilteringTexture[pixelCoord] = float4(albedo * totalIrradiance / totalWeight, 1);
+    WriteResult(pixelCoord, albedo * totalIrradiance / totalWeight);
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Resources/SubsurfaceScattering.shader
@@ -175,8 +175,7 @@ Shader "Hidden/HDRenderPipeline/SubsurfaceScattering"
                     sampleWeight     = _FilterKernelsBasic[profileID][i].rgb;
                     sampleIrradiance = LOAD_TEXTURE2D(_IrradianceSource, samplePosition).rgb;
 
-                    [flatten]
-                    if (any(sampleIrradiance))
+                    if (TestLightingForSSS(sampleIrradiance))
                     {
                         // Apply bilateral weighting.
                         // Ref #1: Skin Rendering by Pseudo–Separable Cross Bilateral Filtering.
@@ -191,10 +190,9 @@ Shader "Hidden/HDRenderPipeline/SubsurfaceScattering"
                     }
                     else
                     {
-                        // The irradiance is 0. This could happen for 3 reasons.
+                        // The irradiance is 0. This could happen for 2 reasons.
                         // Most likely, the surface fragment does not have an SSS material.
                         // Alternatively, our sample comes from a region without any geometry.
-                        // Finally, the surface fragment could be completely shadowed.
                         // Our blur is energy-preserving, so 'centerWeight' should be set to 0.
                         // We do not terminate the loop since we want to gather the contribution
                         // of the remaining samples (e.g. in case of hair covering skin).

--- a/ScriptableRenderPipeline/HDRenderPipeline/ShaderPass/ShaderPassLightTransport.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/ShaderPass/ShaderPassLightTransport.hlsl
@@ -74,7 +74,7 @@ float4 Frag(PackedVaryingsToPS packedInput) : SV_Target
     {
         // Apply diffuseColor Boost from LightmapSettings.
         // put abs here to silent a warning, no cost, no impact as color is assume to be positive.
-        res.rgb = Clamp(pow(abs(lightTransportData.diffuseColor), saturate(unity_OneOverOutputBoost)), 0, unity_MaxOutputValue);
+        res.rgb = clamp(pow(abs(lightTransportData.diffuseColor), saturate(unity_OneOverOutputBoost)), 0, unity_MaxOutputValue);
     }
 
     if (unity_MetaFragmentControl.y)


### PR DESCRIPTION
Before:
; -------- Statistics ---------------------
; SGPRs: 62 out of 104 used
; VGPRs: 43 out of 256 used
; LDS: 6416 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: 1386 ALU, 97 TFETCH

After:
; -------- Statistics ---------------------
; SGPRs: 62 out of 104 used
; VGPRs: 44 out of 256 used
; LDS: 6416 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: 1343 ALU, 75 TFETCH