### PR TITLE
Cleanup parameter setup compute code

### DIFF
--- a/ScriptableRenderPipeline/Core/ProfilingSample.cs
+++ b/ScriptableRenderPipeline/Core/ProfilingSample.cs
@@ -6,20 +6,20 @@ namespace UnityEngine.Experimental.Rendering
 {
     public struct ProfilingSample : IDisposable
     {
-        CommandBuffer m_Cmd;
-        string m_Name;
+        readonly CommandBuffer m_Cmd;
+        readonly string m_Name;
 
         bool m_Disposed;
         CustomSampler m_Sampler;
 
-        public ProfilingSample(CommandBuffer cmd, string name,CustomSampler sampler=null)
+        public ProfilingSample(CommandBuffer cmd, string name,CustomSampler sampler = null)
         {
             m_Cmd = cmd;
             m_Name = name;
             m_Disposed = false;
             cmd.BeginSample(name);
             m_Sampler = sampler;
-            if ( m_Sampler != null )
+            if (m_Sampler != null)
                 m_Sampler.Begin();
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Camera/HDCamera.cs
@@ -210,5 +210,18 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             material.SetMatrix(HDShaderIDs._PrevViewProjMatrix, prevViewProjMatrix);
             material.SetVectorArray(HDShaderIDs._FrustumPlanes, frustumPlaneEquations);
         }
+
+        // TODO: We should set all the value below globally and not let it under the control of Unity,
+        // Need to test that because we are not sure in which order these value are setup, but we need to have control on them, or rename them in our shader.
+        // For now, apply it for all our compute shader to make it work
+        public void SetupComputeShader(ComputeShader cs, CommandBuffer cmd)
+        {
+            // Copy values set by Unity which are not configured in scripts.
+            cmd.SetComputeVectorParam(cs, HDShaderIDs.unity_OrthoParams, Shader.GetGlobalVector(HDShaderIDs.unity_OrthoParams));
+            cmd.SetComputeVectorParam(cs, HDShaderIDs._ProjectionParams, Shader.GetGlobalVector(HDShaderIDs._ProjectionParams));
+            cmd.SetComputeVectorParam(cs, HDShaderIDs._ScreenParams, Shader.GetGlobalVector(HDShaderIDs._ScreenParams));
+            cmd.SetComputeVectorParam(cs, HDShaderIDs._ZBufferParams, Shader.GetGlobalVector(HDShaderIDs._ZBufferParams));
+            cmd.SetComputeVectorParam(cs, HDShaderIDs._WorldSpaceCameraPos, Shader.GetGlobalVector(HDShaderIDs._WorldSpaceCameraPos));
+        }
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Camera/HDCamera.cs
@@ -210,26 +210,5 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             material.SetMatrix(HDShaderIDs._PrevViewProjMatrix, prevViewProjMatrix);
             material.SetVectorArray(HDShaderIDs._FrustumPlanes, frustumPlaneEquations);
         }
-
-        public void SetupComputeShader(ComputeShader cs, CommandBuffer cmd)
-        {
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._ViewMatrix, viewMatrix);
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._InvViewMatrix, viewMatrix.inverse);
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._ProjMatrix, projMatrix);
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._InvProjMatrix, projMatrix.inverse);
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._NonJitteredViewProjMatrix, nonJitteredViewProjMatrix);
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._ViewProjMatrix, viewProjMatrix);
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._InvViewProjMatrix, viewProjMatrix.inverse);
-            cmd.SetComputeVectorParam(cs, HDShaderIDs._InvProjParam, invProjParam);
-            cmd.SetComputeVectorParam(cs, HDShaderIDs._ScreenSize, screenSize);
-            cmd.SetComputeMatrixParam(cs, HDShaderIDs._PrevViewProjMatrix, prevViewProjMatrix);
-            cmd.SetComputeVectorArrayParam(cs, HDShaderIDs._FrustumPlanes, frustumPlaneEquations);
-            // Copy values set by Unity which are not configured in scripts.
-            cmd.SetComputeVectorParam(cs, HDShaderIDs.unity_OrthoParams, Shader.GetGlobalVector(HDShaderIDs.unity_OrthoParams));
-            cmd.SetComputeVectorParam(cs, HDShaderIDs._ProjectionParams, Shader.GetGlobalVector(HDShaderIDs._ProjectionParams));
-            cmd.SetComputeVectorParam(cs, HDShaderIDs._ScreenParams, Shader.GetGlobalVector(HDShaderIDs._ScreenParams));
-            cmd.SetComputeVectorParam(cs, HDShaderIDs._ZBufferParams, Shader.GetGlobalVector(HDShaderIDs._ZBufferParams));
-            cmd.SetComputeVectorParam(cs, HDShaderIDs._WorldSpaceCameraPos, Shader.GetGlobalVector(HDShaderIDs._WorldSpaceCameraPos));
-        }
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDCustomSamplerId.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDCustomSamplerId.cs
@@ -1,0 +1,55 @@
+namespace UnityEngine.Experimental.Rendering.HDPipeline
+{
+    public enum CustomSamplerId
+    {
+        PushGlobalParameters,
+        CopySetDepthBuffer,
+        CopyDepthStencilbuffer,
+        CopyStencilBuffer,
+        Forward,
+        RenderSSAO,
+        RenderShadows,
+        RenderDeferredDirectionalShadow,
+        BuildLightList,
+        BlitToFinalRT,
+        Distortion,
+        ApplyDistortion,
+        DepthPrepass,
+        GBuffer,
+        DisplayDebugViewMaterial,
+        DebugViewMaterialGBuffer,
+        BlitDebugViewMaterialDebug,
+        SubsurfaceScattering,
+        ForwardPassName,
+        ForwardTransparentDepthPrepass,
+        RenderForwardError,
+        Velocity,
+        GaussianPyramidColor,
+        PyramidDepth,
+        PostProcessing,
+        RenderDebug,
+        InitAndClearBuffer,
+        InitGBuffersAndClearDepthStencil,
+        ClearSSSDiffuseTarget,
+        ClearSSSFilteringTarget,
+        ClearStencilTexture,
+        ClearHTile,
+        ClearHDRTarget,
+        ClearGBuffer,
+        HDRenderPipelineRender,
+        CullResultsCull,
+
+        // Profile sampler for tile pass
+        TPPrepareLightsForGPU,
+        TPPushGlobalParameters,
+        TPTiledLightingDebug,
+        TPDeferredDirectionalShadow,
+        TPTileSettingsEnableTileAndCluster,
+        TPForwardPass,
+        TPForwardTiledClusterpass,
+        TPDisplayShadows,
+        TPRenderDeferredLighting,
+
+        Max
+    }
+}

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDCustomSamplerId.cs.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDCustomSamplerId.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae73737f69e72034d8d663de7460a7d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -540,7 +540,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 if (m_SkyManager.IsSkyValid())
                 {
-                    m_SkyManager.SetGlobalSkyTexture();
+                    m_SkyManager.SetGlobalSkyTexture(cmd);
                     cmd.SetGlobalInt(HDShaderIDs._EnvLightSkyEnabled, 1);
                 }
                 else

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -721,7 +721,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_CurrentDebugDisplaySettings = m_DebugDisplaySettings;
             }
 
