### PR TITLE
HDRenderPipeline: Fix the pipeline to be fptl for opaque and cluster for transparent

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplay.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplay.cs
@@ -34,7 +34,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static string kFullScreenDebugMip = "Fullscreen Debug Mip";
         public static string kDisplaySkyReflectionDebug = "Display Sky Reflection";
         public static string kSkyReflectionMipmapDebug = "Sky Reflection Mipmap";
-        public static string kTileDebug = "Tile Debug By Category";
+        public static string kTileClusterCategoryDebug = "Tile/Cluster Debug By Category";
+        public static string kTileClusterDebug = "Tile/Cluster Debug";
 
 
         public float debugOverlayRatio = 0.33f;
@@ -156,7 +157,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, Color>(kDebugLightingAlbedo, () => lightingDebugSettings.debugLightingAlbedo, (value) => lightingDebugSettings.debugLightingAlbedo = (Color)value);
             DebugMenuManager.instance.AddDebugItem<bool>("Lighting", kDisplaySkyReflectionDebug, () => lightingDebugSettings.displaySkyReflection, (value) => lightingDebugSettings.displaySkyReflection = (bool)value);
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, float>(kSkyReflectionMipmapDebug, () => lightingDebugSettings.skyReflectionMipmap, (value) => lightingDebugSettings.skyReflectionMipmap = (float)value, DebugItemFlag.None, new DebugItemHandlerFloatMinMax(0.0f, 1.0f));
-            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, TilePass.TileSettings.TileDebug>(kTileDebug,() => lightingDebugSettings.tileDebugByCategory, (value) => lightingDebugSettings.tileDebugByCategory = (TilePass.TileSettings.TileDebug)value);
+            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, TilePass.TileSettings.TileClusterDebug>(kTileClusterDebug,() => lightingDebugSettings.tileClusterDebug, (value) => lightingDebugSettings.tileClusterDebug = (TilePass.TileSettings.TileClusterDebug)value);
+            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, TilePass.TileSettings.TileClusterCategoryDebug>(kTileClusterCategoryDebug,() => lightingDebugSettings.tileClusterDebugByCategory, (value) => lightingDebugSettings.tileClusterDebugByCategory = (TilePass.TileSettings.TileClusterCategoryDebug)value);
 
             DebugMenuManager.instance.AddDebugItem<bool>("Rendering", "Display Opaque",() => renderingDebugSettings.displayOpaqueObjects, (value) => renderingDebugSettings.displayOpaqueObjects = (bool)value);
             DebugMenuManager.instance.AddDebugItem<bool>("Rendering", "Display Transparency",() => renderingDebugSettings.displayTransparentObjects, (value) => renderingDebugSettings.displayTransparentObjects = (bool)value);
@@ -537,7 +539,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool                 displaySkyReflection = false;
         public float                skyReflectionMipmap = 0.0f;
 
-        public TilePass.TileSettings.TileDebug  tileDebugByCategory = TilePass.TileSettings.TileDebug.None;
+        public TilePass.TileSettings.TileClusterDebug tileClusterDebug = TilePass.TileSettings.TileClusterDebug.None;
+        public TilePass.TileSettings.TileClusterCategoryDebug tileClusterDebugByCategory = TilePass.TileSettings.TileClusterCategoryDebug.Punctual;   
 
         public void OnValidate()
         {

--- a/ScriptableRenderPipeline/HDRenderPipeline/Debug/LightingDebugPanel.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Debug/LightingDebugPanel.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System;
 
 #if UNITY_EDITOR
@@ -114,8 +114,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         break;
                 }
 
-
-                m_DebugPanel.GetDebugItem(DebugDisplaySettings.kTileDebug).handler.OnEditorGUI();
+                DebugItem tileClusterDebug = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kTileClusterDebug);
+                tileClusterDebug.handler.OnEditorGUI();
+                if ((int)tileClusterDebug.GetValue() != 0 && (int)tileClusterDebug.GetValue() != 3) // None and FeatureVariant
+                {
+                    EditorGUI.indentLevel++;
+                    m_DebugPanel.GetDebugItem(DebugDisplaySettings.kTileClusterCategoryDebug).handler.OnEditorGUI();
+                    EditorGUI.indentLevel--;
+                }
 
                 DebugItem displaySkyReflecItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kDisplaySkyReflectionDebug);
                 displaySkyReflecItem.handler.OnEditorGUI();

