### PR TITLE
Add transparent priority support

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/Unlit/BaseUnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/Unlit/BaseUnlitUI.cs
@@ -278,7 +278,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 m_MaterialEditor.ShaderProperty(transparentQueuePriority, StylesBaseUnlit.transparentQueuePriorityText);
                 if (EditorGUI.EndChangeCheck())
                 {
-                    transparentQueuePriority.floatValue = Mathf.Clamp((int)transparentQueuePriority.floatValue, -(int)HDRenderQueuePriority.TransparentPriorityQueueRange, (int)HDRenderQueuePriority.TransparentPriorityQueueRange);
+                    transparentQueuePriority.floatValue = Mathf.Clamp((int)transparentQueuePriority.floatValue, -(int)HDRenderQueue.k_TransparentPriorityQueueRange, (int)HDRenderQueue.k_TransparentPriorityQueueRange);
                 }
             }
 
@@ -351,14 +351,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
                 material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
                 material.SetInt("_ZWrite", 1);
-                material.renderQueue = alphaTestEnable ? (int)HDRenderQueue.AlphaTest : -1;
+                material.renderQueue = alphaTestEnable ? (int)HDRenderQueue.Priority.AlphaTest : -1;
             }
             else
             {
                 material.SetOverrideTag("RenderType", "Transparent");
                 material.SetInt("_ZWrite", 0);
                 var isPrepass = material.HasProperty(kPreRefractionPass) && material.GetFloat(kPreRefractionPass) > 0.0f;
-                material.renderQueue = (int)(isPrepass ? HDRenderQueue.PreRefraction : HDRenderQueue.Transparent) + (int)material.GetFloat(kTransparentQueuePriority);
+                material.renderQueue = (int)(isPrepass ? HDRenderQueue.Priority.PreRefraction : HDRenderQueue.Priority.Transparent) + (int)material.GetFloat(kTransparentQueuePriority);
 
                 if (material.HasProperty(kBlendMode))
                 {

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -144,10 +144,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             "Forward Transparent"
         };
 
-        static readonly RenderQueueRange k_RenderQueue_PreRefraction = new RenderQueueRange { min = (int)HDRenderQueue.PreRefractionMin, max = (int)HDRenderQueue.PreRefractionMax };
-        static readonly RenderQueueRange k_RenderQueue_Transparent = new RenderQueueRange { min = (int)HDRenderQueue.TransparentMin, max = (int)HDRenderQueue.TransparentMax };
-        static readonly RenderQueueRange k_RenderQueue_AllTransparent = new RenderQueueRange { min = (int)HDRenderQueue.PreRefractionMin, max = (int)HDRenderQueue.TransparentMax };
-
         readonly HDRenderPipelineAsset m_Asset;
 
         DiffusionProfileSettings m_InternalSSSAsset;
@@ -1014,7 +1010,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             var filterSettings = new FilterRenderersSettings(true)
             {
-                renderQueueRange = inRenderQueueRange == null ? RenderQueueRange.opaque : inRenderQueueRange.Value
+                renderQueueRange = inRenderQueueRange == null ? HDRenderQueue.k_RenderQueue_AllOpaque : inRenderQueueRange.Value
             };
 
             if (stateBlock == null)
@@ -1072,7 +1068,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             var filterSettings = new FilterRenderersSettings(true)
             {
-                renderQueueRange = inRenderQueueRange == null ? k_RenderQueue_AllTransparent : inRenderQueueRange.Value
+                renderQueueRange = inRenderQueueRange == null ? HDRenderQueue.k_RenderQueue_AllTransparent : inRenderQueueRange.Value
             };
 
             if (stateBlock == null)
@@ -1145,12 +1141,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     // We render first the opaque object as opaque alpha tested are more costly to render and could be reject by early-z (but not Hi-z as it is disable with clip instruction)
                     // This is handled automatically with the RenderQueue value (OpaqueAlphaTested have a different value and thus are sorted after Opaque)
-                    RenderOpaqueRenderList(cull, camera, renderContext, cmd, m_DepthOnlyAndDepthForwardOnlyPassNames, 0, RenderQueueRange.opaque, m_DepthStateOpaque);
+                    RenderOpaqueRenderList(cull, camera, renderContext, cmd, m_DepthOnlyAndDepthForwardOnlyPassNames, 0, HDRenderQueue.k_RenderQueue_AllOpaque, m_DepthStateOpaque);
                 }
                 else // Deferred rendering with partial depth prepass
                 {
                     // We always do a DepthForwardOnly pass with all the opaque (including alpha test)
-                    RenderOpaqueRenderList(cull, camera, renderContext, cmd, m_DepthForwardOnlyPassNames, 0, RenderQueueRange.opaque, m_DepthStateOpaque);
+                    RenderOpaqueRenderList(cull, camera, renderContext, cmd, m_DepthForwardOnlyPassNames, 0, HDRenderQueue.k_RenderQueue_AllOpaque, m_DepthStateOpaque);
 
                     // Render Alpha test only if requested
                     if (addAlphaTestedOnly)
@@ -1189,24 +1185,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 if (m_CurrentDebugDisplaySettings.IsDebugDisplayEnabled())
                 {
                     // When doing debug display, the shader has the clip instruction regardless of the depth prepass so we can use regular depth test.
-                    RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferDebugDisplayName, m_currentRendererConfigurationBakedLighting, RenderQueueRange.opaque, m_DepthStateOpaque);
+                    RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferDebugDisplayName, m_currentRendererConfigurationBakedLighting, HDRenderQueue.k_RenderQueue_AllOpaque, m_DepthStateOpaque);
                 }
                 else
                 {
                     if (m_FrameSettings.enableDepthPrepassWithDeferredRendering)
                     {
-                        var rangeOpaqueNoAlphaTest = new RenderQueueRange { min = (int)RenderQueue.Geometry, max = (int)RenderQueue.AlphaTest - 1 };
-                        var rangeOpaqueAlphaTest = new RenderQueueRange { min = (int)RenderQueue.AlphaTest, max = (int)RenderQueue.GeometryLast - 1 };
-
                         // When using depth prepass for opaque alpha test only we need to use regular depth test for normal opaque objects.
-                        RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferName, m_currentRendererConfigurationBakedLighting, rangeOpaqueNoAlphaTest, m_FrameSettings.enableAlphaTestOnlyInDeferredPrepass ? m_DepthStateOpaque : m_DepthStateOpaqueWithPrepass);
+                        RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferName, m_currentRendererConfigurationBakedLighting, HDRenderQueue.k_RenderQueue_OpaqueNoAlphaTest, m_FrameSettings.enableAlphaTestOnlyInDeferredPrepass ? m_DepthStateOpaque : m_DepthStateOpaqueWithPrepass);
                         // but for opaque alpha tested object we use a depth equal and no depth write. And we rely on the shader pass GbufferWithDepthPrepass