-            ApplyDebugDisplaySettings();
+            ApplyDebugDisplaySettings(cmd);
             UpdateCommonSettings();
 
             ScriptableCullingParameters cullingParams;
@@ -1533,7 +1533,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
         }
 
-        public void ApplyDebugDisplaySettings()
+        public void ApplyDebugDisplaySettings(CommandBuffer cmd)
         {
             m_ShadowSettings.enabled = m_CurrentDebugDisplaySettings.lightingDebugSettings.enableShadows;
 
@@ -1541,10 +1541,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             var debugAlbedo = new Vector4(lightingDebugSettings.debugLightingAlbedo.r, lightingDebugSettings.debugLightingAlbedo.g, lightingDebugSettings.debugLightingAlbedo.b, 0.0f);
             var debugSmoothness = new Vector4(lightingDebugSettings.overrideSmoothness ? 1.0f : 0.0f, lightingDebugSettings.overrideSmoothnessValue, 0.0f, 0.0f);
 
-            Shader.SetGlobalInt(HDShaderIDs._DebugViewMaterial, (int)m_CurrentDebugDisplaySettings.GetDebugMaterialIndex());
-            Shader.SetGlobalInt(HDShaderIDs._DebugLightingMode, (int)m_CurrentDebugDisplaySettings.GetDebugLightingMode());
-            Shader.SetGlobalVector(HDShaderIDs._DebugLightingAlbedo, debugAlbedo);
-            Shader.SetGlobalVector(HDShaderIDs._DebugLightingSmoothness, debugSmoothness);
+            cmd.SetGlobalInt(HDShaderIDs._DebugViewMaterial, (int)m_CurrentDebugDisplaySettings.GetDebugMaterialIndex());
+            cmd.SetGlobalInt(HDShaderIDs._DebugLightingMode, (int)m_CurrentDebugDisplaySettings.GetDebugLightingMode());
+            cmd.SetGlobalVector(HDShaderIDs._DebugLightingAlbedo, debugAlbedo);
+            cmd.SetGlobalVector(HDShaderIDs._DebugLightingSmoothness, debugSmoothness);
         }
 
         public void PushFullScreenDebugTexture(CommandBuffer cb, RenderTargetIdentifier textureID, Camera camera, ScriptableRenderContext renderContext, FullScreenDebugMode debugMode)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -538,23 +538,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 hdCamera.SetupGlobalParams(cmd);
 
-                // TODO: cmd.SetGlobalInt() does not exist, so we are forced to use Shader.SetGlobalInt() instead.
-
                 if (m_SkyManager.IsSkyValid())
                 {
                     m_SkyManager.SetGlobalSkyTexture();
-                    Shader.SetGlobalInt(HDShaderIDs._EnvLightSkyEnabled, 1);
+                    cmd.SetGlobalInt(HDShaderIDs._EnvLightSkyEnabled, 1);
                 }
                 else
                 {
-                    Shader.SetGlobalInt(HDShaderIDs._EnvLightSkyEnabled, 0);
+                    cmd.SetGlobalInt(HDShaderIDs._EnvLightSkyEnabled, 0);
                 }
 
                 // Broadcast SSS parameters to all shaders.
-                Shader.SetGlobalInt(     HDShaderIDs._EnableSSSAndTransmission,   m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission ? 1 : 0);
-                Shader.SetGlobalInt(     HDShaderIDs._TexturingModeFlags,         sssParameters.texturingModeFlags);
-                Shader.SetGlobalInt(     HDShaderIDs._TransmissionFlags,          sssParameters.transmissionFlags);
-                Shader.SetGlobalInt(     HDShaderIDs._UseDisneySSS,               sssParameters.useDisneySSS ? 1 : 0);
+                cmd.SetGlobalInt(HDShaderIDs._EnableSSSAndTransmission, m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission ? 1 : 0);
+                cmd.SetGlobalInt(HDShaderIDs._TexturingModeFlags, sssParameters.texturingModeFlags);
+                cmd.SetGlobalInt(HDShaderIDs._TransmissionFlags, sssParameters.transmissionFlags);
+                cmd.SetGlobalInt(HDShaderIDs._UseDisneySSS, sssParameters.useDisneySSS ? 1 : 0);
                 cmd.SetGlobalVectorArray(HDShaderIDs._ThicknessRemaps,            sssParameters.thicknessRemaps);
                 cmd.SetGlobalVectorArray(HDShaderIDs._ShapeParams,                sssParameters.shapeParams);
                 cmd.SetGlobalVectorArray(HDShaderIDs._HalfRcpVariancesAndWeights, sssParameters.halfRcpVariancesAndWeights);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -89,55 +89,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             Transparent
         }
 
