### PR TITLE
Shadow Refactor v2

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -1080,9 +1080,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
         private void SetupShadowSliceTransform(int cascadeIndex, int shadowResolution, Matrix4x4 proj, Matrix4x4 view)
         {
-            if (cascadeIndex >= 4)
+            if (cascadeIndex >= kMaxCascades)
             {
-                Debug.LogError(String.Format("{0} is an invalid cascade index. Maximum of 4 cascades"));
+                Debug.LogError(String.Format("{0} is an invalid cascade index. Maximum of {1} cascades", cascadeIndex, kMaxCascades));
                 return;
             }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightPassShadow.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightPassShadow.hlsl
@@ -5,6 +5,7 @@
 
 // x: global clip space bias, y: normal world space bias
 float4 _ShadowBias;
+float3 _LightDirection;
 
 struct VertexInput
 {
@@ -17,8 +18,11 @@ float4 ShadowPassVertex(VertexInput v) : SV_POSITION
     float3 positionWS = TransformObjectToWorld(v.position.xyz);
     float3 normalWS = TransformObjectToWorldDir(v.normal);
 
+    float invNdotL = 1.0 - saturate(dot(_LightDirection, normalWS));
+    float scale = invNdotL * _ShadowBias.y;
+
     // normal bias is negative since we want to apply an inset normal offset
-    positionWS = normalWS * _ShadowBias.yyy + positionWS;
+    positionWS = normalWS * scale.xxx + positionWS;
     float4 clipPos = TransformWorldToHClip(positionWS);
 
     // _ShadowBias.x sign depens on if platform has reversed z buffer

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightPassShadow.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightPassShadow.hlsl
@@ -3,9 +3,27 @@
 
 #include "LightweightShaderLibrary/Core.hlsl"
 
-float4 ShadowPassVertex(float4 pos : POSITION) : SV_POSITION
+// x: global clip space bias, y: normal world space bias
+float4 _ShadowBias;
+
+struct VertexInput
 {
-    float4 clipPos = TransformObjectToHClip(pos.xyz);
+    float4 position : POSITION;
+    float3 normal   : NORMAL;
+};
+
+float4 ShadowPassVertex(VertexInput v) : SV_POSITION
+{
+    float3 positionWS = TransformObjectToWorld(v.position.xyz);
+    float3 normalWS = TransformObjectToWorldDir(v.normal);
+
+    // normal bias is negative since we want to apply an inset normal offset
+    positionWS = normalWS * _ShadowBias.yyy + positionWS;
+    float4 clipPos = TransformWorldToHClip(positionWS);
+
+    // _ShadowBias.x sign depens on if platform has reversed z buffer
+    clipPos.z += _ShadowBias.x;
+
 #if defined(UNITY_REVERSED_Z)
     clipPos.z = min(clipPos.z, UNITY_NEAR_CLIP_VALUE);
 #else

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Core.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Core.hlsl
@@ -5,6 +5,28 @@
 #include "CoreRP/ShaderLibrary/Packing.hlsl"
 #include "Input.hlsl"
 
+///////////////////////////////////////////////////////////////////////////////
+// Light Classification defines                                              //
+//                                                                           //
+// In order to reduce shader variations main light keywords were combined    //
+// here we define main light type keywords.                                  //
+// Main light is either a shadow casting light or the brighest directional.  //
+// Lightweight pipeline doesn't support point light shadows so they can't be //
+// classified as main light.                                                 //
+///////////////////////////////////////////////////////////////////////////////
+#if defined(_MAIN_LIGHT_DIRECTIONAL_SHADOW) || defined(_MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE) || defined(_MAIN_LIGHT_DIRECTIONAL_SHADOW_SOFT) || defined(_MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE_SOFT)
+#define _MAIN_LIGHT_DIRECTIONAL
+#endif
+
+#if defined(_MAIN_LIGHT_SPOT_SHADOW) || defined(_MAIN_LIGHT_SPOT_SHADOW_SOFT)
+#define _MAIN_LIGHT_SPOT
+#endif
+
+// In case no shadow casting light we classify main light as directional
+#if !defined(_MAIN_LIGHT_DIRECTIONAL) && !defined(_MAIN_LIGHT_SPOT)
+#define _MAIN_LIGHT_DIRECTIONAL
+#endif
+
 #ifdef _NORMALMAP
     #define OUTPUT_NORMAL(IN, OUT) OutputTangentToWorld(IN.tangent, IN.normal, OUT.tangent, OUT.binormal, OUT.normal)
 #else

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Lighting.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Lighting.hlsl
@@ -164,7 +164,7 @@ half3 DiffuseGI(half3 indirectDiffuse, half3 lambert, half mainLightRealtimeAtte
     // If shadows and mixed subtractive mode is enabled we need to remove direct
     // light contribution from lightmap from occluded pixels so we can have dynamic objects
     // casting shadows onto static correctly.
-#if defined(_MIXED_LIGHTING_SUBTRACTIVE) && defined(LIGHTMAP_ON) && defined(_SHADOWS)
+#if defined(_MIXED_LIGHTING_SUBTRACTIVE) && defined(LIGHTMAP_ON) && defined(_SHADOWS_ENABLED)
     indirectDiffuse = SubtractDirectMainLightFromLightmap(indirectDiffuse, mainLightRealtimeAttenuation, lambert);
 #endif
 
@@ -308,10 +308,10 @@ half3 DirectBDRF(BRDFData brdfData, half roughness2, half3 normal, half3 lightDi
 half CookieAttenuation(float3 worldPos)
 {
 #ifdef _MAIN_LIGHT_COOKIE
-#ifdef _MAIN_DIRECTIONAL_LIGHT
+#ifdef _MAIN_LIGHT_DIRECTIONAL
     float2 cookieUV = mul(_WorldToLight, float4(worldPos, 1.0)).xy;
     return SAMPLE_TEXTURE2D(_MainLightCookie, sampler_MainLightCookie, cookieUV).a;
-#elif defined(_MAIN_SPOT_LIGHT)
+#elif defined(_MAIN_LIGHT_SPOT)
     float4 projPos = mul(_WorldToLight, float4(worldPos, 1.0));
     float2 cookieUV = projPos.xy / projPos.w + 0.5;
     return SAMPLE_TEXTURE2D(_MainLightCookie, sampler_MainLightCookie, cookieUV).a;
@@ -371,7 +371,7 @@ inline half GetLightDirectionAndRealtimeAttenuation(LightInput lightInput, half3
 
 inline half GetMainLightDirectionAndRealtimeAttenuation(LightInput lightInput, half3 normalWS, float3 positionWS, out half3 lightDirection)
 {
-#ifdef _MAIN_DIRECTIONAL_LIGHT
+#if defined(_MAIN_LIGHT_DIRECTIONAL)
     // Light pos holds normalized light dir
     lightDirection = lightInput.position.xyz;
     half attenuation = 1.0;
@@ -381,7 +381,7 @@ inline half GetMainLightDirectionAndRealtimeAttenuation(LightInput lightInput, h
 
     // Cookies and shadows are only computed for main light
     attenuation *= CookieAttenuation(positionWS);
-    attenuation *= LIGHTWEIGHT_SHADOW_ATTENUATION(positionWS, normalWS, lightDirection);
+    attenuation *= RealtimeShadowAttenuation(positionWS, normalWS, lightDirection);
 
     return attenuation;
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Lighting.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Lighting.hlsl
@@ -381,7 +381,7 @@ inline half GetMainLightDirectionAndRealtimeAttenuation(LightInput lightInput, h
 
     // Cookies and shadows are only computed for main light
     attenuation *= CookieAttenuation(positionWS);
-    attenuation *= RealtimeShadowAttenuation(positionWS, normalWS, lightDirection);
+    attenuation *= RealtimeShadowAttenuation(positionWS);
 
     return attenuation;
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Shadows.hlsl
@@ -43,27 +43,24 @@ CBUFFER_END
 inline half SampleShadowmap(float4 shadowCoord)
 {
 #if defined(_SHADOWS_PERSPECTIVE)
-    float3 coord = shadowCoord.xyz /= shadowCoord.w;
-#else
-    float3 coord = shadowCoord.xyz;
+    shadowCoord.xyz = shadowCoord.xyz /= shadowCoord.w;
 #endif
 
-    coord.z = saturate(coord.z);
-    if (coord.x <= 0 || coord.x >= 1 || coord.y <= 0 || coord.y >= 1)
+    if (shadowCoord.x <= 0 || shadowCoord.x >= 1 || shadowCoord.y <= 0 || shadowCoord.y >= 1 || shadowCoord.z <= 0 || shadowCoord.z >= 1)
         return 1;
 
 #ifdef _SHADOWS_SOFT
     // 4-tap hardware comparison
     half4 attenuation;
-    attenuation.x = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, coord + _ShadowOffset0.xyz);
-    attenuation.y = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, coord + _ShadowOffset1.xyz);
-    attenuation.z = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, coord + _ShadowOffset2.xyz);
-    attenuation.w = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, coord + _ShadowOffset3.xyz);
+    attenuation.x = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset0.xyz);
+    attenuation.y = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset1.xyz);
+    attenuation.z = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset2.xyz);
+    attenuation.w = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset3.xyz);
     lerp(attenuation, 1.0, _ShadowData.xxxx);
     return dot(attenuation, 0.25);
 #else
     // 1-tap hardware comparison
-    half attenuation = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, coord);
+    half attenuation = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz);
     return lerp(attenuation, 1.0, _ShadowData.x);
 #endif
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightShaderLibrary/Shadows.hlsl
@@ -50,9 +50,6 @@ inline half SampleShadowmap(float4 shadowCoord)
     shadowCoord.xyz = shadowCoord.xyz /= shadowCoord.w;
 #endif
 
-    if (shadowCoord.x <= 0 || shadowCoord.x >= 1 || shadowCoord.y <= 0 || shadowCoord.y >= 1 || shadowCoord.z <= 0 || shadowCoord.z >= 1)
-        return 1;
-
 #ifdef _SHADOWS_SOFT
     // 4-tap hardware comparison
     half4 attenuation4;
@@ -67,7 +64,11 @@ inline half SampleShadowmap(float4 shadowCoord)
 #endif
 
     // Apply shadow strength
-    return LerpWhiteTo(attenuation, _ShadowData.x);
+    attenuation = LerpWhiteTo(attenuation, _ShadowData.x);
+
+    // Shadow coords that fall out of the light frustum volume must always return attenuation 1.0
+    // TODO: We can set shadowmap sampler to clamptoborder when we don't have a shadow atlas and avoid xy coord bounds check
+    return (shadowCoord.x <= 0 || shadowCoord.x >= 1 || shadowCoord.y <= 0 || shadowCoord.y >= 1 || shadowCoord.z >= 1) ? 1.0 : attenuation;
 }
 
 inline half ComputeCascadeIndex(float3 wpos)

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
@@ -70,6 +70,7 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             #pragma target 3.0
 
             // -------------------------------------
