### PR TITLE
Decouple SSS and Transmission option

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineInspector.Styles.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineInspector.Styles.cs
@@ -15,6 +15,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             public readonly GUIContent supportDBuffer = new GUIContent("Support Decal buffer");
             public readonly GUIContent supportMSAA = new GUIContent("Support MSAA");
+            public readonly GUIContent supportSubsurfaceScattering = new GUIContent("Support SubsurfaceScattering");
+
             // Shadow Settings
             public readonly GUIContent shadowSettings = new GUIContent("Shadow Settings");
             public readonly GUIContent shadowsAtlasWidth = new GUIContent("Atlas Width");

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineInspector.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineInspector.cs
@@ -28,6 +28,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         // Global Render settings
         SerializedProperty m_supportDBuffer;
         SerializedProperty m_supportMSAA;
+        SerializedProperty m_supportSubsurfaceScattering;
         // Global Shadow settings
         SerializedProperty m_ShadowAtlasWidth;
         SerializedProperty m_ShadowAtlasHeight;
@@ -54,6 +55,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // Global Render settings
             m_supportDBuffer = properties.Find(x => x.renderPipelineSettings.supportDBuffer);
             m_supportMSAA = properties.Find(x => x.renderPipelineSettings.supportMSAA);
+            m_supportSubsurfaceScattering = properties.Find(x => x.renderPipelineSettings.supportSubsurfaceScattering);
+
             // Global Shadow settings
             m_ShadowAtlasWidth = properties.Find(x => x.renderPipelineSettings.shadowInitParams.shadowAtlasWidth);
             m_ShadowAtlasHeight = properties.Find(x => x.renderPipelineSettings.shadowInitParams.shadowAtlasHeight);
@@ -97,6 +100,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(m_supportDBuffer, s_Styles.supportDBuffer);
             EditorGUILayout.PropertyField(m_supportMSAA, s_Styles.supportMSAA);
+            EditorGUILayout.PropertyField(m_supportSubsurfaceScattering, s_Styles.supportSubsurfaceScattering);
+
             EditorGUI.indentLevel--;
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
@@ -134,7 +134,8 @@ namespace UnityEditor.Experimental.Rendering
         {
             EditorGUILayout.PropertyField(p.enableSSR, _.GetContent("Enable SSR"));
             EditorGUILayout.PropertyField(p.enableSSAO, _.GetContent("Enable SSAO"));
-            EditorGUILayout.PropertyField(p.enableSSSAndTransmission, _.GetContent("Enable SSS And Transmission"));
+            EditorGUILayout.PropertyField(p.enableSubsurfaceScattering, _.GetContent("Enable SubsurfaceScattering"));
+            EditorGUILayout.PropertyField(p.enableTransmission, _.GetContent("Enable Transmission"));
             EditorGUILayout.PropertyField(p.enableShadow, _.GetContent("Enable Shadow"));
             EditorGUILayout.PropertyField(p.enableShadowMask, _.GetContent("Enable Shadow Masks"));
         }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedFrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedFrameSettings.cs
@@ -9,7 +9,8 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty enableShadow;
         public SerializedProperty enableSSR;
         public SerializedProperty enableSSAO;
-        public SerializedProperty enableSSSAndTransmission;
+        public SerializedProperty enableSubsurfaceScattering;
+        public SerializedProperty enableTransmission;
 
         public SerializedProperty diffuseGlobalDimmer;
         public SerializedProperty specularGlobalDimmer;
@@ -48,7 +49,8 @@ namespace UnityEditor.Experimental.Rendering
             enableShadow = root.Find((FrameSettings d) => d.enableShadow);
             enableSSR = root.Find((FrameSettings d) => d.enableSSR);
             enableSSAO = root.Find((FrameSettings d) => d.enableSSAO);
-            enableSSSAndTransmission = root.Find((FrameSettings d) => d.enableSSSAndTransmission);
+            enableSubsurfaceScattering = root.Find((FrameSettings d) => d.enableSubsurfaceScattering);
+            enableTransmission = root.Find((FrameSettings d) => d.enableTransmission);
             diffuseGlobalDimmer = root.Find((FrameSettings d) => d.diffuseGlobalDimmer);
             specularGlobalDimmer = root.Find((FrameSettings d) => d.specularGlobalDimmer);
             enableForwardRenderingOnly = root.Find((FrameSettings d) => d.enableForwardRenderingOnly);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -1245,7 +1245,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             var options = new LightLoop.LightingPassOptions();
 
