### PR TITLE
metal

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/Resources/VolumetricLighting.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/Resources/VolumetricLighting.compute
@@ -371,8 +371,6 @@ void FillVolumetricLightingBuffer(LightLoopContext context, uint featureFlags,
     float3 totalRadiance = 0;
     float  opticalDepth  = 0;
 
-    uint sliceCountHack = max(VBUFFER_SLICE_COUNT, (uint)_VBufferDepthEncodingParams.w); // Prevent unrolling...
-
 #ifdef LIGHTLOOP_TILE_PASS
     // Our voxel is not necessarily completely inside a single light cluster.
     // Note that Z-binning can solve this problem, as we can iterate over all Z-bins
@@ -383,11 +381,22 @@ void FillVolumetricLightingBuffer(LightLoopContext context, uint featureFlags,
     clusterDepths[0]  = GetLightClusterMinLinearDepth(posInput.tileCoord, clusterIndices[0]);
 #endif // LIGHTLOOP_TILE_PASS
 
+#if defined(SHADER_API_METAL)
+    [fastopt]
+    for (uint slice = 0; slice < VBUFFER_SLICE_COUNT; slice++)
+#else
+    uint sliceCountHack = max(VBUFFER_SLICE_COUNT, (uint)_VBufferDepthEncodingParams.w); // Prevent unrolling...
+
     // TODO: replace 'sliceCountHack' with VBUFFER_SLICE_COUNT when the shader compiler bug is fixed.
     for (uint slice = 0; slice < sliceCountHack; slice++)
+#endif
     {
         float e1 = slice * de + de; // (slice + 1) / sliceCount
+#if defined(SHADER_API_METAL)
+        float z1 = DecodeLogarithmicDepth(e1, _VBufferDepthDecodingParams);
+#else
         float z1 = DecodeLogarithmicDepthGeneralized(e1, _VBufferDepthDecodingParams);
+#endif
         float t1 = ray.strataDirInvViewZ * z1; // Convert view space Z to distance along the stratified ray
         float dt = t1 - t0;
 

--- a/build.py.meta
+++ b/build.py.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 335d624799dcb41af916ffe1772883cf
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
sliceCountHack works around long shader compilation times when [loop] doesn't work,
but seems to partially cause issues with Apple's frontend compiler later

Code generated using [fastopt] seems to look pretty much the same as with sliceCountHack,
so for now enabling it at least for Metal
