### PR TITLE
Update tile/cluster management for forward/deferred

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplay.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplay.cs
@@ -34,7 +34,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static string kFullScreenDebugMip = "Fullscreen Debug Mip";
         public static string kDisplaySkyReflectionDebug = "Display Sky Reflection";
         public static string kSkyReflectionMipmapDebug = "Sky Reflection Mipmap";
-        public static string kTileDebug = "Tile Debug By Category";
+        public static string kTileClusterCategoryDebug = "Tile/Cluster Debug By Category";
+        public static string kTileClusterDebug = "Tile/Cluster Debug";
 
 
         public float debugOverlayRatio = 0.33f;
@@ -156,7 +157,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, Color>(kDebugLightingAlbedo, () => lightingDebugSettings.debugLightingAlbedo, (value) => lightingDebugSettings.debugLightingAlbedo = (Color)value);
             DebugMenuManager.instance.AddDebugItem<bool>("Lighting", kDisplaySkyReflectionDebug, () => lightingDebugSettings.displaySkyReflection, (value) => lightingDebugSettings.displaySkyReflection = (bool)value);
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, float>(kSkyReflectionMipmapDebug, () => lightingDebugSettings.skyReflectionMipmap, (value) => lightingDebugSettings.skyReflectionMipmap = (float)value, DebugItemFlag.None, new DebugItemHandlerFloatMinMax(0.0f, 1.0f));
-            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, TilePass.TileSettings.TileDebug>(kTileDebug,() => lightingDebugSettings.tileDebugByCategory, (value) => lightingDebugSettings.tileDebugByCategory = (TilePass.TileSettings.TileDebug)value);
+            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, TilePass.TileSettings.TileClusterDebug>(kTileClusterDebug,() => lightingDebugSettings.tileClusterDebug, (value) => lightingDebugSettings.tileClusterDebug = (TilePass.TileSettings.TileClusterDebug)value);
+            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, TilePass.TileSettings.TileClusterCategoryDebug>(kTileClusterCategoryDebug,() => lightingDebugSettings.tileClusterDebugByCategory, (value) => lightingDebugSettings.tileClusterDebugByCategory = (TilePass.TileSettings.TileClusterCategoryDebug)value);
 
             DebugMenuManager.instance.AddDebugItem<bool>("Rendering", "Display Opaque",() => renderingDebugSettings.displayOpaqueObjects, (value) => renderingDebugSettings.displayOpaqueObjects = (bool)value);
             DebugMenuManager.instance.AddDebugItem<bool>("Rendering", "Display Transparency",() => renderingDebugSettings.displayTransparentObjects, (value) => renderingDebugSettings.displayTransparentObjects = (bool)value);
@@ -537,7 +539,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool                 displaySkyReflection = false;
         public float                skyReflectionMipmap = 0.0f;
 
-        public TilePass.TileSettings.TileDebug  tileDebugByCategory = TilePass.TileSettings.TileDebug.None;
+        public TilePass.TileSettings.TileClusterDebug tileClusterDebug = TilePass.TileSettings.TileClusterDebug.None;
+        public TilePass.TileSettings.TileClusterCategoryDebug tileClusterDebugByCategory = TilePass.TileSettings.TileClusterCategoryDebug.Punctual;   
 
         public void OnValidate()
         {

--- a/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugViewTiles.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugViewTiles.shader
@@ -6,6 +6,7 @@ Shader "Hidden/HDRenderPipeline/DebugViewTiles"
         Pass
         {
             ZWrite Off
+            ZTest Always
             Blend SrcAlpha OneMinusSrcAlpha
 
             HLSLPROGRAM

--- a/ScriptableRenderPipeline/HDRenderPipeline/Debug/LightingDebugPanel.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Debug/LightingDebugPanel.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using System;
 
 #if UNITY_EDITOR
@@ -114,8 +114,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         break;
                 }
 
-
-                m_DebugPanel.GetDebugItem(DebugDisplaySettings.kTileDebug).handler.OnEditorGUI();
+                DebugItem tileClusterDebug = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kTileClusterDebug);
+                tileClusterDebug.handler.OnEditorGUI();
+                if ((int)tileClusterDebug.GetValue() != 0 && (int)tileClusterDebug.GetValue() != 3) // None and FeatureVariant
+                {
+                    EditorGUI.indentLevel++;
+                    m_DebugPanel.GetDebugItem(DebugDisplaySettings.kTileClusterCategoryDebug).handler.OnEditorGUI();
+                    EditorGUI.indentLevel--;
+                }
 
                 DebugItem displaySkyReflecItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kDisplaySkyReflectionDebug);
                 displaySkyReflecItem.handler.OnEditorGUI();

--- a/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.Styles.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.Styles.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
@@ -38,8 +38,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public readonly GUIContent enableComputeLightEvaluation = new GUIContent("Compute Light Evaluation");
             public readonly GUIContent enableComputeLightVariants = new GUIContent("Compute Light Variants");
             public readonly GUIContent enableComputeMaterialVariants = new GUIContent("Compute Material Variants");