--- a/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.Styles.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.Styles.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
@@ -38,8 +38,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public readonly GUIContent enableComputeLightEvaluation = new GUIContent("Compute Light Evaluation");
             public readonly GUIContent enableComputeLightVariants = new GUIContent("Compute Light Variants");
             public readonly GUIContent enableComputeMaterialVariants = new GUIContent("Compute Material Variants");
-            public readonly GUIContent enableClustered = new GUIContent("Clustered");
-            public readonly GUIContent enableFptlForOpaqueWhenClustered = new GUIContent("Fptl For Opaque When Clustered");
             public readonly GUIContent enableBigTilePrepass = new GUIContent("Big tile prepass");
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
@@ -16,8 +16,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         SerializedProperty m_enableComputeLightEvaluation;
         SerializedProperty m_enableComputeLightVariants;
         SerializedProperty m_enableComputeMaterialVariants;
-        SerializedProperty m_enableClustered;
-        SerializedProperty m_enableFptlForOpaqueWhenClustered;
         SerializedProperty m_enableBigTilePrepass;
 
         // Rendering Settings
@@ -47,8 +45,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_enableComputeLightEvaluation = properties.Find(x => x.tileSettings.enableComputeLightEvaluation);
             m_enableComputeLightVariants = properties.Find(x => x.tileSettings.enableComputeLightVariants);
             m_enableComputeMaterialVariants = properties.Find(x => x.tileSettings.enableComputeMaterialVariants);
-            m_enableClustered = properties.Find(x => x.tileSettings.enableClustered);
-            m_enableFptlForOpaqueWhenClustered = properties.Find(x => x.tileSettings.enableFptlForOpaqueWhenClustered);
             m_enableBigTilePrepass = properties.Find(x => x.tileSettings.enableBigTilePrepass);
 
             // Shadow settings
@@ -90,22 +86,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(m_enableBigTilePrepass, s_Styles.enableBigTilePrepass);
-                EditorGUILayout.PropertyField(m_enableClustered, s_Styles.enableClustered);
 
-                // Tag: SUPPORT_COMPUTE_CLUSTER_OPAQUE - Uncomment this if you want to do cluster opaque with compute shader (by default we support only fptl on opaque)
-                // if (m_enableClustered.boolValue)
-                if (m_enableClustered.boolValue && !m_enableComputeLightEvaluation.boolValue)
-                {
-                    EditorGUI.indentLevel++;
-                    EditorGUILayout.PropertyField(m_enableFptlForOpaqueWhenClustered, s_Styles.enableFptlForOpaqueWhenClustered);
-                    EditorGUI.indentLevel--;
-                }
                 EditorGUILayout.PropertyField(m_enableComputeLightEvaluation, s_Styles.enableComputeLightEvaluation);
                 if (m_enableComputeLightEvaluation.boolValue)
                 {
-                    // Tag: SUPPORT_COMPUTE_CLUSTER_OPAQUE - Uncomment this if you want to do cluster opaque with compute shader (by default we support only fptl on opaque)
-                    m_enableFptlForOpaqueWhenClustered.boolValue = true; // Force fptl to be always true if compute evaluation is enable
-
                     EditorGUI.indentLevel++;
                     EditorGUILayout.PropertyField(m_enableComputeLightVariants, s_Styles.enableComputeLightVariants);
                     EditorGUILayout.PropertyField(m_enableComputeMaterialVariants, s_Styles.enableComputeMaterialVariants);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -385,7 +385,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Tile/Cluster", () => m_Asset.tileSettings.enableTileAndCluster, (value) => m_Asset.tileSettings.enableTileAndCluster = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Big Tile", () => m_Asset.tileSettings.enableBigTilePrepass, (value) => m_Asset.tileSettings.enableBigTilePrepass = (bool)value, DebugItemFlag.RuntimeOnly);