+            // Material Keywords
             #pragma shader_feature _NORMALMAP
             #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
             #pragma shader_feature _EMISSION
@@ -81,16 +82,24 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             #pragma shader_feature _GLOSSYREFLECTIONS_OFF
             #pragma shader_feature _SPECULAR_SETUP
 
+            // -------------------------------------
+            // Lightweight Pipeline keywords
+            // We have no good approach exposed to skip shader variants, e.g, ideally we would like to skip _CASCADE for all puctual lights
+            // Lightweight combines light classification and shadows keywords to reduce shader variants.
+            // Lightweight shader library declares defines based on these keywords to avoid having to check them in the shaders
+            // Core.hlsl defines _MAIN_LIGHT_DIRECTIONAL and _MAIN_LIGHT_SPOT (point lights can't be main light)
+            // Shadow.hlsl defines _SHADOWS_ENABLED, _SHADOWS_SOFT, _SHADOWS_CASCADE, _SHADOWS_PERSPECTIVE
+            #pragma multi_compile _ _MAIN_LIGHT_DIRECTIONAL_SHADOW _MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE _MAIN_LIGHT_DIRECTIONAL_SHADOW_SOFT _MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE_SOFT _MAIN_LIGHT_SPOT_SHADOW _MAIN_LIGHT_SPOT_SHADOW_SOFT
             #pragma multi_compile _ _MAIN_LIGHT_COOKIE
