### PR TITLE
HDRenderPipeline: Update correctly AtmosphericScattering.cs.hlsl

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/AtmosphericScattering/AtmosphericScattering.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/AtmosphericScattering/AtmosphericScattering.cs
@@ -57,6 +57,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         Exponential
     }
 
+    [GenerateHLSL]
+    public enum FogColorMode
+    {
+        ConstantColor,
+        SkyColor,
+    }
+
     [Serializable]
     public sealed class FogTypeParameter : VolumeParameter<FogType>
     {
@@ -64,13 +71,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             : base(value, overrideState)
         {
         }
-    }
-
-    [GenerateHLSL]
-    public enum FogColorMode
-    {
-        ConstantColor,
-        SkyColor,
     }
 
     [Serializable]

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/AtmosphericScattering/AtmosphericScattering.cs.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/AtmosphericScattering/AtmosphericScattering.cs.hlsl
@@ -5,14 +5,14 @@
 #ifndef ATMOSPHERICSCATTERING_CS_HLSL
 #define ATMOSPHERICSCATTERING_CS_HLSL
 //
-// UnityEngine.Experimental.Rendering.HDPipeline.AtmosphericScatteringSettings+FogType:  static fields
+// UnityEngine.Experimental.Rendering.HDPipeline.FogType:  static fields
 //
 #define FOGTYPE_NONE (0)
 #define FOGTYPE_LINEAR (1)
 #define FOGTYPE_EXPONENTIAL (2)
 
 //
-// UnityEngine.Experimental.Rendering.HDPipeline.AtmosphericScatteringSettings+FogColorMode:  static fields
+// UnityEngine.Experimental.Rendering.HDPipeline.FogColorMode:  static fields
 //
 #define FOGCOLORMODE_CONSTANT_COLOR (0)
 #define FOGCOLORMODE_SKY_COLOR (1)


### PR DESCRIPTION
@JulienIgnace-Unity 

It appear that the AtmosphericScattering.cs.hlsl is incorrectly generated if the structure FogColorMode  is after the FogTypeParameter  class. We need to dig into the issue that cause this in the ShaderGenerator but in the mean time move it above so it work.