### PR TITLE
HDRenderPipeline: use width instead of height for depth and color pyramid for consistency

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -1415,7 +1415,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             using (new ProfilingSample(cmd, "Gaussian Pyramid Color", GetSampler(CustomSamplerId.GaussianPyramidColor)))
             {
                 var colorPyramidDesc = m_GaussianPyramidColorBufferDesc;
-                var pyramidSideSize = colorPyramidDesc.height;
+                var pyramidSideSize = colorPyramidDesc.width;
 
                 // The gaussian pyramid compute works in blocks of 8x8 so make sure the last lod has a
                 // minimum size of 8x8
@@ -1470,7 +1470,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             using (new ProfilingSample(cmd, "Pyramid Depth", GetSampler(CustomSamplerId.PyramidDepth)))
             {
                 var depthPyramidDesc = m_DepthPyramidBufferDesc;
-                var pyramidSideSize = depthPyramidDesc.height;
+                var pyramidSideSize = depthPyramidDesc.width;
 
                 // The gaussian pyramid compute works in blocks of 8x8 so make sure the last lod has a
                 // minimum size of 8x8
@@ -1749,7 +1749,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             var pyramidSize = CalculatePyramidSize((int)hdCamera.screenSize.x, (int)hdCamera.screenSize.y);
 
-            // for stereo double-wide, each half of the texture will represent a single eye's pyramid 
+            // for stereo double-wide, each half of the texture will represent a single eye's pyramid
             //var widthModifier = 1;
             //if (stereoEnabled && (desc.dimension != TextureDimension.Tex2DArray))
             //    widthModifier = 2; // double-wide

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.hlsl
@@ -75,11 +75,13 @@ struct SSSData
 // SSSBuffer texture declaration
 TEXTURE2D(_SSSBufferTexture0);
 
+// Note: The SSS buffer used here is sRGB
 void EncodeIntoSSSBuffer(SSSData sssData, uint2 positionSS, out SSSBufferType0 outSSSBuffer0)
 {
     outSSSBuffer0 = float4(sssData.diffuseColor, PackFloatInt8bit(sssData.subsurfaceRadius, sssData.subsurfaceProfile, 16.0));
 }
 
+// Note: The SSS buffer used here is sRGB
 void DecodeFromSSSBuffer(float4 sssBuffer, uint2 positionSS, out SSSData sssData)
 {
     sssData.diffuseColor = sssBuffer.rgb;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
@@ -51,7 +51,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // for SSS
         public void InitSSSBuffersFromGBuffer(GBufferManager gbufferManager)
         {
-            m_RTIDs[0] = gbufferManager.GetGBuffers()[0];
+            m_RTIDs[0] = gbufferManager.GetGBuffers()[0]; // Note: This buffer must be sRGB (which is the case with Lit.shader)
         }
 
         // In case of full forward we must allocate the render target for forward SSS (or reuse one already existing)
@@ -62,7 +62,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             desc.depthBufferBits = 0;
             desc.colorFormat = RenderTextureFormat.ARGB32;
-            desc.sRGB = false;
+            desc.sRGB = true;  // Note: This buffer must be sRGB to match deferred case (which is the case with Lit.shader)
 
             cmd.ReleaseTemporaryRT(m_SSSBuffer0);
             cmd.GetTemporaryRT(m_SSSBuffer0, desc, FilterMode.Point);


### PR DESCRIPTION
- use width instead of height for depth and color pyramid for consistency
- use sRGB for SSSBuffer in forward only to match deferred and have better precision