### PR TITLE
Set the pipeline asset once for a batch of tests.

### DIFF
--- a/Tests/GraphicsTests/Framework/Editor/TestFramework.cs
+++ b/Tests/GraphicsTests/Framework/Editor/TestFramework.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -39,23 +40,42 @@ namespace UnityEditor.Experimental.Rendering
 
         }
 
-		// collect the scenes that we can use
+        // Renderpipeline assets used for the tests
+        public static Dictionary<string, string> renderPipelineAssets = new Dictionary<string, string>()
+        {
+            { "HDRP", "HDRenderPipeline/CommonAssets/HDRP_GraphicTests_Asset.asset" },
+            { "LWRP", "LightweightPipeline/LightweightPipelineAsset.asset" }
+        };
+
+        // Renderpipeline assets used for the tests
+        public static Dictionary<string, string> renderPipelineScenesFolder = new Dictionary<string, string>()
+        {
+            { "HDRP", "HDRenderPipeline/Scenes" },
+            { "LWRP", "LightweightPipeline" }
+        };
+
+        // collect the scenes that we can use
         public static class CollectScenes
         {
-            public static IEnumerable HDScenes
+            public static IEnumerable HDRP
             {
                 get
                 {
-                    return GetScenesForPipeline("HDRenderPipeline/Scenes");
+                    return GetScenesForPipelineID("HDRP");
                 }
             }
 
-            public static IEnumerable LWScenes
+            public static IEnumerable LWRP
             {
                 get
                 {
-                    return GetScenesForPipeline("LightweightPipeline");
+                    return GetScenesForPipelineID("LWRP");
                 }
+            }
+
+            public static  IEnumerable GetScenesForPipelineID( string _pipelineID )
+            {
+                return GetScenesForPipeline( renderPipelineScenesFolder[_pipelineID] );
             }
 
             public static IEnumerable GetScenesForPipeline(string _pipelinePath)
@@ -65,11 +85,17 @@ namespace UnityEditor.Experimental.Rendering
                 var filesPath = Path.Combine(absoluteScenesPath, _pipelinePath);
 
                 // find all the scenes
-                var allPaths = System.IO.Directory.GetFiles(filesPath, "*.unity", System.IO.SearchOption.AllDirectories);
+                var allPaths = Directory.GetFiles(filesPath, "*.unity", SearchOption.AllDirectories);
+
+                // Convert to List for easy sorting in alphabetical ordre
+                List<string> allPaths_List = new List<string>(allPaths);
+                allPaths_List.Sort();
 
                 // construct all the needed test infos
-                foreach (var path in allPaths)
+                for (int i=0; i<allPaths_List.Count; ++i)
                 {
+                    var path = allPaths_List[i];
+
                     var p = new FileInfo(path);
                     var split = s_Path.Aggregate("", Path.Combine);
                     split = string.Format("{0}{1}", split, Path.DirectorySeparatorChar);
@@ -86,29 +112,54 @@ namespace UnityEditor.Experimental.Rendering
             }
         }
 
-        [TearDown]
-        public void TearDown()
-        {
-            var testSetup = Object.FindObjectOfType<SetupSceneForRenderPipelineTest>();
-            if (testSetup == null)
-                return;
 
-            testSetup.TearDown();
+        // Change the SRP before a full batch of tests
+        public virtual string _SRP_ID { get { return "NONE"; } }
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            SetupRenderPipeAsset();
         }
 
-        [UnityTest]
-        public IEnumerator HDRP_TestScene([ValueSource(typeof(CollectScenes), "HDScenes")]TestInfo testInfo)
+        [OneTimeTearDown]
+        public void OnTimeTearDown()
         {
-            return TestScene(testInfo);
+            RestoreRenderPipeAsset();
         }
 