-            if (m_FrameSettings.enableSSSAndTransmission)
+            if (m_FrameSettings.enableSubsurfaceScattering)
             {
                 // Output split lighting for materials asking for it (masked in the stencil buffer)
                 options.outputSplitLighting = true;
@@ -1309,7 +1309,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 if (pass == ForwardPass.Opaque)
                 {
                     // In case of forward SSS we will bind all the required target. It is up to the shader to write into it or not.
-                    if (m_FrameSettings.enableSSSAndTransmission)
+                    if (m_FrameSettings.enableSubsurfaceScattering)
                     {
                         RenderTargetIdentifier[] m_MRTWithSSS = new RenderTargetIdentifier[2 + m_SSSBufferManager.sssBufferCount];
                         m_MRTWithSSS[0] = m_CameraColorBufferRT; // Store the specular color

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDStringConstants.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDStringConstants.cs
@@ -137,7 +137,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _SkyTexture = Shader.PropertyToID("_SkyTexture");
         public static readonly int _SkyTextureMipCount = Shader.PropertyToID("_SkyTextureMipCount");
 
-        public static readonly int _EnableSSSAndTransmission = Shader.PropertyToID("_EnableSSSAndTransmission");
+        public static readonly int _EnableSubsurfaceScattering = Shader.PropertyToID("_EnableSubsurfaceScattering");
+        public static readonly int _TransmittanceMultiplier = Shader.PropertyToID("_TransmittanceMultiplier");
         public static readonly int _TexturingModeFlags = Shader.PropertyToID("_TexturingModeFlags");
         public static readonly int _TransmissionFlags = Shader.PropertyToID("_TransmissionFlags");
         public static readonly int _ThicknessRemaps = Shader.PropertyToID("_ThicknessRemaps");

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Deferred.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Deferred.shader
@@ -120,7 +120,7 @@ Shader "Hidden/HDRenderPipeline/Deferred"
                 Outputs outputs;
 
             #ifdef OUTPUT_SPLIT_LIGHTING
-                if (_EnableSSSAndTransmission != 0 && HaveSubsurfaceScattering(bsdfData))
+                if (_EnableSubsurfaceScattering != 0 && HaveSubsurfaceScattering(bsdfData))
                 {
                     outputs.specularLighting = float4(specularLighting, 1.0);
                     outputs.diffuseLighting  = TagLightingForSSS(diffuseLighting);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/Deferred.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/Deferred.compute
@@ -150,7 +150,7 @@ void SHADE_OPAQUE_ENTRY(uint2 dispatchThreadId : SV_DispatchThreadID, uint2 grou
     float3 specularLighting;
     LightLoop(V, posInput, preLightData, bsdfData, bakeLightingData, featureFlags, diffuseLighting, specularLighting);
 
-    if (_EnableSSSAndTransmission != 0 && HaveSubsurfaceScattering(bsdfData))
+    if (_EnableSubsurfaceScattering != 0 && HaveSubsurfaceScattering(bsdfData))
     {
         specularLightingUAV[pixelCoord] = float4(specularLighting, 1.0);
         diffuseLightingUAV[pixelCoord]  = TagLightingForSSS(diffuseLighting);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
@@ -2087,7 +2087,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     {
                         // If SSS is disable, do lighting for both split lighting and no split lighting
                         // This is for debug purpose, so fine to use immediate material mode here to modify render state
-                        if (!m_FrameSettings.enableSSSAndTransmission)
+                        if (!m_FrameSettings.enableSubsurfaceScattering)
                         {
                             currentLightingMaterial.SetInt(HDShaderIDs._StencilRef, (int)StencilLightingUsage.NoLighting);
                             currentLightingMaterial.SetInt(HDShaderIDs._StencilCmp, (int)CompareFunction.NotEqual);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.hlsl
@@ -9,7 +9,8 @@
 CBUFFER_START(UnitySSSAndTransmissionParameters)
 // Warning: Unity is not able to losslessly transfer integers larger than 2^24 to the shader system.
 // Therefore, we bitcast uint to float in C#, and bitcast back to uint in the shader.
-uint   _EnableSSSAndTransmission; // Globally toggles subsurface and transmission scattering on/off
+uint   _EnableSubsurfaceScattering; // Globally toggles subsurface and transmission scattering on/off
+float  _TransmittanceMultiplier;    // Allow to switch on/off the transmittance but doesn't save the cost
 float  _TexturingModeFlags;       // 1 bit/profile; 0 = PreAndPostScatter, 1 = PostScatter
 float  _TransmissionFlags;        // 2 bit/profile; 0 = inf. thick, 1 = thin, 2 = regular
 // Old SSS Model >>>
@@ -32,12 +33,12 @@ float3 ApplySubsurfaceScatteringTexturingMode(float3 color, int diffusionProfile
 {
 #if defined(SHADERPASS) && (SHADERPASS == SHADERPASS_SUBSURFACE_SCATTERING)
     // If the SSS pass is executed, we know we have SSS enabled.
-    bool enableSssAndTransmission = true;
+    bool enableSss = true;
 #else
-    bool enableSssAndTransmission = _EnableSSSAndTransmission != 0;
+    bool enableSss = _EnableSubsurfaceScattering != 0;
 #endif
 
-    if (enableSssAndTransmission)
+    if (enableSss)
     {
         bool performPostScatterTexturing = IsBitSet(asuint(_TexturingModeFlags), diffusionProfile);
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
@@ -121,7 +121,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public void PushGlobalParams(CommandBuffer cmd, DiffusionProfileSettings sssParameters, FrameSettings frameSettings)
         {
             // Broadcast SSS parameters to all shaders.
-            cmd.SetGlobalInt(HDShaderIDs._EnableSSSAndTransmission, frameSettings.enableSSSAndTransmission ? 1 : 0);
+            cmd.SetGlobalInt(HDShaderIDs._EnableSubsurfaceScattering, frameSettings.enableSubsurfaceScattering ? 1 : 0);
+            cmd.SetGlobalFloat(HDShaderIDs._TransmittanceMultiplier, frameSettings.enableTransmission ? 1.0f : 0.0f);
             unsafe
             {
                 // Warning: Unity is not able to losslessly transfer integers larger than 2^24 to the shader system.
@@ -153,7 +154,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public void SubsurfaceScatteringPass(HDCamera hdCamera, CommandBuffer cmd, DiffusionProfileSettings sssParameters, FrameSettings frameSettings,
                                             RenderTargetIdentifier colorBufferRT, RenderTargetIdentifier diffuseBufferRT, RenderTargetIdentifier depthStencilBufferRT, RenderTargetIdentifier depthTextureRT)
         {
-            if (sssParameters == null || !frameSettings.enableSSSAndTransmission)
+            if (sssParameters == null || !frameSettings.enableSubsurfaceScattering)
                 return;
 
             using (new ProfilingSample(cmd, "Subsurface Scattering", HDRenderPipeline.GetSampler(CustomSamplerId.SubsurfaceScattering)))

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
@@ -11,7 +11,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static string kEnableShadow = "Enable Shadow";
         public static string kEnableSSR = "Enable SSR";
         public static string kEnableSSAO = "Enable SSAO";
-        public static string kEnableSSSAndTransmission = "Enable SSS and Transmission";
+        public static string kEnableSubsurfaceScattering = "Enable SubsurfaceScattering";
+        public static string kEnableTransmission = "Enable Transmission";
 
         public static string kForwardOnly = "Forward Only";
         public static string kDeferredDepthPrepass = "Deferred Depth Prepass";
@@ -41,7 +42,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool enableShadow = true;
         public bool enableSSR = true; // Depends on DepthPyramid
         public bool enableSSAO = true;
-        public bool enableSSSAndTransmission = true;
+        public bool enableSubsurfaceScattering = true;
+        public bool enableTransmission = true;  // Caution: this is only for debug, it doesn't save the cost of Transmission execution
 
         // Setup by system
         public float diffuseGlobalDimmer = 1.0f;
@@ -79,7 +81,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             frameSettings.enableShadow = this.enableShadow;
             frameSettings.enableSSR = this.enableSSR;
             frameSettings.enableSSAO = this.enableSSAO;
-            frameSettings.enableSSSAndTransmission = this.enableSSSAndTransmission;
+            frameSettings.enableSubsurfaceScattering = this.enableSubsurfaceScattering;
+            frameSettings.enableTransmission = this.enableTransmission;
 
             frameSettings.diffuseGlobalDimmer = this.diffuseGlobalDimmer;
             frameSettings.specularGlobalDimmer = this.specularGlobalDimmer;
@@ -134,7 +137,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             aggregate.enableShadow = frameSettings.enableShadow;
             aggregate.enableSSR = camera.cameraType == CameraType.Reflection ? false : frameSettings.enableSSR && renderPipelineSettings.supportSSR;
             aggregate.enableSSAO = frameSettings.enableSSAO && renderPipelineSettings.supportSSAO;
-            aggregate.enableSSSAndTransmission = camera.cameraType == CameraType.Reflection ? false : frameSettings.enableSSSAndTransmission && renderPipelineSettings.supportSSSAndTransmission;
+            aggregate.enableSubsurfaceScattering = camera.cameraType == CameraType.Reflection ? false : frameSettings.enableSubsurfaceScattering && renderPipelineSettings.supportSubsurfaceScattering;
+            aggregate.enableTransmission = frameSettings.enableTransmission;
 
             // We have to fall back to forward-only rendering when scene view is using wireframe rendering mode
             // as rendering everything in wireframe + deferred do not play well together
@@ -178,7 +182,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             DebugMenuManager.instance.AddDebugItem<bool>(menuName, kEnableShadow, () => frameSettings.enableShadow, (value) => frameSettings.enableShadow = (bool)value);
             DebugMenuManager.instance.AddDebugItem<bool>(menuName, kEnableSSR, () => frameSettings.enableSSR, (value) => frameSettings.enableSSR = (bool)value);
             DebugMenuManager.instance.AddDebugItem<bool>(menuName, kEnableSSAO, () => frameSettings.enableSSAO, (value) => frameSettings.enableSSAO = (bool)value);
-            DebugMenuManager.instance.AddDebugItem<bool>(menuName, kEnableSSSAndTransmission, () => frameSettings.enableSSSAndTransmission, (value) => frameSettings.enableSSSAndTransmission = (bool)value);
+            DebugMenuManager.instance.AddDebugItem<bool>(menuName, kEnableSubsurfaceScattering, () => frameSettings.enableSubsurfaceScattering, (value) => frameSettings.enableSubsurfaceScattering = (bool)value);
+            DebugMenuManager.instance.AddDebugItem<bool>(menuName, kEnableTransmission, () => frameSettings.enableTransmission, (value) => frameSettings.enableTransmission = (bool)value);
+
 
             DebugMenuManager.instance.AddDebugItem<bool>(menuName, kForwardOnly, () => frameSettings.enableForwardRenderingOnly, (value) => frameSettings.enableForwardRenderingOnly = (bool)value);
             DebugMenuManager.instance.AddDebugItem<bool>(menuName, kDeferredDepthPrepass, () => frameSettings.enableDepthPrepassWithDeferredRendering, (value) => frameSettings.enableDepthPrepassWithDeferredRendering = (bool)value);
@@ -212,7 +218,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             DebugMenuManager.instance.RemoveDebugItem(menuName, kEnableShadow);
             DebugMenuManager.instance.RemoveDebugItem(menuName, kEnableSSR);
             DebugMenuManager.instance.RemoveDebugItem(menuName, kEnableSSAO);
-            DebugMenuManager.instance.RemoveDebugItem(menuName, kEnableSSSAndTransmission);
+            DebugMenuManager.instance.RemoveDebugItem(menuName, kEnableSubsurfaceScattering);
+            DebugMenuManager.instance.RemoveDebugItem(menuName, kEnableTransmission);
 
             DebugMenuManager.instance.RemoveDebugItem(menuName, kForwardOnly);
             DebugMenuManager.instance.RemoveDebugItem(menuName, kDeferredDepthPrepassATestOnly);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/RenderPipelineSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/RenderPipelineSettings.cs
@@ -23,7 +23,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool supportShadowMask = true;
         public bool supportSSR = true;
         public bool supportSSAO = true;
-        public bool supportSSSAndTransmission = true;
+        public bool supportSubsurfaceScattering = true;
 
         // Engine
         public bool supportDBuffer = false;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForward.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForward.hlsl
@@ -79,7 +79,7 @@ void Frag(PackedVaryingsToPS packedInput,
         LightLoop(V, posInput, preLightData, bsdfData, bakeLightingData, featureFlags, diffuseLighting, specularLighting);
 
 #ifdef OUTPUT_SPLIT_LIGHTING
-        if (_EnableSSSAndTransmission != 0 && HaveSubsurfaceScattering(bsdfData))
+        if (_EnableSubsurfaceScattering != 0 && HaveSubsurfaceScattering(bsdfData))
         {
             outColor = float4(specularLighting, 1.0);
             outDiffuseLighting = float4(TagLightingForSSS(diffuseLighting), 1.0);


### PR DESCRIPTION
Rename EnableSSSAndTransmission as EnableSubsurfaceScattering and
EnableTransmission
Note: Disabling Transmission doesn't save the ALU if it is enabled in
the profile

+ Add supportSubsurfaceScattering in UI
+ Small cosmetic rearrangement at the beginning of lit.hlsl