### PR TITLE
Add global override of properties for debug

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.cs
@@ -35,10 +35,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static string kShadowMinValueDebug = "Shadow Range Min Value";
         public static string kShadowMaxValueDebug = "Shadow Range Max Value";
         public static string kLightingDebugMode = "Lighting Debug Mode";
+
+        public static string kOverrideAlbedoDebug = "Override Albedo";
+        public static string kOverrideAlbedoValueDebug = "Override Albedo Value";
         public static string kOverrideSmoothnessDebug = "Override Smoothness";
-        public static string kOverrideSmoothnessValueDebug = "Override Smoothness Value"; 
+        public static string kOverrideSmoothnessValueDebug = "Override Smoothness Value";
+        public static string kOverrideNormalDebug = "Override normal";
+
         public static string kDebugEnvironmentProxyDepthScale = "Debug Environment Proxy Depth Scale";
-        public static string kDebugLightingAlbedo = "Debug Lighting Albedo";
         public static string kFullScreenDebugMode = "Fullscreen Debug Mode";
         public static string kFullScreenDebugMip = "Fullscreen Debug Mip";
         public static string kDisplaySkyReflectionDebug = "Display Sky Reflection";
@@ -186,7 +190,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, DebugLightingMode>(kLightingDebugMode, () => lightingDebugSettings.debugLightingMode, (value) => SetDebugLightingMode((DebugLightingMode)value));
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, bool>(kOverrideSmoothnessDebug, () => lightingDebugSettings.overrideSmoothness, (value) => lightingDebugSettings.overrideSmoothness = (bool)value);
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, float>(kOverrideSmoothnessValueDebug, () => lightingDebugSettings.overrideSmoothnessValue, (value) => lightingDebugSettings.overrideSmoothnessValue = (float)value, DebugItemFlag.None, new DebugItemHandlerFloatMinMax(0.0f, 1.0f));
-            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, Color>(kDebugLightingAlbedo, () => lightingDebugSettings.debugLightingAlbedo, (value) => lightingDebugSettings.debugLightingAlbedo = (Color)value);
+            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, bool>(kOverrideAlbedoDebug, () => lightingDebugSettings.overrideAlbedo, (value) => lightingDebugSettings.overrideAlbedo = (bool)value);
+            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, Color>(kOverrideAlbedoValueDebug, () => lightingDebugSettings.overrideAlbedoValue, (value) => lightingDebugSettings.overrideAlbedoValue = (Color)value);
+            DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, bool>(kOverrideNormalDebug, () => lightingDebugSettings.overrideNormal, (value) => lightingDebugSettings.overrideNormal = (bool)value);
             DebugMenuManager.instance.AddDebugItem<bool>("Lighting", kDisplaySkyReflectionDebug, () => lightingDebugSettings.displaySkyReflection, (value) => lightingDebugSettings.displaySkyReflection = (bool)value);
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, float>(kSkyReflectionMipmapDebug, () => lightingDebugSettings.skyReflectionMipmap, (value) => lightingDebugSettings.skyReflectionMipmap = (float)value, DebugItemFlag.None, new DebugItemHandlerFloatMinMax(0.0f, 1.0f));
             DebugMenuManager.instance.AddDebugItem<LightingDebugPanel, LightLoop.TileClusterDebug>(kTileClusterDebug,() => lightingDebugSettings.tileClusterDebug, (value) => lightingDebugSettings.tileClusterDebug = (LightLoop.TileClusterDebug)value);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.hlsl
@@ -13,8 +13,9 @@ CBUFFER_START(UnityDebugDisplay)
 int _DebugLightingMode; // Match enum DebugLightingMode
 int _DebugViewMaterial; // Contain the id (define in various materialXXX.cs.hlsl) of the property to display
 int _DebugMipMapMode; // Match enum DebugMipMapMode
-float4 _DebugLightingAlbedo; // xyz = albedo for diffuse, w unused
+float4 _DebugLightingAlbedo; // x == bool override, yzw = albedo for diffuse
 float4 _DebugLightingSmoothness; // x == bool override, y == override value