-            DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Cluster", () => m_Asset.tileSettings.enableClustered, (value) => m_Asset.tileSettings.enableClustered = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Compute Lighting", () => m_Asset.tileSettings.enableComputeLightEvaluation, (value) => m_Asset.tileSettings.enableComputeLightEvaluation = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Light Classification", () => m_Asset.tileSettings.enableComputeLightVariants, (value) => m_Asset.tileSettings.enableComputeLightVariants = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Material Classification", () => m_Asset.tileSettings.enableComputeMaterialVariants, (value) => m_Asset.tileSettings.enableComputeMaterialVariants = (bool)value, DebugItemFlag.RuntimeOnly);
@@ -879,7 +878,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
 
-                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings);
+                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, true);
 
                 RenderSky(hdCamera, cmd);
 
@@ -1345,9 +1344,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             return m_SkyManager.ExportSkyToTexture();
         }
 
-        void RenderLightingDebug(HDCamera camera, CommandBuffer cmd, RenderTargetIdentifier colorBuffer, DebugDisplaySettings debugDisplaySettings)
+        void RenderLightingDebug(HDCamera camera, CommandBuffer cmd, RenderTargetIdentifier colorBuffer, DebugDisplaySettings debugDisplaySettings, bool renderOpaque)
         {
-            m_LightLoop.RenderLightingDebug(camera, cmd, colorBuffer, debugDisplaySettings);
+            m_LightLoop.RenderLightingDebug(camera, cmd, colorBuffer, debugDisplaySettings, renderOpaque);
         }
 
         // Render forward is use for both transparent and opaque objects. In case of deferred we can still render opaque object in forward.

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -877,7 +877,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
-
                 RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, true);
 
                 RenderSky(hdCamera, cmd);
@@ -894,6 +893,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Render all type of transparent forward (unlit, lit, complex (hair...)) to keep the sorting between transparent objects.
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Transparent);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Transparent);
+                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, false);
 
                 PushFullScreenDebugTexture(cmd, m_CameraColorBuffer, camera, renderContext, FullScreenDebugMode.NanTracker);
 
@@ -923,7 +923,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
             }
 
-            RenderDebug(hdCamera, cmd);
+            if (camera.cameraType != CameraType.Reflection)
+                RenderDebug(hdCamera, cmd);                          
 
 #if UNITY_EDITOR
             // bind depth surface for editor grid/gizmo/selection rendering

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
@@ -36,12 +36,13 @@ Shader "Hidden/HDRenderPipeline/Deferred"
 
             // Chose supported lighting architecture in case of deferred rendering
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
-            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             // Split lighting is utilized during the SSS pass.
             #pragma multi_compile _ OUTPUT_SPLIT_LIGHTING
             #pragma multi_compile _ SHADOWS_SHADOWMASK
             #pragma multi_compile _ DEBUG_DISPLAY
+
+            #define USE_FPTL_LIGHTLIST // deferred (opaque) always use FPTL
 
             //-------------------------------------------------------------------------------------
             // Include

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Forward.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Forward.hlsl
@@ -2,12 +2,11 @@
 // Those that are control from inside the "Material".shader with "Pass" concept like forward lighting. Call later forward lighting architecture.
 // Those that are control outside the "Material".shader in a "Lighting".shader like deferred lighting. Call later deferred lighting architecture.
 
-// When dealing with deferred lighting architecture, the renderloop is in charge to call the correct .shader.
-// RenderLoop can do multiple call of various deferred lighting architecture.
+// When dealing with deferred lighting architecture, the renderPipeline is in charge to call the correct .shader.
+// renderPipeline can do multiple call of various deferred lighting architecture.
 // (Note: enabled variant for deferred lighting architecture are in deferred.shader)
-// When dealing with forward lighting architecture, the renderloop must specify a shader pass (like "forward") but it also need
+// When dealing with forward lighting architecture, the renderPipeline must specify a shader pass (like "forward") but it also need
 // to specify which variant of the forward lighting architecture he want (with cmd.EnableShaderKeyword()).
