### PR TITLE
Reduced GC pressure in LWRP

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -159,6 +159,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         // and per-object light lists.
         private List<int> m_SortedLightIndexMap = new List<int>();
 
+        private Dictionary<VisibleLight, int> m_VisibleLightsIDMap = new Dictionary<VisibleLight, int>(new LightEqualityComparer());
+
         private Mesh m_BlitQuad;
         private Material m_BlitMaterial;
         private Material m_CopyDepthMaterial;
@@ -675,9 +677,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         {
             int totalVisibleLights = visibleLights.Length;
 
-            Dictionary<int, int> visibleLightsIDMap = new Dictionary<int, int>();
+            m_VisibleLightsIDMap.Clear();
             for (int i = 0; i < totalVisibleLights; ++i)
-                visibleLightsIDMap.Add(visibleLights[i].GetHashCode(), i);
+                m_VisibleLightsIDMap.Add(visibleLights[i], i);
 
             // Sorts light so we have all directionals first, then local lights.
             // Directionals are sorted further by shadow, cookie and intensity
@@ -686,7 +688,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             Array.Sort(visibleLights, m_LightCompararer);
 
             for (int i = 0; i < totalVisibleLights; ++i)
-                m_SortedLightIndexMap.Add(visibleLightsIDMap[visibleLights[i].GetHashCode()]);
+                m_SortedLightIndexMap.Add(m_VisibleLightsIDMap[visibleLights[i]]);
 
             return GetMainLight(visibleLights);
         }
@@ -920,7 +922,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 bias = light.shadowBias * proj.m22 * 0.5f * sign;
 
                 // Currently only square POT cascades resolutions are used.
-                // We scale normalBias 
+                // We scale normalBias
                 double frustumWidth = 2.0 / (double)proj.m00;
                 double frustumHeight = 2.0 / (double)proj.m11;
                 float texelSizeX = (float)(frustumWidth / (double)cascadeResolution);
@@ -1138,7 +1140,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             worldToShadow = cascadeAtlas * worldToShadow;
 
             m_ShadowSlices[cascadeIndex].atlasX = atlasX;
-            m_ShadowSlices[cascadeIndex].atlasY = atlasY; 
+            m_ShadowSlices[cascadeIndex].atlasY = atlasY;
             m_ShadowSlices[cascadeIndex].shadowResolution = shadowResolution;
             m_ShadowSlices[cascadeIndex].shadowTransform = worldToShadow;
         }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -172,7 +172,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         private PostProcessLayer m_CameraPostProcessLayer;
 
         private CameraComparer m_CameraComparer = new CameraComparer();
-        private LightComparer m_LightCompararer = new LightComparer();
+        private LightComparer m_LightComparer = new LightComparer();
 
         // Maps from sorted light indices to original unsorted. We need this for shadow rendering
         // and per-object light lists.
@@ -703,8 +703,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             // Sorts light so we have all directionals first, then local lights.
             // Directionals are sorted further by shadow, cookie and intensity
             // Locals are sorted further by shadow, cookie and distance to camera
-            m_LightCompararer.CurrCamera = m_CurrCamera;
-            visibleLights.Sort(m_LightCompararer);
+            m_LightComparer.CurrCamera = m_CurrCamera;
+            visibleLights.Sort(m_LightComparer);
 
             for (int i = 0; i < totalVisibleLights; ++i)
                 m_SortedLightIndexMap.Add(m_VisibleLightsIDMap[visibleLights[i]]);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine.Rendering;
 
 namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 {
@@ -67,6 +66,19 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         {
             Vector3 lightCameraVector = lightPos - CurrCamera.transform.position;
             return Vector3.Dot(lightCameraVector, lightCameraVector);
+        }
+    }
+
+    public class LightEqualityComparer : IEqualityComparer<VisibleLight>
+    {
+        public bool Equals(VisibleLight x, VisibleLight y)
+        {
+            return x.light.GetInstanceID() == y.light.GetInstanceID();
+        }
+
+        public int GetHashCode(VisibleLight obj)
+        {
+            return obj.light.GetInstanceID();
         }
     }
 


### PR DESCRIPTION
6.9KB/frame -> 0.8KB/frame.

`LightweightPipeline.SetShaderKeywords()` can still be improved. The rest is engine-garbage we have no control over in user-land.

I haven't been able to run tests as the test framework is currently broken so just to be safe let's wait for it to be fixed & run it before we merge this in.