-            public readonly GUIContent enableClustered = new GUIContent("Clustered");
-            public readonly GUIContent enableFptlForOpaqueWhenClustered = new GUIContent("Fptl For Opaque When Clustered");
             public readonly GUIContent enableBigTilePrepass = new GUIContent("Big tile prepass");
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.Styles.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.Styles.cs
@@ -38,6 +38,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public readonly GUIContent enableComputeLightEvaluation = new GUIContent("Compute Light Evaluation");
             public readonly GUIContent enableComputeLightVariants = new GUIContent("Compute Light Variants");
             public readonly GUIContent enableComputeMaterialVariants = new GUIContent("Compute Material Variants");
+            public readonly GUIContent enableFptlForForwardOpaque = new GUIContent("Fptl for forward opaque");
             public readonly GUIContent enableBigTilePrepass = new GUIContent("Big tile prepass");
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
@@ -16,8 +16,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         SerializedProperty m_enableComputeLightEvaluation;
         SerializedProperty m_enableComputeLightVariants;
         SerializedProperty m_enableComputeMaterialVariants;
-        SerializedProperty m_enableClustered;
-        SerializedProperty m_enableFptlForOpaqueWhenClustered;
         SerializedProperty m_enableBigTilePrepass;
 
         // Rendering Settings
@@ -47,8 +45,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_enableComputeLightEvaluation = properties.Find(x => x.tileSettings.enableComputeLightEvaluation);
             m_enableComputeLightVariants = properties.Find(x => x.tileSettings.enableComputeLightVariants);
             m_enableComputeMaterialVariants = properties.Find(x => x.tileSettings.enableComputeMaterialVariants);
-            m_enableClustered = properties.Find(x => x.tileSettings.enableClustered);
-            m_enableFptlForOpaqueWhenClustered = properties.Find(x => x.tileSettings.enableFptlForOpaqueWhenClustered);
             m_enableBigTilePrepass = properties.Find(x => x.tileSettings.enableBigTilePrepass);
 
             // Shadow settings
@@ -90,22 +86,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(m_enableBigTilePrepass, s_Styles.enableBigTilePrepass);
-                EditorGUILayout.PropertyField(m_enableClustered, s_Styles.enableClustered);
 
-                // Tag: SUPPORT_COMPUTE_CLUSTER_OPAQUE - Uncomment this if you want to do cluster opaque with compute shader (by default we support only fptl on opaque)
-                // if (m_enableClustered.boolValue)
-                if (m_enableClustered.boolValue && !m_enableComputeLightEvaluation.boolValue)
-                {
-                    EditorGUI.indentLevel++;
-                    EditorGUILayout.PropertyField(m_enableFptlForOpaqueWhenClustered, s_Styles.enableFptlForOpaqueWhenClustered);
-                    EditorGUI.indentLevel--;
-                }
                 EditorGUILayout.PropertyField(m_enableComputeLightEvaluation, s_Styles.enableComputeLightEvaluation);
                 if (m_enableComputeLightEvaluation.boolValue)
                 {
-                    // Tag: SUPPORT_COMPUTE_CLUSTER_OPAQUE - Uncomment this if you want to do cluster opaque with compute shader (by default we support only fptl on opaque)
-                    m_enableFptlForOpaqueWhenClustered.boolValue = true; // Force fptl to be always true if compute evaluation is enable
-
                     EditorGUI.indentLevel++;
                     EditorGUILayout.PropertyField(m_enableComputeLightVariants, s_Styles.enableComputeLightVariants);
                     EditorGUILayout.PropertyField(m_enableComputeMaterialVariants, s_Styles.enableComputeMaterialVariants);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
@@ -16,6 +16,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         SerializedProperty m_enableComputeLightEvaluation;
         SerializedProperty m_enableComputeLightVariants;
         SerializedProperty m_enableComputeMaterialVariants;
+        SerializedProperty m_enableFptlForForwardOpaque;
         SerializedProperty m_enableBigTilePrepass;
 
         // Rendering Settings
@@ -45,6 +46,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_enableComputeLightEvaluation = properties.Find(x => x.tileSettings.enableComputeLightEvaluation);
             m_enableComputeLightVariants = properties.Find(x => x.tileSettings.enableComputeLightVariants);
             m_enableComputeMaterialVariants = properties.Find(x => x.tileSettings.enableComputeMaterialVariants);
+            m_enableFptlForForwardOpaque = properties.Find(x => x.tileSettings.enableFptlForForwardOpaque);
             m_enableBigTilePrepass = properties.Find(x => x.tileSettings.enableBigTilePrepass);
 
             // Shadow settings
@@ -86,6 +88,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(m_enableBigTilePrepass, s_Styles.enableBigTilePrepass);
+
+                // Allow to disable cluster for foward opaque when in forward only (option have no effect when MSAA is enabled)
+                // Deferred opaque are always tiled
+                EditorGUILayout.PropertyField(m_enableFptlForForwardOpaque, s_Styles.enableFptlForForwardOpaque);
 
                 EditorGUILayout.PropertyField(m_enableComputeLightEvaluation, s_Styles.enableComputeLightEvaluation);
                 if (m_enableComputeLightEvaluation.boolValue)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -385,7 +385,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Tile/Cluster", () => m_Asset.tileSettings.enableTileAndCluster, (value) => m_Asset.tileSettings.enableTileAndCluster = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Big Tile", () => m_Asset.tileSettings.enableBigTilePrepass, (value) => m_Asset.tileSettings.enableBigTilePrepass = (bool)value, DebugItemFlag.RuntimeOnly);
