### PR TITLE
HDRenderPipeline: Update UI for AO (Remap), Distortion (ScaleBias) an…

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -38,6 +38,16 @@ Shader "HDRenderPipeline/LayeredLit"
         _SmoothnessRemapMax2("SmoothnessRemapMax2", Range(0.0, 1.0)) = 1.0
         _SmoothnessRemapMax3("SmoothnessRemapMax3", Range(0.0, 1.0)) = 1.0
 
+        _AORemapMin0("AORemapMin0", Range(0.0, 1.0)) = 0.0
+        _AORemapMin1("AORemapMin1", Range(0.0, 1.0)) = 0.0
+        _AORemapMin2("AORemapMin2", Range(0.0, 1.0)) = 0.0
+        _AORemapMin3("AORemapMin3", Range(0.0, 1.0)) = 0.0
+
+        _AORemapMax0("AORemapMax0", Range(0.0, 1.0)) = 1.0
+        _AORemapMax1("AORemapMax1", Range(0.0, 1.0)) = 1.0
+        _AORemapMax2("AORemapMax2", Range(0.0, 1.0)) = 1.0
+        _AORemapMax3("AORemapMax3", Range(0.0, 1.0)) = 1.0
+
         _MaskMap0("MaskMap0", 2D) = "white" {}
         _MaskMap1("MaskMap1", 2D) = "white" {}
         _MaskMap2("MaskMap2", 2D) = "white" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -38,6 +38,16 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _SmoothnessRemapMax2("SmoothnessRemapMax2", Range(0.0, 1.0)) = 1.0
         _SmoothnessRemapMax3("SmoothnessRemapMax3", Range(0.0, 1.0)) = 1.0
 
+        _AORemapMin0("AORemapMin0", Range(0.0, 1.0)) = 0.0
+        _AORemapMin1("AORemapMin1", Range(0.0, 1.0)) = 0.0
+        _AORemapMin2("AORemapMin2", Range(0.0, 1.0)) = 0.0
+        _AORemapMin3("AORemapMin3", Range(0.0, 1.0)) = 0.0
+
+        _AORemapMax0("AORemapMax0", Range(0.0, 1.0)) = 1.0
+        _AORemapMax1("AORemapMax1", Range(0.0, 1.0)) = 1.0
+        _AORemapMax2("AORemapMax2", Range(0.0, 1.0)) = 1.0
+        _AORemapMax3("AORemapMax3", Range(0.0, 1.0)) = 1.0
+
         _MaskMap0("MaskMap0", 2D) = "white" {}
         _MaskMap1("MaskMap1", 2D) = "white" {}
         _MaskMap2("MaskMap2", 2D) = "white" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
@@ -17,6 +17,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static GUIContent metallicText = new GUIContent("Metallic", "Metallic scale factor");
             public static GUIContent smoothnessText = new GUIContent("Smoothness", "Smoothness scale factor");
             public static GUIContent smoothnessRemappingText = new GUIContent("Smoothness Remapping", "Smoothness remapping");
+            public static GUIContent aoRemappingText = new GUIContent("AmbientOcclusion Remapping", "AmbientOcclusion remapping");
             public static GUIContent maskMapSText = new GUIContent("Mask Map - M(R), AO(G), D(B), S(A)", "Mask map");
             public static GUIContent maskMapSpecularText = new GUIContent("Mask Map - AO(G), D(B), S(A)", "Mask map");            
 
@@ -145,6 +146,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kSmoothnessRemapMin = "_SmoothnessRemapMin";
         protected MaterialProperty[] smoothnessRemapMax = new MaterialProperty[kMaxLayerCount];
         protected const string kSmoothnessRemapMax = "_SmoothnessRemapMax";
+        protected MaterialProperty[] aoRemapMin = new MaterialProperty[kMaxLayerCount];
+        protected const string kAORemapMin = "_AORemapMin";
+        protected MaterialProperty[] aoRemapMax = new MaterialProperty[kMaxLayerCount];
+        protected const string kAORemapMax = "_AORemapMax";
         protected MaterialProperty[] maskMap = new MaterialProperty[kMaxLayerCount];
         protected const string kMaskMap = "_MaskMap";
         protected MaterialProperty[] normalScale = new MaterialProperty[kMaxLayerCount];
@@ -264,6 +269,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 smoothness[i] = FindProperty(string.Format("{0}{1}", kSmoothness, m_PropertySuffixes[i]), props);
                 smoothnessRemapMin[i] = FindProperty(string.Format("{0}{1}", kSmoothnessRemapMin, m_PropertySuffixes[i]), props);
                 smoothnessRemapMax[i] = FindProperty(string.Format("{0}{1}", kSmoothnessRemapMax, m_PropertySuffixes[i]), props);
