### PR TITLE
HDRenderPipeline: Disable Unused camera draw mode

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine.Rendering;
 using UnityEngine.Experimental.Rendering;
 using System;
@@ -172,14 +173,16 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         static public void SetupDrawMode()
         {
-            SceneView sceneView = EditorWindow.GetWindow<SceneView>();
-            sceneView.onValidateCameraMode += RejectDrawMode;
+            ArrayList sceneViewArray = SceneView.sceneViews;
+            foreach (SceneView sceneView in sceneViewArray)
+                sceneView.onValidateCameraMode += RejectDrawMode;
         }
 
         static public void ResetDrawMode()
         {
-            SceneView sceneView = EditorWindow.GetWindow<SceneView>();
-            sceneView.onValidateCameraMode -= RejectDrawMode;
+            ArrayList sceneViewArray = SceneView.sceneViews;
+            foreach (SceneView sceneView in sceneViewArray)
+                sceneView.onValidateCameraMode -= RejectDrawMode;
         }
     }
 #endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -1,15 +1,10 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine.Rendering;
 using UnityEngine.Experimental.Rendering;
 using System;
 using System.Diagnostics;
 using System.Linq;
 using UnityEngine.Rendering.PostProcessing;
-#if UNITY_EDITOR
-using UnityEditor;
-using UnityEditor.Experimental.Rendering;
-#endif
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
@@ -145,47 +140,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 			CoreUtils.ResizeHTile(ref m_HTile, ref m_HTileRT, camera.renderTextureDesc);
         }
     }
-
-#if UNITY_EDITOR
-    public class SceneViewDrawMode
-    {
-        static private bool RejectDrawMode(SceneView.CameraMode cameraMode)
-        {
-            if (cameraMode.drawMode == DrawCameraMode.TexturedWire ||
-                cameraMode.drawMode == DrawCameraMode.ShadowCascades ||
-                cameraMode.drawMode == DrawCameraMode.RenderPaths ||
-                cameraMode.drawMode == DrawCameraMode.AlphaChannel ||
-                cameraMode.drawMode == DrawCameraMode.Overdraw ||
-                cameraMode.drawMode == DrawCameraMode.Mipmaps ||
-                cameraMode.drawMode == DrawCameraMode.DeferredDiffuse ||
-                cameraMode.drawMode == DrawCameraMode.DeferredSpecular ||
-                cameraMode.drawMode == DrawCameraMode.DeferredSmoothness ||
-                cameraMode.drawMode == DrawCameraMode.DeferredNormal ||
-                cameraMode.drawMode == DrawCameraMode.ValidateAlbedo ||
-                cameraMode.drawMode == DrawCameraMode.ValidateMetalSpecular ||
-                cameraMode.drawMode == DrawCameraMode.ShadowMasks ||
-                cameraMode.drawMode == DrawCameraMode.LightOverlap
-                )
-                return false;
-
-            return true;
-        }
-
-        static public void SetupDrawMode()
-        {
-            ArrayList sceneViewArray = SceneView.sceneViews;
-            foreach (SceneView sceneView in sceneViewArray)
-                sceneView.onValidateCameraMode += RejectDrawMode;
-        }
-
-        static public void ResetDrawMode()
-        {
-            ArrayList sceneViewArray = SceneView.sceneViews;
-            foreach (SceneView sceneView in sceneViewArray)
-                sceneView.onValidateCameraMode -= RejectDrawMode;
-        }
-    }
-#endif
 
     public class HDRenderPipeline : RenderPipeline
     {

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/SceneViewDrawMode.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/SceneViewDrawMode.cs
@@ -1,0 +1,44 @@
+#if UNITY_EDITOR
+using System.Collections;
+using UnityEditor;
+using UnityEditor.Experimental.Rendering;
+
+public class SceneViewDrawMode
+{
+    static private bool RejectDrawMode(SceneView.CameraMode cameraMode)
+    {
+        if (cameraMode.drawMode == DrawCameraMode.TexturedWire ||
+            cameraMode.drawMode == DrawCameraMode.ShadowCascades ||
+            cameraMode.drawMode == DrawCameraMode.RenderPaths ||
+            cameraMode.drawMode == DrawCameraMode.AlphaChannel ||
+            cameraMode.drawMode == DrawCameraMode.Overdraw ||
+            cameraMode.drawMode == DrawCameraMode.Mipmaps ||
+            cameraMode.drawMode == DrawCameraMode.DeferredDiffuse ||
+            cameraMode.drawMode == DrawCameraMode.DeferredSpecular ||
+            cameraMode.drawMode == DrawCameraMode.DeferredSmoothness ||
+            cameraMode.drawMode == DrawCameraMode.DeferredNormal ||
+            cameraMode.drawMode == DrawCameraMode.ValidateAlbedo ||
+            cameraMode.drawMode == DrawCameraMode.ValidateMetalSpecular ||
+            cameraMode.drawMode == DrawCameraMode.ShadowMasks ||
+            cameraMode.drawMode == DrawCameraMode.LightOverlap
+            )
+            return false;
+
+        return true;
+    }
+
+    static public void SetupDrawMode()
+    {
+        ArrayList sceneViewArray = SceneView.sceneViews;
+        foreach (SceneView sceneView in sceneViewArray)
+            sceneView.onValidateCameraMode += RejectDrawMode;
+    }
+
+    static public void ResetDrawMode()
+    {
+        ArrayList sceneViewArray = SceneView.sceneViews;
+        foreach (SceneView sceneView in sceneViewArray)
+            sceneView.onValidateCameraMode -= RejectDrawMode;
+    }
+}
+#endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/SceneViewDrawMode.cs.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/SceneViewDrawMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ce13303c7796bd4d80d623d982e7460
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Note: This doesn't handle the case where user create a windows after we init the HDPipeline