-                        RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferWithPrepassName, m_currentRendererConfigurationBakedLighting, rangeOpaqueAlphaTest, m_DepthStateOpaqueWithPrepass);
+                        RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferWithPrepassName, m_currentRendererConfigurationBakedLighting, HDRenderQueue.k_RenderQueue_OpaqueAlphaTest, m_DepthStateOpaqueWithPrepass);
                     }
                     else
                     {
                         // No depth prepass, use regular depth test - Note that we will render opaque then opaque alpha tested (based on the RenderQueue system)
-                        RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferName, m_currentRendererConfigurationBakedLighting, RenderQueueRange.opaque, m_DepthStateOpaque);
+                        RenderOpaqueRenderList(cull, camera, renderContext, cmd, HDShaderPassNames.s_GBufferName, m_currentRendererConfigurationBakedLighting, HDRenderQueue.k_RenderQueue_AllOpaque, m_DepthStateOpaque);
                     }
                 }
             }
@@ -1409,7 +1402,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT);
 
                     var passNames = m_CurrentDebugDisplaySettings.IsDebugDisplayEnabled() ? m_AllTransparentDebugDisplayPassNames : m_AllTransparentPassNames;
-                    RenderTransparentRenderList(cullResults, camera, renderContext, cmd, passNames, m_currentRendererConfigurationBakedLighting, pass == ForwardPass.PreRefraction ? k_RenderQueue_PreRefraction : k_RenderQueue_Transparent);
+                    RenderTransparentRenderList(cullResults, camera, renderContext, cmd, passNames, m_currentRendererConfigurationBakedLighting, pass == ForwardPass.PreRefraction ? HDRenderQueue.k_RenderQueue_PreRefraction : HDRenderQueue.k_RenderQueue_Transparent);
                 }
             }
         }
