### PR TITLE
Fixed a missing Render Target clear in the sky system that caused NaN…

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyRenderingContext.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyRenderingContext.cs
@@ -224,6 +224,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 if (skyContext.skyParametersHash != 0)
                 {
+                    CoreUtils.ClearCubemap(cmd, m_SkyboxCubemapRT, Color.black, true);
                     if (m_SupportsConvolution)
                     {
                         CoreUtils.ClearCubemap(cmd, m_SkyboxGGXCubemapRT, Color.black, true);


### PR DESCRIPTION
…s on some platform when no sky is specified.