-// Renderloop can suppose dynamically switching from regular forward to tile forward for example within the same "Forward" pass.
 
 // The purpose of the following pragma is to define the variant available for "Forward" Pass in "Material".shader.
 // If only one keyword is present it mean that only one type of forward lighting architecture is supported.
@@ -15,5 +14,9 @@
 // Must match name in GetKeyword() method of forward lighting architecture .cs file
 // #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS -> can't use a pragma from include... (for now)
 
-// No USE_FPTL_LIGHTLIST as we are in forward and this use the cluster path (but cluster path can use the tile light list for opaque)
+// Forward transparent surface use clustering, forward opaque use FPTL
+#ifdef _SURFACE_TYPE_TRANSPARENT
 #define USE_CLUSTERED_LIGHTLIST
+#else
+#define USE_FPTL_LIGHTLIST
+#endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
@@ -2,10 +2,6 @@
 #pragma kernel Deferred_Direct_Fptl_DebugDisplay                    SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl_DebugDisplay                   USE_FPTL_LIGHTLIST          DEBUG_DISPLAY
 #pragma kernel Deferred_Direct_ShadowMask_Fptl                     SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl                    USE_FPTL_LIGHTLIST          SHADOWS_SHADOWMASK
 #pragma kernel Deferred_Direct_ShadowMask_Fptl_DebugDisplay        SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl_DebugDisplay       USE_FPTL_LIGHTLIST          SHADOWS_SHADOWMASK  DEBUG_DISPLAY
-#pragma kernel Deferred_Direct_Clustered                            SHADE_OPAQUE_ENTRY=Deferred_Direct_Clustered                           USE_CLUSTERED_LIGHTLIST
-#pragma kernel Deferred_Direct_Clustered_DebugDisplay               SHADE_OPAQUE_ENTRY=Deferred_Direct_Clustered_DebugDisplay              USE_CLUSTERED_LIGHTLIST     DEBUG_DISPLAY
-#pragma kernel Deferred_Direct_ShadowMask_Clustered                SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Clustered               USE_CLUSTERED_LIGHTLIST     SHADOWS_SHADOWMASK
-#pragma kernel Deferred_Direct_ShadowMask_Clustered_DebugDisplay   SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Clustered_DebugDisplay  USE_CLUSTERED_LIGHTLIST     SHADOWS_SHADOWMASK  DEBUG_DISPLAY
 
 // Variant with and without shadowmask
 #pragma kernel Deferred_Indirect_Fptl_Variant0      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant0      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=0
@@ -63,36 +59,6 @@
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant24      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant24      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=24
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant25      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant25      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=25
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant26      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant26      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=26
-
-/* Tag: SUPPORT_COMPUTE_CLUSTER_OPAQUE - Uncomment this if you want to do cluster opaque with compute shader (by default we support only fptl on opaque)
-#pragma kernel Deferred_Indirect_Clustered_Variant0          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant0              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=0
-#pragma kernel Deferred_Indirect_Clustered_Variant1          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant1              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=1
-#pragma kernel Deferred_Indirect_Clustered_Variant2          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant2              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=2
-#pragma kernel Deferred_Indirect_Clustered_Variant3          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant3              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=3
-#pragma kernel Deferred_Indirect_Clustered_Variant4          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant4              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=4
-#pragma kernel Deferred_Indirect_Clustered_Variant5          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant5              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=5
-#pragma kernel Deferred_Indirect_Clustered_Variant6          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant6              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=6
-#pragma kernel Deferred_Indirect_Clustered_Variant7          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant7              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=7
-#pragma kernel Deferred_Indirect_Clustered_Variant8          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant8              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=8
-#pragma kernel Deferred_Indirect_Clustered_Variant9          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant9              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=9
-#pragma kernel Deferred_Indirect_Clustered_Variant10         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant10             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=10
-#pragma kernel Deferred_Indirect_Clustered_Variant11         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant11             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=11
-#pragma kernel Deferred_Indirect_Clustered_Variant12         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant12             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=12
-#pragma kernel Deferred_Indirect_Clustered_Variant13         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant13             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=13
-#pragma kernel Deferred_Indirect_Clustered_Variant14         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant14             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=14
-#pragma kernel Deferred_Indirect_Clustered_Variant15         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant15             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=15
-#pragma kernel Deferred_Indirect_Clustered_Variant16         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant16             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=16
-#pragma kernel Deferred_Indirect_Clustered_Variant17         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant17             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=17
-#pragma kernel Deferred_Indirect_Clustered_Variant18         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant18             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=18
-#pragma kernel Deferred_Indirect_Clustered_Variant19         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant19             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=19
-#pragma kernel Deferred_Indirect_Clustered_Variant20         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant20             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=20
-#pragma kernel Deferred_Indirect_Clustered_Variant21         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant21             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=21
-#pragma kernel Deferred_Indirect_Clustered_Variant22         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant22             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=22
-#pragma kernel Deferred_Indirect_Clustered_Variant23         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant23             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=23
-#pragma kernel Deferred_Indirect_Clustered_Variant24         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant24             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=24
-#pragma kernel Deferred_Indirect_Clustered_Variant25         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant25             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=25
-#pragma kernel Deferred_Indirect_Clustered_Variant26         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant26             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=26
-*/
 
 #define LIGHTLOOP_TILE_PASS 1
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.hlsl
@@ -1,4 +1,4 @@
-﻿#include "TilePass.cs.hlsl"
+#include "TilePass.cs.hlsl"
 #include "../../Sky/SkyVariables.hlsl"
 
 StructuredBuffer<uint> g_vLightListGlobal;      // don't support Buffer yet in unity
