### PR TITLE
HDRenderPipeline: Add support for depth postpass and backface/frontface rendering

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -186,6 +186,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         // The pass "SRPDefaultUnlit" is a fall back to legacy unlit rendering and is required to support unity 2d + unity UI that render in the scene.
         ShaderPassName[] m_ForwardAndForwardOnlyPassNames = { new ShaderPassName(), new ShaderPassName(), HDShaderPassNames.s_SRPDefaultUnlitName};
+        ShaderPassName[] m_ForwardOnlyPassNames = { new ShaderPassName(), HDShaderPassNames.s_SRPDefaultUnlitName };
 
         ShaderPassName[] m_AllTransparentPassNames = {  HDShaderPassNames.s_TransparentDepthPrepassName,
                                                         HDShaderPassNames.s_TransparentBackfaceName,
@@ -201,7 +202,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                                                     HDShaderPassNames.s_TransparentDepthPostpassName,
                                                                     HDShaderPassNames.s_SRPDefaultUnlitName };
 
-        ShaderPassName[] m_ForwardOnlyPassNames = { new ShaderPassName(), HDShaderPassNames.s_SRPDefaultUnlitName};
+        ShaderPassName[] m_AllForwardDebugDisplayPassNames = {  HDShaderPassNames.s_TransparentBackfaceDebugDisplayName,
+                                                                HDShaderPassNames.s_ForwardOnlyDebugDisplayName,
+                                                                HDShaderPassNames.s_ForwardDebugDisplayName };
+
         ShaderPassName[] m_DepthOnlyAndDepthForwardOnlyPassNames = { HDShaderPassNames.s_DepthForwardOnlyName, HDShaderPassNames.s_DepthOnlyName };
         ShaderPassName[] m_DepthForwardOnlyPassNames = { HDShaderPassNames.s_DepthForwardOnlyName };
         ShaderPassName[] m_DepthOnlyPassNames = { HDShaderPassNames.s_DepthOnlyName };
@@ -1198,10 +1202,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT, ClearFlag.All, CoreUtils.clearColorAllBlack);
                     // Render Opaque forward
-                    RenderOpaqueRenderList(cull, hdCamera.camera, renderContext, cmd, HDShaderPassNames.s_ForwardDebugDisplayName, m_currentRendererConfigurationBakedLighting);
+                    RenderOpaqueRenderList(cull, hdCamera.camera, renderContext, cmd, m_AllForwardDebugDisplayPassNames, m_currentRendererConfigurationBakedLighting);
 
                     // Render forward transparent
-                    RenderTransparentRenderList(cull, hdCamera.camera, renderContext, cmd, HDShaderPassNames.s_ForwardDebugDisplayName, m_currentRendererConfigurationBakedLighting);
+                    RenderTransparentRenderList(cull, hdCamera.camera, renderContext, cmd, m_AllForwardDebugDisplayPassNames, m_currentRendererConfigurationBakedLighting);
                 }
             }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDStringConstants.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDStringConstants.cs
@@ -17,6 +17,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly string s_MotionVectorsStr = "MotionVectors";
         public static readonly string s_DistortionVectorsStr = "DistortionVectors";
         public static readonly string s_TransparentDepthPrepassStr = "TransparentDepthPrepass";
+        public static readonly string s_TransparentBackfaceStr = "TransparentBackface";
+        public static readonly string s_TransparentBackfaceDebugDisplayStr = "TransparentBackfaceDebugDisplay";
+        public static readonly string s_TransparentDepthPostpassStr = "TransparentDepthPostpass";
         public static readonly string s_MetaStr = "Meta";
         public static readonly string s_ShadowCasterStr = "ShadowCaster";
 
@@ -35,6 +38,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly ShaderPassName s_MotionVectorsName = new ShaderPassName(s_MotionVectorsStr);
         public static readonly ShaderPassName s_DistortionVectorsName = new ShaderPassName(s_DistortionVectorsStr);
         public static readonly ShaderPassName s_TransparentDepthPrepassName = new ShaderPassName(s_TransparentDepthPrepassStr);
+        public static readonly ShaderPassName s_TransparentBackfaceName = new ShaderPassName(s_TransparentBackfaceStr);
+        public static readonly ShaderPassName s_TransparentBackfaceDebugDisplayName = new ShaderPassName(s_TransparentBackfaceDebugDisplayStr);
+        public static readonly ShaderPassName s_TransparentDepthPostpassName = new ShaderPassName(s_TransparentDepthPostpassStr);
 
         // Legacy name
         public static readonly ShaderPassName s_AlwaysName = new ShaderPassName("Always");

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/BaseUnlitUI.cs
@@ -26,7 +26,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static GUIContent alphaCutoffText = new GUIContent("Alpha Cutoff", "Threshold for alpha cutoff");
             public static GUIContent alphaCutoffShadowText = new GUIContent("Alpha Cutoff Shadow", "Threshold for alpha cutoff in case of shadow pass");
             public static GUIContent alphaCutoffPrepassText = new GUIContent("Alpha Cutoff Prepass", "Threshold for alpha cutoff in case of depth prepass");
