### PR TITLE
Bugfix transmission

### DIFF
--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Macros.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Macros.hlsl
@@ -32,9 +32,9 @@
 #define LOG2_E      1.44269504088896340736
 #define INFINITY    asfloat(0x7F800000)
 
-#define FLT_EPS     1.192092896e-07	// Smallest positive number, such that 1.0 + FLT_EPS != 1.0
-#define FLT_MIN     1.175494351e-38	// Minimum representable positive floating-point number
-#define FLT_MAX     3.402823466e+38	// Maximum representable floating-point number
+#define FLT_EPS     1.192092896e-07 // Smallest positive number, such that 1.0 + FLT_EPS != 1.0
+#define FLT_MIN     1.175494351e-38 // Minimum representable positive floating-point number
+#define FLT_MAX     3.402823466e+38 // Maximum representable floating-point number
 #define HALF_MIN    6.103515625e-5  // 2^-14, the same value for 10, 11 and 16-bit: https://www.khronos.org/opengl/wiki/Small_Float_Formats
 #define HALF_MAX    65504.0
 #define UINT_MAX    0xFFFFFFFFu

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
@@ -781,7 +781,6 @@ float3 ClearCoatTransform(float3 X, float3 N, float ieta)
 PreLightData GetPreLightData(float3 V, PositionInputs posInput, BSDFData bsdfData)
 {
     PreLightData preLightData;
-    ZERO_INITIALIZE(PreLightData, preLightData);
 
     float3 N;
     float  NdotV;


### PR DESCRIPTION
The refactor still suffers from a performance regression which needs to be investigated and fixed.
Could it be because FastSign() is implemented using control flow? Will test later.

Deferred.shader pre-rafactor:

; -------- Statistics ---------------------
; SGPRs: 100 out of 104 used
; VGPRs: 156 out of 256 used
; LDS: 0 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: 2650 ALU, **167** Control Flow, 78 TFETCH

Deferred.shader post-rafactor:

; -------- Statistics ---------------------
; SGPRs: 100 out of 104 used
; VGPRs: 156 out of 256 used
; LDS: 0 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: 2652 ALU, **178** Control Flow, 78 TFETCH