-            DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Cluster", () => m_Asset.tileSettings.enableClustered, (value) => m_Asset.tileSettings.enableClustered = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Compute Lighting", () => m_Asset.tileSettings.enableComputeLightEvaluation, (value) => m_Asset.tileSettings.enableComputeLightEvaluation = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Light Classification", () => m_Asset.tileSettings.enableComputeLightVariants, (value) => m_Asset.tileSettings.enableComputeLightVariants = (bool)value, DebugItemFlag.RuntimeOnly);
             DebugMenuManager.instance.AddDebugItem<bool>("HDRP", "Enable Material Classification", () => m_Asset.tileSettings.enableComputeMaterialVariants, (value) => m_Asset.tileSettings.enableComputeMaterialVariants = (bool)value, DebugItemFlag.RuntimeOnly);
@@ -879,7 +878,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
 
-                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings);
+                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, true);
 
                 RenderSky(hdCamera, cmd);
 
@@ -1345,9 +1344,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             return m_SkyManager.ExportSkyToTexture();
         }
 
-        void RenderLightingDebug(HDCamera camera, CommandBuffer cmd, RenderTargetIdentifier colorBuffer, DebugDisplaySettings debugDisplaySettings)
+        void RenderLightingDebug(HDCamera camera, CommandBuffer cmd, RenderTargetIdentifier colorBuffer, DebugDisplaySettings debugDisplaySettings, bool renderOpaque)
         {
-            m_LightLoop.RenderLightingDebug(camera, cmd, colorBuffer, debugDisplaySettings);
+            m_LightLoop.RenderLightingDebug(camera, cmd, colorBuffer, debugDisplaySettings, renderOpaque);
         }
 
         // Render forward is use for both transparent and opaque objects. In case of deferred we can still render opaque object in forward.

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -91,16 +91,16 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         static readonly string[] k_ForwardPassDebugName =
         {
-            "Forward Opaque Debug Display",
-            "Forward PreRefraction Debug Display",
-            "Forward Transparent Debug Display"
+            "Forward Opaque Debug",
+            "Forward PreRefraction Debug",
+            "Forward Transparent Debug"
         };
 
         static readonly string[] k_ForwardPassName =
         {
-            "Forward Opaque Display",
-            "Forward PreRefraction Display",
-            "Forward Transparent Display"
+            "Forward Opaque",
+            "Forward PreRefraction",
+            "Forward Transparent"
         };
 
         static readonly RenderQueueRange k_RenderQueue_PreRefraction = new RenderQueueRange { min = (int)HDRenderQueue.PreRefraction, max = (int)HDRenderQueue.Transparent - 1 };
@@ -353,7 +353,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             m_MaterialList.ForEach(material => material.Build(asset.renderPipelineResources));
 
-            m_LightLoop.Build(asset.renderPipelineResources, asset.tileSettings, asset.textureSettings, asset.shadowInitParams, m_ShadowSettings);
+            m_LightLoop.Build(asset.renderPipelineResources, asset.renderingSettings, asset.tileSettings, asset.textureSettings, asset.shadowInitParams, m_ShadowSettings);
 
             m_SkyManager.Build(asset.renderPipelineResources);
             m_SkyManager.skySettings = skySettingsToUse;
@@ -593,7 +593,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             // Currently, Unity does not offer a way to bind the stencil buffer as a texture in a compute shader.
             // Therefore, it's manually copied using a pixel shader.
-            return m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission || LightLoop.GetFeatureVariantsEnabled(m_Asset.tileSettings);
+            return m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission || m_LightLoop.GetFeatureVariantsEnabled();
         }
 
         bool NeedHTileCopy()

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -877,7 +877,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
-                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, true);
 
                 RenderSky(hdCamera, cmd);
 
@@ -893,7 +892,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Render all type of transparent forward (unlit, lit, complex (hair...)) to keep the sorting between transparent objects.
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Transparent);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Transparent);
-                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, false);
 
                 PushFullScreenDebugTexture(cmd, m_CameraColorBuffer, camera, renderContext, FullScreenDebugMode.NanTracker);
 
@@ -923,8 +921,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
             }
 
-            if (camera.cameraType != CameraType.Reflection)
-                RenderDebug(hdCamera, cmd);                          
+            RenderDebug(hdCamera, cmd);                
 
 #if UNITY_EDITOR
             // bind depth surface for editor grid/gizmo/selection rendering
@@ -1345,11 +1342,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             return m_SkyManager.ExportSkyToTexture();
         }
 
-        void RenderLightingDebug(HDCamera camera, CommandBuffer cmd, RenderTargetIdentifier colorBuffer, DebugDisplaySettings debugDisplaySettings, bool renderOpaque)
-        {
-            m_LightLoop.RenderLightingDebug(camera, cmd, colorBuffer, debugDisplaySettings, renderOpaque);
-        }
-
         // Render forward is use for both transparent and opaque objects. In case of deferred we can still render opaque object in forward.
         void RenderForward(CullResults cullResults, Camera camera, ScriptableRenderContext renderContext, CommandBuffer cmd, ForwardPass pass)
         {
@@ -1676,7 +1668,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     HDUtils.NextOverlayCoord(ref x, ref y, overlaySize, overlaySize, camera.camera.pixelWidth);
                 }
 
