### PR TITLE
Fix GameObject menu item priority

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/CoreUtils.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/CoreUtils.cs
@@ -49,6 +49,7 @@ namespace UnityEngine.Experimental.Rendering
         public const int editMenuPriority2 = 331;
         public const int assetCreateMenuPriority1 = 230;
         public const int assetCreateMenuPriority2 = 241;
+        public const int gameObjectMenuPriority = 10;
 
         static Cubemap m_BlackCubeTexture;
         public static Cubemap blackCubeTexture

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Decal/DecalMenuItems.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Decal/DecalMenuItems.cs
@@ -1,12 +1,13 @@
 using System.IO;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class DecalMenuItems
     {
-        [MenuItem("GameObject/Render Pipeline/High Definition/DecalProjector", false, 0)]
+        [MenuItem("GameObject/Render Pipeline/High Definition/DecalProjector", priority = CoreUtils.gameObjectMenuPriority)]
         static void CreateDecal(MenuCommand menuCommand)
         {
             // Create a custom game object

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineMenuItems.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineMenuItems.cs
@@ -272,7 +272,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
-        [MenuItem("GameObject/Render Pipeline/High Definition/Scene Settings", priority = 10)]
+        [MenuItem("GameObject/Render Pipeline/High Definition/Scene Settings", priority = CoreUtils.gameObjectMenuPriority)]
         static void CreateCustomGameObject(MenuCommand menuCommand)
         {
             var sceneSettings = new GameObject("Scene Settings");


### PR DESCRIPTION
Specify priority for all menu items under `GameObject/Render Pipeline/High Definition/` to ensure they appear in correct order.