@@ -21,7 +21,6 @@ float g_fFarPlane;
 int g_iLog2NumClusters; // We need to always define these to keep constant buffer layouts compatible
 
 uint g_isLogBaseBufferEnabled;
-uint _UseTileLightList;
 //#endif
 
 //#ifdef USE_CLUSTERED_LIGHTLIST

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
@@ -84,10 +84,7 @@ uint FetchIndex(uint tileOffset, uint lightIndex)
 
 uint GetTileSize()
 {
-    if (_UseTileLightList)
-        return TILE_SIZE_FPTL;
-    else
-        return TILE_SIZE_CLUSTERED;
+    return TILE_SIZE_CLUSTERED;
 }
 
 void GetCountAndStartCluster(PositionInputs posInput, uint lightCategory, out uint start, out uint lightCount)
@@ -111,26 +108,12 @@ void GetCountAndStartCluster(PositionInputs posInput, uint lightCategory, out ui
 
 void GetCountAndStart(PositionInputs posInput, uint lightCategory, out uint start, out uint lightCount)
 {
-    if (_UseTileLightList)
-        GetCountAndStartTile(posInput, lightCategory, start, lightCount);
-    else
-        GetCountAndStartCluster(posInput, lightCategory, start, lightCount);
+    GetCountAndStartCluster(posInput, lightCategory, start, lightCount);
 }
 
 uint FetchIndex(uint tileOffset, uint lightIndex)
 {
-    uint offset = tileOffset + lightIndex;
-    const uint lightIndexPlusOne = lightIndex + 1; // Add +1 as first slot is reserved to store number of light
-
-    if (_UseTileLightList)
-        offset = DWORD_PER_TILE * tileOffset + (lightIndexPlusOne >> 1);
-
-    // Avoid generated HLSL bytecode to always access g_vLightListGlobal with
-    // two different offsets, fixes out of bounds issue
-    uint value = g_vLightListGlobal[offset];
-
-    // Light index are store on 16bit
-    return (_UseTileLightList ? ((value >> ((lightIndexPlusOne & 1) * DWORD_PER_TILE)) & 0xffff) : value);
+    return g_vLightListGlobal[tileOffset + lightIndex];
 }
 
 #endif // USE_FPTL_LIGHTLIST


### PR DESCRIPTION
This PR fix tile pass to use FPTL on opaque and cluster on transparent
- Clean selection code of the list in tilepass.hlsl
- Remove option and code to switch to opaque cluster

+ fix an issue with mono (clean code of multiple generated variant of deferredlighting matirial)