### PR TITLE
Graphic TestRunner Optimisation

### DIFF
--- a/Tests/GraphicsTests/Framework/Editor/TestFramework.cs
+++ b/Tests/GraphicsTests/Framework/Editor/TestFramework.cs
@@ -46,7 +46,7 @@ namespace UnityEditor.Experimental.Rendering
             {
                 get
                 {
-                    return GetScenesForPipeline("HDRenderPipeline");
+                    return GetScenesForPipeline("HDRenderPipeline/Scenes");
                 }
             }
 

--- a/Tests/GraphicsTests/Framework/SetupSceneForRenderPipelineTest.cs
+++ b/Tests/GraphicsTests/Framework/SetupSceneForRenderPipelineTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine.Rendering;
+using UnityEngine.Rendering;
 
 namespace UnityEngine.Experimental.Rendering
 {
@@ -16,12 +16,12 @@ namespace UnityEngine.Experimental.Rendering
 		public void Setup()
 		{
 			m_OriginalAsset = GraphicsSettings.renderPipelineAsset;
-			GraphicsSettings.renderPipelineAsset = renderPipeline;
+            if (m_OriginalAsset != renderPipeline) GraphicsSettings.renderPipelineAsset = renderPipeline;
 		}
 
 		public void TearDown()
 		{
-			GraphicsSettings.renderPipelineAsset = m_OriginalAsset;
+			if ( GraphicsSettings.renderPipelineAsset != m_OriginalAsset ) GraphicsSettings.renderPipelineAsset = m_OriginalAsset;
 		}
 	}
 }


### PR DESCRIPTION
Disable re-setting the renderPipeline for a graphic if it is already set.
This allows to speed the HD tests from 42 to 27 seconds in average.

Add "/Scenes" to the hd pipe test scenes search, to ignore the playmod test scene.