-                m_LightLoop.RenderDebugOverlay(camera.camera, cmd, m_CurrentDebugDisplaySettings, ref x, ref y, overlaySize, camera.camera.pixelWidth);
+                m_LightLoop.RenderDebugOverlay(camera, cmd, m_CurrentDebugDisplaySettings, ref x, ref y, overlaySize, camera.camera.pixelWidth);
             }
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -877,7 +877,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Opaque);
-
                 RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, true);
 
                 RenderSky(hdCamera, cmd);
@@ -894,6 +893,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Render all type of transparent forward (unlit, lit, complex (hair...)) to keep the sorting between transparent objects.
                 RenderForward(m_CullResults, camera, renderContext, cmd, ForwardPass.Transparent);
                 RenderForwardError(m_CullResults, camera, renderContext, cmd, ForwardPass.Transparent);
+                RenderLightingDebug(hdCamera, cmd, m_CameraColorBufferRT, m_CurrentDebugDisplaySettings, false);
 
                 PushFullScreenDebugTexture(cmd, m_CameraColorBuffer, camera, renderContext, FullScreenDebugMode.NanTracker);
 
@@ -923,7 +923,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
             }
 
-            RenderDebug(hdCamera, cmd);
+            if (camera.cameraType != CameraType.Reflection)
+                RenderDebug(hdCamera, cmd);                          
 
 #if UNITY_EDITOR
             // bind depth surface for editor grid/gizmo/selection rendering

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
@@ -42,7 +42,7 @@ Shader "Hidden/HDRenderPipeline/Deferred"
             #pragma multi_compile _ SHADOWS_SHADOWMASK
             #pragma multi_compile _ DEBUG_DISPLAY
 
-            #define USE_FPTL_LIGHTLIST // deferred (opaque) always use FPTL
+            #define USE_FPTL_LIGHTLIST // deferred opaque always use FPTL
 
             //-------------------------------------------------------------------------------------
             // Include

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Deferred.shader
@@ -36,12 +36,13 @@ Shader "Hidden/HDRenderPipeline/Deferred"
 
             // Chose supported lighting architecture in case of deferred rendering
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
-            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             // Split lighting is utilized during the SSS pass.
             #pragma multi_compile _ OUTPUT_SPLIT_LIGHTING
             #pragma multi_compile _ SHADOWS_SHADOWMASK
             #pragma multi_compile _ DEBUG_DISPLAY
+
+            #define USE_FPTL_LIGHTLIST // deferred (opaque) always use FPTL
 
             //-------------------------------------------------------------------------------------
             // Include

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Forward.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Forward.hlsl
@@ -2,12 +2,11 @@
 // Those that are control from inside the "Material".shader with "Pass" concept like forward lighting. Call later forward lighting architecture.
 // Those that are control outside the "Material".shader in a "Lighting".shader like deferred lighting. Call later deferred lighting architecture.
 
-// When dealing with deferred lighting architecture, the renderloop is in charge to call the correct .shader.
-// RenderLoop can do multiple call of various deferred lighting architecture.
+// When dealing with deferred lighting architecture, the renderPipeline is in charge to call the correct .shader.
+// renderPipeline can do multiple call of various deferred lighting architecture.
 // (Note: enabled variant for deferred lighting architecture are in deferred.shader)
-// When dealing with forward lighting architecture, the renderloop must specify a shader pass (like "forward") but it also need
+// When dealing with forward lighting architecture, the renderPipeline must specify a shader pass (like "forward") but it also need
 // to specify which variant of the forward lighting architecture he want (with cmd.EnableShaderKeyword()).
-// Renderloop can suppose dynamically switching from regular forward to tile forward for example within the same "Forward" pass.
 
 // The purpose of the following pragma is to define the variant available for "Forward" Pass in "Material".shader.
 // If only one keyword is present it mean that only one type of forward lighting architecture is supported.
@@ -15,5 +14,9 @@
 // Must match name in GetKeyword() method of forward lighting architecture .cs file
 // #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS -> can't use a pragma from include... (for now)
 
-// No USE_FPTL_LIGHTLIST as we are in forward and this use the cluster path (but cluster path can use the tile light list for opaque)
+// Forward transparent surface use clustering, forward opaque use FPTL
+#ifdef _SURFACE_TYPE_TRANSPARENT
 #define USE_CLUSTERED_LIGHTLIST
+#else
+#define USE_FPTL_LIGHTLIST
+#endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Forward.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Forward.hlsl
@@ -13,10 +13,6 @@
 
 // Must match name in GetKeyword() method of forward lighting architecture .cs file
 // #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS -> can't use a pragma from include... (for now)
