### PR TITLE
Fix issue with camera frame settings

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
@@ -61,10 +61,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // otherwise it is the serialized m_FrameSettings that are used
         // This is required so each camera have its own debug settings even if they all use the RenderingPath.Default path
         // and important at Runtime as Default Camera from Scene Preview doesn't exist
+        // assetFrameSettingsIsDirty is the current dirty frame settings state of HDRenderPipelineAsset
+        // if it is dirty and camera use RenderingPath.Default, we need to update it
         // defaultFrameSettings are the settings store in the HDRenderPipelineAsset
-        public void UpdateDirtyFrameSettings(FrameSettings defaultFrameSettings)
+        public void UpdateDirtyFrameSettings(bool assetFrameSettingsIsDirty, FrameSettings defaultFrameSettings)
         {
-            if (m_frameSettingsIsDirty)
+            if (m_frameSettingsIsDirty || assetFrameSettingsIsDirty)
             {
                 // We do a copy of the settings to those effectively used
                 if (renderingPath == RenderingPath.Default)
@@ -86,7 +88,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 // Note that we register m_FrameSettingsRuntime, so manipulating it in the Debug windows
                 // doesn't affect the serialized version
-                FrameSettings.RegisterDebug(m_camera.name, GetFrameSettings());
+                if (m_camera.cameraType != CameraType.Preview)
+                {
+                    FrameSettings.RegisterDebug(m_camera.name, GetFrameSettings());
+                }
                 m_CameraRegisterName = m_camera.name;
                 m_IsDebugRegistered = true;
             }
@@ -96,7 +101,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             if (m_IsDebugRegistered)
             {
-                FrameSettings.UnRegisterDebug(m_CameraRegisterName);
+                if (m_camera.cameraType != CameraType.Preview)
+                {
+                    FrameSettings.UnRegisterDebug(m_CameraRegisterName);
+                }
                 m_IsDebugRegistered = false;
             }
         }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
@@ -12,6 +12,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         float m_Version = 1.0f;
 #pragma warning restore 414
 
+        Camera m_camera;
+
         // This struct allow to add specialized path in HDRenderPipeline (can be use to render mini map or planar reflection etc...)
         // A rendering path is the list of rendering pass that will be executed at runtime and depends on the associated FrameSettings
         // Default is the default rendering path define by the HDRendeRPipelineAsset FrameSettings.
@@ -35,21 +37,55 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [FormerlySerializedAs("serializedFrameSettings")]
         FrameSettings    m_FrameSettings = new FrameSettings(); // Serialize frameSettings
 
-        // Not serialized, not visible
+        // Not serialized, visible only in the debug windows
         FrameSettings m_FrameSettingsRuntime = new FrameSettings();
+
+        bool m_frameSettingsIsDirty = true;
+
+        // Use for debug windows
+        // When camera name change we need to update the name in DebugWindows.
+        // This is the purpose of this class
+        bool    m_IsDebugRegistered = false;
+        string  m_CameraRegisterName;
+
+        // This is the function use outside to access FrameSettings. It return the current state of FrameSettings for the camera
+        // taking into account the customization via the debug menu
         public FrameSettings GetFrameSettings()
         {
             return m_FrameSettingsRuntime;
         }
 
