### PR TITLE
HDRenderPipeline: Fix issue with double sided and reflection probe

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
@@ -19,6 +19,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public Vector4[] frustumPlaneEquations;
         public Camera camera;
         public uint taaFrameIndex;
+        public Vector4 viewParam;
         public PostProcessRenderContext postprocessRenderContext;
 
         public Matrix4x4 viewProjMatrix
@@ -123,7 +124,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 isFirstFrame = false;
 
                 const uint taaFrameCount = 8;
-                taaFrameIndex = taaEnabled ? (uint)Time.renderedFrameCount % taaFrameCount : 0; 
+                taaFrameIndex = taaEnabled ? (uint)Time.renderedFrameCount % taaFrameCount : 0;
             }
             else
             {
@@ -137,6 +138,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             nonJitteredProjMatrix = gpuNonJitteredProj;
             cameraPos = pos;
             screenSize = new Vector4(camera.pixelWidth, camera.pixelHeight, 1.0f / camera.pixelWidth, 1.0f / camera.pixelHeight);
+            viewParam = new Vector4(viewMatrix.determinant, 0.0f, 0.0f, 0.0f);
 
             if (ShaderConfig.s_CameraRelativeRendering != 0)
             {
@@ -207,28 +209,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetGlobalMatrix(HDShaderIDs._NonJitteredViewProjMatrix, nonJitteredViewProjMatrix);
             cmd.SetGlobalMatrix(HDShaderIDs._ViewProjMatrix, viewProjMatrix);
             cmd.SetGlobalMatrix(HDShaderIDs._InvViewProjMatrix, viewProjMatrix.inverse);
+            cmd.SetGlobalVector(HDShaderIDs._ViewParam, viewParam);
             cmd.SetGlobalVector(HDShaderIDs._InvProjParam, invProjParam);
             cmd.SetGlobalVector(HDShaderIDs._ScreenSize, screenSize);
             cmd.SetGlobalMatrix(HDShaderIDs._PrevViewProjMatrix, prevViewProjMatrix);
             cmd.SetGlobalVectorArray(HDShaderIDs._FrustumPlanes, frustumPlaneEquations);
             cmd.SetGlobalInt(HDShaderIDs._TaaFrameIndex, (int)taaFrameIndex);
-        }
-
-        // Does not modify global settings. Used for shadows, low res. rendering, etc.
-        public void OverrideGlobalParams(Material material)
-        {
-            material.SetMatrix(HDShaderIDs._ViewMatrix, viewMatrix);
-            material.SetMatrix(HDShaderIDs._InvViewMatrix, viewMatrix.inverse);
-            material.SetMatrix(HDShaderIDs._ProjMatrix, projMatrix);
-            material.SetMatrix(HDShaderIDs._InvProjMatrix, projMatrix.inverse);
-            material.SetMatrix(HDShaderIDs._NonJitteredViewProjMatrix, nonJitteredViewProjMatrix);
-            material.SetMatrix(HDShaderIDs._ViewProjMatrix, viewProjMatrix);
-            material.SetMatrix(HDShaderIDs._InvViewProjMatrix, viewProjMatrix.inverse);
-            material.SetVector(HDShaderIDs._InvProjParam, invProjParam);
-            material.SetVector(HDShaderIDs._ScreenSize, screenSize);
-            material.SetMatrix(HDShaderIDs._PrevViewProjMatrix, prevViewProjMatrix);
-            material.SetVectorArray(HDShaderIDs._FrustumPlanes, frustumPlaneEquations);
-            material.SetInt(HDShaderIDs._TaaFrameIndex, (int)taaFrameIndex);
         }
 
         // TODO: We should set all the value below globally and not let it under the control of Unity,
@@ -239,6 +225,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // Copy values set by Unity which are not configured in scripts.
             cmd.SetComputeVectorParam(cs, HDShaderIDs.unity_OrthoParams, Shader.GetGlobalVector(HDShaderIDs.unity_OrthoParams));
             cmd.SetComputeVectorParam(cs, HDShaderIDs._ProjectionParams, Shader.GetGlobalVector(HDShaderIDs._ProjectionParams));
+            cmd.SetComputeVectorParam(cs, HDShaderIDs._ViewParam, Shader.GetGlobalVector(HDShaderIDs._ViewParam));
             cmd.SetComputeVectorParam(cs, HDShaderIDs._ScreenParams, Shader.GetGlobalVector(HDShaderIDs._ScreenParams));
             cmd.SetComputeVectorParam(cs, HDShaderIDs._ZBufferParams, Shader.GetGlobalVector(HDShaderIDs._ZBufferParams));
             cmd.SetComputeVectorParam(cs, HDShaderIDs._WorldSpaceCameraPos, Shader.GetGlobalVector(HDShaderIDs._WorldSpaceCameraPos));

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDStringConstants.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDStringConstants.cs
@@ -186,6 +186,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _NonJitteredViewProjMatrix = Shader.PropertyToID("_NonJitteredViewProjMatrix");
         public static readonly int _ViewProjMatrix = Shader.PropertyToID("_ViewProjMatrix");
         public static readonly int _InvViewProjMatrix = Shader.PropertyToID("_InvViewProjMatrix");
+        public static readonly int _ViewParam = Shader.PropertyToID("_ViewParam");
         public static readonly int _InvProjParam = Shader.PropertyToID("_InvProjParam");
         public static readonly int _ScreenSize = Shader.PropertyToID("_ScreenSize");
         public static readonly int _PrevViewProjMatrix = Shader.PropertyToID("_PrevViewProjMatrix");

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/VaryingMesh.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/VaryingMesh.hlsl
@@ -142,7 +142,7 @@ FragInputs UnpackVaryingsMeshToFragInputs(PackedVaryingsMeshToPS input)
 
 #ifdef VARYINGS_NEED_TANGENT_TO_WORLD
     float4 tangentWS = float4(input.interpolators2.xyz, input.interpolators2.w > 0.0 ? 1.0 : -1.0);	// must not be normalized (mikkts requirement)
-    
+
     // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
 	float3 unnormalizedNormalWS = input.interpolators1.xyz;
     float renormFactor = 1.0 / length(unnormalizedNormalWS);
@@ -176,6 +176,9 @@ FragInputs UnpackVaryingsMeshToFragInputs(PackedVaryingsMeshToPS input)
 
 #if defined(VARYINGS_NEED_CULLFACE) && SHADER_STAGE_FRAGMENT
     output.isFrontFace = IS_FRONT_VFACE(input.cullFace, true, false);
+    // Handle handness of the view matrix (In Unity view matrix default to a determinant of -1)
+    // when we render a cubemap the view matrix handness is flipped (due to convention used for cubemap) we have a determinant of +1
+    output.isFrontFace = _ViewParam.x <  0.0 ? output.isFrontFace : !output.isFrontFace;
 #endif
 
     return output;


### PR DESCRIPTION
THis PR add view determinant test for FrontFace result which allow to correctly handle cubemap with double sided