+                aoRemapMin[i] = FindProperty(string.Format("{0}{1}", kAORemapMin, m_PropertySuffixes[i]), props);
+                aoRemapMax[i] = FindProperty(string.Format("{0}{1}", kAORemapMax, m_PropertySuffixes[i]), props);
                 maskMap[i] = FindProperty(string.Format("{0}{1}", kMaskMap, m_PropertySuffixes[i]), props);
                 normalMap[i] = FindProperty(string.Format("{0}{1}", kNormalMap, m_PropertySuffixes[i]), props);
                 normalMapOS[i] = FindProperty(string.Format("{0}{1}", kNormalMapOS, m_PropertySuffixes[i]), props);
@@ -452,6 +459,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 {
                     smoothnessRemapMin[layerIndex].floatValue = remapMin;
                     smoothnessRemapMax[layerIndex].floatValue = remapMax;
+                }
+
+                float aoMin = aoRemapMin[layerIndex].floatValue;
+                float aoMax = aoRemapMax[layerIndex].floatValue;
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.MinMaxSlider(Styles.aoRemappingText, ref aoMin, ref aoMax, 0.0f, 1.0f);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    aoRemapMin[layerIndex].floatValue = aoMin;
+                    aoRemapMax[layerIndex].floatValue = aoMax;
                 }
             }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -14,6 +14,8 @@ Shader "HDRenderPipeline/Lit"
         _MaskMap("MaskMap", 2D) = "white" {}
         _SmoothnessRemapMin("SmoothnessRemapMin", Float) = 0.0
         _SmoothnessRemapMax("SmoothnessRemapMax", Float) = 1.0
+        _AORemapMin("AORemapMin", Float) = 0.0
+        _AORemapMax("AORemapMax", Float) = 1.0
 
         _NormalMap("NormalMap", 2D) = "bump" {}     // Tangent space normal map
         _NormalMapOS("NormalMapOS", 2D) = "white" {} // Object space normal map - no good default value
@@ -71,6 +73,8 @@ Shader "HDRenderPipeline/Lit"
         [HideInInspector] _DistortionBlurDstBlend("Distortion Blur Blend Dst", Int) = 0
         [HideInInspector] _DistortionBlurBlendMode("Distortion Blur Blend Mode", Int) = 0
         _DistortionScale("Distortion Scale", Float) = 1