-        bool    m_IsDebugRegistered = false;
-        Camera  m_camera;
-        string  m_CameraRegisterName;
+        // This function is call at the beginning of camera loop in HDRenderPipeline.Render()
+        // It allow to correctly init the m_FrameSettingsRuntime to use.
+        // If the camera use defaultFrameSettings it must be copied in m_FrameSettingsRuntime
+        // otherwise it is the serialized m_FrameSettings that are used
+        // This is required so each camera have its own debug settings even if they all use the RenderingPath.Default path
+        // and important at Runtime as Default Camera from Scene Preview doesn't exist
+        // defaultFrameSettings are the settings store in the HDRenderPipelineAsset
+        public void UpdateDirtyFrameSettings(FrameSettings defaultFrameSettings)
+        {
+            if (m_frameSettingsIsDirty)
+            {
+                // We do a copy of the settings to those effectively used
+                if (renderingPath == RenderingPath.Default)
+                {
+                    defaultFrameSettings.CopyTo(m_FrameSettingsRuntime);
+                }
+                else
+                {
+                    m_FrameSettings.CopyTo(m_FrameSettingsRuntime);
+                }
+
+                m_frameSettingsIsDirty = false;
+            }
+        }
 
         void RegisterDebug()
         {
             if (!m_IsDebugRegistered)
             {
+                // Note that we register m_FrameSettingsRuntime, so manipulating it in the Debug windows
+                // doesn't affect the serialized version
                 FrameSettings.RegisterDebug(m_camera.name, GetFrameSettings());
                 m_CameraRegisterName = m_camera.name;
                 m_IsDebugRegistered = true;
@@ -74,13 +110,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_camera = GetComponent<Camera>();
             m_camera.allowHDR = false;
 
-            m_FrameSettings.CopyTo(m_FrameSettingsRuntime);
+            //  Tag as dirty so frameSettings are correctly initialize at next HDRenderPipeline.Render() call
+            m_frameSettingsIsDirty = true;
 
             RegisterDebug();
         }
 
         void Update()
         {
+            // We need to detect name change in the editor and update debug windows accordingly
 #if UNITY_EDITOR
             if (m_camera.name != m_CameraRegisterName)
             {
@@ -101,8 +139,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void OnAfterDeserialize()
         {
-            // We do a copy of the settings to those effectively used
-            m_FrameSettings.CopyTo(m_FrameSettingsRuntime);
+            // This is call on load or when this settings are change.
+            // When FrameSettings are manipulated or RenderPath change we reset them to reflect the change, discarding all the Debug Windows change.
+            // Tag as dirty so frameSettings are correctly initialize at next HDRenderPipeline.Render() call
+            m_frameSettingsIsDirty = true;
         }
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraEditor.Handlers.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraEditor.Handlers.cs
@@ -36,7 +36,7 @@ namespace UnityEditor.Experimental.Rendering
             EditorUtility.CopySerialized(c.GetComponent<HDAdditionalCameraData>(), m_PreviewAdditionalCameraData);
             var layer = c.GetComponent<PostProcessLayer>() ?? ComponentSingleton<PostProcessLayer>.instance;
             EditorUtility.CopySerialized(layer, m_PreviewPostProcessLayer);
-            m_PreviewCamera.cameraType = CameraType.SceneView;
+            m_PreviewCamera.cameraType = CameraType.SceneView; // This is required else if we use Preview the image is flipped... (Unity...)
             m_PreviewHDCamera.Update(m_PreviewPostProcessLayer, m_PreviewAdditionalCameraData.GetFrameSettings());
 
             var previewTexture = GetPreviewTextureWithSize((int)previewSize.x, (int)previewSize.y);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraEditor.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraEditor.cs
@@ -25,9 +25,10 @@ namespace UnityEditor.Experimental.Rendering
             m_UIState.Reset(m_SerializedCamera, Repaint);
 
             m_PreviewCamera = EditorUtility.CreateGameObjectWithHideFlags("Preview Camera", HideFlags.HideAndDontSave, typeof(Camera)).GetComponent<Camera>();
+            m_PreviewCamera.enabled = false;
+            m_PreviewCamera.cameraType = CameraType.Preview; // Must be init before adding HDAdditionalCameraData
             m_PreviewAdditionalCameraData = m_PreviewCamera.gameObject.AddComponent<HDAdditionalCameraData>();
             m_PreviewPostProcessLayer = m_PreviewCamera.gameObject.AddComponent<PostProcessLayer>();
-            m_PreviewCamera.enabled = false;
             m_PreviewHDCamera = new HDCamera(m_PreviewCamera);
             m_PreviewHDCamera.Update(m_PreviewPostProcessLayer, m_PreviewAdditionalCameraData.GetFrameSettings());
         }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/RenderPipelineSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/RenderPipelineSettingsUI.cs
@@ -38,7 +38,7 @@ namespace UnityEditor.Experimental.Rendering
         public RenderPipelineSettingsUI()
             : base(0)
         {
-            
+
         }
 
         public override void Reset(SerializedRenderPipelineSettings data, UnityAction repaint)
@@ -65,7 +65,6 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUILayout.PropertyField(d.supportDBuffer, _.GetContent("Support Decal Buffer"));
             EditorGUILayout.PropertyField(d.supportMSAA, _.GetContent("Support MSAA"));
             EditorGUILayout.PropertyField(d.supportSubsurfaceScattering, _.GetContent("Support Subsurface Scattering"));
-            EditorGUILayout.PropertyField(d.supportAsyncCompute, _.GetContent("Support AsyncCompute"));
             --EditorGUI.indentLevel;
         }
     }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedRenderPipelineSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedRenderPipelineSettings.cs
