### PR TITLE
Refactor directional and punctual light code

### DIFF
--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
@@ -262,11 +262,21 @@ static const float4x4 k_identity4x4 = {1.0, 0.0, 0.0, 0.0,
 // PositivePow remove this warning when you know the value is positive and avoid inf/NAN.
 TEMPLATE_2_FLT(PositivePow, base, power, return pow(max(abs(base), FLT_EPS), power))
 
-// Ref: https://twitter.com/SebAaltonen/status/878250919879639040
-// 2 mads (mad_sat and mad), faster than regular sign
-float FastSign(float x)
+// Returns -1 for negative numbers and -0, 1 for positive numbers and +0.
+// This behavior is different from the Signum function sign(), which returns 0 for 0.
+// 2x VALU.
+float FastSign(float s)
 {
-    return saturate(x * FLT_MAX) * 2.0 - 1.0;
+    uint negZero = 0x80000000u;
+    uint signBit = negZero & asuint(s);
+    return asfloat(signBit | asuint(1.0));
+}
+
+// Multiplies 'x' by the sign of 's'. Treats -0 as 0.
+// 2x VALU compared to 3x VALU of (x * FastSign(s)).
+float FastMulBySignOf(float x, float s)
+{
+    return (s >= 0) ? x : -x;
 }
 
 // Orthonormalizes the tangent frame using the Gram-Schmidt process.

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
@@ -374,7 +374,7 @@ float LinearEyeDepth(float2 positionSS, float deviceDepth, float4 invProjParam)
 // Z buffer to linear depth.
 // Correctly handles oblique view frustums.
 // Typically, this is the cheapest variant, provided you've already computed 'positionWS'.
-float LinearEyeDepth(float3 positionWS, float3x3 viewProjMatrix)
+float LinearEyeDepth(float3 positionWS, float4x4 viewProjMatrix)
 {
     return mul(viewProjMatrix, float4(positionWS, 1.0)).w;
 }

--- a/ScriptableRenderPipeline/Core/ShaderLibrary/CommonMaterial.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/CommonMaterial.hlsl
@@ -165,16 +165,17 @@ float ComputeWrappedDiffuseLighting(float NdotL, float w)
 // It can be accomplished by reading the stencil buffer.
 // A faster solution (which avoids an extra texture fetch) is to simply make sure that
 // all pixels which belong to an SSS material are not black (those that don't always are).
+// We choose the blue color channel since it's perceptually the least noticeable.
 float3 TagLightingForSSS(float3 subsurfaceLighting)
 {
-    subsurfaceLighting.r = max(subsurfaceLighting.r, HALF_MIN);
+    subsurfaceLighting.b = max(subsurfaceLighting.b, HALF_MIN);
     return subsurfaceLighting;
 }
 
 // See TagLightingForSSS() for details.
 bool TestLightingForSSS(float3 subsurfaceLighting)
 {
-    return subsurfaceLighting.r > 0;
+    return subsurfaceLighting.b > 0;
 }
 
 // MACRO from Legacy Untiy

--- a/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
+++ b/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
@@ -1296,7 +1296,7 @@ namespace UnityEngine.Experimental.Rendering
             }
 
             m_TmpSortKeys.Sort( new SortReverter() );
-            m_TmpSortKeys.ExtractTo( shadowRequests, 0, out shadowRequestsCount, delegate(long key) { return (int) (key & UINT_MAX); } );
+            m_TmpSortKeys.ExtractTo( shadowRequests, 0, out shadowRequestsCount, delegate(long key) { return (int) (key & 0xffffffff); } );
         }
 
         protected override void PruneShadowCasters( Camera camera, List<VisibleLight> lights, ref VectorArray<int> shadowRequests, ref ShadowRequestVector requestsGranted, out uint totalRequestCount )

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/LightDefinition.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/LightDefinition.cs
@@ -45,15 +45,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public Vector3 forward;
         public int cookieIndex; // -1 if unused
 
-        public Vector3 right;   // Rescaled by (2 / shapeLenght)
+        public Vector3 right;   // Rescaled by (2 / shapeLength)
         public float specularScale;
 
         public Vector3 up;      // Rescaled by (2 / shapeWidth)
         public float diffuseScale;
 
-        public bool dynamicShadowCasterOnly; // Use with ShadowMask feature
         public Vector2 fadeDistanceScaleAndBias; // Use with ShadowMask feature
         public float unused0;
+        public bool dynamicShadowCasterOnly; // Use with ShadowMask feature
 
         public Vector4 shadowMaskSelector; // Use with ShadowMask feature
     };
@@ -70,10 +70,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public Vector3 forward;
         public int cookieIndex; // -1 if unused
 
-        public Vector3 right;   // If spot: rescaled by cot(outerHalfAngle); if projector: rescaled by (2 / shapeLenght)
+        public Vector3 right;   // If spot: rescaled by cot(outerHalfAngle); if projector: rescaled by (2 / shapeLength)
         public float specularScale;
 
