### PR TITLE
Remove multiply blendmode

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -381,7 +381,7 @@ Shader "HDRenderPipeline/LayeredLit"
 
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
-    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_MULTIPLY _BLENDMODE_PRE_MULTIPLY
+    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature _BLENDMODE_PRESERVE_SPECULAR_LIGHTING
     #pragma shader_feature _ENABLE_FOG_ON_TRANSPARENT
 
@@ -653,7 +653,7 @@ Shader "HDRenderPipeline/LayeredLit"
             #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
 
             #define SHADERPASS SHADERPASS_FORWARD
-            #include "../../ShaderVariables.hlsl"          
+            #include "../../ShaderVariables.hlsl"
             #include "../../Lighting/Lighting.hlsl"
             #include "../Lit/ShaderPass/LitSharePass.hlsl"
             #include "LayeredLitData.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -391,7 +391,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
 
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
-    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_MULTIPLY _BLENDMODE_PRE_MULTIPLY
+    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature _BLENDMODE_PRESERVE_SPECULAR_LIGHTING
     #pragma shader_feature _ENABLE_FOG_ON_TRANSPARENT
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -195,7 +195,7 @@ Shader "HDRenderPipeline/Lit"
 
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
-    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_MULTIPLY _BLENDMODE_PRE_MULTIPLY
+    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature _BLENDMODE_PRESERVE_SPECULAR_LIGHTING
     #pragma shader_feature _ENABLE_FOG_ON_TRANSPARENT
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -207,7 +207,7 @@ Shader "HDRenderPipeline/LitTessellation"
 
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
-    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_MULTIPLY _BLENDMODE_PRE_MULTIPLY
+    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature _BLENDMODE_PRESERVE_SPECULAR_LIGHTING
     #pragma shader_feature _ENABLE_FOG_ON_TRANSPARENT
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Material.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Material.hlsl
@@ -15,7 +15,7 @@
 // There is a set of Material Keyword that a HD shaders must define (or not define). We call them system KeyWord.
 // .Shader need to define:
 // - _SURFACE_TYPE_TRANSPARENT if they use a transparent material
-// - _BLENDMODE_ALPHA, _BLENDMODE_ADD, _BLENDMODE_MULTIPLY, _BLENDMODE_PRE_MULTIPLY for blend mode
+// - _BLENDMODE_ALPHA, _BLENDMODE_ADD, _BLENDMODE_PRE_MULTIPLY for blend mode
 // - _BLENDMODE_PRESERVE_SPECULAR_LIGHTING for correct lighting when blend mode are use with a Lit material
 // - _ENABLE_FOG_ON_TRANSPARENT if fog is enable on transparent surface
 
@@ -35,13 +35,13 @@ float4 ApplyBlendMode(float3 diffuseLighting, float3 specularLighting, float opa
     // However this have precision issue when reaching 0, so we change the blend mode and apply src * src_a inside the shader instead
     #if defined(_BLENDMODE_ADD) || defined(_BLENDMODE_ALPHA)
     return float4(diffuseLighting * opacity + specularLighting, opacity);
-    #else // defined(_BLENDMODE_MULTIPLY) || defined(_BLENDMODE_PRE_MULTIPLY)
+    #else // defined(_BLENDMODE_PRE_MULTIPLY)
     return float4(diffuseLighting + specularLighting, opacity);
     #endif
 #else
     #if defined(_BLENDMODE_ADD) || defined(_BLENDMODE_ALPHA)
     return float4((diffuseLighting + specularLighting) * opacity, opacity);
-    #else // defined(_BLENDMODE_MULTIPLY) || defined(_BLENDMODE_PRE_MULTIPLY)
+    #else // defined(_BLENDMODE_PRE_MULTIPLY)
     return float4(diffuseLighting + specularLighting, opacity);
     #endif
 #endif
@@ -71,9 +71,6 @@ float4 EvaluateAtmosphericScattering(PositionInputs posInput, float4 inputColor)
     #elif defined(_BLENDMODE_ADD)
     // For additive, we just need to fade to black with fog density (black + background == background color == fog color)
     result.rgb = result.rgb * (1.0 - fog.a);
-    #elif defined(_BLENDMODE_MULTIPLY)
-    // For multiplicative, we just need to fade to white with fog density (white * background == background color == fog color)
-    result.rgb = lerp(result.rgb, float3(1.0, 1.0, 1.0), fog.a);
     #elif defined(_BLENDMODE_PRE_MULTIPLY)
     // For Pre-Multiplied Alpha Blend, we need to multiply fog color by src alpha to match regular alpha blending formula.
     result.rgb = lerp(result.rgb, fog.rgb * result.a, fog.a);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
@@ -349,13 +349,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                             material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.One);
                             break;
 