@@ -12,7 +12,6 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty supportDBuffer;
         public SerializedProperty supportMSAA;
         public SerializedProperty supportSubsurfaceScattering;
-        public SerializedProperty supportAsyncCompute;
 
         public SerializedGlobalLightLoopSettings lightLoopSettings;
         public SerializedShadowInitParameters shadowInitParams;
@@ -27,7 +26,6 @@ namespace UnityEditor.Experimental.Rendering
             supportDBuffer = root.Find((RenderPipelineSettings s) => s.supportDBuffer);
             supportMSAA = root.Find((RenderPipelineSettings s) => s.supportMSAA);
             supportSubsurfaceScattering = root.Find((RenderPipelineSettings s) => s.supportSubsurfaceScattering);
-            supportAsyncCompute = root.Find((RenderPipelineSettings s) => s.supportAsyncCompute);
 
             lightLoopSettings = new SerializedGlobalLightLoopSettings(root.Find((RenderPipelineSettings s) => s.lightLoopSettings));
             shadowInitParams = new SerializedShadowInitParameters(root.Find((RenderPipelineSettings s) => s.shadowInitParams));

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -634,11 +634,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     continue;
 
                 // First, get aggregate of frame settings base on global settings, camera frame settings and debug settings
+                // Note: the SceneView camera will never have additionalCameraData
                 var additionalCameraData = camera.GetComponent<HDAdditionalCameraData>();
-                // Note: the scene view camera will never have additionalCameraData
-                var srcFrameSettings = (additionalCameraData && additionalCameraData.renderingPath != HDAdditionalCameraData.RenderingPath.Default)
-                    ? additionalCameraData.GetFrameSettings()
-                    : m_Asset.GetFrameSettings();
+
+                // Get the effective frame settings for this camera (This is camera frame settings and debug settings)
+                FrameSettings srcFrameSettings;
+                if (additionalCameraData)
+                {
+                    additionalCameraData.UpdateDirtyFrameSettings(m_Asset.GetFrameSettings());
+                    srcFrameSettings = additionalCameraData.GetFrameSettings();
+                }
+                else
+                {
+                    srcFrameSettings = m_Asset.GetFrameSettings();
+                }
+                // Get the effective frame settings for this camera taking into account the global setting and camera type
                 FrameSettings.InitializeFrameSettings(camera, m_Asset.GetRenderPipelineSettings(), srcFrameSettings, ref m_FrameSettings);
 
                 // This is the main command buffer used for the frame.

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
@@ -67,7 +67,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool enablePostprocess = true;
 
         public bool enableStereo = true;
-        public bool enableAsyncCompute = false;
+        public bool enableAsyncCompute = true;
 
         public bool enableOpaqueObjects = true;
         public bool enableTransparentObjects = true;
@@ -167,7 +167,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // Force forward if we request stereo. TODO: We should not enforce that, users should be able to chose deferred
             aggregate.enableForwardRenderingOnly = aggregate.enableForwardRenderingOnly || aggregate.enableStereo;
 
-            aggregate.enableAsyncCompute = srcFrameSettings.enableAsyncCompute && renderPipelineSettings.supportAsyncCompute;
+            aggregate.enableAsyncCompute = srcFrameSettings.enableAsyncCompute && SystemInfo.supportsAsyncCompute;
 
             aggregate.enableOpaqueObjects = srcFrameSettings.enableOpaqueObjects;
             aggregate.enableTransparentObjects = srcFrameSettings.enableTransparentObjects;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/RenderPipelineSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/RenderPipelineSettings.cs
@@ -28,7 +28,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // Engine
         public bool supportDBuffer = false;
         public bool supportMSAA = false;
-        public bool supportAsyncCompute = false;
 
         public GlobalLightLoopSettings  lightLoopSettings = new GlobalLightLoopSettings();
         public ShadowInitParameters     shadowInitParams = new ShadowInitParameters();


### PR DESCRIPTION
This PR update the behavior of frameSettings.
At runtime, camera must init from DefaultFrameSettings to be correct.
Currently it init from the SerializedFrameSettings which is wrong if the
camera rendering path is set to Default

- Suppres support async compute
- Add dirty state to asset render pipeline for frame settings