+        _DistortionVectorScale("Distortion Vector Scale", Float) = 2
+        _DistortionVectorBias("Distortion Vector Bias", Float) = -1
         _DistortionBlurScale("Distortion Blur Scale", Float) = 1
         _DistortionBlurRemapMin("DistortionBlurRemapMin", Float) = 0.0
         _DistortionBlurRemapMax("DistortionBlurRemapMax", Float) = 1.0

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -63,7 +63,8 @@ void GetBuiltinData(FragInputs input, SurfaceData surfaceData, float alpha, floa
     builtinData.velocity = float2(0.0, 0.0);
 
 #if (SHADERPASS == SHADERPASS_DISTORTION) || defined(DEBUG_DISPLAY)
-    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb * 2.0 - 1.0;
+    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb;
+    distortion.rg *= _DistortionVectorScale + _DistortionVectorBias;
     builtinData.distortion = distortion.rg * _DistortionScale;
     builtinData.distortionBlur = clamp(distortion.b * _DistortionBlurScale, 0.0, 1.0) * (_DistortionBlurRemapMax - _DistortionBlurRemapMin) + _DistortionBlurRemapMin;
 #else

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataIndividualLayer.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataIndividualLayer.hlsl
@@ -233,10 +233,11 @@ float ADD_IDX(GetSurfaceData)(FragInputs input, LayerTexCoord layerTexCoord, out
     surfaceData.perceptualSmoothness = lerp(surfaceData.perceptualSmoothness, saturate(smoothnessOverlay), detailMask);
 #endif
 
-    // MaskMap is RGBA: Metallic, Ambient Occlusion (Optional), emissive Mask (Optional), Smoothness
+    // MaskMap is RGBA: Metallic, Ambient Occlusion (Optional), detail Mask (Optional), Smoothness
 #ifdef _MASKMAP_IDX
     surfaceData.metallic = SAMPLE_UVMAPPING_TEXTURE2D(ADD_IDX(_MaskMap), SAMPLER_MASKMAP_IDX, ADD_IDX(layerTexCoord.base)).r;
     surfaceData.ambientOcclusion = SAMPLE_UVMAPPING_TEXTURE2D(ADD_IDX(_MaskMap), SAMPLER_MASKMAP_IDX, ADD_IDX(layerTexCoord.base)).g;
+    surfaceData.ambientOcclusion = lerp(ADD_IDX(_AORemapMin), ADD_IDX(_AORemapMax), surfaceData.ambientOcclusion);
 #else
     surfaceData.metallic = 1.0;
     surfaceData.ambientOcclusion = 1.0;

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
@@ -94,6 +94,8 @@ CBUFFER_START(_PerMaterial)
 float _AlphaCutoff;
 float4 _DoubleSidedConstants;
 float _DistortionScale;
+float _DistortionVectorScale;
+float _DistortionVectorBias;
 float _DistortionBlurScale;
 float _DistortionBlurRemapMin;
 float _DistortionBlurRemapMax;
@@ -140,6 +142,8 @@ float _Metallic;
 float _Smoothness;
 float _SmoothnessRemapMin;
 float _SmoothnessRemapMax;
+float _AORemapMin;
+float _AORemapMax;
 
 float _NormalScale;
 
@@ -184,6 +188,9 @@ PROP_DECL(float, _Metallic);
 PROP_DECL(float, _Smoothness);
 PROP_DECL(float, _SmoothnessRemapMin);
 PROP_DECL(float, _SmoothnessRemapMax);
+PROP_DECL(float, _AORemapMin);
+PROP_DECL(float, _AORemapMax);
+
 PROP_DECL(float, _NormalScale);
 float4 _NormalMap0_TexelSize; // Unity facility. This will provide the size of the base normal to the shader
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -14,6 +14,8 @@ Shader "HDRenderPipeline/LitTessellation"
         _MaskMap("MaskMap", 2D) = "white" {}
         _SmoothnessRemapMin("SmoothnessRemapMin", Float) = 0.0
         _SmoothnessRemapMax("SmoothnessRemapMax", Float) = 1.0
+        _AORemapMin("AORemapMin", Float) = 0.0
+        _AORemapMax("AORemapMax", Float) = 1.0
 
         _NormalMap("NormalMap", 2D) = "bump" {}     // Tangent space normal map
         _NormalMapOS("NormalMapOS", 2D) = "white" {} // Object space normal map - no good default value
@@ -72,6 +74,8 @@ Shader "HDRenderPipeline/LitTessellation"
         [HideInInspector] _DistortionBlurDstBlend("Distortion Blur Blend Dst", Int) = 0
         [HideInInspector] _DistortionBlurBlendMode("Distortion Blur Blend Mode", Int) = 0
         _DistortionScale("Distortion Scale", Float) = 1
+        _DistortionVectorScale("Distortion Vector Scale", Float) = 2
+        _DistortionVectorBias("Distortion Vector Bias", Float) = -1
         _DistortionBlurScale("Distortion Blur Scale", Float) = 1
         _DistortionBlurRemapMin("DistortionBlurRemapMin", Float) = 0.0
         _DistortionBlurRemapMax("DistortionBlurRemapMax", Float) = 1.0

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
@@ -91,6 +91,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kDistortionBlendMode = "_DistortionBlendMode";
         protected MaterialProperty distortionScale = null;
         protected const string kDistortionScale = "_DistortionScale";
+        protected MaterialProperty distortionVectorScale = null;
+        protected const string kDistortionVectorScale = "_DistortionVectorScale";
+        protected MaterialProperty distortionVectorBias = null;
+        protected const string kDistortionVectorBias = "_DistortionVectorBias";
         protected MaterialProperty distortionBlurScale = null;
         protected const string kDistortionBlurScale = "_DistortionBlurScale";
         protected MaterialProperty distortionBlurRemapMin = null;
@@ -141,6 +145,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             distortionVectorMap = FindProperty(kDistortionVectorMap, props, false);
             distortionBlendMode = FindProperty(kDistortionBlendMode, props, false);
             distortionScale = FindProperty(kDistortionScale, props, false);
+            distortionVectorScale = FindProperty(kDistortionVectorScale, props, false);
+            distortionVectorBias = FindProperty(kDistortionVectorBias, props, false);
             distortionBlurScale = FindProperty(kDistortionBlurScale, props, false);
             distortionBlurRemapMin = FindProperty(kDistortionBlurRemapMin, props, false);
             distortionBlurRemapMax = FindProperty(kDistortionBlurRemapMax, props, false);
@@ -256,7 +262,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     m_MaterialEditor.ShaderProperty(distortionDepthTest, StylesBaseUnlit.distortionDepthTestText);
 
                     EditorGUI.indentLevel++;
-                    m_MaterialEditor.TexturePropertySingleLine(StylesBaseUnlit.distortionVectorMapText, distortionVectorMap);
+                    m_MaterialEditor.TexturePropertySingleLine(StylesBaseUnlit.distortionVectorMapText, distortionVectorMap, distortionVectorScale, distortionVectorBias);
                     EditorGUI.indentLevel++;
                     m_MaterialEditor.ShaderProperty(distortionScale, StylesBaseUnlit.distortionScaleText);
                     m_MaterialEditor.ShaderProperty(distortionBlurScale, StylesBaseUnlit.distortionBlurScaleText);
@@ -458,7 +464,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             if (material.HasProperty(kDistortionEnable))
             {
-                bool distortionEnable = material.GetFloat(kDistortionEnable) > 0.0f;
+                bool distortionEnable = material.GetFloat(kDistortionEnable) > 0.0f && ((SurfaceType)material.GetFloat(kSurfaceType) == SurfaceType.Transparent);
 
                 bool distortionOnly = false;
                 if (material.HasProperty(kDistortionOnly))

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/UnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/UnlitUI.cs
@@ -41,6 +41,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUILayout.LabelField(Styles.InputsText, EditorStyles.boldLabel);
 
             m_MaterialEditor.TexturePropertySingleLine(Styles.colorText, colorMap, color);
+            m_MaterialEditor.TextureScaleOffsetProperty(colorMap);
 
             m_MaterialEditor.TexturePropertySingleLine(Styles.emissiveText, emissiveColorMap, emissiveColor);
             m_MaterialEditor.TextureScaleOffsetProperty(emissiveColorMap);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
@@ -21,6 +21,8 @@ Shader "HDRenderPipeline/Unlit"
         [HideInInspector] _DistortionBlurDstBlend("Distortion Blur Blend Dst", Int) = 0
         [HideInInspector] _DistortionBlurBlendMode("Distortion Blur Blend Mode", Int) = 0
         _DistortionScale("Distortion Scale", Float) = 1
+        _DistortionVectorScale("Distortion Vector Scale", Float) = 2
+        _DistortionVectorBias("Distortion Vector Bias", Float) = -1
         _DistortionBlurScale("Distortion Blur Scale", Float) = 1
         _DistortionBlurRemapMin("DistortionBlurRemapMin", Float) = 0.0
         _DistortionBlurRemapMax("DistortionBlurRemapMax", Float) = 1.0

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitData.hlsl
@@ -4,8 +4,9 @@
 
 void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
 {
-    surfaceData.color = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, input.texCoord0).rgb * _UnlitColor.rgb;
-    float alpha = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, input.texCoord0).a * _UnlitColor.a;
+    float2 unlitColorMapUv = TRANSFORM_TEX(input.texCoord0, _UnlitColorMap);
+    surfaceData.color = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, unlitColorMapUv).rgb * _UnlitColor.rgb;
+    float alpha = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, unlitColorMapUv).a * _UnlitColor.a;
 
 #ifdef _ALPHATEST_ON
     DoAlphaTest(alpha, _AlphaCutoff);
