### PR TITLE
Feature/hd render pipeline editor

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineInspector.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineInspector.cs
@@ -75,20 +75,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_FrameSettingsUI.Reset(serializedFrameSettings, Repaint);
         }
 
-        static void HackSetDirty(RenderPipelineAsset asset)
-        {
-            EditorUtility.SetDirty(asset);
-            var method = typeof(RenderPipelineAsset).GetMethod("OnValidate", BindingFlags.FlattenHierarchy | BindingFlags.NonPublic | BindingFlags.Instance);
-            if (method != null)
-                method.Invoke(asset, new object[0]);
-        }
-
         void GlobalLightLoopSettingsUI(HDRenderPipelineAsset hdAsset)
         {
             EditorGUILayout.Space();
             EditorGUILayout.LabelField(s_Styles.textureSettings);
             EditorGUI.indentLevel++;
-            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_SpotCookieSize, s_Styles.spotCookieSize);
             EditorGUILayout.PropertyField(m_PointCookieSize, s_Styles.pointCookieSize);
             EditorGUILayout.PropertyField(m_ReflectionCubemapSize, s_Styles.reflectionCubemapSize);
@@ -96,10 +87,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             //EditorGUILayout.PropertyField(m_ReflectionCacheCompressed, s_Styles.reflectionCacheCompressed);
             EditorGUILayout.PropertyField(m_SkyReflectionSize, s_Styles.skyReflectionSize);
             EditorGUILayout.PropertyField(m_SkyLightingOverrideLayerMask, s_Styles.skyLightingOverride);
-            if (EditorGUI.EndChangeCheck())
-            {
-                HackSetDirty(hdAsset); // Repaint
-            }
             EditorGUI.indentLevel--;
         }
 
@@ -108,13 +95,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUILayout.Space();
             EditorGUILayout.LabelField(s_Styles.renderingSettingsLabel);
             EditorGUI.indentLevel++;
-            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_supportDBuffer, s_Styles.supportDBuffer);
             EditorGUILayout.PropertyField(m_supportMSAA, s_Styles.supportMSAA);
-            if (EditorGUI.EndChangeCheck())
-            {
-                HackSetDirty(hdAsset); // Repaint
-            }
             EditorGUI.indentLevel--;
         }
 
@@ -123,13 +105,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUILayout.Space();
             EditorGUILayout.LabelField(s_Styles.shadowSettings);
             EditorGUI.indentLevel++;
-            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_ShadowAtlasWidth, s_Styles.shadowsAtlasWidth);
             EditorGUILayout.PropertyField(m_ShadowAtlasHeight, s_Styles.shadowsAtlasHeight);
-            if (EditorGUI.EndChangeCheck())
-            {
-                HackSetDirty(hdAsset); // Repaint
-            }
             EditorGUI.indentLevel--;
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/LightLoopSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/LightLoopSettingsUI.cs
@@ -38,9 +38,6 @@ namespace UnityEditor.Experimental.Rendering
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(p.enableBigTilePrepass, _.GetContent("Enable Big Tile Prepass"));
-                // Allow to disable cluster for forward opaque when in forward only (option have no effect when MSAA is enabled)
-                // Deferred opaque are always tiled
-                EditorGUILayout.PropertyField(p.enableFptlForForwardOpaque, _.GetContent("Enable FPTL For Forward Opaque"));
                 EditorGUILayout.PropertyField(p.enableComputeLightEvaluation, _.GetContent("Enable Compute Light Evaluation"));
                 GUILayout.BeginVertical();
                 if (EditorGUILayout.BeginFadeGroup(s.isSectionExpandedComputeLightEvaluation.faded))
@@ -58,6 +55,8 @@ namespace UnityEditor.Experimental.Rendering
             GUILayout.EndVertical();
 
             EditorGUILayout.PropertyField(p.isFptlEnabled, _.GetContent("Enable FPTL"));
+            // Allow to disable cluster for forward opaque when in forward only (option have no effect when MSAA is enabled)
+            // Deferred opaque are always tiled
             EditorGUILayout.PropertyField(p.enableFptlForForwardOpaque, _.GetContent("Enable FPTL For Forward Opaque"));
         }
     }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipelineAsset.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipelineAsset.cs
@@ -42,6 +42,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // Modification of defaultFrameSettings in the inspector will call OnValidate().
             // We do a copy of the settings to those effectively used
             serializedFrameSettings.CopyTo(m_FrameSettings);
+
+            // All instance created in the editor have obsolete settings
+            // So we must dispose them
+            DestroyCreatedInstances();
         }
 
         // Store the various RenderPipelineSettings for each platform (for now only one)


### PR DESCRIPTION
Added  DestroyCreatedInstances() in HDRenderPipelineAsset.OnValidate

HDRenderPipelineAsset redefines a private method OnValidate that hides its parent's one.
So DestroyCreatedInstances was not called whne the asset is updated