### PR TITLE
Separate hierarchy in testrunner for the different pipelines

### DIFF
--- a/Tests/GraphicsTests/Framework/Editor/TestFramework.cs
+++ b/Tests/GraphicsTests/Framework/Editor/TestFramework.cs
@@ -23,12 +23,6 @@ namespace UnityEditor.Experimental.Rendering
             "RenderPipeline"
         };
 
-        private static readonly string[] s_PipelinePath =
-        {
-            "LightweightPipeline",
-            "HDRenderPipeline",
-        };
-
         // info that gets generated for use
         // in a dod way
         public struct TestInfo
@@ -48,52 +42,6 @@ namespace UnityEditor.Experimental.Rendering
 		// collect the scenes that we can use
         public static class CollectScenes
         {
-            public static IEnumerable scenes
-            {
-                get
-                {
-                    var absoluteScenesPath = s_Path.Aggregate(s_RootPath, Path.Combine);
-
-                    foreach (var pipelinePath in s_PipelinePath)
-                    {
-
-                        var filesPath = Path.Combine(absoluteScenesPath, pipelinePath);
-
-                        // find all the scenes
-                        var allPaths = System.IO.Directory.GetFiles(filesPath, "*.unity", System.IO.SearchOption.AllDirectories);
-
-                        // construct all the needed test infos
-                        foreach (var path in allPaths)
-                        {
-                            var p = new FileInfo(path);
-                            var split = s_Path.Aggregate("", Path.Combine);
-                            split = string.Format("{0}{1}", split, Path.DirectorySeparatorChar);
-                            var splitPaths = p.FullName.Split(new[] { split }, StringSplitOptions.RemoveEmptyEntries);
-
-                            // Add prefix to the name for easier reading
-                            var name = p.Name;
-                            switch (pipelinePath)
-                            {
-                                case "LightweightPipeline":
-                                    name = "LTRP_" + name;
-                                    break;
-                                case "HDRenderPipeline":
-                                    name = "HDRP_" + name;
-                                    break;
-                            }
-
-                            yield return new TestInfo
-                            {
-                                name = name,
-                                relativePath = splitPaths.Last(),
-                                threshold = 0.02f,
-                                frameWait = 100
-                            };
-                        }
-                    }
-                }
-            }
-
             public static IEnumerable HDScenes
             {
                 get
@@ -102,7 +50,7 @@ namespace UnityEditor.Experimental.Rendering
                 }
             }
 
-            public static IEnumerable LTScenes
+            public static IEnumerable LWScenes
             {
                 get
                 {
@@ -127,21 +75,9 @@ namespace UnityEditor.Experimental.Rendering
                     split = string.Format("{0}{1}", split, Path.DirectorySeparatorChar);
                     var splitPaths = p.FullName.Split(new[] { split }, StringSplitOptions.RemoveEmptyEntries);
 
-                    // Add prefix to the name for easier reading
-                    var name = p.Name;
-                    switch (_pipelinePath)
-                    {
-                        case "LightweightPipeline":
-                            name = "LTRP_" + name;
-                            break;
-                        case "HDRenderPipeline":
-                            name = "HDRP_" + name;
-                            break;
-                    }
-
                     yield return new TestInfo
                     {
-                        name = name,
+                        name = p.Name,
                         relativePath = splitPaths.Last(),
                         threshold = 0.02f,
                         frameWait = 100
@@ -167,12 +103,12 @@ namespace UnityEditor.Experimental.Rendering
         }
 
         [UnityTest]
-        public IEnumerator LTRP_TestScene([ValueSource(typeof(CollectScenes), "LTScenes")]TestInfo testInfo)
+        public IEnumerator LWRP_TestScene([ValueSource(typeof(CollectScenes), "LWScenes")]TestInfo testInfo)
         {
             return TestScene(testInfo);
         }
 
-        public IEnumerator TestScene([ValueSource(typeof(CollectScenes), "scenes")]TestInfo testInfo)
+        public IEnumerator TestScene(TestInfo testInfo)
         {
 			var prjRelativeGraphsPath = s_Path.Aggregate(s_RootPath, Path.Combine);
 			var filePath = Path.Combine(prjRelativeGraphsPath, testInfo.relativePath);


### PR DESCRIPTION
Split the "TestScene" function and it's dependencies to have a separate hierarchy in the testrunner window for the different render pipelines graphic tests.