-        public enum CustomSamplerId
-        {
-            PushGlobal_Parameters,
-            Copy_SetDepthBuffer,
-            Copydepth_stencilbuffer,
-            Copy_StencilBuffer,
-            Forward,
-            Build_Light_list_and_render_shadows,
-            Blit_to_final_RT,
-            Distortion,
-            ApplyDistortion,
-            Depth_Prepass,
-            GBuffer,
-            DisplayDebug_ViewMaterial,
-            DebugViewMaterialGBuffer,
-            Blit_DebugView_Material_Debug,
-            Subsurface_Scattering,
-            ForwardPassName,
-            Forward_Transparent_Depth_Prepass,
-            Render_Forward_Error,
-            Velocity,
-            Gaussian_Pyramid_Color,
-            Pyramid_Depth,
-            Post_processing,
-            Render_Debug,
-            InitAndClearBuffer,
-            InitGBuffers_and_clear_Depth_Stencil,
-            Clear_SSS_diffuse_target,
-            Clear_SSS_filtering_target,
-            Clear_stencil_texture,
-            Clear_HTile,
-            Clear_HDR_target,
-            Clear_GBuffer,
-            HDRenderPipeline_Render,
-            CullResults_Cull,
-
-            TP_PrepareLightsForGPU,
-            TP_Push_Global_Parameters,
-            TP_Tiled_Lighting_Debug,
-            TP_Deferred_Directional,
-            TP_m_TileSettings_enableTileAndCluster,
-            TP_Forward_pass,
-            TP_Forward_Tiled_Cluster_pass,
-            TP_Display_Shadows,
-            TP_RenderDeferredLighting,
-
-            Max
-        }
-
         static readonly string[] k_ForwardPassDebugName =
         {
             "Forward Opaque Debug Display",
@@ -231,7 +182,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         RenderTargetIdentifier m_CameraStencilBufferCopyRT;
         RenderTargetIdentifier m_HTileRT;
 
-        static CustomSampler[] m_samplers = new CustomSampler[ (int)CustomSamplerId.Max ];
+        static CustomSampler[] m_samplers = new CustomSampler[(int)CustomSamplerId.Max];
 
         // The pass "SRPDefaultUnlit" is a fall back to legacy unlit rendering and is required to support unity 2d + unity UI that render in the scene.
         ShaderPassName[] m_ForwardAndForwardOnlyPassNames = { new ShaderPassName(), new ShaderPassName(), HDShaderPassNames.s_SRPDefaultUnlitName};
@@ -307,7 +258,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         CommonSettings.Settings m_CommonSettings = CommonSettings.Settings.s_Defaultsettings;
         SkySettings m_SkySettings = null;
 
-        static public CustomSampler   GetSampler( CustomSamplerId id )
+        static public CustomSampler   GetSampler(CustomSamplerId id)
         {
             return m_samplers[(int)id];
         }
@@ -414,10 +365,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
 
             // Init all samplers
-            for (int i=0;i<(int)CustomSamplerId.Max;i++)
+            for (int i = 0; i < (int)CustomSamplerId.Max; i++)
             {
                 CustomSamplerId id = (CustomSamplerId)i;
-                m_samplers[i] = CustomSampler.Create("C#_"+id.ToString());
+                m_samplers[i] = CustomSampler.Create("C#_" + id.ToString());
             }
 
             InitializeRenderStateBlocks();
@@ -599,7 +550,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void PushGlobalParams(HDCamera hdCamera, CommandBuffer cmd, SubsurfaceScatteringSettings sssParameters)
         {
-            using (new ProfilingSample(cmd, "Push Global Parameters", GetSampler(CustomSamplerId.PushGlobal_Parameters)))
+            using (new ProfilingSample(cmd, "Push Global Parameters", GetSampler(CustomSamplerId.PushGlobalParameters)))
             {
                 hdCamera.SetupGlobalParams(cmd);
 
@@ -675,11 +626,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void CopyDepthBufferIfNeeded(CommandBuffer cmd)
         {
-            using (new ProfilingSample(cmd, NeedDepthBufferCopy() ? "Copy DepthBuffer" : "Set DepthBuffer",GetSampler(CustomSamplerId.Copy_SetDepthBuffer)))
+            using (new ProfilingSample(cmd, NeedDepthBufferCopy() ? "Copy DepthBuffer" : "Set DepthBuffer", GetSampler(CustomSamplerId.CopySetDepthBuffer)))
             {
                 if (NeedDepthBufferCopy())
                 {
-                    using (new ProfilingSample(cmd, "Copy depth-stencil buffer",GetSampler(CustomSamplerId.Copydepth_stencilbuffer)))
+                    using (new ProfilingSample(cmd, "Copy depth-stencil buffer", GetSampler(CustomSamplerId.CopyDepthStencilbuffer)))
                     {
                         cmd.CopyTexture(m_CameraDepthStencilBufferRT, m_CameraDepthBufferCopyRT);
                     }
@@ -693,7 +644,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             if (NeedStencilBufferCopy())
             {
-                using (new ProfilingSample(cmd, "Copy StencilBuffer",GetSampler(CustomSamplerId.Copy_StencilBuffer)))
+                using (new ProfilingSample(cmd, "Copy StencilBuffer", GetSampler(CustomSamplerId.CopyStencilBuffer)))
                 {
                     cmd.SetRandomWriteTarget(1, GetHTile());
                     // Our method of exporting the stencil requires one pass per unique stencil value.
@@ -731,7 +682,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // This is the main command buffer used for the frame.
             var cmd = CommandBufferPool.Get("");
 
-            using (new ProfilingSample(cmd, "HDRenderPipeline::Render", GetSampler(CustomSamplerId.HDRenderPipeline_Render)))
+            using (new ProfilingSample(cmd, "HDRenderPipeline::Render", GetSampler(CustomSamplerId.HDRenderPipelineRender)))
             {
                 base.Render(renderContext, cameras);
 
@@ -808,7 +759,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
 #endif
 
-            using (new ProfilingSample(cmd, "CullResults.Cull", GetSampler(CustomSamplerId.CullResults_Cull)))
+            using (new ProfilingSample(cmd, "CullResults.Cull", GetSampler(CustomSamplerId.CullResultsCull)))
             {
                 CullResults.Cull(ref cullingParams, renderContext,ref m_CullResults);
             }
@@ -851,7 +802,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // It mean that when we build a standalone player, if we detect a light with bake shadow mask, we generate all shader variant (with and without shadow mask) and at runtime, when a bake shadow mask light is visible, we dynamically allocate an extra GBuffer and switch the shader.
             // So the first thing to do is to go through all the light: PrepareLightsForGPU
             bool enableBakeShadowMask;
-            using (new ProfilingSample(cmd, "TP_PrepareLightsForGPU", HDRenderPipeline.GetSampler(HDRenderPipeline.CustomSamplerId.TP_PrepareLightsForGPU)))
+            using (new ProfilingSample(cmd, "TP_PrepareLightsForGPU", GetSampler(CustomSamplerId.TPPrepareLightsForGPU)))
             {
                 enableBakeShadowMask = m_LightLoop.PrepareLightsForGPU(m_ShadowSettings, m_CullResults, camera);
             }
@@ -877,19 +828,28 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
             else
             {
-                using (new ProfilingSample(cmd, "Build Light list and render shadows",GetSampler(CustomSamplerId.Build_Light_list_and_render_shadows)))
+                using (new ProfilingSample(cmd, "Render SSAO", GetSampler(CustomSamplerId.RenderSSAO)))
                 {
                     // TODO: Everything here (SSAO, Shadow, Build light list, deferred shadow, material and light classification can be parallelize with Async compute)
                     RenderSSAO(cmd, camera, renderContext, postProcessLayer);
+                }
 
+                using (new ProfilingSample(cmd, "Render shadows", GetSampler(CustomSamplerId.RenderShadows)))
+                {
                     m_LightLoop.RenderShadows(renderContext, cmd, m_CullResults);
+                    // TODO: check if statement below still apply
+                    renderContext.SetupCameraProperties(camera); // Need to recall SetupCameraProperties after RenderShadows as it modify our view/proj matrix
+                }
 
-                    cmd.GetTemporaryRT(m_DeferredShadowBuffer, camera.pixelWidth, camera.pixelHeight, 0, FilterMode.Point, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear, 1 , true);
+                using (new ProfilingSample(cmd, "Deferred directional shadows", GetSampler(CustomSamplerId.RenderDeferredDirectionalShadow)))
+                {
+                    cmd.GetTemporaryRT(m_DeferredShadowBuffer, camera.pixelWidth, camera.pixelHeight, 0, FilterMode.Point, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear, 1, true);
                     m_LightLoop.RenderDeferredDirectionalShadow(hdCamera, m_DeferredShadowBufferRT, GetDepthTexture(), cmd);
-
                     PushFullScreenDebugTexture(cmd, m_DeferredShadowBuffer, hdCamera.camera, renderContext, FullScreenDebugMode.DeferredShadows);
+                }
 
-                    renderContext.SetupCameraProperties(camera); // Need to recall SetupCameraProperties after m_ShadowPass.Render
+                using (new ProfilingSample(cmd, "Build Light list", GetSampler(CustomSamplerId.BuildLightList)))
+                {
                     m_LightLoop.BuildGPULightLists(camera, cmd, m_CameraDepthStencilBufferRT, GetStencilTexture());
                 }
 
@@ -934,7 +894,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Planar and real time cubemap doesn't need post process and render in FP16
                 if (camera.cameraType == CameraType.Reflection)
                 {
-                    using (new ProfilingSample(cmd, "Blit to final RT",GetSampler(CustomSamplerId.Blit_to_final_RT)))
+                    using (new ProfilingSample(cmd, "Blit to final RT", GetSampler(CustomSamplerId.BlitToFinalRT)))
                     {
                         // Simple blit
                         cmd.Blit(m_CameraColorBufferRT, BuiltinRenderTextureType.CameraTarget);
@@ -1093,7 +1053,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (!m_CurrentDebugDisplaySettings.renderingDebugSettings.enableDistortion)
                 return;
 
-            using (new ProfilingSample(cmd, "Distortion",GetSampler(CustomSamplerId.Distortion)))
+            using (new ProfilingSample(cmd, "Distortion", GetSampler(CustomSamplerId.Distortion)))
             {
                 int w = camera.pixelWidth;
                 int h = camera.pixelHeight;
@@ -1110,7 +1070,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderDistortion(CommandBuffer cmd, RenderPipelineResources resources)
         {
-            using (new ProfilingSample(cmd, "ApplyDistortion",GetSampler(CustomSamplerId.ApplyDistortion)))
+            using (new ProfilingSample(cmd, "ApplyDistortion", GetSampler(CustomSamplerId.ApplyDistortion)))
             {
                 var size = new Vector4(m_CurrentWidth, m_CurrentHeight, 1f / m_CurrentWidth, 1f / m_CurrentHeight);
                 uint x, y, z;
@@ -1144,7 +1104,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             bool addFullDepthPrepass = m_Asset.renderingSettings.ShouldUseForwardRenderingOnly() || m_Asset.renderingSettings.useDepthPrepassWithDeferredRendering;
             bool addAlphaTestedOnly = !m_Asset.renderingSettings.ShouldUseForwardRenderingOnly() && m_Asset.renderingSettings.useDepthPrepassWithDeferredRendering && m_Asset.renderingSettings.renderAlphaTestOnlyInDeferredPrepass;
 
-            using (new ProfilingSample(cmd, addAlphaTestedOnly ? "Depth Prepass alpha test" : "Depth Prepass",GetSampler(CustomSamplerId.Depth_Prepass)))
+            using (new ProfilingSample(cmd, addAlphaTestedOnly ? "Depth Prepass alpha test" : "Depth Prepass", GetSampler(CustomSamplerId.DepthPrepass)))
             {
                 CoreUtils.SetRenderTarget(cmd, m_CameraDepthStencilBufferRT);
                 if (addFullDepthPrepass && !addAlphaTestedOnly) // Always true in case of forward rendering, use in case of deferred rendering if requesting a full depth prepass
@@ -1175,7 +1135,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 return;
 
-            using (new ProfilingSample(cmd, m_CurrentDebugDisplaySettings.IsDebugDisplayEnabled() ? "GBufferDebugDisplay" : "GBuffer",GetSampler(CustomSamplerId.GBuffer)))
+            using (new ProfilingSample(cmd, m_CurrentDebugDisplaySettings.IsDebugDisplayEnabled() ? "GBufferDebugDisplay" : "GBuffer", GetSampler(CustomSamplerId.GBuffer)))
             {
                 // setup GBuffer for rendering
                 CoreUtils.SetRenderTarget(cmd, m_GbufferManager.GetGBuffers(), m_CameraDepthStencilBufferRT);
@@ -1209,11 +1169,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderDebugViewMaterial(CullResults cull, HDCamera hdCamera, ScriptableRenderContext renderContext, CommandBuffer cmd)
         {
-            using (new ProfilingSample(cmd, "DisplayDebug ViewMaterial",GetSampler(CustomSamplerId.DisplayDebug_ViewMaterial)))
+            using (new ProfilingSample(cmd, "DisplayDebug ViewMaterial", GetSampler(CustomSamplerId.DisplayDebugViewMaterial)))
             {
                 if (m_CurrentDebugDisplaySettings.materialDebugSettings.IsDebugGBufferEnabled() && !m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 {
-                    using (new ProfilingSample(cmd, "DebugViewMaterialGBuffer",GetSampler(CustomSamplerId.DebugViewMaterialGBuffer)))
+                    using (new ProfilingSample(cmd, "DebugViewMaterialGBuffer", GetSampler(CustomSamplerId.DebugViewMaterialGBuffer)))
                     {
                         CoreUtils.DrawFullScreen(cmd, m_currentDebugViewMaterialGBuffer, m_CameraColorBufferRT);
                     }
@@ -1231,7 +1191,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             // Last blit
             {
-                using (new ProfilingSample(cmd, "Blit DebugView Material Debug",GetSampler(CustomSamplerId.Blit_DebugView_Material_Debug)))
+                using (new ProfilingSample(cmd, "Blit DebugView Material Debug", GetSampler(CustomSamplerId.BlitDebugViewMaterialDebug)))
                 {
                     cmd.Blit(m_CameraColorBufferRT, BuiltinRenderTextureType.CameraTarget);
                 }
@@ -1258,7 +1218,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     return;
                 }
             }
-            
+
             // No AO applied - neutral is black, see the comment in the shaders
             cmd.SetGlobalTexture(HDShaderIDs._AmbientOcclusionTexture, RuntimeUtilities.blackTexture);
             cmd.SetGlobalVector(HDShaderIDs._AmbientOcclusionParam, Vector4.zero);
@@ -1296,10 +1256,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (!m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission || m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 return;
 
-            using (new ProfilingSample(cmd, "Subsurface Scattering",GetSampler(CustomSamplerId.Subsurface_Scattering)))
+            using (new ProfilingSample(cmd, "Subsurface Scattering", GetSampler(CustomSamplerId.SubsurfaceScattering)))
             {
                 if (sssSettings.useDisneySSS)
                 {
+                    // TODO: Remove this once fix, see comment inside the function
+                    hdCamera.SetupComputeShader(m_SubsurfaceScatteringCS, cmd);
+
                     cmd.SetComputeIntParam(        m_SubsurfaceScatteringCS, HDShaderIDs._TexturingModeFlags, sssParameters.texturingModeFlags);
                     cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._WorldScales,        sssParameters.worldScales);
                     cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._FilterKernels,      sssParameters.filterKernels);
@@ -1393,7 +1356,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 profileName = k_ForwardPassName[(int)pass];
             }
 
-            using (new ProfilingSample(cmd, profileName,GetSampler(CustomSamplerId.ForwardPassName)))
+            using (new ProfilingSample(cmd, profileName, GetSampler(CustomSamplerId.ForwardPassName)))
             {
                 CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT);
 
@@ -1425,7 +1388,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderTransparentDepthPrepass(CullResults cullResults, Camera camera, ScriptableRenderContext renderContext, CommandBuffer cmd)
         {
-            using (new ProfilingSample(cmd,"Forward Transparent Depth Prepass",GetSampler(CustomSamplerId.Forward_Transparent_Depth_Prepass)))
+            using (new ProfilingSample(cmd,"Forward Transparent Depth Prepass", GetSampler(CustomSamplerId.ForwardTransparentDepthPrepass)))
             {
                 CoreUtils.SetRenderTarget(cmd, m_CameraDepthStencilBufferRT);
                 RenderTransparentRenderList(cullResults, camera, renderContext, cmd, HDShaderPassNames.s_TransparentDepthPrepassName, preRefractionQueue: true);
@@ -1437,7 +1400,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [Conditional("DEVELOPMENT_BUILD"), Conditional("UNITY_EDITOR")]
         void RenderForwardError(CullResults cullResults, Camera camera, ScriptableRenderContext renderContext, CommandBuffer cmd, ForwardPass pass)
         {
-            using (new ProfilingSample(cmd, "Render Forward Error",GetSampler(CustomSamplerId.Render_Forward_Error)))
+            using (new ProfilingSample(cmd, "Render Forward Error", GetSampler(CustomSamplerId.RenderForwardError)))
             {
                 CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT);
 
@@ -1455,7 +1418,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderVelocity(CullResults cullResults, HDCamera hdcam, ScriptableRenderContext renderContext, CommandBuffer cmd)
         {
-            using (new ProfilingSample(cmd, "Velocity",GetSampler(CustomSamplerId.Velocity)))
+            using (new ProfilingSample(cmd, "Velocity", GetSampler(CustomSamplerId.Velocity)))
             {
                 // If opaque velocity have been render during GBuffer no need to render it here
                 // TODO: Currently we can't render velocity vector into GBuffer, neither during forward pass (in case of forward opaque), so it is always a separate pass
@@ -1490,7 +1453,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (!m_CurrentDebugDisplaySettings.renderingDebugSettings.enableGaussianPyramid)
                 return;
 
-            using (new ProfilingSample(cmd, "Gaussian Pyramid Color",GetSampler(CustomSamplerId.Gaussian_Pyramid_Color)))
+            using (new ProfilingSample(cmd, "Gaussian Pyramid Color", GetSampler(CustomSamplerId.GaussianPyramidColor)))
             {
                 int w = camera.pixelWidth;
                 int h = camera.pixelHeight;
@@ -1540,7 +1503,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (!m_CurrentDebugDisplaySettings.renderingDebugSettings.enableGaussianPyramid)
                 return;
 
-            using (new ProfilingSample(cmd, "Pyramid Depth",GetSampler(CustomSamplerId.Pyramid_Depth)))
+            using (new ProfilingSample(cmd, "Pyramid Depth", GetSampler(CustomSamplerId.PyramidDepth)))
             {
                 int w = camera.pixelWidth;
                 int h = camera.pixelHeight;
@@ -1585,7 +1548,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderPostProcesses(Camera camera, CommandBuffer cmd, PostProcessLayer layer)
         {
-            using (new ProfilingSample(cmd, "Post-processing",GetSampler(CustomSamplerId.Post_processing)))
+            using (new ProfilingSample(cmd, "Post-processing", GetSampler(CustomSamplerId.PostProcessing)))
             {
                 if (CoreUtils.IsPostProcessingActive(layer))
                 {
@@ -1667,7 +1630,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (camera.camera.cameraType == CameraType.Reflection || camera.camera.cameraType == CameraType.Preview)
                 return;
 
-            using (new ProfilingSample(cmd, "Render Debug",GetSampler(CustomSamplerId.Render_Debug)))
+            using (new ProfilingSample(cmd, "Render Debug", GetSampler(CustomSamplerId.RenderDebug)))
             {
                 // We make sure the depth buffer is bound because we need it to write depth at near plane for overlays otherwise the editor grid end up visible in them.
                 CoreUtils.SetRenderTarget(cmd, BuiltinRenderTextureType.CameraTarget, m_CameraDepthStencilBufferRT);
@@ -1705,11 +1668,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void InitAndClearBuffer(HDCamera camera, bool enableBakeShadowMask, CommandBuffer cmd)
         {
-            using (new ProfilingSample(cmd, "InitAndClearBuffer",GetSampler(CustomSamplerId.InitAndClearBuffer)))
+            using (new ProfilingSample(cmd, "InitAndClearBuffer", GetSampler(CustomSamplerId.InitAndClearBuffer)))
             {
                 // We clear only the depth buffer, no need to clear the various color buffer as we overwrite them.
                 // Clear depth/stencil and init buffers
-                using (new ProfilingSample(cmd, "InitGBuffers and clear Depth/Stencil",GetSampler(CustomSamplerId.InitGBuffers_and_clear_Depth_Stencil)))
+                using (new ProfilingSample(cmd, "InitGBuffers and clear Depth/Stencil", GetSampler(CustomSamplerId.InitGBuffersAndClearDepthStencil)))
                 {
                     // Init buffer
                     // With scriptable render loop we must allocate ourself depth and color buffer (We must be independent of backbuffer for now, hope to fix that later).
@@ -1744,7 +1707,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
 
                 // Clear the diffuse SSS lighting target
-                using (new ProfilingSample(cmd, "Clear SSS diffuse target",GetSampler(CustomSamplerId.Clear_SSS_diffuse_target)))
+                using (new ProfilingSample(cmd, "Clear SSS diffuse target", GetSampler(CustomSamplerId.ClearSSSDiffuseTarget)))
                 {
                     CoreUtils.SetRenderTarget(cmd, m_CameraSssDiffuseLightingBufferRT, ClearFlag.Color, CoreUtils.clearColorAllBlack);
                 }
@@ -1753,7 +1716,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 if (NeedTemporarySubsurfaceBuffer())
                 {
                     // Clear the SSS filtering target
-                    using (new ProfilingSample(cmd, "Clear SSS filtering target",GetSampler(CustomSamplerId.Clear_SSS_filtering_target)))
+                    using (new ProfilingSample(cmd, "Clear SSS filtering target", GetSampler(CustomSamplerId.ClearSSSFilteringTarget)))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_CameraFilteringBuffer, ClearFlag.Color, CoreUtils.clearColorAllBlack);
                     }
@@ -1762,7 +1725,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 if (NeedStencilBufferCopy())
                 {
-                    using (new ProfilingSample(cmd, "Clear stencil texture",GetSampler(CustomSamplerId.Clear_stencil_texture)))
+                    using (new ProfilingSample(cmd, "Clear stencil texture", GetSampler(CustomSamplerId.ClearStencilTexture)))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_CameraStencilBufferCopyRT, ClearFlag.Color, CoreUtils.clearColorAllBlack);
                     }
@@ -1770,7 +1733,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 if (NeedHTileCopy())
                 {
-                    using (new ProfilingSample(cmd, "Clear HTile",GetSampler(CustomSamplerId.Clear_HTile)))
+                    using (new ProfilingSample(cmd, "Clear HTile", GetSampler(CustomSamplerId.ClearHTile)))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_HTileRT, ClearFlag.Color, CoreUtils.clearColorAllBlack);
                     }
@@ -1779,7 +1742,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // TODO: As we are in development and have not all the setup pass we still clear the color in emissive buffer and gbuffer, but this will be removed later.
 
                 // Clear the HDR target
-                using (new ProfilingSample(cmd, "Clear HDR target",GetSampler(CustomSamplerId.Clear_HDR_target)))
+                using (new ProfilingSample(cmd, "Clear HDR target", GetSampler(CustomSamplerId.ClearHDRTarget)))
                 {
                     CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT, ClearFlag.Color, CoreUtils.clearColorAllBlack);
                 }
@@ -1787,7 +1750,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Clear GBuffers
                 if (!m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 {
-                    using (new ProfilingSample(cmd, "Clear GBuffer",GetSampler(CustomSamplerId.Clear_GBuffer)))
+                    using (new ProfilingSample(cmd, "Clear GBuffer", GetSampler(CustomSamplerId.ClearGBuffer)))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_GbufferManager.GetGBuffers(), m_CameraDepthStencilBufferRT, ClearFlag.Color, CoreUtils.clearColorAllBlack);
                     }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -1201,13 +1201,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Output split lighting for materials asking for it (masked in the stencil buffer)
                 options.outputSplitLighting = true;
 
-                m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_CameraDepthStencilBufferRT, depthTexture, m_DeferredShadowBuffer, options);
+                m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_CameraDepthStencilBufferRT, depthTexture, options);
             }
 
             // Output combined lighting for all the other materials.
             options.outputSplitLighting = false;
 
-            m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_CameraDepthStencilBufferRT, depthTexture, m_DeferredShadowBuffer, options);
+            m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_CameraDepthStencilBufferRT, depthTexture, options);
         }
 
         // Combines specular lighting and diffuse lighting with subsurface scattering.

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -1221,8 +1221,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 if (sssSettings.useDisneySSS)
                 {
-                    hdCamera.SetupComputeShader(m_SubsurfaceScatteringCS, cmd);
-
                     cmd.SetComputeIntParam(        m_SubsurfaceScatteringCS, HDShaderIDs._TexturingModeFlags, sssParameters.texturingModeFlags);
                     cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._WorldScales,        sssParameters.worldScales);
                     cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._FilterKernels,      sssParameters.filterKernels);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -1997,6 +1997,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 string singlePassName = "SinglePass - Deferred Lighting Pass";
                 string SinglePassMRTName = "SinglePass - Deferred Lighting Pass MRT";
 
+                                   Texture skyTexture = Shader.GetGlobalTexture(HDShaderIDs._SkyTexture);
+                       float skyTextureMipCount = Shader.GetGlobalFloat(HDShaderIDs._SkyTextureMipCount);
+
+
                 using (new ProfilingSample(cmd, m_TileSettings.enableTileAndCluster ?
                     (options.outputSplitLighting ? tilePassMRTName : tilePassName) :
                     (options.outputSplitLighting ? SinglePassMRTName : singlePassName)))
@@ -2057,6 +2061,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             // TODO: Is it possible to setup this outside the loop ? Can figure out how, get this: Property (specularLightingUAV) at kernel index (21) is not set
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.specularLightingUAV, colorBuffers[0]);
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.diffuseLightingUAV,  colorBuffers[1]);
+
+                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._SkyTexture, skyTexture ? skyTexture : m_DefaultTexture2DArray);
+                            cmd.SetComputeFloatParam(deferredComputeShader, HDShaderIDs._SkyTextureMipCount, skyTextureMipCount);
+
 
                             // always do deferred lighting in blocks of 16x16 (not same as tiled light size)
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -1963,7 +1963,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 using (new ProfilingSample(cmd, "Deferred Directional"))
                 {
-                    hdCamera.SetupComputeShader(deferredDirectionalShadowComputeShader, cmd);
                     m_ShadowMgr.BindResources(cmd, deferredDirectionalShadowComputeShader, s_deferredDirectionalShadowKernel);
 
                     cmd.SetComputeFloatParam(deferredDirectionalShadowComputeShader, HDShaderIDs._DirectionalShadowIndex, (float)m_CurrentSunLightShadowIndex);
@@ -2019,10 +2018,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         if (enableFeatureVariants)
                             numVariants = LightDefinitions.s_NumFeatureVariants;
 
-
-                        Texture skyTexture = Shader.GetGlobalTexture(HDShaderIDs._SkyTexture);
-                        float skyTextureMipCount = Shader.GetGlobalFloat(HDShaderIDs._SkyTextureMipCount);
-
                         for (int variant = 0; variant < numVariants; variant++)
                         {
                             int kernel;
@@ -2053,8 +2048,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                         kernel = usingFptl ? s_shadeOpaqueDirectShadowMaskFptlKernel : s_shadeOpaqueDirectShadowMaskClusteredKernel;
                                 }
                             }
-
-                            hdCamera.SetupComputeShader(deferredComputeShader, cmd);
 
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._MainDepthTexture, depthTexture);
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -2063,9 +2063,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._AmbientOcclusionTexture, HDShaderIDs._AmbientOcclusionTexture);
 
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._SkyTexture, skyTexture ? skyTexture : m_DefaultTexture2DArray);
-                            cmd.SetComputeFloatParam(deferredComputeShader, HDShaderIDs._SkyTextureMipCount, skyTextureMipCount);
-
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.specularLightingUAV, colorBuffers[0]);
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.diffuseLightingUAV,  colorBuffers[1]);
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -2051,11 +2051,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._MainDepthTexture, depthTexture);
 
-                            // TODO: Don't know why but If we use Shader.GetGlobalTexture(HDShaderIDs._GBufferTexture0) instead of HDShaderIDs._GBufferTexture0 the screen start to flicker in SceneView...
-                            // Need to investigate what is happening. But this may be unnecessary as development of SetGlobalTexture for compute shader have begin
-
+                            // TODO: Should remove this setting but can't remove it else get error: Property (_AmbientOcclusionTexture) at kernel index (32) is not set. Check why
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._AmbientOcclusionTexture, HDShaderIDs._AmbientOcclusionTexture);
 
+                            // TODO: Is it possible to setup this outside the loop ? Can figure out how, get this: Property (specularLightingUAV) at kernel index (21) is not set
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.specularLightingUAV, colorBuffers[0]);
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.diffuseLightingUAV,  colorBuffers[1]);
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -2000,7 +2000,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             public void RenderDeferredLighting( HDCamera hdCamera, CommandBuffer cmd,
                                                 DebugDisplaySettings debugDisplaySettings,
-                                                RenderTargetIdentifier[] colorBuffers, RenderTargetIdentifier depthStencilBuffer, RenderTargetIdentifier depthTexture, RenderTargetIdentifier deferredShadowTexture,
+                                                RenderTargetIdentifier[] colorBuffers, RenderTargetIdentifier depthStencilBuffer, RenderTargetIdentifier depthTexture,
                                                 LightingPassOptions options)
             {
                 var bUseClusteredForDeferred = !usingFptl;
@@ -2082,18 +2082,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
  
                             cmd.SetComputeBufferParam(deferredComputeShader, kernel, HDShaderIDs.g_vLightListGlobal, bUseClusteredForDeferred ? s_PerVoxelLightLists : s_LightList);
 
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._DeferredShadowTexture, deferredShadowTexture);
 
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._MainDepthTexture, depthTexture);
 
                             // TODO: Don't know why but If we use Shader.GetGlobalTexture(HDShaderIDs._GBufferTexture0) instead of HDShaderIDs._GBufferTexture0 the screen start to flicker in SceneView...
                             // Need to investigate what is happening. But this may be unnecessary as development of SetGlobalTexture for compute shader have begin
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._GBufferTexture0, HDShaderIDs._GBufferTexture0);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._GBufferTexture1, HDShaderIDs._GBufferTexture1);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._GBufferTexture2, HDShaderIDs._GBufferTexture2);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._GBufferTexture3, HDShaderIDs._GBufferTexture3);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._ShadowMaskTexture, HDShaderIDs._ShadowMaskTexture);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._VelocityTexture, HDShaderIDs._VelocityTexture);
+
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._AmbientOcclusionTexture, HDShaderIDs._AmbientOcclusionTexture);
 
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._SkyTexture, skyTexture ? skyTexture : m_DefaultTexture2DArray);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -1820,7 +1820,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 s_LightVolumeDataBuffer.SetData(m_lightList.lightVolumes);
             }
 
-            public void PushGlobalParams(Camera camera, CommandBuffer cmd)
+             void PushGlobalParams(Camera camera, CommandBuffer cmd)
             {
                 using (new ProfilingSample(cmd, "Push Global Parameters", HDRenderPipeline.GetSampler(CustomSamplerId.TPPushGlobalParameters)))
                 {

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -1859,7 +1859,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 if (activeComputeShader)
                     activeCommandBuffer.SetComputeIntParam(activeComputeShader, nameID, value);
                 else
-                    Shader.SetGlobalInt(nameID, value);
+                    activeCommandBuffer.SetGlobalInt(nameID, value);
             }
 
             private void SetGlobalFloat(int nameID, float value)
@@ -2106,35 +2106,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         if (enableFeatureVariants)
                             numVariants = LightDefinitions.s_NumFeatureVariants;
 
-                        int debugViewMaterial = Shader.GetGlobalInt(HDShaderIDs._DebugViewMaterial);
-                        int debugLightingMode = Shader.GetGlobalInt(HDShaderIDs._DebugLightingMode);
-                        Vector4 debugLightingAlbedo = Shader.GetGlobalVector(HDShaderIDs._DebugLightingAlbedo);
-                        Vector4 debugLightingSmoothness = Shader.GetGlobalVector(HDShaderIDs._DebugLightingSmoothness);
-
-                        Texture ltcData = Shader.GetGlobalTexture(HDShaderIDs._LtcData);
-                        Texture preIntegratedFGD = Shader.GetGlobalTexture(HDShaderIDs._PreIntegratedFGD);
-                        Texture ltcGGXMatrix = Shader.GetGlobalTexture(HDShaderIDs._LtcGGXMatrix);
-                        Texture ltcDisneyDiffuseMatrix = Shader.GetGlobalTexture(HDShaderIDs._LtcDisneyDiffuseMatrix);
-                        Texture ltcMultiGGXFresnelDisneyDiffuse = Shader.GetGlobalTexture(HDShaderIDs._LtcMultiGGXFresnelDisneyDiffuse);
-
-                        Matrix4x4 invScrProjection = Shader.GetGlobalMatrix(HDShaderIDs.g_mInvScrProjection);
-                        int useTileLightList = Shader.GetGlobalInt(HDShaderIDs._UseTileLightList);
-
-                        Vector4 time = Shader.GetGlobalVector(HDShaderIDs._Time);
-                        Vector4 sinTime = Shader.GetGlobalVector(HDShaderIDs._SinTime);
-                        Vector4 cosTime = Shader.GetGlobalVector(HDShaderIDs._CosTime);
-                        Vector4 unity_DeltaTime = Shader.GetGlobalVector(HDShaderIDs.unity_DeltaTime);
-                        int envLightSkyEnabled = Shader.GetGlobalInt(HDShaderIDs._EnvLightSkyEnabled);
-                        Vector4 ambientOcclusionParam = Shader.GetGlobalVector(HDShaderIDs._AmbientOcclusionParam);
-
-                        int enableSSSAndTransmission = Shader.GetGlobalInt(HDShaderIDs._EnableSSSAndTransmission);
-                        int texturingModeFlags = Shader.GetGlobalInt(HDShaderIDs._TexturingModeFlags);
-                        int transmissionFlags = Shader.GetGlobalInt(HDShaderIDs._TransmissionFlags);
-                        int useDisneySSS = Shader.GetGlobalInt(HDShaderIDs._UseDisneySSS);
-                        Vector4[] thicknessRemaps = Shader.GetGlobalVectorArray(HDShaderIDs._ThicknessRemaps);
-                        Vector4[] shapeParams = Shader.GetGlobalVectorArray(HDShaderIDs._ShapeParams);
-                        Vector4[] transmissionTints = Shader.GetGlobalVectorArray(HDShaderIDs._TransmissionTints);
-                        Vector4[] halfRcpVariancesAndWeights = Shader.GetGlobalVectorArray(HDShaderIDs._HalfRcpVariancesAndWeights);
 
                         Texture skyTexture = Shader.GetGlobalTexture(HDShaderIDs._SkyTexture);
                         float skyTextureMipCount = Shader.GetGlobalFloat(HDShaderIDs._SkyTextureMipCount);
@@ -2176,11 +2147,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             hdCamera.SetupComputeShader(deferredComputeShader, cmd);
 
                             // TODO: Update value like in ApplyDebugDisplaySettings() call. Sadly it is high likely that this will not be keep in sync. we really need to get rid of this by making global parameters visible to compute shaders
-                            cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._DebugViewMaterial, debugViewMaterial);
-                            cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._DebugLightingMode, debugLightingMode);
-                            cmd.SetComputeVectorParam(deferredComputeShader, HDShaderIDs._DebugLightingAlbedo, debugLightingAlbedo);
-                            cmd.SetComputeVectorParam(deferredComputeShader, HDShaderIDs._DebugLightingSmoothness, debugLightingSmoothness);
-
+ 
                             cmd.SetComputeBufferParam(deferredComputeShader, kernel, HDShaderIDs.g_vLightListGlobal, bUseClusteredForDeferred ? s_PerVoxelLightLists : s_LightList);
 
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._DeferredShadowTexture, deferredShadowTexture);
@@ -2197,34 +2164,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._VelocityTexture, HDShaderIDs._VelocityTexture);
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._AmbientOcclusionTexture, HDShaderIDs._AmbientOcclusionTexture);
 
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._LtcData, ltcData);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._PreIntegratedFGD, preIntegratedFGD);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._LtcGGXMatrix, ltcGGXMatrix);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._LtcDisneyDiffuseMatrix, ltcDisneyDiffuseMatrix);
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._LtcMultiGGXFresnelDisneyDiffuse, ltcMultiGGXFresnelDisneyDiffuse);
-
-                            cmd.SetComputeMatrixParam(deferredComputeShader, HDShaderIDs.g_mInvScrProjection, invScrProjection);
-                            cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._UseTileLightList, useTileLightList);
-
-                            cmd.SetComputeVectorParam(deferredComputeShader, HDShaderIDs._Time, time);
-                            cmd.SetComputeVectorParam(deferredComputeShader, HDShaderIDs._SinTime, sinTime);
-                            cmd.SetComputeVectorParam(deferredComputeShader, HDShaderIDs._CosTime, cosTime);
-                            cmd.SetComputeVectorParam(deferredComputeShader, HDShaderIDs.unity_DeltaTime, unity_DeltaTime);
-                            cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._EnvLightSkyEnabled, envLightSkyEnabled);
-                            cmd.SetComputeVectorParam(deferredComputeShader, HDShaderIDs._AmbientOcclusionParam, ambientOcclusionParam);
-
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._SkyTexture, skyTexture ? skyTexture : m_DefaultTexture2DArray);
                             cmd.SetComputeFloatParam(deferredComputeShader, HDShaderIDs._SkyTextureMipCount, skyTextureMipCount);