-        public Vector3 up;      // If spot: rescaled by cot(outerHalfAngle); if projector: rescaled by * (2 / shapeWidth)
+        public Vector3 up;      // If spot: rescaled by cot(outerHalfAngle); if projector: rescaled by (2 / shapeWidth)
         public float diffuseScale;
 
         public float angleScale;  // Spot light
@@ -81,13 +81,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public float shadowDimmer;
         public bool dynamicShadowCasterOnly; // Use with ShadowMask feature
 
-        public Vector2 size;      // Used by area, frustum projector and spot lights (x = cot(outerHalfAngle))
+        public Vector4 shadowMaskSelector; // Use with ShadowMask feature
+
+        public Vector2 size;      // Used by area and pyramid projector lights
         public GPULightType lightType;
         public float minRoughness;  // This is use to give a small "area" to punctual light, as if we have a light with a radius.
-
-        public Vector4 shadowMaskSelector; // Use with ShadowMask feature
     };
-
 
 
     [GenerateHLSL]

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/LightDefinition.cs.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/LightDefinition.cs.hlsl
@@ -55,9 +55,9 @@ struct DirectionalLightData
     float specularScale;
     float3 up;
     float diffuseScale;
-    bool dynamicShadowCasterOnly;
     float2 fadeDistanceScaleAndBias;
     float unused0;
+    bool dynamicShadowCasterOnly;
     float4 shadowMaskSelector;
 };
 
@@ -79,10 +79,10 @@ struct LightData
     float angleOffset;
     float shadowDimmer;
     bool dynamicShadowCasterOnly;
+    float4 shadowMaskSelector;
     float2 size;
     int lightType;
     float minRoughness;
-    float4 shadowMaskSelector;
 };
 
 // Generated from UnityEngine.Experimental.Rendering.HDPipeline.EnvLightData
@@ -146,10 +146,6 @@ float GetDiffuseScale(DirectionalLightData value)
 {
 	return value.diffuseScale;
 }
-bool GetDynamicShadowCasterOnly(DirectionalLightData value)
-{
-	return value.dynamicShadowCasterOnly;
-}
 float2 GetFadeDistanceScaleAndBias(DirectionalLightData value)
 {
 	return value.fadeDistanceScaleAndBias;
@@ -157,6 +153,10 @@ float2 GetFadeDistanceScaleAndBias(DirectionalLightData value)
 float GetUnused0(DirectionalLightData value)
 {
 	return value.unused0;
+}
+bool GetDynamicShadowCasterOnly(DirectionalLightData value)
+{
+	return value.dynamicShadowCasterOnly;
 }
 float4 GetShadowMaskSelector(DirectionalLightData value)
 {
@@ -222,6 +222,10 @@ bool GetDynamicShadowCasterOnly(LightData value)
 {
 	return value.dynamicShadowCasterOnly;
 }
+float4 GetShadowMaskSelector(LightData value)
+{
+	return value.shadowMaskSelector;
+}
 float2 GetSize(LightData value)
 {
 	return value.size;
@@ -233,10 +237,6 @@ int GetLightType(LightData value)
 float GetMinRoughness(LightData value)
 {
 	return value.minRoughness;
-}
-float4 GetShadowMaskSelector(LightData value)
-{
-	return value.shadowMaskSelector;
 }
 
 //

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
@@ -164,7 +164,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         for (i = 0; i < punctualLightCount; ++i)
         {
             int punctualIndex = FetchIndex(punctualLightStart, i);
-            DirectLighting lighting = EvaluateBSDF_Punctual(context, V, posInput, preLightData, _LightDatas[punctualIndex], bsdfData, bakeLightingData, _LightDatas[punctualIndex].lightType);
+            DirectLighting lighting = EvaluateBSDF_Punctual(context, V, posInput, preLightData, _LightDatas[punctualIndex], bsdfData, bakeLightingData);
             AccumulateDirectLighting(lighting, aggregateLighting);
         }
 
@@ -172,7 +172,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 
         for (i = 0; i < _PunctualLightCount; ++i)
         {
-            DirectLighting lighting = EvaluateBSDF_Punctual(context, V, posInput, preLightData, _LightDatas[i], bsdfData, bakeLightingData, _LightDatas[i].lightType);
+            DirectLighting lighting = EvaluateBSDF_Punctual(context, V, posInput, preLightData, _LightDatas[i], bsdfData, bakeLightingData);
             AccumulateDirectLighting(lighting, aggregateLighting);
         }
 


### PR DESCRIPTION
Before:

; -------- Statistics ---------------------
; SGPRs: 100 out of 104 used
; VGPRs: 156 out of 256 used
; LDS: 0 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: 2650 ALU, 167 Control Flow, 78 TFETCH

After:

; -------- Statistics ---------------------
; SGPRs: 100 out of 104 used
; VGPRs: 156 out of 256 used
; LDS: 0 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: 2656 ALU, 175 Control Flow, 78 TFETCH

The performance regression will be fixed later.