### PR TITLE
Removed sunlight from baking sky computation 

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyManager.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyManager.cs
@@ -259,7 +259,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             UpdateSkyTypes();
             UpdateCurrentSkySettings(camera);
 
-            m_NeedUpdateBakingSky = m_BakingSkyRenderingContext.UpdateEnvironment(m_BakingSky, camera, sunLight, m_UpdateRequired, cmd);
+            // For the baking sky, we don't want to take the sun into account because we usually won't include it (this would cause double highlight in the reflection for example).
+            // So we pass null so that's it doesn't affect the hash and the rendering.
+            m_NeedUpdateBakingSky = m_BakingSkyRenderingContext.UpdateEnvironment(m_BakingSky, camera, null, m_UpdateRequired, cmd);
             SkyUpdateContext currentSky = m_LightingOverrideSky.IsValid() ? m_LightingOverrideSky : m_VisualSky;
             m_NeedUpdateRealtimeEnv = m_SkyRenderingContext.UpdateEnvironment(currentSky, camera, sunLight, m_UpdateRequired, cmd);
 


### PR DESCRIPTION
It can cause discrepancy while baking depending on its current state in the scene and we usually don't want it in the bake anyway to avoid double highlights.