-
-// Forward transparent surface use clustering, forward opaque use FPTL
-#ifdef _SURFACE_TYPE_TRANSPARENT
-#define USE_CLUSTERED_LIGHTLIST
-#else
-#define USE_FPTL_LIGHTLIST
-#endif
+// For forward transparent are always cluster and opaque can be either cluster or fptl (sadly we have no to do multicompile only if opaque)
+// Moreover, we would like to do it only for LIGHTLOOP_TILE_PASS variant...
+// #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
@@ -1,66 +1,68 @@
-#pragma kernel Deferred_Direct_Fptl                                 SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl                                USE_FPTL_LIGHTLIST
-#pragma kernel Deferred_Direct_Fptl_DebugDisplay                    SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl_DebugDisplay                   USE_FPTL_LIGHTLIST          DEBUG_DISPLAY
-#pragma kernel Deferred_Direct_ShadowMask_Fptl                     SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl                    USE_FPTL_LIGHTLIST          SHADOWS_SHADOWMASK
-#pragma kernel Deferred_Direct_ShadowMask_Fptl_DebugDisplay        SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl_DebugDisplay       USE_FPTL_LIGHTLIST          SHADOWS_SHADOWMASK  DEBUG_DISPLAY
+#pragma kernel Deferred_Direct_Fptl                                SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl
+#pragma kernel Deferred_Direct_Fptl_DebugDisplay                   SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl_DebugDisplay             DEBUG_DISPLAY
+#pragma kernel Deferred_Direct_ShadowMask_Fptl                     SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl               SHADOWS_SHADOWMASK
+#pragma kernel Deferred_Direct_ShadowMask_Fptl_DebugDisplay        SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl_DebugDisplay  SHADOWS_SHADOWMASK  DEBUG_DISPLAY
 
 // Variant with and without shadowmask