+float4 _DebugLightingNormal; // x == bool override
 float4 _MousePixelCoord;  // xy unorm, zw norm
 float _DebugEnvironmentProxyDepthScale;
 CBUFFER_END

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebug.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebug.cs
@@ -45,7 +45,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public bool                 overrideSmoothness = false;
         public float                overrideSmoothnessValue = 0.5f;
-        public Color                debugLightingAlbedo = new Color(0.5f, 0.5f, 0.5f);
+        public bool                 overrideAlbedo = false;
+        public Color                overrideAlbedoValue = new Color(0.5f, 0.5f, 0.5f);
+        public bool                 overrideNormal = false;
 
         public bool                 displaySkyReflection = false;
         public float                skyReflectionMipmap = 0.0f;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebug.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebug.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     {
         public bool IsDebugDisplayEnabled()
         {
-            return debugLightingMode != DebugLightingMode.None;
+            return debugLightingMode != DebugLightingMode.None || overrideSmoothness || overrideAlbedo || overrideNormal;
         }
 
         public DebugLightingMode    debugLightingMode = DebugLightingMode.None;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebugPanel.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebugPanel.cs
@@ -77,6 +77,19 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 DebugItem shadowMaxValue = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kShadowMaxValueDebug);
                 shadowMaxValue.handler.OnEditorGUI();
 
+                DebugItem lightingDebugModeItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kLightingDebugMode);
+                lightingDebugModeItem.handler.OnEditorGUI();
+                switch ((DebugLightingMode)lightingDebugModeItem.GetValue())
+                {
+                    case DebugLightingMode.EnvironmentProxyVolume:
+                        {
+                            ++EditorGUI.indentLevel;
+                            m_DebugPanel.GetDebugItem(DebugDisplaySettings.kDebugEnvironmentProxyDepthScale).handler.OnEditorGUI();
+                            --EditorGUI.indentLevel;
+                            break;
+                        }
+                }
+
                 DebugItem overrideSmoothnessItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideSmoothnessDebug);
                 overrideSmoothnessItem.handler.OnEditorGUI();
                 if ((bool)overrideSmoothnessItem.GetValue())
@@ -93,24 +106,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 DebugItem overrideNormalItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideNormalDebug);
                 overrideNormalItem.handler.OnEditorGUI();
-
-                DebugItem lightingDebugModeItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kLightingDebugMode);
-                lightingDebugModeItem.handler.OnEditorGUI();
-                switch ((DebugLightingMode)lightingDebugModeItem.GetValue())
-                {
-                    case DebugLightingMode.DiffuseLighting:
-                        {
-                            overrideAlbedoItem.SetValue(true); // Force to be true for diffuse lighting mode
-                            break;
-                        }
-                    case DebugLightingMode.EnvironmentProxyVolume:
-                        {
-                            ++EditorGUI.indentLevel;
-                            m_DebugPanel.GetDebugItem(DebugDisplaySettings.kDebugEnvironmentProxyDepthScale).handler.OnEditorGUI();
-                            --EditorGUI.indentLevel;
-                            break;
-                        }
-                }
 
                 var fullScreenDebugModeHandler = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kFullScreenDebugMode);
                 fullScreenDebugModeHandler.handler.OnEditorGUI();

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebugPanel.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/LightingDebugPanel.cs
@@ -77,27 +77,30 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 DebugItem shadowMaxValue = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kShadowMaxValueDebug);
                 shadowMaxValue.handler.OnEditorGUI();
 