-
-                            // Set SSS parameters.
-                            cmd.SetComputeIntParam(        deferredComputeShader, HDShaderIDs._EnableSSSAndTransmission,   enableSSSAndTransmission);
-                            cmd.SetComputeIntParam(        deferredComputeShader, HDShaderIDs._TexturingModeFlags,         texturingModeFlags);
-                            cmd.SetComputeIntParam(        deferredComputeShader, HDShaderIDs._TransmissionFlags,          transmissionFlags);
-                            cmd.SetComputeIntParam(        deferredComputeShader, HDShaderIDs._UseDisneySSS,               useDisneySSS);
-                            cmd.SetComputeVectorArrayParam(deferredComputeShader, HDShaderIDs._ThicknessRemaps,            thicknessRemaps);
-                            cmd.SetComputeVectorArrayParam(deferredComputeShader, HDShaderIDs._ShapeParams,                shapeParams);
-                            cmd.SetComputeVectorArrayParam(deferredComputeShader, HDShaderIDs._TransmissionTints,          transmissionTints);
-                            cmd.SetComputeVectorArrayParam(deferredComputeShader, HDShaderIDs._HalfRcpVariancesAndWeights, halfRcpVariancesAndWeights);
 
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.specularLightingUAV, colorBuffers[0]);
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.diffuseLightingUAV,  colorBuffers[1]);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -2035,16 +2035,16 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                 if (m_enableBakeShadowMask)
                                 {
                                     if (debugDisplaySettings.IsDebugDisplayEnabled())
-                                        kernel = usingFptl ? s_shadeOpaqueDirectFptlDebugDisplayKernel : s_shadeOpaqueDirectClusteredDebugDisplayKernel;
+                                        kernel = usingFptl ? s_shadeOpaqueDirectShadowMaskFptlDebugDisplayKernel : s_shadeOpaqueDirectShadowMaskClusteredDebugDisplayKernel;
                                     else
-                                        kernel = usingFptl ? s_shadeOpaqueDirectFptlKernel : s_shadeOpaqueDirectClusteredKernel;
+                                        kernel = usingFptl ? s_shadeOpaqueDirectShadowMaskFptlKernel : s_shadeOpaqueDirectShadowMaskClusteredKernel;
                                 }
                                 else
                                 {
                                     if (debugDisplaySettings.IsDebugDisplayEnabled())
-                                        kernel = usingFptl ? s_shadeOpaqueDirectShadowMaskFptlDebugDisplayKernel : s_shadeOpaqueDirectShadowMaskClusteredDebugDisplayKernel;
+                                        kernel = usingFptl ? s_shadeOpaqueDirectFptlDebugDisplayKernel : s_shadeOpaqueDirectClusteredDebugDisplayKernel;
                                     else
-                                        kernel = usingFptl ? s_shadeOpaqueDirectShadowMaskFptlKernel : s_shadeOpaqueDirectShadowMaskClusteredKernel;
+                                        kernel = usingFptl ? s_shadeOpaqueDirectFptlKernel : s_shadeOpaqueDirectClusteredKernel;
                                 }
                             }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Sky/SkyManager.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Sky/SkyManager.cs