-            public static GUIContent transparentDepthPrepassEnableText = new GUIContent("Enable transparent depth prepass", "It allow to ");
+            public static GUIContent alphaCutoffPostpassText = new GUIContent("Alpha Cutoff Postpass", "Threshold for alpha cutoff in case of depth postpass");
+            public static GUIContent transparentDepthPrepassEnableText = new GUIContent("Enable transparent depth prepass", "It allow to to fill depth buffer to improve sorting");
+            public static GUIContent transparentDepthPostpassEnableText = new GUIContent("Enable transparent depth postpass", "It allow to fill depth buffer for postprocess effect like DOF");
+            public static GUIContent transparentBackfaceEnableText = new GUIContent("Enable back then front rendering", "It allow to better sort transparent mesh by first rendering back faces then front faces in two separate drawcall");
             public static GUIContent enableTransparentFogText = new GUIContent("Enable fog", "Enable fog on transparent material");
             public static GUIContent enableBlendModePreserveSpecularLightingText = new GUIContent("Blend preserve specular lighting", "Blend mode will only affect diffuse lighting, allowing correct specular lighting (reflection) on transparent object");
 
@@ -72,8 +75,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kAlphaCutoffShadow = "_AlphaCutoffShadow";
         protected MaterialProperty alphaCutoffPrepass = null;
         protected const string kAlphaCutoffPrepass = "_AlphaCutoffPrepass";
+        protected MaterialProperty alphaCutoffPostpass = null;
+        protected const string kAlphaCutoffPostpass = "_AlphaCutoffPostpass";
         protected MaterialProperty transparentDepthPrepassEnable = null;
         protected const string kTransparentDepthPrepassEnable = "_TransparentDepthPrepassEnable";
+        protected MaterialProperty transparentDepthPostpassEnable = null;
+        protected const string kTransparentDepthPostpassEnable = "_TransparentDepthPostpassEnable";
+        protected MaterialProperty transparentBackfaceEnable = null;
+        protected const string kTransparentBackfaceEnable = "_TransparentBackfaceEnable";
         protected MaterialProperty doubleSidedEnable = null;
         protected const string kDoubleSidedEnable = "_DoubleSidedEnable";
         protected MaterialProperty blendMode = null;
@@ -132,7 +141,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             alphaCutoffShadow = FindProperty(kAlphaCutoffShadow, props, false);
             alphaCutoffPrepass = FindProperty(kAlphaCutoffPrepass, props, false);
+            alphaCutoffPostpass = FindProperty(kAlphaCutoffPostpass, props, false);
             transparentDepthPrepassEnable = FindProperty(kTransparentDepthPrepassEnable, props, false);
+            transparentDepthPostpassEnable = FindProperty(kTransparentDepthPostpassEnable, props, false);
+            transparentBackfaceEnable = FindProperty(kTransparentBackfaceEnable, props, false);
 
             doubleSidedEnable = FindProperty(kDoubleSidedEnable, props, false);
             blendMode = FindProperty(kBlendMode, props, false);
@@ -236,12 +248,35 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                             EditorGUI.indentLevel--;
                         }
                     }
+
+                    if (transparentDepthPostpassEnable != null)
+                    {
+                        m_MaterialEditor.ShaderProperty(transparentDepthPostpassEnable, StylesBaseUnlit.transparentDepthPostpassEnableText);
+                        if (transparentDepthPostpassEnable.floatValue == 1.0f)
+                        {
+                            EditorGUI.indentLevel++;
+                            m_MaterialEditor.ShaderProperty(alphaCutoffPostpass, StylesBaseUnlit.alphaCutoffPostpassText);
+                            EditorGUI.indentLevel--;
+                        }
+                    }
                 }
                 EditorGUI.indentLevel--;
             }
+
+            if (transparentBackfaceEnable != null && ((SurfaceType)surfaceType.floatValue == SurfaceType.Transparent))
+                m_MaterialEditor.ShaderProperty(transparentBackfaceEnable, StylesBaseUnlit.transparentBackfaceEnableText);
+
             // This function must finish with double sided option (see LitUI.cs)
             if (doubleSidedEnable != null)
-                m_MaterialEditor.ShaderProperty(doubleSidedEnable, StylesBaseUnlit.doubleSidedEnableText);
+            {
+                // Grey the option is backface rendering is enabled
+                bool disabledScope = transparentBackfaceEnable != null && transparentBackfaceEnable.floatValue > 0.0f && ((SurfaceType)surfaceType.floatValue == SurfaceType.Transparent);
+
+                using (new EditorGUI.DisabledScope(disabledScope))
+                {
+                    m_MaterialEditor.ShaderProperty(doubleSidedEnable, StylesBaseUnlit.doubleSidedEnableText);
+                }
+            }
 
             EditorGUI.indentLevel--;
         }
@@ -360,18 +395,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
 