@@ -1428,7 +1421,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
                 else
                 {
-                    RenderTransparentRenderList(cullResults, camera, renderContext, cmd, m_ForwardErrorPassNames, 0, pass == ForwardPass.PreRefraction ? k_RenderQueue_PreRefraction : k_RenderQueue_Transparent, null, m_ErrorMaterial);
+                    RenderTransparentRenderList(cullResults, camera, renderContext, cmd, m_ForwardErrorPassNames, 0, pass == ForwardPass.PreRefraction ? HDRenderQueue.k_RenderQueue_PreRefraction : HDRenderQueue.k_RenderQueue_Transparent, null, m_ErrorMaterial);
                 }
             }
         }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -144,9 +144,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             "Forward Transparent"
         };
 
-        static readonly RenderQueueRange k_RenderQueue_PreRefraction = new RenderQueueRange { min = (int)HDRenderQueue.PreRefraction, max = (int)HDRenderQueue.Transparent - 1 };
-        static readonly RenderQueueRange k_RenderQueue_Transparent = new RenderQueueRange { min = (int)HDRenderQueue.Transparent, max = (int)HDRenderQueue.Overlay - 1 };
-        static readonly RenderQueueRange k_RenderQueue_AllTransparent = new RenderQueueRange { min = (int)HDRenderQueue.PreRefraction, max = (int)HDRenderQueue.Overlay - 1 };
+        static readonly RenderQueueRange k_RenderQueue_PreRefraction = new RenderQueueRange { min = (int)HDRenderQueue.PreRefractionMin, max = (int)HDRenderQueue.PreRefractionMax };
+        static readonly RenderQueueRange k_RenderQueue_Transparent = new RenderQueueRange { min = (int)HDRenderQueue.TransparentMin, max = (int)HDRenderQueue.TransparentMax };
+        static readonly RenderQueueRange k_RenderQueue_AllTransparent = new RenderQueueRange { min = (int)HDRenderQueue.PreRefractionMin, max = (int)HDRenderQueue.TransparentMax };
 
         readonly HDRenderPipelineAsset m_Asset;
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderQueue.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderQueue.cs
@@ -7,25 +7,35 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     // In the case of transparent we want to use RenderQueue to help with sorting. We define a neutral value for the RenderQueue and priority going from -X to +X
     // going from -X to +X instead of 0 to +X as builtin Unity is better for artists as they can decide late to sort behind or in front of the scene.
 
-    public enum HDRenderQueuePriority
+    public class HDRenderQueue
     {
-        TransparentPriorityQueueRange = 100
-    }
+        public const int k_TransparentPriorityQueueRange = 100;
 