-#pragma kernel Deferred_Indirect_Fptl_Variant0      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant0      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=0
-#pragma kernel Deferred_Indirect_Fptl_Variant1      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant1      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=1
-#pragma kernel Deferred_Indirect_Fptl_Variant2      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant2      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=2
-#pragma kernel Deferred_Indirect_Fptl_Variant3      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant3      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=3
-#pragma kernel Deferred_Indirect_Fptl_Variant4      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant4      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=4
-#pragma kernel Deferred_Indirect_Fptl_Variant5      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant5      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=5
-#pragma kernel Deferred_Indirect_Fptl_Variant6      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant6      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=6
-#pragma kernel Deferred_Indirect_Fptl_Variant7      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant7      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=7
-#pragma kernel Deferred_Indirect_Fptl_Variant8      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant8      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=8
-#pragma kernel Deferred_Indirect_Fptl_Variant9      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant9      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=9
-#pragma kernel Deferred_Indirect_Fptl_Variant10     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant10     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=10
-#pragma kernel Deferred_Indirect_Fptl_Variant11     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant11     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=11
-#pragma kernel Deferred_Indirect_Fptl_Variant12     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant12     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=12
-#pragma kernel Deferred_Indirect_Fptl_Variant13     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant13     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=13
-#pragma kernel Deferred_Indirect_Fptl_Variant14     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant14     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=14
-#pragma kernel Deferred_Indirect_Fptl_Variant15     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant15     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=15
-#pragma kernel Deferred_Indirect_Fptl_Variant16     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant16     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=16
-#pragma kernel Deferred_Indirect_Fptl_Variant17     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant17     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=17
-#pragma kernel Deferred_Indirect_Fptl_Variant18     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant18     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=18
-#pragma kernel Deferred_Indirect_Fptl_Variant19     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant19     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=19
-#pragma kernel Deferred_Indirect_Fptl_Variant20     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant20     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=20
-#pragma kernel Deferred_Indirect_Fptl_Variant21     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant21     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=21
-#pragma kernel Deferred_Indirect_Fptl_Variant22     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant22     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=22
-#pragma kernel Deferred_Indirect_Fptl_Variant23     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant23     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=23
-#pragma kernel Deferred_Indirect_Fptl_Variant24     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant24     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=24
-#pragma kernel Deferred_Indirect_Fptl_Variant25     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant25     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=25
-#pragma kernel Deferred_Indirect_Fptl_Variant26     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant26     USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=26
+#pragma kernel Deferred_Indirect_Fptl_Variant0      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant0      USE_INDIRECT    VARIANT=0
+#pragma kernel Deferred_Indirect_Fptl_Variant1      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant1      USE_INDIRECT    VARIANT=1
+#pragma kernel Deferred_Indirect_Fptl_Variant2      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant2      USE_INDIRECT    VARIANT=2
+#pragma kernel Deferred_Indirect_Fptl_Variant3      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant3      USE_INDIRECT    VARIANT=3
+#pragma kernel Deferred_Indirect_Fptl_Variant4      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant4      USE_INDIRECT    VARIANT=4
+#pragma kernel Deferred_Indirect_Fptl_Variant5      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant5      USE_INDIRECT    VARIANT=5
+#pragma kernel Deferred_Indirect_Fptl_Variant6      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant6      USE_INDIRECT    VARIANT=6
+#pragma kernel Deferred_Indirect_Fptl_Variant7      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant7      USE_INDIRECT    VARIANT=7
+#pragma kernel Deferred_Indirect_Fptl_Variant8      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant8      USE_INDIRECT    VARIANT=8
+#pragma kernel Deferred_Indirect_Fptl_Variant9      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant9      USE_INDIRECT    VARIANT=9
+#pragma kernel Deferred_Indirect_Fptl_Variant10     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant10     USE_INDIRECT    VARIANT=10
+#pragma kernel Deferred_Indirect_Fptl_Variant11     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant11     USE_INDIRECT    VARIANT=11
+#pragma kernel Deferred_Indirect_Fptl_Variant12     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant12     USE_INDIRECT    VARIANT=12
+#pragma kernel Deferred_Indirect_Fptl_Variant13     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant13     USE_INDIRECT    VARIANT=13
+#pragma kernel Deferred_Indirect_Fptl_Variant14     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant14     USE_INDIRECT    VARIANT=14
+#pragma kernel Deferred_Indirect_Fptl_Variant15     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant15     USE_INDIRECT    VARIANT=15
+#pragma kernel Deferred_Indirect_Fptl_Variant16     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant16     USE_INDIRECT    VARIANT=16
+#pragma kernel Deferred_Indirect_Fptl_Variant17     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant17     USE_INDIRECT    VARIANT=17
+#pragma kernel Deferred_Indirect_Fptl_Variant18     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant18     USE_INDIRECT    VARIANT=18
+#pragma kernel Deferred_Indirect_Fptl_Variant19     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant19     USE_INDIRECT    VARIANT=19
+#pragma kernel Deferred_Indirect_Fptl_Variant20     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant20     USE_INDIRECT    VARIANT=20
+#pragma kernel Deferred_Indirect_Fptl_Variant21     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant21     USE_INDIRECT    VARIANT=21
+#pragma kernel Deferred_Indirect_Fptl_Variant22     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant22     USE_INDIRECT    VARIANT=22
+#pragma kernel Deferred_Indirect_Fptl_Variant23     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant23     USE_INDIRECT    VARIANT=23
+#pragma kernel Deferred_Indirect_Fptl_Variant24     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant24     USE_INDIRECT    VARIANT=24
+#pragma kernel Deferred_Indirect_Fptl_Variant25     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant25     USE_INDIRECT    VARIANT=25
+#pragma kernel Deferred_Indirect_Fptl_Variant26     SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant26     USE_INDIRECT    VARIANT=26
 
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant0       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant0       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=0
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant1       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant1       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=1
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant2       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant2       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=2
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant3       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant3       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=3
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant4       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant4       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=4
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant5       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant5       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=5
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant6       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant6       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=6
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant7       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant7       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=7
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant8       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant8       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=8
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant9       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant9       USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=9
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant10      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant10      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=10
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant11      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant11      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=11
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant12      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant12      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=12
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant13      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant13      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=13
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant14      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant14      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=14
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant15      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant15      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=15
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant16      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant16      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=16
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant17      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant17      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=17
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant18      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant18      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=18
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant19      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant19      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=19
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant20      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant20      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=20
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant21      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant21      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=21
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant22      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant22      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=22
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant23      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant23      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=23
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant24      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant24      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=24
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant25      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant25      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=25
-#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant26      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant26      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=26
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant0       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant0       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=0
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant1       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant1       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=1
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant2       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant2       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=2
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant3       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant3       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=3
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant4       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant4       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=4
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant5       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant5       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=5
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant6       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant6       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=6
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant7       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant7       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=7
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant8       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant8       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=8
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant9       SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant9       USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=9
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant10      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant10      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=10
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant11      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant11      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=11
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant12      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant12      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=12
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant13      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant13      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=13
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant14      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant14      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=14
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant15      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant15      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=15
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant16      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant16      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=16
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant17      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant17      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=17
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant18      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant18      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=18
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant19      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant19      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=19
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant20      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant20      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=20
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant21      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant21      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=21
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant22      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant22      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=22
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant23      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant23      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=23
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant24      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant24      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=24
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant25      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant25      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=25
+#pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant26      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant26      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=26
 
 #define LIGHTLOOP_TILE_PASS 1
+// deferred opaque always use FPTL
+#define USE_FPTL_LIGHTLIST 1
 
 //#pragma enable_d3d11_debug_symbols
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/Deferred.compute
@@ -2,10 +2,6 @@
 #pragma kernel Deferred_Direct_Fptl_DebugDisplay                    SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl_DebugDisplay                   USE_FPTL_LIGHTLIST          DEBUG_DISPLAY
 #pragma kernel Deferred_Direct_ShadowMask_Fptl                     SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl                    USE_FPTL_LIGHTLIST          SHADOWS_SHADOWMASK
 #pragma kernel Deferred_Direct_ShadowMask_Fptl_DebugDisplay        SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl_DebugDisplay       USE_FPTL_LIGHTLIST          SHADOWS_SHADOWMASK  DEBUG_DISPLAY
