### PR TITLE
metal fixes

### DIFF
--- a/ScriptableRenderPipeline/Core/Shadow/Resources/DebugDisplayShadowMap.shader
+++ b/ScriptableRenderPipeline/Core/Shadow/Resources/DebugDisplayShadowMap.shader
@@ -2,7 +2,7 @@ Shader "Hidden/ScriptableRenderPipeline/DebugDisplayShadowMap"
 {
     HLSLINCLUDE
         #pragma target 4.5
-        #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: unitl we go futher in dev
+        #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
 
         #include "../../../Core/ShaderLibrary/Common.hlsl"
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplayLatlong.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplayLatlong.shader
@@ -11,7 +11,7 @@ Shader "Hidden/HDRenderPipeline/DebugDisplayLatlong"
 
             HLSLPROGRAM
             #pragma target 4.5
-            #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: unitl we go futher in dev
+            #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
 
             #pragma vertex Vert
             #pragma fragment Frag

--- a/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugFullScreen.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugFullScreen.shader
@@ -11,7 +11,7 @@ Shader "Hidden/HDRenderPipeline/DebugFullScreen"
 
             HLSLPROGRAM
             #pragma target 4.5
-            #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: unitl we go futher in dev
+            #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
 
             #pragma vertex Vert
             #pragma fragment Frag

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -304,6 +304,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             static ComputeBuffer s_shadowDatas = null;
 
             static Texture2DArray m_DefaultTexture2DArray;
+            static Cubemap m_DefaultTextureCube;
 
             TextureCacheCubemap m_CubeReflTexArray;
             int m_CubeReflTexArraySize = 128;
@@ -596,6 +597,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_DefaultTexture2DArray = new Texture2DArray(1, 1, 1, TextureFormat.ARGB32, false);
                 m_DefaultTexture2DArray.SetPixels32(new Color32[1] { new Color32(128, 128, 128, 128) }, 0);
                 m_DefaultTexture2DArray.Apply();
+
+                m_DefaultTextureCube = new Cubemap(16, TextureFormat.ARGB32, false);
+                m_DefaultTextureCube.Apply();
 
 #if UNITY_EDITOR
                 UnityEditor.SceneView.onSceneGUIDelegate -= OnSceneGUI;
@@ -1993,7 +1997,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs.diffuseLightingUAV,  colorBuffers[1]);
 
                             // TODO: Check if we can remove this, when I test I can't
-                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._SkyTexture, skyTexture);
+                            cmd.SetComputeTextureParam(deferredComputeShader, kernel, HDShaderIDs._SkyTexture, skyTexture ? skyTexture : m_DefaultTextureCube);
                             cmd.SetComputeFloatParam(deferredComputeShader, HDShaderIDs._SkyTextureMipCount, skyTextureMipCount);
 
                             // always do deferred lighting in blocks of 16x16 (not same as tiled light size)

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -326,7 +326,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
     HLSLINCLUDE
 
     #pragma target 5.0
-    #pragma only_renderers d3d11 ps4 vulkan // TEMP: until we go further in dev
+    #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
     // #pragma enable_d3d11_debug_symbols
 
     #pragma shader_feature _ALPHATEST_ON

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -158,7 +158,7 @@ Shader "HDRenderPipeline/Lit"
     HLSLINCLUDE
 
     #pragma target 4.5
-    #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go futher in dev
+    #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
     //#pragma enable_d3d11_debug_symbols
 
     //-------------------------------------------------------------------------------------

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -169,7 +169,7 @@ Shader "HDRenderPipeline/LitTessellation"
     HLSLINCLUDE
 
     #pragma target 5.0
-    #pragma only_renderers d3d11 ps4 vulkan// TEMP: until we go futher in dev
+    #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
     // #pragma enable_d3d11_debug_symbols
 
     //-------------------------------------------------------------------------------------

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Unlit.shader
@@ -60,7 +60,7 @@ Shader "HDRenderPipeline/Unlit"
     HLSLINCLUDE
 
     #pragma target 4.5
-    #pragma only_renderers d3d11 ps4 vulkan metal  // TEMP: until we go further in dev
+    #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
     //#pragma enable_d3d11_debug_symbols
 
     //-------------------------------------------------------------------------------------

--- a/ScriptableRenderPipeline/HDRenderPipeline/Sky/BlacksmithlSky/Resources/SkyBlacksmith.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Sky/BlacksmithlSky/Resources/SkyBlacksmith.shader
@@ -11,7 +11,7 @@ Shader "Hidden/HDRenderPipeline/Sky/SkyBlacksmith"
 
             HLSLPROGRAM
             #pragma target 4.5
-            #pragma only_renderers d3d11 ps4 vulkan metal  // TEMP: until we go further in dev
+            #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
 
             #pragma vertex Vert
             #pragma fragment Frag

--- a/ScriptableRenderPipeline/HDRenderPipeline/Sky/GGXConvolve.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Sky/GGXConvolve.shader
@@ -11,7 +11,7 @@ Shader "Hidden/HDRenderPipeline/GGXConvolve"
 
             HLSLPROGRAM
             #pragma target 4.5
-            #pragma only_renderers d3d11 ps4 vulkan metal  // TEMP: until we go further in dev
+            #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
 
             #pragma multi_compile _ USE_MIS
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Sky/OpaqueAtmosphericScattering.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Sky/OpaqueAtmosphericScattering.shader
@@ -11,7 +11,7 @@
 
             HLSLPROGRAM
             #pragma target 4.5
-            #pragma only_renderers d3d11 ps4 vulkan metal  // TEMP: until we go further in dev
+            #pragma only_renderers d3d11 ps4 vulkan metal // TEMP: until we go further in dev
 
             #pragma vertex Vert
             #pragma fragment Frag


### PR DESCRIPTION
enable metal tessellation, pass skytexture placeholder in proper format to avoid API validation errors