-    public enum HDRenderQueue
-    {
-        Background = UnityEngine.Rendering.RenderQueue.Background,
-        Geometry = UnityEngine.Rendering.RenderQueue.Geometry,
-        AlphaTest = UnityEngine.Rendering.RenderQueue.AlphaTest,
-        GeometryLast = UnityEngine.Rendering.RenderQueue.GeometryLast,
-        // For transparent pass we define a range of 200 value to define the priority
-        // Warning: Be sure no range are overlapping
-        PreRefractionMin = 2750 - HDRenderQueuePriority.TransparentPriorityQueueRange,
-        PreRefraction = 2750,
-        PreRefractionMax = 2750 + HDRenderQueuePriority.TransparentPriorityQueueRange,
-        TransparentMin = UnityEngine.Rendering.RenderQueue.Transparent - HDRenderQueuePriority.TransparentPriorityQueueRange,
-        Transparent = UnityEngine.Rendering.RenderQueue.Transparent,
-        TransparentMax = UnityEngine.Rendering.RenderQueue.Transparent + HDRenderQueuePriority.TransparentPriorityQueueRange,
-        Overlay = UnityEngine.Rendering.RenderQueue.Overlay
+        public enum Priority
+        {
+            Background = UnityEngine.Rendering.RenderQueue.Background,
+            Geometry = UnityEngine.Rendering.RenderQueue.Geometry,
+            AlphaTest = UnityEngine.Rendering.RenderQueue.AlphaTest,
+            GeometryLast = UnityEngine.Rendering.RenderQueue.GeometryLast,
+            // For transparent pass we define a range of 200 value to define the priority
+            // Warning: Be sure no range are overlapping
+            PreRefractionFirst = 2750 - k_TransparentPriorityQueueRange,
+            PreRefraction = 2750,
+            PreRefractionLast = 2750 + k_TransparentPriorityQueueRange,
+            TransparentFirst = UnityEngine.Rendering.RenderQueue.Transparent - k_TransparentPriorityQueueRange,
+            Transparent = UnityEngine.Rendering.RenderQueue.Transparent,
+            TransparentLast = UnityEngine.Rendering.RenderQueue.Transparent + k_TransparentPriorityQueueRange,
+            Overlay = UnityEngine.Rendering.RenderQueue.Overlay
+        }
+
+        public static readonly RenderQueueRange k_RenderQueue_OpaqueNoAlphaTest = new RenderQueueRange { min = (int)Priority.Geometry, max = (int)Priority.AlphaTest - 1 };
+        public static readonly RenderQueueRange k_RenderQueue_OpaqueAlphaTest = new RenderQueueRange { min = (int)Priority.AlphaTest, max = (int)Priority.GeometryLast };
+        public static readonly RenderQueueRange k_RenderQueue_AllOpaque = new RenderQueueRange { min = (int)Priority.Geometry, max = (int)Priority.GeometryLast };
+
+        public static readonly RenderQueueRange k_RenderQueue_PreRefraction = new RenderQueueRange { min = (int)Priority.PreRefractionFirst, max = (int)Priority.PreRefractionLast };
+        public static readonly RenderQueueRange k_RenderQueue_Transparent = new RenderQueueRange { min = (int)Priority.TransparentFirst, max = (int)Priority.TransparentLast };
+        public static readonly RenderQueueRange k_RenderQueue_AllTransparent = new RenderQueueRange { min = (int)Priority.PreRefractionFirst, max = (int)Priority.TransparentLast };
+
+        public static readonly RenderQueueRange k_RenderQueue_All = new RenderQueueRange { min = 0, max = 5000 };
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderQueue.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderQueue.cs
@@ -2,14 +2,30 @@
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
+    // In HD we don't expose HDRenderQueue instead we create as much value as needed in the enum for our different pass
+    // and use inspector to manipulate the value.
+    // In the case of transparent we want to use RenderQueue to help with sorting. We define a neutral value for the RenderQueue and priority going from -X to +X
+    // going from -X to +X instead of 0 to +X as builtin Unity is better for artists as they can decide late to sort behind or in front of the scene.
+
+    public enum HDRenderQueuePriority
+    {
+        TransparentPriorityQueueRange = 100
+    }
+
     public enum HDRenderQueue
     {
         Background = UnityEngine.Rendering.RenderQueue.Background,
         Geometry = UnityEngine.Rendering.RenderQueue.Geometry,
         AlphaTest = UnityEngine.Rendering.RenderQueue.AlphaTest,
         GeometryLast = UnityEngine.Rendering.RenderQueue.GeometryLast,
+        // For transparent pass we define a range of 200 value to define the priority
+        // Warning: Be sure no range are overlapping
+        PreRefractionMin = 2750 - HDRenderQueuePriority.TransparentPriorityQueueRange,
         PreRefraction = 2750,
+        PreRefractionMax = 2750 + HDRenderQueuePriority.TransparentPriorityQueueRange,
+        TransparentMin = UnityEngine.Rendering.RenderQueue.Transparent - HDRenderQueuePriority.TransparentPriorityQueueRange,
         Transparent = UnityEngine.Rendering.RenderQueue.Transparent,
+        TransparentMax = UnityEngine.Rendering.RenderQueue.Transparent + HDRenderQueuePriority.TransparentPriorityQueueRange,
         Overlay = UnityEngine.Rendering.RenderQueue.Overlay
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLit.shader
@@ -239,6 +239,7 @@ Shader "HDRenderPipeline/LayeredLit"
         [ToggleUI] _AlphaCutoffEnable("Alpha Cutoff Enable", Float) = 0.0
 
         _AlphaCutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+        _TransparentQueuePriority("_TransparentQueuePriority", Float) = 0
 
         // Stencil state
         [HideInInspector] _StencilRef("_StencilRef", Int) = 2 // StencilLightingUsage.RegularLighting

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLitTessellation.shader
@@ -239,6 +239,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         [ToggleUI] _AlphaCutoffEnable("Alpha Cutoff Enable", Float) = 0.0
 
         _AlphaCutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+        _TransparentQueuePriority("_TransparentQueuePriority", Float) = 0
 
         // Stencil state
         [HideInInspector] _StencilRef("_StencilRef", Int) = 2 // StencilLightingUsage.RegularLighting

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.shader
@@ -98,6 +98,7 @@ Shader "HDRenderPipeline/Lit"
         [ToggleUI] _TransparentDepthPrepassEnable("_TransparentDepthPrepassEnable", Float) = 0.0
         [ToggleUI] _TransparentBackfaceEnable("_TransparentBackfaceEnable", Float) = 0.0
         [ToggleUI] _TransparentDepthPostpassEnable("_TransparentDepthPostpassEnable", Float) = 0.0
+        _TransparentQueuePriority("_TransparentQueuePriority", Float) = 0
 
         // Transparency
         [Enum(None, 0, Plane, 1, Sphere, 2)]_RefractionMode("Refraction Mode", Int) = 0

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/LitTessellation.shader
@@ -99,6 +99,7 @@ Shader "HDRenderPipeline/LitTessellation"
         [ToggleUI] _TransparentDepthPrepassEnable("_TransparentDepthPrepassEnable", Float) = 0.0
         [ToggleUI] _TransparentBackfaceEnable("_TransparentBackfaceEnable", Float) = 0.0
         [ToggleUI] _TransparentDepthPostpassEnable("_TransparentDepthPostpassEnable", Float) = 0.0
+        _TransparentQueuePriority("_TransparentQueuePriority", Float) = 0
 
         // Transparency
         [Enum(None, 0, Plane, 1, Sphere, 2)]_RefractionMode("Refraction Mode", Int) = 0

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Unlit/Unlit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Unlit/Unlit.shader
@@ -32,6 +32,7 @@ Shader "HDRenderPipeline/Unlit"
 
         [ToggleUI]  _AlphaCutoffEnable("Alpha Cutoff Enable", Float) = 0.0
         _AlphaCutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+        _TransparentQueuePriority("_TransparentQueuePriority", Float) = 0
 
         // Blending state
         [HideInInspector] _SurfaceType("__surfacetype", Float) = 0.0


### PR DESCRIPTION
This PR update the HDRenderQueue class. Main goal is to support priority for Transparent surface (i.e being able to force order of transparent via the RenderQueue). Value can goes from -100 to 100 for the transparent priority and define the "neutral" value of 0 as current TransparentQueue (so compatible with current Unity). This transparent Queue priority is added to the current RenderQueue allowing to change betwene preRefractoin and Transparent without trouble.

- Move all RenderQueueRange of the code in the HDRenderQueue
- Add min/max for preRefraction and Transparent