-#pragma kernel Deferred_Direct_Clustered                            SHADE_OPAQUE_ENTRY=Deferred_Direct_Clustered                           USE_CLUSTERED_LIGHTLIST
-#pragma kernel Deferred_Direct_Clustered_DebugDisplay               SHADE_OPAQUE_ENTRY=Deferred_Direct_Clustered_DebugDisplay              USE_CLUSTERED_LIGHTLIST     DEBUG_DISPLAY
-#pragma kernel Deferred_Direct_ShadowMask_Clustered                SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Clustered               USE_CLUSTERED_LIGHTLIST     SHADOWS_SHADOWMASK
-#pragma kernel Deferred_Direct_ShadowMask_Clustered_DebugDisplay   SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Clustered_DebugDisplay  USE_CLUSTERED_LIGHTLIST     SHADOWS_SHADOWMASK  DEBUG_DISPLAY
 
 // Variant with and without shadowmask
 #pragma kernel Deferred_Indirect_Fptl_Variant0      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant0      USE_FPTL_LIGHTLIST      USE_INDIRECT    VARIANT=0
@@ -63,36 +59,6 @@
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant24      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant24      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=24
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant25      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant25      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=25
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant26      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant26      USE_FPTL_LIGHTLIST      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=26
-
-/* Tag: SUPPORT_COMPUTE_CLUSTER_OPAQUE - Uncomment this if you want to do cluster opaque with compute shader (by default we support only fptl on opaque)
-#pragma kernel Deferred_Indirect_Clustered_Variant0          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant0              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=0
-#pragma kernel Deferred_Indirect_Clustered_Variant1          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant1              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=1
-#pragma kernel Deferred_Indirect_Clustered_Variant2          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant2              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=2
-#pragma kernel Deferred_Indirect_Clustered_Variant3          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant3              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=3
-#pragma kernel Deferred_Indirect_Clustered_Variant4          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant4              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=4
-#pragma kernel Deferred_Indirect_Clustered_Variant5          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant5              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=5
-#pragma kernel Deferred_Indirect_Clustered_Variant6          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant6              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=6
-#pragma kernel Deferred_Indirect_Clustered_Variant7          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant7              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=7
-#pragma kernel Deferred_Indirect_Clustered_Variant8          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant8              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=8
-#pragma kernel Deferred_Indirect_Clustered_Variant9          SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant9              USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=9
-#pragma kernel Deferred_Indirect_Clustered_Variant10         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant10             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=10
-#pragma kernel Deferred_Indirect_Clustered_Variant11         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant11             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=11
-#pragma kernel Deferred_Indirect_Clustered_Variant12         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant12             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=12
-#pragma kernel Deferred_Indirect_Clustered_Variant13         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant13             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=13
-#pragma kernel Deferred_Indirect_Clustered_Variant14         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant14             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=14
-#pragma kernel Deferred_Indirect_Clustered_Variant15         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant15             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=15
-#pragma kernel Deferred_Indirect_Clustered_Variant16         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant16             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=16
-#pragma kernel Deferred_Indirect_Clustered_Variant17         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant17             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=17
-#pragma kernel Deferred_Indirect_Clustered_Variant18         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant18             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=18
-#pragma kernel Deferred_Indirect_Clustered_Variant19         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant19             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=19
-#pragma kernel Deferred_Indirect_Clustered_Variant20         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant20             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=20
-#pragma kernel Deferred_Indirect_Clustered_Variant21         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant21             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=21
-#pragma kernel Deferred_Indirect_Clustered_Variant22         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant22             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=22
-#pragma kernel Deferred_Indirect_Clustered_Variant23         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant23             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=23
-#pragma kernel Deferred_Indirect_Clustered_Variant24         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant24             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=24
-#pragma kernel Deferred_Indirect_Clustered_Variant25         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant25             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=25
-#pragma kernel Deferred_Indirect_Clustered_Variant26         SHADE_OPAQUE_ENTRY=Deferred_Indirect_Clustered_Variant26             USE_CLUSTERED_LIGHTLIST     USE_INDIRECT    VARIANT=26
-*/
 
 #define LIGHTLOOP_TILE_PASS 1
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.hlsl
@@ -1,4 +1,4 @@
-﻿#include "TilePass.cs.hlsl"
+#include "TilePass.cs.hlsl"
 #include "../../Sky/SkyVariables.hlsl"
 
 StructuredBuffer<uint> g_vLightListGlobal;      // don't support Buffer yet in unity
@@ -21,7 +21,6 @@ float g_fFarPlane;
 int g_iLog2NumClusters; // We need to always define these to keep constant buffer layouts compatible
 
 uint g_isLogBaseBufferEnabled;
-uint _UseTileLightList;
 //#endif
 
 //#ifdef USE_CLUSTERED_LIGHTLIST

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
@@ -84,10 +84,7 @@ uint FetchIndex(uint tileOffset, uint lightIndex)
 
 uint GetTileSize()
 {
-    if (_UseTileLightList)
-        return TILE_SIZE_FPTL;
-    else
-        return TILE_SIZE_CLUSTERED;
+    return TILE_SIZE_CLUSTERED;
 }
 
 void GetCountAndStartCluster(PositionInputs posInput, uint lightCategory, out uint start, out uint lightCount)