-            bool doubleSidedEnable = material.HasProperty(kDoubleSidedEnable) && material.GetFloat(kDoubleSidedEnable) > 0.0f;
-            if (doubleSidedEnable)
-            {
-                material.SetInt("_CullMode", (int)UnityEngine.Rendering.CullMode.Off);
-            }
-            else
-            {
-                material.SetInt("_CullMode", (int)UnityEngine.Rendering.CullMode.Back);
-            }
-            SetKeyword(material, "_DOUBLESIDED_ON", doubleSidedEnable);
-
-
             bool fogEnabled = material.HasProperty(kEnableFogOnTransparent) && material.GetFloat(kEnableFogOnTransparent) > 0.0f && surfaceType == SurfaceType.Transparent;
             SetKeyword(material, "_ENABLE_FOG_ON_TRANSPARENT", fogEnabled);
 
@@ -410,6 +433,21 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                         break;
                 }
             }
+
+            // Can't enable double sided and backface rendering at the same time, give priority to backface rendering
+            bool isBackFaceEnable = material.HasProperty(kTransparentBackfaceEnable) && material.GetFloat(kTransparentBackfaceEnable) > 0.0f && surfaceType == SurfaceType.Transparent;
+            bool doubleSidedEnable = material.HasProperty(kDoubleSidedEnable) && material.GetFloat(kDoubleSidedEnable) > 0.0f && !isBackFaceEnable;
+
+            if (doubleSidedEnable)
+            {
+                material.SetInt("_CullMode", (int)UnityEngine.Rendering.CullMode.Off);
+            }
+            // For both regular and backface, forward pass use backface culling
+            else
+            {
+                material.SetInt("_CullMode", (int)UnityEngine.Rendering.CullMode.Back);
+            }
+            SetKeyword(material, "_DOUBLESIDED_ON", doubleSidedEnable);
 
             // A material's GI flag internally keeps track of whether emission is enabled at all, it's enabled but has no effect
             // or is enabled and may be modified at runtime. This state depends on the values of the current flag and emissive color.
@@ -495,6 +533,36 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     material.SetShaderPassEnabled(HDShaderPassNames.s_TransparentDepthPrepassStr, false);
                 }
             }
+
+            if (material.HasProperty(kTransparentDepthPostpassEnable))
+            {
+                bool depthWriteEnable = (material.GetFloat(kTransparentDepthPostpassEnable) > 0.0f) && ((SurfaceType)material.GetFloat(kSurfaceType) == SurfaceType.Transparent);
+                if (depthWriteEnable)
+                {
+                    material.SetShaderPassEnabled(HDShaderPassNames.s_TransparentDepthPostpassStr, true);
+                }
+                else
+                {
+                    material.SetShaderPassEnabled(HDShaderPassNames.s_TransparentDepthPostpassStr, false);
+                }
+            }
+
+            if (material.HasProperty(kTransparentBackfaceEnable))
+            {
+                bool backFaceEnable = (material.GetFloat(kTransparentBackfaceEnable) > 0.0f) && ((SurfaceType)material.GetFloat(kSurfaceType) == SurfaceType.Transparent);
+                if (backFaceEnable)
+                {
+                    material.SetShaderPassEnabled(HDShaderPassNames.s_TransparentBackfaceStr, true);
+                    material.SetShaderPassEnabled(HDShaderPassNames.s_TransparentBackfaceDebugDisplayStr, true);
+                }
+                else
+                {
+                    material.SetShaderPassEnabled(HDShaderPassNames.s_TransparentBackfaceStr, false);
+                    material.SetShaderPassEnabled(HDShaderPassNames.s_TransparentBackfaceDebugDisplayStr, false);
+                }
+            }
+
+
         }
 
         // Dedicated to emissive - for emissive Enlighten/PVR


### PR DESCRIPTION
This PR add what is needed to add a transparent post pass to a shader (i.E a pass use to fill the depth buffer for the depth with transparent object).

It also add an option to render backface then frontface transparent mesh (useful for transparent sorting problem).

Order of the pass must be declare in the shader as follow:

TransparentDepthPrepass, TransparentBackface, TransparentBackfaceDebugDisplay, Forward/ForwardOnly, ForwardDebugDisplay/ForwardOnlyDebugDisplay, TransparentDepthPostpass

Typical declration in shader properties:

        [ToggleOff]  _AlphaCutoffEnable("Alpha Cutoff Enable", Float) = 0.0
        _AlphaCutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5

        _AlphaCutoffShadow("_AlphaCutoffShadow", Range(0.0, 1.0)) = 0.5
        _AlphaCutoffPrepass("_AlphaCutoffPrepass", Range(0.0, 1.0)) = 0.5
        _AlphaCutoffPostpass("_AlphaCutoffPostpass", Range(0.0, 1.0)) = 0.5

        [ToggleOff] _TransparentDepthPrepassEnable("_TransparentDepthPrepassEnable", Float) = 0.0
        [ToggleOff] _TransparentDepthPostpassEnable("_TransparentDepthPostpassEnable", Float) = 0.0
        [ToggleOff] _TransparentBackfaceEnable("_TransparentBackfaceEnable", Float) = 0.0
