### PR TITLE
Fixed profiler errors

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -946,9 +946,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 #endif
 
             renderContext.ExecuteCommandBuffer(cmd);
+            }
+
             CommandBufferPool.Release(cmd);
             renderContext.Submit();
-            }
         }
 
         void RenderOpaqueRenderList(CullResults             cull,


### PR DESCRIPTION
When switching to play mode in the editor you get spammed with:
```
Non matching Profiler.EndSample (BeginSample and EndSample count must match): HDRenderPipeline::Render
```
This PR fixes this (in a nutshell, the command buffer was being released before it could end the profiling sample). This also makes the profiling sample correct, previously it would keep profiling till the end of the frame (and thus you'd get editor related stuff in RenderDoc in `HDRenderPipeline::Render`).