@@ -252,11 +252,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         // Sets the global MIP-mapped cubemap '_SkyTexture' in the shader.
         // The texture being set is the sky (environment) map pre-convolved with GGX.
-        public void SetGlobalSkyTexture()
+        public void SetGlobalSkyTexture(CommandBuffer cmd)
         {
-            Shader.SetGlobalTexture(HDShaderIDs._SkyTexture, m_SkyboxGGXCubemapRT);
+            cmd.SetGlobalTexture(HDShaderIDs._SkyTexture, m_SkyboxGGXCubemapRT);
             float mipCount = Mathf.Clamp(Mathf.Log((float)m_SkyboxGGXCubemapRT.width, 2.0f) + 1, 0.0f, 6.0f);
-            Shader.SetGlobalFloat(HDShaderIDs._SkyTextureMipCount, mipCount);
+            cmd.SetGlobalFloat(HDShaderIDs._SkyTextureMipCount, mipCount);
         }
 
         public void Resize(float nearPlane, float farPlane)


### PR DESCRIPTION
- Remove various SetComputeParam function as now SetGlobalXXX function are supported by compute shader. 
=> This is a huge performance win C# side
- Also rely on GetTemporaryRT automatic bind
- Fix an issue in shadow mask texture not bind in display debug mode
- Change All Shader.SetInt() to cmd.SetGlobalInt()
- Clean Profil Sampler to match the Unity convention
- Add few more profile marker