-                        // Multiplicative
-                        // color: src * dst
-                        case BlendMode.Multiplicative:
-                            material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.DstColor);
-                            material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                            break;
-
                         // PremultipliedAlpha
                         // color: src * src_a + dst * (1 - src_a)
                         // src is supposed to have been multiplied by alpha in the texture on artists side.

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
@@ -56,7 +56,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             Alpha = 0,
             Additive = 1,
-            Multiplicative = 3,
             PremultipliedAlpha = 4
         }
 
@@ -107,7 +106,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kEnableFogOnTransparent = "_EnableFogOnTransparent";
         protected MaterialProperty enableBlendModePreserveSpecularLighting = null;
         protected const string kEnableBlendModePreserveSpecularLighting = "_EnableBlendModePreserveSpecularLighting";
-        
+
 
         // See comment in LitProperties.hlsl
         const string kEmissionColor = "_EmissionColor";
@@ -153,7 +152,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             preRefractionPass = FindProperty(kPreRefractionPass, props, false);
 
             enableFogOnTransparent = FindProperty(kEnableFogOnTransparent, props, false);
-            enableBlendModePreserveSpecularLighting = FindProperty(kEnableBlendModePreserveSpecularLighting, props, false);            
+            enableBlendModePreserveSpecularLighting = FindProperty(kEnableBlendModePreserveSpecularLighting, props, false);
         }
 
         void SurfaceTypePopup()
@@ -307,7 +306,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // These need to always been set either with opaque or transparent! So a users can switch to opaque and remove the keyword correctly
             SetKeyword(material, "_BLENDMODE_ALPHA", false);
             SetKeyword(material, "_BLENDMODE_ADD", false);
-            SetKeyword(material, "_BLENDMODE_MULTIPLY", false);
             SetKeyword(material, "_BLENDMODE_PRE_MULTIPLY", false);
 
             if (surfaceType == SurfaceType.Opaque)
@@ -331,7 +329,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
                     SetKeyword(material, "_BLENDMODE_ALPHA", BlendMode.Alpha == blendMode);
                     SetKeyword(material, "_BLENDMODE_ADD", BlendMode.Additive == blendMode);
-                    SetKeyword(material, "_BLENDMODE_MULTIPLY", BlendMode.Multiplicative == blendMode);
                     SetKeyword(material, "_BLENDMODE_PRE_MULTIPLY", BlendMode.PremultipliedAlpha == blendMode);
 
                     switch (blendMode)

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
@@ -50,7 +50,7 @@ Shader "HDRenderPipeline/Unlit"
         // In our case we don't use such a mechanism but need to keep the code quiet. We declare the value and always enable it.
         // TODO: Fix the code in legacy unity so we can customize the beahvior for GI
         _EmissionColor("Color", Color) = (1, 1, 1)
-        
+
         // HACK: GI Baking system relies on some properties existing in the shader ("_MainTex", "_Cutoff" and "_Color") for opacity handling, so we need to store our version of those parameters in the hard-coded name the GI baking system recognizes.
         _MainTex("Albedo", 2D) = "white" {}
         _Color("Color", Color) = (1,1,1,1)
@@ -74,7 +74,7 @@ Shader "HDRenderPipeline/Unlit"
 
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
-    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_MULTIPLY _BLENDMODE_PRE_MULTIPLY
+    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature _ENABLE_FOG_ON_TRANSPARENT
 
     //-------------------------------------------------------------------------------------

--- a/Tests/GraphicsTests/RenderPipeline/LightweightPipeline/Scenes/037_Particles/Scripts.meta
+++ b/Tests/GraphicsTests/RenderPipeline/LightweightPipeline/Scenes/037_Particles/Scripts.meta
@@ -1,8 +1,6 @@
 fileFormatVersion: 2
-guid: e475c42352524461ca0371d90bbca97f
+guid: c6fe8859c4c681d428c024202d9f27b4
 folderAsset: yes
-timeCreated: 1509363645
-licenseType: Pro
 DefaultImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
- Multiply make it easy to do mistake (inf, negative number, NaN) and
prevent optimization like half res rendering or offscreen compositing