@@ -33,7 +34,8 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     builtinData.shadowMask3 = 0.0;
 
 #if (SHADERPASS == SHADERPASS_DISTORTION) || defined(DEBUG_DISPLAY)
-    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb * 2.0 - 1.0;
+    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb;
+    distortion.rg *= _DistortionVectorScale + _DistortionVectorBias;
     builtinData.distortion = distortion.rg * _DistortionScale;
     builtinData.distortionBlur = clamp(distortion.b * _DistortionBlurScale, 0.0, 1.0) * (_DistortionBlurRemapMax - _DistortionBlurRemapMin) + _DistortionBlurRemapMin;
 #else

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/UnlitProperties.hlsl
@@ -1,6 +1,7 @@
 float4  _UnlitColor;
 TEXTURE2D(_UnlitColorMap);
 SAMPLER2D(sampler_UnlitColorMap);
+float4 _UnlitColorMap_ST;
 
 TEXTURE2D(_DistortionVectorMap);
 SAMPLER2D(sampler_DistortionVectorMap);
@@ -14,6 +15,8 @@ float _EmissiveIntensity;
 
 float _AlphaCutoff;
 float _DistortionScale;
+float _DistortionVectorScale;
+float _DistortionVectorBias;
 float _DistortionBlurScale;
 float _DistortionBlurRemapMin;
 float _DistortionBlurRemapMax;
@@ -21,5 +24,5 @@ float _DistortionBlurRemapMax;
 // Caution: C# code in BaseLitUI.cs call LightmapEmissionFlagsProperty() which assume that there is an existing "_EmissionColor"
 // value that exist to identify if the GI emission need to be enabled.
 // In our case we don't use such a mechanism but need to keep the code quiet. We declare the value and always enable it.
-// TODO: Fix the code in legacy unity so we can customize the beahvior for GI
+// TODO: Fix the code in legacy unity so we can customize the behavior for GI
 float3 _EmissionColor;


### PR DESCRIPTION
Add uv mapping for unlit color
Add scale and bias control on distortion vector (note: the UI don't work correctly for 2017.3, need trunk)
Add AO remapping control