@@ -111,26 +108,12 @@ void GetCountAndStartCluster(PositionInputs posInput, uint lightCategory, out ui
 
 void GetCountAndStart(PositionInputs posInput, uint lightCategory, out uint start, out uint lightCount)
 {
-    if (_UseTileLightList)
-        GetCountAndStartTile(posInput, lightCategory, start, lightCount);
-    else
-        GetCountAndStartCluster(posInput, lightCategory, start, lightCount);
+    GetCountAndStartCluster(posInput, lightCategory, start, lightCount);
 }
 
 uint FetchIndex(uint tileOffset, uint lightIndex)
 {
-    uint offset = tileOffset + lightIndex;
-    const uint lightIndexPlusOne = lightIndex + 1; // Add +1 as first slot is reserved to store number of light
-
-    if (_UseTileLightList)
-        offset = DWORD_PER_TILE * tileOffset + (lightIndexPlusOne >> 1);
-
-    // Avoid generated HLSL bytecode to always access g_vLightListGlobal with
-    // two different offsets, fixes out of bounds issue
-    uint value = g_vLightListGlobal[offset];
-
-    // Light index are store on 16bit
-    return (_UseTileLightList ? ((value >> ((lightIndexPlusOne & 1) * DWORD_PER_TILE)) & 0xffff) : value);
+    return g_vLightListGlobal[tileOffset + lightIndex];
 }
 
 #endif // USE_FPTL_LIGHTLIST

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -648,11 +648,12 @@ Shader "HDRenderPipeline/LayeredLit"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define SHADERPASS SHADERPASS_FORWARD
-            #include "../../ShaderVariables.hlsl"
-            #include "../../Lighting/Forward.hlsl"
+            #include "../../ShaderVariables.hlsl"          
             #include "../../Lighting/Lighting.hlsl"
             #include "../Lit/ShaderPass/LitSharePass.hlsl"
             #include "LayeredLitData.hlsl"
@@ -676,13 +677,14 @@ Shader "HDRenderPipeline/LayeredLit"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define DEBUG_DISPLAY
             #define SHADERPASS SHADERPASS_FORWARD
             #include "../../ShaderVariables.hlsl"
             #include "../../Debug/DebugDisplay.hlsl"
-            #include "../../Lighting/Forward.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "../Lit/ShaderPass/LitSharePass.hlsl"
             #include "LayeredLitData.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -687,11 +687,12 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define SHADERPASS SHADERPASS_FORWARD
             #include "../../ShaderVariables.hlsl"
-            #include "../../Lighting/Forward.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "../Lit/ShaderPass/LitSharePass.hlsl"
             #include "LayeredLitData.hlsl"
@@ -718,13 +719,14 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define DEBUG_DISPLAY
             #define SHADERPASS SHADERPASS_FORWARD
             #include "../../ShaderVariables.hlsl"
             #include "../../Debug/DebugDisplay.hlsl"
-            #include "../../Lighting/Forward.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "../Lit/ShaderPass/LitSharePass.hlsl"
             #include "LayeredLitData.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -469,11 +469,12 @@ Shader "HDRenderPipeline/Lit"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define SHADERPASS SHADERPASS_FORWARD
             #include "../../ShaderVariables.hlsl"
-            #include "../../Lighting/Forward.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "ShaderPass/LitSharePass.hlsl"
             #include "LitData.hlsl"
@@ -497,13 +498,14 @@ Shader "HDRenderPipeline/Lit"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define DEBUG_DISPLAY
             #define SHADERPASS SHADERPASS_FORWARD
             #include "../../ShaderVariables.hlsl"
             #include "../../Debug/DebugDisplay.hlsl"
-            #include "../../Lighting/Forward.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "ShaderPass/LitSharePass.hlsl"
             #include "LitData.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -512,11 +512,12 @@ Shader "HDRenderPipeline/LitTessellation"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define SHADERPASS SHADERPASS_FORWARD
             #include "../../ShaderVariables.hlsl"
-            #include "../../Lighting/Forward.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "ShaderPass/LitSharePass.hlsl"
             #include "LitData.hlsl"
@@ -543,13 +544,14 @@ Shader "HDRenderPipeline/LitTessellation"
             #pragma multi_compile DIRLIGHTMAP_OFF DIRLIGHTMAP_COMBINED
             #pragma multi_compile DYNAMICLIGHTMAP_OFF DYNAMICLIGHTMAP_ON
             #pragma multi_compile _ SHADOWS_SHADOWMASK
+            // #include "../../Lighting/Forward.hlsl"
             #pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define DEBUG_DISPLAY
             #define SHADERPASS SHADERPASS_FORWARD
             #include "../../ShaderVariables.hlsl"
             #include "../../Debug/DebugDisplay.hlsl"
-            #include "../../Lighting/Forward.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "ShaderPass/LitSharePass.hlsl"
             #include "LitData.hlsl"


### PR DESCRIPTION
This PR change the current behavior to:
- Deferred opaque always use tile
- Forward opaque can use tile or cluster (create a forward keyword for this case)
- Forward transparent use cluster
- Prepare code to handle MSAA case. With MSAA we only enabled cluster. MSAA is only supported in forward (which allow to remove all the cluster variant from deferred.compute)
- Remove enable Cluster option (cluster is always enabled whatever the settings)

Refactor the code that manage variant of m_lightingMaterial (rename m_deferredlightingMaterial) in TilePass to work correctly with Mono (was causing a crash)

Refactor the code of RenderLightingDebug, move it to RenderDebugOverlay

Update the debug view mode to allow to display either tile or cluster debug (note that cluster debug is only for opaque for now)