+                DebugItem overrideSmoothnessItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideSmoothnessDebug);
+                overrideSmoothnessItem.handler.OnEditorGUI();
+                if ((bool)overrideSmoothnessItem.GetValue())
+                {
+                    m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideSmoothnessValueDebug).handler.OnEditorGUI();
+                }
+
+                DebugItem overrideAlbedoItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideAlbedoDebug);
+                overrideAlbedoItem.handler.OnEditorGUI();
+                if ((bool)overrideAlbedoItem.GetValue())
+                {
+                    m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideAlbedoValueDebug).handler.OnEditorGUI();
+                }
+
+                DebugItem overrideNormalItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideNormalDebug);
+                overrideNormalItem.handler.OnEditorGUI();
+
                 DebugItem lightingDebugModeItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kLightingDebugMode);
                 lightingDebugModeItem.handler.OnEditorGUI();
                 switch ((DebugLightingMode)lightingDebugModeItem.GetValue())
                 {
-                    case DebugLightingMode.SpecularLighting:
-                        {
-                            EditorGUI.indentLevel++;
-                            DebugItem overrideSmoothnessItem = m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideSmoothnessDebug);
-                            overrideSmoothnessItem.handler.OnEditorGUI();
-                            if ((bool)overrideSmoothnessItem.GetValue())
-                            {
-                                m_DebugPanel.GetDebugItem(DebugDisplaySettings.kOverrideSmoothnessValueDebug).handler.OnEditorGUI();
-                            }
-                            EditorGUI.indentLevel--;
-                            break;
-                        }
                     case DebugLightingMode.DiffuseLighting:
                         {
-                            EditorGUI.indentLevel++;
-                            m_DebugPanel.GetDebugItem(DebugDisplaySettings.kDebugLightingAlbedo).handler.OnEditorGUI();
-                            EditorGUI.indentLevel--;
+                            overrideAlbedoItem.SetValue(true); // Force to be true for diffuse lighting mode
                             break;
                         }
                     case DebugLightingMode.EnvironmentProxyVolume:

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -1703,15 +1703,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_CurrentDebugDisplaySettings.colorPickerDebugSettings.colorPickerMode != ColorPickerDebugMode.None)
             {
                 var lightingDebugSettings = m_CurrentDebugDisplaySettings.lightingDebugSettings;
-                var debugAlbedo = new Vector4(lightingDebugSettings.debugLightingAlbedo.r, lightingDebugSettings.debugLightingAlbedo.g, lightingDebugSettings.debugLightingAlbedo.b, 0.0f);
+                var debugAlbedo = new Vector4(lightingDebugSettings.overrideAlbedo ? 1.0f : 0.0f, lightingDebugSettings.overrideAlbedoValue.r, lightingDebugSettings.overrideAlbedoValue.g, lightingDebugSettings.overrideAlbedoValue.b);
                 var debugSmoothness = new Vector4(lightingDebugSettings.overrideSmoothness ? 1.0f : 0.0f, lightingDebugSettings.overrideSmoothnessValue, 0.0f, 0.0f);
+                var debugNormal = new Vector4(lightingDebugSettings.overrideNormal ? 1.0f : 0.0f, 0.0f, 0.0f, 0.0f);
 
                 cmd.SetGlobalInt(HDShaderIDs._DebugViewMaterial, (int)m_CurrentDebugDisplaySettings.GetDebugMaterialIndex());
                 cmd.SetGlobalInt(HDShaderIDs._DebugLightingMode, (int)m_CurrentDebugDisplaySettings.GetDebugLightingMode());
                 cmd.SetGlobalInt(HDShaderIDs._DebugMipMapMode, (int)m_CurrentDebugDisplaySettings.GetDebugMipMapMode());
-                cmd.SetGlobalVector(HDShaderIDs._DebugLightingAlbedo, debugAlbedo);
 
+                cmd.SetGlobalVector(HDShaderIDs._DebugLightingAlbedo, debugAlbedo);
                 cmd.SetGlobalVector(HDShaderIDs._DebugLightingSmoothness, debugSmoothness);
+                cmd.SetGlobalVector(HDShaderIDs._DebugLightingNormal, debugNormal);
 
                 Vector2 mousePixelCoord = MousePositionDebug.instance.GetMousePosition(hdCamera.screenSize.y);
                 var mouseParam = new Vector4(mousePixelCoord.x, mousePixelCoord.y, mousePixelCoord.x / hdCamera.screenSize.x, mousePixelCoord.y / hdCamera.screenSize.y);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDStringConstants.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDStringConstants.cs
@@ -130,6 +130,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _DebugLightingMode = Shader.PropertyToID("_DebugLightingMode");
         public static readonly int _DebugLightingAlbedo = Shader.PropertyToID("_DebugLightingAlbedo");
         public static readonly int _DebugLightingSmoothness = Shader.PropertyToID("_DebugLightingSmoothness");
+        public static readonly int _DebugLightingNormal = Shader.PropertyToID("_DebugLightingNormal");
         public static readonly int _AmbientOcclusionTexture = Shader.PropertyToID("_AmbientOcclusionTexture");
         public static readonly int _DebugMipMapMode = Shader.PropertyToID("_DebugMipMapMode");
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
@@ -339,7 +339,7 @@ void GetPreIntegratedFGD(float NdotV, float perceptualRoughness, float3 fresnel0
     reflectivity = preFGD.y;
 }
 
-void ApplyDebugToSurfaceData(FragInputs input, inout SurfaceData surfaceData)
+void ApplyDebugToSurfaceData(float3x3 worldToTangent, inout SurfaceData surfaceData)
 {
 #ifdef DEBUG_DISPLAY
     // Override value if requested by user
@@ -363,7 +363,7 @@ void ApplyDebugToSurfaceData(FragInputs input, inout SurfaceData surfaceData)
     if (overrideNormal)
     {
         float overrideNormalValue = _DebugLightingNormal.yzw;
-        surfaceData.normalWS = input.worldToTangent[2];
+        surfaceData.normalWS = worldToTangent[2];
     }
 #endif
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
@@ -339,6 +339,9 @@ void GetPreIntegratedFGD(float NdotV, float perceptualRoughness, float3 fresnel0
     reflectivity = preFGD.y;
 }
 
+// This function is use to help with debugging and must be implemented by any lit material
+// Implementer must take into account what are the current override component and 
+// adjust SurfaceData properties accordingdly
 void ApplyDebugToSurfaceData(float3x3 worldToTangent, inout SurfaceData surfaceData)
 {
 #ifdef DEBUG_DISPLAY

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
@@ -59,7 +59,7 @@ TEXTURE2D_ARRAY(_LtcData); // We pack the 3 Ltc data inside a texture array
 #define GBUFFER_LIT_STANDARD         0
 // we have not enough space (3bit) to store mat feature to have SSS and Transmission as bitmask, such why we have all variant
 #define GBUFFER_LIT_SSS              1
-#define GBUFFER_LIT_TRANSMISSION     2 
+#define GBUFFER_LIT_TRANSMISSION     2
 #define GBUFFER_LIT_TRANSMISSION_SSS 3
 #define GBUFFER_LIT_ANISOTROPIC      4
 #define GBUFFER_LIT_IRIDESCENCE      5 // TODO
@@ -239,7 +239,7 @@ void FillMaterialTransmission(uint diffusionProfile, float thickness, inout BSDF
     bsdfData.fresnel0 = _TransmissionTintsAndFresnel0[diffusionProfile].a;
 
     bsdfData.thickness = _ThicknessRemaps[diffusionProfile].x + _ThicknessRemaps[diffusionProfile].y * thickness;
- 
+
 #if SHADEROPTIONS_USE_DISNEY_SSS
     bsdfData.transmittance = ComputeTransmittanceDisney(    _ShapeParams[diffusionProfile].rgb,
                                                             _TransmissionTintsAndFresnel0[diffusionProfile].rgb,
@@ -339,23 +339,31 @@ void GetPreIntegratedFGD(float NdotV, float perceptualRoughness, float3 fresnel0
     reflectivity = preFGD.y;
 }
 
-void ApplyDebugToSurfaceData(inout SurfaceData surfaceData)
+void ApplyDebugToSurfaceData(FragInputs input, inout SurfaceData surfaceData)
 {
 #ifdef DEBUG_DISPLAY
-    if (_DebugLightingMode == DEBUGLIGHTINGMODE_SPECULAR_LIGHTING)
-    {
-        bool overrideSmoothness = _DebugLightingSmoothness.x != 0.0;
-        float overrideSmoothnessValue = _DebugLightingSmoothness.y;
+    // Override value if requested by user
+    // this can be use also in case of debug lighting mode like diffuse only
+    bool overrideAlbedo = _DebugLightingAlbedo.x != 0.0;
+    bool overrideSmoothness = _DebugLightingSmoothness.x != 0.0;
+    bool overrideNormal = _DebugLightingNormal.x != 0.0;
 
-        if (overrideSmoothness)
-        {
-            surfaceData.perceptualSmoothness = overrideSmoothnessValue;
-        }
+    if (overrideAlbedo)
+    {
+        float3 overrideAlbedoValue = _DebugLightingAlbedo.yzw;
+        surfaceData.baseColor = overrideAlbedoValue;
     }
 
-    if (_DebugLightingMode == DEBUGLIGHTINGMODE_DIFFUSE_LIGHTING)
+    if (overrideSmoothness)
     {
-        surfaceData.baseColor = _DebugLightingAlbedo.xyz;
+        float overrideSmoothnessValue = _DebugLightingSmoothness.y;
+        surfaceData.perceptualSmoothness = overrideSmoothnessValue;
+    }
+
+    if (overrideNormal)
+    {
+        float overrideNormalValue = _DebugLightingNormal.yzw;
+        surfaceData.normalWS = input.worldToTangent[2];
     }
 #endif
 }
@@ -377,8 +385,6 @@ SSSData ConvertSurfaceDataToSSSData(SurfaceData surfaceData)
 
 BSDFData ConvertSurfaceDataToBSDFData(SurfaceData surfaceData)
 {
-    ApplyDebugToSurfaceData(surfaceData);
-
     BSDFData bsdfData;
     ZERO_INITIALIZE(BSDFData, bsdfData);
 
@@ -505,8 +511,6 @@ void EncodeIntoGBuffer( SurfaceData surfaceData,
                         out GBufferType3 outGBuffer3
                         )
 {
-    ApplyDebugToSurfaceData(surfaceData);
-
     // RT0 - 8:8:8:8 sRGB
     // Warning: the contents are later overwritten for Standard and SSS!
     outGBuffer0 = float4(surfaceData.baseColor, surfaceData.specularOcclusion);
@@ -574,7 +578,7 @@ void EncodeIntoGBuffer( SurfaceData surfaceData,
     }
     else // Standard
     {
-        // In the case of standard or specular color we always convert to specular color parametrization before encoding, 
+        // In the case of standard or specular color we always convert to specular color parametrization before encoding,
         // so decoding is more efficient (it allow better optimization for the compiler and save VGPR)
         // This mean that on the decode side, MATERIALFEATUREFLAGS_LIT_SPECULAR_COLOR doesn't exist anymore
         materialFeatureId = GBUFFER_LIT_STANDARD;
@@ -684,8 +688,8 @@ uint DecodeFromGBuffer(uint2 positionSS, uint tileFeatureFlags, out BSDFData bsd
 
         // Overwrite the diffusion profile/subsurfaceMask extracted by DecodeFromSSSBuffer().
         // We must do this so the compiler can optimize away the read from the G-Buffer 0 to the very end (in PostEvaluateBSDF)
-        // Note that we don't use sssData.subsurfaceMask here. But it is still assign so we can have the information in the 
-        // material debug view + If we require it in the future. 
+        // Note that we don't use sssData.subsurfaceMask here. But it is still assign so we can have the information in the
+        // material debug view + If we require it in the future.
         UnpackFloatInt8bit(inGBuffer2.b, 16, sssData.subsurfaceMask, sssData.diffusionProfile);
 
         // Reminder: when using SSS we exchange specular occlusion and subsurfaceMask/profileID
@@ -1714,7 +1718,7 @@ DirectLighting EvaluateBSDF_Area(LightLoopContext lightLoopContext,
 // _preIntegratedFGD and _CubemapLD are unique for each BRDF
 IndirectLighting EvaluateBSDF_Env(  LightLoopContext lightLoopContext,
                                     float3 V, PositionInputs posInput,
-                                    PreLightData preLightData, EnvLightData lightData, BSDFData bsdfData, 
+                                    PreLightData preLightData, EnvLightData lightData, BSDFData bsdfData,
                                     int influenceShapeType, int GPUImageBasedLightingType,
                                     inout float hierarchyWeight)
 {

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForward.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForward.hlsl
@@ -52,6 +52,10 @@ void Frag(PackedVaryingsToPS packedInput,
     BuiltinData builtinData;
     GetSurfaceAndBuiltinData(input, V, posInput, surfaceData, builtinData);
 
+#ifdef DEBUG_DISPLAY
+    ApplyDebugToSurfaceData(input, surfaceData);
+#endif
+
     BSDFData bsdfData = ConvertSurfaceDataToBSDFData(surfaceData);
 
     PreLightData preLightData = GetPreLightData(V, posInput, bsdfData);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForward.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForward.hlsl
@@ -53,7 +53,7 @@ void Frag(PackedVaryingsToPS packedInput,
     GetSurfaceAndBuiltinData(input, V, posInput, surfaceData, builtinData);
 
 #ifdef DEBUG_DISPLAY
-    ApplyDebugToSurfaceData(input, surfaceData);
+    ApplyDebugToSurfaceData(input.worldToTangent, surfaceData);
 #endif
 
     BSDFData bsdfData = ConvertSurfaceDataToBSDFData(surfaceData);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForwardUnlit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassForwardUnlit.hlsl
@@ -42,7 +42,6 @@ float4 Frag(PackedVaryingsToPS packedInput) : SV_Target
     GetSurfaceAndBuiltinData(input, V, posInput, surfaceData, builtinData);
 
     // Not lit here (but emissive is allowed)
-
     BSDFData bsdfData = ConvertSurfaceDataToBSDFData(surfaceData);
 
     // TODO: we must not access bsdfData here, it break the genericity of the code!

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassGBuffer.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassGBuffer.hlsl
@@ -48,7 +48,7 @@ void Frag(  PackedVaryingsToPS packedInput,
     GetSurfaceAndBuiltinData(input, V, posInput, surfaceData, builtinData);
 
 #ifdef DEBUG_DISPLAY
-    ApplyDebugToSurfaceData(input, surfaceData);
+    ApplyDebugToSurfaceData(input.worldToTangent, surfaceData);
 #endif
 
     BSDFData bsdfData = ConvertSurfaceDataToBSDFData(surfaceData);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassGBuffer.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassGBuffer.hlsl
@@ -47,6 +47,10 @@ void Frag(  PackedVaryingsToPS packedInput,
     BuiltinData builtinData;
     GetSurfaceAndBuiltinData(input, V, posInput, surfaceData, builtinData);
 
+#ifdef DEBUG_DISPLAY
+    ApplyDebugToSurfaceData(input, surfaceData);
+#endif
+
     BSDFData bsdfData = ConvertSurfaceDataToBSDFData(surfaceData);
 
     PreLightData preLightData = GetPreLightData(V, posInput, bsdfData);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassLightTransport.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/ShaderPass/ShaderPassLightTransport.hlsl
@@ -89,6 +89,8 @@ float4 Frag(PackedVaryingsToPS packedInput) : SV_Target
     BuiltinData builtinData;
     GetSurfaceAndBuiltinData(input, V, posInput, surfaceData, builtinData);
 
+    // no debug apply during light transport pass
+
     BSDFData bsdfData = ConvertSurfaceDataToBSDFData(surfaceData);
     LightTransportData lightTransportData = GetLightTransportData(surfaceData, builtinData, bsdfData);
 


### PR DESCRIPTION
This PR add support of override smoothness, albedo and normal to debug windows for all mode (even when there is no lighting debug mode enabled).

Override normal draw the vertex normal.

Note: ApplyDebugToSurfaceData now need to be implemented by all lit material