-            #pragma multi_compile _MAIN_DIRECTIONAL_LIGHT _MAIN_SPOT_LIGHT
             #pragma multi_compile _ _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
+
+            // -------------------------------------
+            // Unity defined keywords
             #pragma multi_compile _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
-            #pragma multi_compile _ _HARD_SHADOWS _SOFT_SHADOWS _HARD_SHADOWS_CASCADES _SOFT_SHADOWS_CASCADES
-            #pragma multi_compile _ _VERTEX_LIGHTS
-
             #pragma multi_compile_fog
 
             #pragma vertex LitPassVertex

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticles.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticles.shader
@@ -1,5 +1,7 @@
-// No support to Distortion
-// No support to Shadows
+// ------------------------------------------
+// Only directional light is supported for lit particles
+// No shadow
+// No distortion
 Shader "LightweightPipeline/Particles/Standard"
 {
     Properties
@@ -58,7 +60,6 @@ Shader "LightweightPipeline/Particles/Standard"
             #pragma vertex ParticlesLitVertex
             #pragma fragment ParticlesLitFragment
             #pragma multi_compile __ SOFTPARTICLES_ON
-            #pragma multi_compile _MAIN_DIRECTIONAL_LIGHT _MAIN_SPOT_LIGHT
             #pragma target 3.5
 
             #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON _ALPHAMODULATE_ON

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
@@ -63,21 +63,33 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
             // Required to compile gles 2.0 with standard srp library
             #pragma prefer_hlslcc gles
             #pragma target 3.0
+
+            // -------------------------------------
+            // Material Keywords
             #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON
             #pragma shader_feature _ _SPECGLOSSMAP _SPECULAR_COLOR
             #pragma shader_feature _ _GLOSSINESS_FROM_BASE_ALPHA
             #pragma shader_feature _NORMALMAP
             #pragma shader_feature _EMISSION
 
+            // -------------------------------------
+            // Lightweight Pipeline keywords
+            // We have no good approach exposed to skip shader variants, e.g, ideally we would like to skip _CASCADE for all puctual lights
+            // Lightweight combines light classification and shadows keywords to reduce shader variants.
+            // Lightweight shader library declares defines based on these keywords to avoid having to check them in the shaders
+            // Core.hlsl defines _MAIN_LIGHT_DIRECTIONAL and _MAIN_LIGHT_SPOT (point lights can't be main light)
+            // Shadow.hlsl defines _SHADOWS_ENABLED, _SHADOWS_SOFT, _SHADOWS_CASCADE, _SHADOWS_PERSPECTIVE
+            #pragma multi_compile _ _MAIN_LIGHT_DIRECTIONAL_SHADOW _MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE _MAIN_LIGHT_DIRECTIONAL_SHADOW_SOFT _MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE_SOFT _MAIN_LIGHT_SPOT_SHADOW _MAIN_LIGHT_SPOT_SHADOW_SOFT
             #pragma multi_compile _ _MAIN_LIGHT_COOKIE
-            #pragma multi_compile _MAIN_DIRECTIONAL_LIGHT _MAIN_SPOT_LIGHT
             #pragma multi_compile _ _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ _VERTEX_LIGHTS            
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
+
+            // -------------------------------------
+            // Unity defined keywords
             #pragma multi_compile _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
-            #pragma multi_compile _ _HARD_SHADOWS _SOFT_SHADOWS _HARD_SHADOWS_CASCADES _SOFT_SHADOWS_CASCADES
-            #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile_fog
 
             #pragma vertex LitPassVertex

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardTerrain.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardTerrain.shader
@@ -41,18 +41,17 @@ Shader "LightweightPipeline/Standard Terrain"
             #pragma vertex SplatmapVert
             #pragma fragment SpatmapFragment
 
+            #pragma multi_compile _ _MAIN_LIGHT_DIRECTIONAL_SHADOW _MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE _MAIN_LIGHT_DIRECTIONAL_SHADOW_SOFT _MAIN_LIGHT_DIRECTIONAL_SHADOW_CASCADE_SOFT _MAIN_LIGHT_SPOT_SHADOW _MAIN_LIGHT_SPOT_SHADOW_SOFT
             #pragma multi_compile _ _MAIN_LIGHT_COOKIE
-            #pragma multi_compile _MAIN_DIRECTIONAL_LIGHT _MAIN_SPOT_LIGHT
             #pragma multi_compile _ _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             #pragma multi_compile _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
-            #pragma multi_compile _ _HARD_SHADOWS _SOFT_SHADOWS _HARD_SHADOWS_CASCADES _SOFT_SHADOWS_CASCADES
-            #pragma multi_compile _ _VERTEX_LIGHTS
+            #pragma multi_compile_fog
 
             #pragma multi_compile __ _TERRAIN_NORMAL_MAP
-            #pragma multi_compile_fog
 
             #include "LightweightShaderLibrary/Lighting.hlsl"
 


### PR DESCRIPTION
 * Reduced shader variants by ~30% by combining shadow and light classification keywords
 * Removed all branching from shadow shader code. 
 * Moved bias and normal bias to caster side.
 * Bias values match Unity legacy. zclip bias is scaled by frustum depth range and normal bias use same kernel as built-in pipeline.
 * Fixed OpenGL clip space depth range while computing shadow projection.
 * Small improvement of shader ALU and constant access