### PR TITLE
Fix cracks in tessellation

### DIFF
--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
@@ -559,6 +559,12 @@ float2 ComputeScreenSpacePosition(float4 positionCS)
     return positionSS;
 }
 
+float2 ComputeScreenSpacePosition(float3 positionWS, float4x4 viewProjectionMatrix)
+{
+    float4 positionCS = mul(viewProjectionMatrix, float4(positionWS, 1.0));
+    return ComputeScreenSpacePosition(positionCS);
+}
+
 float3 ComputeViewSpacePosition(float2 positionSS, float depthRaw, float4x4 invProjMatrix)
 {
     float4 positionCS = ComputeClipSpacePosition(positionSS, depthRaw);

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/GeometricTools.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/GeometricTools.hlsl
@@ -130,14 +130,16 @@ bool CullTriangleFrustum(float3 p0, float3 p1, float3 p2, float epsilon, float4 
 
 // Returns 'true' if a triangle defined by 3 vertices is back-facing.
 // 'epsilon' is the (negative) value of dot(N, V) below which we cull the triangle.
-bool CullTriangleBackFace(float3 p0, float3 p1, float3 p2, float epsilon, float3 viewPos)
+// 'winding' can be used to change the order: pass 1 for (p0 -> p1 -> p2), or -1 for (p0 -> p2 -> p1).
+bool CullTriangleBackFace(float3 p0, float3 p1, float3 p2, float epsilon, float3 viewPos,
+                          float winding)
 {
     float3 edge1 = p1 - p0;
     float3 edge2 = p2 - p0;
 
     float3 N     = cross(edge1, edge2);
     float3 V     = viewPos - p0;
-    float  NdotV = dot(N, V);
+    float  NdotV = dot(N, V) * winding;
 
     // Optimize:
     // NdotV / (length(N) * length(V)) < Epsilon

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/GeometricTools.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/GeometricTools.hlsl
@@ -142,7 +142,7 @@ bool CullTriangleBackFace(float3 p0, float3 p1, float3 p2, float epsilon, float3
     // Optimize:
     // NdotV / (length(N) * length(V)) < Epsilon
     // NdotV < Epsilon * length(N) * length(V)
-    // NdotV < Epsilon * sqrt(dot(N, N) * sqrt(dot(V, V)
+    // NdotV < Epsilon * sqrt(dot(N, N)) * sqrt(dot(V, V))
     // NdotV < Epsilon * sqrt(dot(N, N) * dot(V, V))
     return NdotV < epsilon * sqrt(dot(N, N) * dot(V, V));
 }

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/GeometricTools.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/GeometricTools.hlsl
@@ -115,17 +115,17 @@ float DistanceFromPlane(float3 p, float4 plane)
 // 'epsilon' is the (negative) distance to (outside of) the frustum below which we cull the triangle.
 bool CullTriangleFrustum(float3 p0, float3 p1, float3 p2, float epsilon, float4 frustumPlanes[4])
 {
-    bool hidden = false;
+    bool outside = false;
 
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 4; i++)
     {
         // If all 3 points are behind any of the planes, we cull.
-        hidden = hidden || Max3(DistanceFromPlane(p0, frustumPlanes[i]),
-                                DistanceFromPlane(p1, frustumPlanes[i]),
-                                DistanceFromPlane(p2, frustumPlanes[i])) < epsilon;
+        outside = outside || Max3(DistanceFromPlane(p0, frustumPlanes[i]),
+                                  DistanceFromPlane(p1, frustumPlanes[i]),
+                                  DistanceFromPlane(p2, frustumPlanes[i])) < epsilon;
     }
 
-    return hidden;
+    return outside;
 }
 
 // Returns 'true' if a triangle defined by 3 vertices is back-facing.

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Tessellation.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Tessellation.hlsl
@@ -54,7 +54,7 @@ float3 GetDistanceBasedTessFactor(float3 p0, float3 p1, float3 p2, float3 camera
     return tessFactor;
 }
 
-float4 CalcTriEdgeTessFactors(float3 triVertexFactors)
+float4 CalcTriTessFactorsFromEdgeTessFactors(float3 triVertexFactors)
 {
     float4 tess;
     tess.x = triVertexFactors.x;

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Tessellation.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Tessellation.hlsl
@@ -1,11 +1,5 @@
 #define TESSELLATION_INTERPOLATE_BARY(name, bary) ouput.name = input0.name * bary.x +  input1.name * bary.y +  input2.name * bary.z
 
-// TODO: Move in geomtry.hlsl
-float3 ProjectPointOnPlane(float3 position, float3 planePosition, float3 planeNormal)
-{
-    return position - (dot(position - planePosition, planeNormal) * planeNormal);
-}
-
 // p0, p1, p2 triangle world position
 // p0, p1, p2 triangle world vertex normal
 float3 PhongTessellation(float3 positionWS, float3 p0, float3 p1, float3 p2, float3 n0, float3 n1, float3 n2, float3 baryCoords, float shape)
@@ -21,36 +15,13 @@ float3 PhongTessellation(float3 positionWS, float3 p0, float3 p1, float3 p2, flo
 
 // Reference: http://twvideo01.ubm-us.net/o1/vault/gdc10/slides/Bilodeau_Bill_Direct3D11TutorialTessellation.pdf
 
-// Return true if the triangle must be culled
-// backFaceCullEpsilon is the threshold of the dot product between view and normal ( < 0 mean we cull)
-bool BackFaceCullTriangle(float3 p0, float3 p1, float3 p2, float backFaceCullEpsilon, float3 cameraPosWS)
-{
-    float3 edge0 = p1 - p0;
-    float3 edge2 = p2 - p0;
-
-    float3 N = normalize(cross(edge0, edge2));
-    float3 midpoint = (p0 + p1 + p2) / 3.0;
-    float3 V = normalize(cameraPosWS - midpoint);
-
-    return (dot(V, N) < backFaceCullEpsilon) ? true : false;
-}
-
-float2 GetScreenSpacePosition(float3 positionWS, float4x4 viewProjectionMatrix, float4 screenSize)
-{
-    float4 positionCS = mul(viewProjectionMatrix, float4(positionWS, 1.0));
-    float2 positionSS = positionCS.xy / positionCS.w;
-
-    // TODO: Check if we need to invert y
-    return (positionSS * 0.5 + 0.5) * float2(screenSize.x, -screenSize.y);
-}
-
 // Compute both screen and distance based adaptation - return factor between 0 and 1
 float3 GetScreenSpaceTessFactor(float3 p0, float3 p1, float3 p2, float4x4 viewProjectionMatrix, float4 screenSize, float triangleSize)
 {
     // Get screen space adaptive scale factor
-    float2 edgeScreenPosition0 = GetScreenSpacePosition(p0, viewProjectionMatrix, screenSize);
-    float2 edgeScreenPosition1 = GetScreenSpacePosition(p1, viewProjectionMatrix, screenSize);
-    float2 edgeScreenPosition2 = GetScreenSpacePosition(p2, viewProjectionMatrix, screenSize);
+    float2 edgeScreenPosition0 = ComputeScreenSpacePosition(p0, viewProjectionMatrix) * screenSize;
+    float2 edgeScreenPosition1 = ComputeScreenSpacePosition(p1, viewProjectionMatrix) * screenSize;
+    float2 edgeScreenPosition2 = ComputeScreenSpacePosition(p2, viewProjectionMatrix) * screenSize;
 
     float EdgeScale = 1.0 / triangleSize; // Edge size in reality, but name is simpler
     float3 tessFactor;
@@ -67,7 +38,8 @@ float3 GetDistanceBasedTessFactor(float3 p0, float3 p1, float3 p2, float3 camera
     float3 edgePosition1 = 0.5 * (p0 + p2);
     float3 edgePosition2 = 0.5 * (p0 + p1);
 
-    // TODO: Move to camera relative and change distance to length
+    // In case camera-relative rendering is enabled, 'cameraPosWS' is statically known to be 0,
+    // so the compiler will be able to optimize distance() to length().
     float dist0 = distance(edgePosition0, cameraPosWS);
     float dist1 = distance(edgePosition1, cameraPosWS);
     float dist2 = distance(edgePosition2, cameraPosWS);
@@ -91,38 +63,4 @@ float4 CalcTriEdgeTessFactors(float3 triVertexFactors)
     tess.w = (triVertexFactors.x + triVertexFactors.y + triVertexFactors.z) / 3.0;
 
     return tess;
-}
-
-// TODO: Move in geomtry.hlsl
-float DistanceFromPlane(float3 pos, float4 plane)
-{
-    float d = dot(float4(pos, 1.0), plane);
-    return d;
-}
-
-// Returns true if triangle with given 3 world positions is outside of camera's view frustum.
-// cullEps is distance outside of frustum that is still considered to be inside (i.e. max displacement)
-bool WorldViewFrustumCull(float3 p0, float3 p1, float3 p2, float cullEps, float4 cameraWorldClipPlanes[4])
-{
-    float4 planeTest;
-
-    // left
-    planeTest.x =   ((DistanceFromPlane(p0, cameraWorldClipPlanes[0]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p1, cameraWorldClipPlanes[0]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p2, cameraWorldClipPlanes[0]) > -cullEps) ? 1.0 : 0.0);
-    // right
-    planeTest.y =   ((DistanceFromPlane(p0, cameraWorldClipPlanes[1]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p1, cameraWorldClipPlanes[1]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p2, cameraWorldClipPlanes[1]) > -cullEps) ? 1.0 : 0.0);
-    // top
-    planeTest.z =   ((DistanceFromPlane(p0, cameraWorldClipPlanes[2]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p1, cameraWorldClipPlanes[2]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p2, cameraWorldClipPlanes[2]) > -cullEps) ? 1.0 : 0.0);
-    // bottom
-    planeTest.w =   ((DistanceFromPlane(p0, cameraWorldClipPlanes[3]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p1, cameraWorldClipPlanes[3]) > -cullEps) ? 1.0 : 0.0) +
-                    ((DistanceFromPlane(p2, cameraWorldClipPlanes[3]) > -cullEps) ? 1.0 : 0.0);
-
-    // has to pass all 4 plane tests to be visible
-    return !all(planeTest);
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -412,6 +412,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
 
     #include "../../../Core/ShaderLibrary/common.hlsl"
     #include "../../../Core/ShaderLibrary/Wind.hlsl"
+    #include "../../../Core/ShaderLibrary/GeometricTools.hlsl"
     #include "../../../Core/ShaderLibrary/tessellation.hlsl"
     #include "../../ShaderPass/FragInputs.hlsl"
     #include "../../ShaderPass/ShaderPass.cs.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataMeshModification.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataMeshModification.hlsl
@@ -60,22 +60,20 @@ float4 GetTessellationFactors(float3 p0, float3 p1, float3 p2, float3 n0, float3
     // For the culling part however we want to use the current view (shadow view).
     // Thus the following code play with both.
 
-    float frustumCullEps = -maxDisplacement;
+    float frustumEps = -maxDisplacement;
+    bool3 frustumCullEdgesMainView = CullTriangleEdgesFrustum(p0, p1, p2, frustumEps, _FrustumPlanes, 5); // Do not test the far plane
 
 #if defined(SHADERPASS) && (SHADERPASS != SHADERPASS_SHADOWS)
-    bool frustumCulledCurrentView = CullTriangleFrustum(p0, p1, p2, frustumCullEps, (float4[4])_FrustumPlanes); // _FrustumPlanes are primary camera planes
-    bool frustumCulledMainView = false;
+    bool frustumCullCurrView = all(frustumCullEdgesMainView);
 #else
-    // 'unity_CameraWorldClipPlanes' are set by the legacy Unity and are not aware of camera-relative rendering.
-    bool frustumCulledCurrentView = CullTriangleFrustum(GetAbsolutePositionWS(p0), GetAbsolutePositionWS(p1), GetAbsolutePositionWS(p2), frustumCullEps, (float4[4])unity_CameraWorldClipPlanes);
-    // In the case of shadow, we don't want to tessellate anything that is not seen by the main view frustum. It can result in minor popping of tessellation into a shadow but we can't afford it anyway.
-    bool frustumCulledMainView = CullTriangleFrustum(p0, p1, p2, frustumCullEps, (float4[4])_FrustumPlanes);
+    // 'unity_CameraWorldClipPlanes' are camera-relative rendering aware.
+    bool frustumCullCurrView = CullTriangleFrustum(p0, p1, p2, frustumEps, unity_CameraWorldClipPlanes, 4); // Do not test near/far planes
 #endif
 
     bool faceCull = false;
 
 #ifndef _DOUBLESIDED_ON
-    if (_TessellationBackFaceCullEpsilon > -1) // Is backface culling enabled ?
+    if (_TessellationBackFaceCullEpsilon > -1.0) // Is back-face culling enabled ?
     {
         // Handle transform mirroring (like negative scaling)
         float winding = unity_WorldTransformParams.w;
@@ -83,22 +81,26 @@ float4 GetTessellationFactors(float3 p0, float3 p1, float3 p2, float3 n0, float3
     }
 #endif
 
-    if (frustumCulledCurrentView || faceCull)
+    if (frustumCullCurrView || faceCull)
     {
         // Settings factor to 0 will kill the triangle
-        return float4(0.0, 0.0, 0.0, 0.0);
+        return 0;
     }
 
-    // We use the parameters of the primary (scene view) camera in order
-    // to have identical tessellation levels for both the scene view and
-    // shadow views. Otherwise, depth comparisons become meaningless!
-    float3 tessFactor = float3(1.0, 1.0, 1.0);
+    // For performance reasons, we choose not to tessellate outside of the main camera view
+    // (we perform this test both during the regular scene rendering and the shadow pass).
+    // For edges not visible from the main view, our goal is to set the tessellation factor to 1.
+    // In this case, we set the tessellation factor to 0 here.
+    // That way, all scaling of this tessellation factor will still result in 0.
+    // Before we call CalcTriTessFactorsFromEdgeTessFactors(), all factors are clamped by max(f, 1),
+    // which achieves the desired effect.
+    float3 edgeTessFactors = float3(frustumCullEdgesMainView.x ? 0 : 1, frustumCullEdgesMainView.y ? 0 : 1, frustumCullEdgesMainView.z ? 0 : 1);
 
     // Adaptive screen space tessellation
     if (_TessellationFactorTriangleSize > 0.0)
     {
         // return a value between 0 and 1
-        tessFactor *= GetScreenSpaceTessFactor( p0, p1, p2, _ViewProjMatrix, _ScreenSize, _TessellationFactorTriangleSize); // Use primary camera view
+        edgeTessFactors *= GetScreenSpaceTessFactor( p0, p1, p2, _ViewProjMatrix, _ScreenSize, _TessellationFactorTriangleSize); // Use primary camera view
     }
 
     // Distance based tessellation
@@ -106,27 +108,15 @@ float4 GetTessellationFactors(float3 p0, float3 p1, float3 p2, float3 n0, float3
     {
         float3 distFactor = GetDistanceBasedTessFactor(p0, p1, p2, GetPrimaryCameraPosition(), _TessellationFactorMinDistance, _TessellationFactorMaxDistance);  // Use primary camera view
         // We square the disance factor as it allow a better percptual descrease of vertex density.
-        tessFactor *= distFactor * distFactor;
+        edgeTessFactors *= distFactor * distFactor;
     }
 
-    tessFactor *= _TessellationFactor;
+    edgeTessFactors *= _TessellationFactor;
 
     // TessFactor below 1.0 have no effect. At 0 it kill the triangle, so clamp it to 1.0
-    tessFactor.xyz = float3(max(1.0, tessFactor.x), max(1.0, tessFactor.y), max(1.0, tessFactor.z));
+    edgeTessFactors = max(edgeTessFactors, float3(1.0, 1.0, 1.0));
 
-    float4 triTessFactors = CalcTriEdgeTessFactors(tessFactor);
-
-    // See comment above:
-    // During shadow passes, we decide that anything outside the main view frustum should not be tessellated.
-    if (frustumCulledMainView)
-    {
-        // Warning: we cannot modify the edge tessellation factors, as that creates cracks between patches.
-        // Therefore, we only modify the inside tessellation factor.
-        // TODO: find a way to modify the edge tessellation factors as well.
-        triTessFactors.w = 1.0;
-    }
-
-    return triTessFactors;
+    return CalcTriTessFactorsFromEdgeTessFactors(edgeTessFactors);
 }
 
 // tessellationFactors

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataMeshModification.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataMeshModification.hlsl
@@ -78,11 +78,8 @@ float4 GetTessellationFactors(float3 p0, float3 p1, float3 p2, float3 n0, float3
     if (_TessellationBackFaceCullEpsilon > -1) // Is backface culling enabled ?
     {
         // Handle transform mirroring (like negative scaling)
-        // Caution: don't change p1/p2 directly as it is use later
-        float3 backfaceP1 = unity_WorldTransformParams.w < 0.0 ? p2 : p1;
-        float3 backfaceP2 = unity_WorldTransformParams.w < 0.0 ? p1 : p2;
-
-        faceCull = CullTriangleBackFace(p0, backfaceP1, backfaceP2, _TessellationBackFaceCullEpsilon, GetCurrentViewPosition()); // Use shadow view
+        float winding = unity_WorldTransformParams.w;
+        faceCull = CullTriangleBackFace(p0, p1, p2, _TessellationBackFaceCullEpsilon, GetCurrentViewPosition(), winding); // Use shadow view
     }
 #endif
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -234,6 +234,7 @@ Shader "HDRenderPipeline/LitTessellation"
 
     #include "../../../Core/ShaderLibrary/common.hlsl"
     #include "../../../Core/ShaderLibrary/Wind.hlsl"
+    #include "../../../Core/ShaderLibrary/GeometricTools.hlsl"
     #include "../../../Core/ShaderLibrary/tessellation.hlsl"
     #include "../../ShaderPass/FragInputs.hlsl"
     #include "../../ShaderPass/ShaderPass.cs.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/ShaderPass/TessellationShare.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/ShaderPass/TessellationShare.hlsl
@@ -31,7 +31,7 @@ TessellationFactors HullConstant(InputPatch<PackedVaryingsToDS, 3> input)
     output.edge[0] = min(tf.x, MAX_TESSELLATION_FACTORS);
     output.edge[1] = min(tf.y, MAX_TESSELLATION_FACTORS);
     output.edge[2] = min(tf.z, MAX_TESSELLATION_FACTORS);
-    output.inside = min(tf.w, MAX_TESSELLATION_FACTORS);
+    output.inside  = min(tf.w, MAX_TESSELLATION_FACTORS);
 
     return output;
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/ShaderVariables.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/ShaderVariables.hlsl
@@ -233,8 +233,8 @@ float4x4 _InvViewProjMatrix;
 float4x4 _InvViewMatrix;
 float4x4 _InvProjMatrix;
 float4   _InvProjParam;
-float4   _ScreenSize;       // (w, h, 1/w, 1/h)
-float4   _FrustumPlanes[6]; // (N, -dot(N, P))
+float4   _ScreenSize;       // {w, h, 1/w, 1/h}
+float4   _FrustumPlanes[6]; // {(a, b, c) = N, d = -dot(N, P)} [L, R, T, B, N, F]
 CBUFFER_END
 
 #ifdef USE_LEGACY_UNITY_MATRIX_VARIABLES

--- a/ScriptableRenderPipeline/HDRenderPipeline/ShaderVariablesFunctions.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/ShaderVariablesFunctions.hlsl
@@ -91,7 +91,11 @@ float3 GetCameraRelativePositionWS(float3 positionWS)
 // Note: '_WorldSpaceCameraPos' is set by the legacy Unity code.
 float3 GetPrimaryCameraPosition()
 {
-    return GetCameraRelativePositionWS(_WorldSpaceCameraPos);
+#if (SHADEROPTIONS_CAMERA_RELATIVE_RENDERING != 0)
+    return float3(0, 0, 0);
+#else
+    return _WorldSpaceCameraPos;
+#endif
 }
 
 // Could be e.g. the position of a primary camera or a shadow-casting light.


### PR DESCRIPTION
Problem:  setting all tessellation factors to 1 for triangles outside of the main view creates a potential discrepancy between edge tessellation factors of these triangles, and their direct neighbors (which may still be tessellated).
Solution: frustum cull triangle edges, and assign the tessellation factor of 1 only to those edges outside of the main view.