### PR TITLE
Add MSAA sample count support thru RenderPipelineSettings

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
@@ -192,7 +192,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (frameSettings.enableMSAA)
             {
                 // this is already pre-validated to be a valid sample count by InitializeFrameSettings
-                var sampleCount = QualitySettings.antiAliasing;
+                var sampleCount = (int)frameSettings.msaaSampleCount; 
                 tempDesc.msaaSamples = sampleCount;
             }
             else

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/RenderPipelineSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/RenderPipelineSettingsUI.cs
@@ -73,7 +73,7 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUILayout.PropertyField(d.supportSSR, _.GetContent("Support SSR"));
             EditorGUILayout.PropertyField(d.supportSSAO, _.GetContent("Support SSAO"));
             EditorGUILayout.PropertyField(d.supportDBuffer, _.GetContent("Support Decal Buffer"));
-            EditorGUILayout.PropertyField(d.supportMSAA, _.GetContent("Support MSAA"));
+            EditorGUILayout.PropertyField(d.msaaSampleCount, _.GetContent("MSAA Sample Count"));
             EditorGUILayout.PropertyField(d.supportSubsurfaceScattering, _.GetContent("Support Subsurface Scattering"));
             --EditorGUI.indentLevel;
         }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedRenderPipelineSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedRenderPipelineSettings.cs
@@ -10,7 +10,7 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty supportSSR;
         public SerializedProperty supportSSAO;
         public SerializedProperty supportDBuffer;
-        public SerializedProperty supportMSAA;
+        public SerializedProperty msaaSampleCount;
         public SerializedProperty supportSubsurfaceScattering;
 
         public SerializedGlobalLightLoopSettings lightLoopSettings;
@@ -25,7 +25,7 @@ namespace UnityEditor.Experimental.Rendering
             supportSSR = root.Find((RenderPipelineSettings s) => s.supportSSR);
             supportSSAO = root.Find((RenderPipelineSettings s) => s.supportSSAO);
             supportDBuffer = root.Find((RenderPipelineSettings s) => s.supportDBuffer);
-            supportMSAA = root.Find((RenderPipelineSettings s) => s.supportMSAA);
+            msaaSampleCount = root.Find((RenderPipelineSettings s) => s.msaaSampleCount);
             supportSubsurfaceScattering = root.Find((RenderPipelineSettings s) => s.supportSubsurfaceScattering);
 
             lightLoopSettings = new SerializedGlobalLightLoopSettings(root.Find((RenderPipelineSettings s) => s.lightLoopSettings));

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
@@ -73,6 +73,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool enableTransparentObjects = true;
 
         public bool enableMSAA = false;
+        public MSAASamples msaaSampleCount { get; private set; }
 
         public bool enableShadowMask = false;
 
@@ -172,9 +173,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             aggregate.enableOpaqueObjects = srcFrameSettings.enableOpaqueObjects;
             aggregate.enableTransparentObjects = srcFrameSettings.enableTransparentObjects;
 
-            aggregate.enableMSAA = srcFrameSettings.enableMSAA && renderPipelineSettings.supportMSAA;
-            if (QualitySettings.antiAliasing < 1)
-                aggregate.enableMSAA = false;
+            aggregate.enableMSAA = srcFrameSettings.enableMSAA && ((int)renderPipelineSettings.msaaSampleCount > 1);
+            aggregate.msaaSampleCount = aggregate.enableMSAA ? renderPipelineSettings.msaaSampleCount : MSAASamples.None;
+
             aggregate.ConfigureMSAADependentSettings();
 
             aggregate.enableShadowMask = srcFrameSettings.enableShadowMask && renderPipelineSettings.supportShadowMask;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/RenderPipelineSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/RenderPipelineSettings.cs
@@ -27,7 +27,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         // Engine
         public bool supportDBuffer = false;
-        public bool supportMSAA = false;
+        public MSAASamples msaaSampleCount = MSAASamples.None;
 
         public GlobalLightLoopSettings  lightLoopSettings = new GlobalLightLoopSettings();
         public ShadowInitParameters     shadowInitParams = new ShadowInitParameters();


### PR DESCRIPTION
RenderPipelineSettings owns the global MSAA sample count level.  Each camera can control whether MSAA is supported or not via FrameSettings.enableMSAA. 

If the camera enables MSAA, then the sample count will be sourced from the RenderPipelineSettings value.

Bonus: I was able to use the new MSAASamples enum in RTHandle