-        [UnityTest]
-        public IEnumerator LWRP_TestScene([ValueSource(typeof(CollectScenes), "LWScenes")]TestInfo testInfo)
+        public static RenderPipelineAsset GetRenderPipelineAsset(string _SRP_ID)
         {
-            return TestScene(testInfo);
+            string absolutePath = s_Path.Aggregate(s_RootPath, Path.Combine);
+
+            string filePath = Path.Combine(absolutePath, renderPipelineAssets[_SRP_ID] );
+
+            return (RenderPipelineAsset)AssetDatabase.LoadAssetAtPath(filePath, typeof(RenderPipelineAsset));
         }
 
-        public IEnumerator TestScene(TestInfo testInfo)
+        public static RenderPipelineAsset beforeTestsRenderPipeAsset;
+        public static RenderPipelineAsset wantedTestsRenderPipeAsset;
+
+        public void SetupRenderPipeAsset()
+        {
+            Debug.Log("Set " + _SRP_ID + " render pipeline.");
+
+            beforeTestsRenderPipeAsset = UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset;
+            wantedTestsRenderPipeAsset = GetRenderPipelineAsset(_SRP_ID);
+
+            if (wantedTestsRenderPipeAsset != beforeTestsRenderPipeAsset)
+                UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset = wantedTestsRenderPipeAsset;
+        }
+
+        public void RestoreRenderPipeAsset()
+        {
+            if (wantedTestsRenderPipeAsset != beforeTestsRenderPipeAsset)
+                UnityEngine.Rendering.GraphicsSettings.renderPipelineAsset = beforeTestsRenderPipeAsset;
+        }
+
+
+        // the actual test
+        public static IEnumerator TestScene(TestInfo testInfo)
         {
 			var prjRelativeGraphsPath = s_Path.Aggregate(s_RootPath, Path.Combine);
 			var filePath = Path.Combine(prjRelativeGraphsPath, testInfo.relativePath);
@@ -116,7 +167,7 @@ namespace UnityEditor.Experimental.Rendering
 			// open the scene
             EditorSceneManager.OpenScene(filePath);
 
-            var testSetup = Object.FindObjectOfType<SetupSceneForRenderPipelineTest> ();
+            SetupSceneForRenderPipelineTest testSetup = Object.FindObjectOfType<SetupSceneForRenderPipelineTest> ();
 			Assert.IsNotNull(testSetup, "No SetupSceneForRenderPipelineTest in scene " + testInfo.name);
 			Assert.IsNotNull(testSetup.cameraToUse, "No configured camera in <SetupSceneForRenderPipelineTest>");
 
@@ -188,10 +239,12 @@ namespace UnityEditor.Experimental.Rendering
             }
 
 			Assert.IsTrue(areEqual, "Scene from {0}, did not match .template file.", testInfo.relativePath);
+
+            testSetup.TearDown();
         }
 
 		// compare textures, use RMS for this
-        private bool CompareTextures(Texture2D fromDisk, Texture2D captured, float threshold)
+        private static bool CompareTextures(Texture2D fromDisk, Texture2D captured, float threshold)
         {
             if (fromDisk == null || captured == null)
                 return false;
@@ -220,6 +273,29 @@ namespace UnityEditor.Experimental.Rendering
 			}
 			float rmse = Mathf.Sqrt(sumOfSquaredColorDistances / numberOfPixels);
 			return rmse < threshold;
+        }
+
+        // Graphic Tests Subclasses that inherit the functions bot provide different SRP_ID
+        public class HDRP : GraphicsTests
+        {
+            public override string _SRP_ID { get { return "HDRP"; } }
+
+            [UnityTest]
+            public IEnumerator HDRP_Test([ValueSource(typeof(CollectScenes), "HDRP")]TestInfo testInfo)
+            {
+                return TestScene(testInfo);
+            }
+        }
+
+        public class LTRP : GraphicsTests
+        {
+            public override string _SRP_ID { get { return "LWRP"; } }
+
+            [UnityTest]
+            public IEnumerator LWRP_Test([ValueSource(typeof(CollectScenes), "LWRP")]TestInfo testInfo)
+            {
+                return TestScene(testInfo);
+            }
         }
     }
 }


### PR DESCRIPTION
Modify graphic test to set the pipeline asset once for a batch of tests. Can gain time when running tests.