### PR TITLE
Optimize divergent execution of the anisotropic GGX

### DIFF
--- a/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
+++ b/ScriptableRenderPipeline/Core/ShaderLibrary/Common.hlsl
@@ -85,7 +85,9 @@
 // ----------------------------------------------------------------------------
 
 #ifndef INTRINSIC_BITFIELD_EXTRACT
-// unsigned integer bit field extract implementation
+// Unsigned integer bit field extraction.
+// Note that the intrinsic itself generates a vector instruction.
+// Wrap this function with WaveReadFirstLane() to get scalar output.
 uint BitFieldExtract(uint data, uint numBits, uint offset)
 {
     uint mask = UINT_MAX >> (32u - numBits);
@@ -93,9 +95,24 @@ uint BitFieldExtract(uint data, uint numBits, uint offset)
 }
 #endif // INTRINSIC_BITFIELD_EXTRACT
 
-bool IsBitSet(uint data, uint bitPos)
+bool IsBitSet(uint data, uint offset)
 {
-    return BitFieldExtract(data, 1u, bitPos) != 0;
+    return BitFieldExtract(data, 1u, offset) != 0;
+}
+
+void SetBit(inout uint data, uint offset)
+{
+    data |= 1u << offset;
+}
+
+void ClearBit(inout uint data, uint offset)
+{
+    data &= ~(1u << offset);
+}
+
+void ToggleBit(inout uint data, uint offset)
+{
+    data ^= 1u << offset;
 }
 
 #ifndef INTRINSIC_WAVEREADFIRSTLANE


### PR DESCRIPTION
If the tile has any pixels with anisotropic GGX, we evaluate the entire tile with anisotropic GGX rather than first evaluating pixels with anisotropic GGX and then pixels with isotropic GGX.

Before

; --- Statistics for Deferred.compute on GCN (Pitcairn) ---
; SGPRs: **92** out of 104 used
; VGPRs: 128 out of 256 used
; LDS: 0 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: **2676 ALU**, 183 Control Flow, 50 TFETCH

After

; --- Statistics for Deferred.compute on GCN (Pitcairn) ---
; SGPRs: **94** out of 104 used
; VGPRs: 128 out of 256 used
; LDS: 0 out of 32768 bytes used
; 0 bytes scratch space used
; Instructions: **2583 ALU**, 183 Control Flow, 50 TFETCH