### PR TITLE
Update sss and transmisison ui

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/LayeredLit/LayeredLitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/LayeredLit/LayeredLitUI.cs
@@ -657,18 +657,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             CoreUtils.SetKeyword(material, "_DENSITY_MODE", useDensityModeEnable);
 
             BaseLitGUI.MaterialId materialId = (BaseLitGUI.MaterialId)material.GetFloat(kMaterialID);
-            BaseLitGUI.SSSAndTransmissionType sssAndTransmissionType = (BaseLitGUI.SSSAndTransmissionType)material.GetFloat(kSSSAndTransmissionType);
-
-            if (materialId == BaseLitGUI.MaterialId.LitSSSAndTransmission)
-            {
-                CoreUtils.SetKeyword(material, "_MATERIAL_FEATURE_SUBSURFACE_SCATTERING", sssAndTransmissionType == BaseLitGUI.SSSAndTransmissionType.LitSSSAndTransmission || sssAndTransmissionType == BaseLitGUI.SSSAndTransmissionType.LitSSSOnly);
-                CoreUtils.SetKeyword(material, "_MATERIAL_FEATURE_TRANSMISSION", sssAndTransmissionType == BaseLitGUI.SSSAndTransmissionType.LitSSSAndTransmission || sssAndTransmissionType == BaseLitGUI.SSSAndTransmissionType.LitTransmissionOnly);
-            }
-            else
-            {
-                CoreUtils.SetKeyword(material, "_MATERIAL_FEATURE_SUBSURFACE_SCATTERING", false);
-                CoreUtils.SetKeyword(material, "_MATERIAL_FEATURE_TRANSMISSION", false);
-            }
+            CoreUtils.SetKeyword(material, "_MATERIAL_FEATURE_SUBSURFACE_SCATTERING", materialId == BaseLitGUI.MaterialId.LitSSS);
+            CoreUtils.SetKeyword(material, "_MATERIAL_FEATURE_TRANSMISSION", materialId == BaseLitGUI.MaterialId.LitTranslucent || (materialId == BaseLitGUI.MaterialId.LitSSS && material.GetFloat(kTransmissionEnable) > 0.0f));
         }
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/Lit/BaseLitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/Lit/BaseLitUI.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             // Material ID
             public static GUIContent materialIDText = new GUIContent("Material type", "Select a material feature to enable on top of regular material");
-            public static GUIContent SSSAndTransmissionTypeText = new GUIContent("SSS and Transmission type", "Subsurface Scattering for translucent materials such as skin, vegetation, fruit, marble, wax and milk., Transmission for back lighting");
+            public static GUIContent transmissionEnableText = new GUIContent("Enable Transmission", "Enable Transmission for getting  back lighting");
 
             // Per pixel displacement
             public static GUIContent ppdMinSamplesText = new GUIContent("Minimum steps", "Minimum steps (texture sample) to use with per pixel displacement mapping");
@@ -84,18 +84,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         public enum MaterialId
         {
-            LitSSSAndTransmission = 0,
+            LitSSS = 0,
             LitStandard = 1,
             LitAniso = 2,
             LitIridescence = 3,
-            LitSpecular = 4
-        };
-
-        public enum SSSAndTransmissionType
-        {
-            LitSSSAndTransmission = 0,
-            LitSSSOnly = 1,
-            LitTransmissionOnly = 2,
+            LitSpecular = 4,
+            LitTranslucent = 5
         };
 
         public enum HeightmapParametrization
@@ -113,8 +107,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         // Material ID
         protected MaterialProperty materialID  = null;
         protected const string kMaterialID = "_MaterialID";
-        protected MaterialProperty sssAndTransmissionType = null;
-        protected const string kSSSAndTransmissionType = "_SSSAndTransmissionType";        
+        protected MaterialProperty transmissionEnable = null;
+        protected const string kTransmissionEnable = "_TransmissionEnable";
 
         protected const string kStencilRef = "_StencilRef";
         protected const string kStencilWriteMask = "_StencilWriteMask";
@@ -189,7 +183,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             // MaterialID
             materialID = FindProperty(kMaterialID, props);
-            sssAndTransmissionType = FindProperty(kSSSAndTransmissionType, props);      
+            transmissionEnable = FindProperty(kTransmissionEnable, props);
 
             displacementMode = FindProperty(kDisplacementMode, props);
             displacementLockObjectScale = FindProperty(kDisplacementLockObjectScale, props);
@@ -259,11 +253,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
 
             m_MaterialEditor.ShaderProperty(materialID, StylesBaseLit.materialIDText);
-
-            if ((int)materialID.floatValue == (int)BaseLitGUI.MaterialId.LitSSSAndTransmission)
-            {
-                m_MaterialEditor.ShaderProperty(sssAndTransmissionType, StylesBaseLit.SSSAndTransmissionTypeText);                
-            }                
 
             m_MaterialEditor.ShaderProperty(supportDBuffer, StylesBaseLit.supportDBufferText);
 
@@ -373,13 +362,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             // Set the reference value for the stencil test.
             int stencilRef = (int)StencilLightingUsage.RegularLighting;
-            if ((int)material.GetFloat(kMaterialID) == (int)BaseLitGUI.MaterialId.LitSSSAndTransmission)
+            if ((int)material.GetFloat(kMaterialID) == (int)BaseLitGUI.MaterialId.LitSSS)
             {
-                if ((int)material.GetFloat(kSSSAndTransmissionType) == (int)BaseLitGUI.SSSAndTransmissionType.LitSSSAndTransmission ||
-                    (int)material.GetFloat(kSSSAndTransmissionType) == (int)BaseLitGUI.SSSAndTransmissionType.LitSSSOnly)
-                {
-                    stencilRef = (int)StencilLightingUsage.SplitLighting;
-                }
+                stencilRef = (int)StencilLightingUsage.SplitLighting;
             }
             // As we tag both during velocity pass and Gbuffer pass we need a separate state and we need to use the write mask
             material.SetInt(kStencilRef, stencilRef);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/Lit/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/Lit/LitUI.cs
@@ -443,8 +443,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 m_MaterialEditor.TexturePropertySingleLine(Styles.subsurfaceMaskMapText, subsurfaceMaskMap[layerIndex]);
             }
 
-            if ((int)materialID.floatValue == (int)BaseLitGUI.MaterialId.LitSSS ||
-                ((int)materialID.floatValue == (int)BaseLitGUI.MaterialId.LitTranslucent && transmissionEnable.floatValue > 0.0f))
+            if ((int)materialID.floatValue == (int)BaseLitGUI.MaterialId.LitTranslucent ||
+                ((int)materialID.floatValue == (int)BaseLitGUI.MaterialId.LitSSS && transmissionEnable.floatValue > 0.0f))
             {
                 m_MaterialEditor.TexturePropertySingleLine(Styles.thicknessMapText, thicknessMap[layerIndex]);
                 if (thicknessMap[layerIndex].textureValue != null)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLit.shader
@@ -259,8 +259,8 @@ Shader "HDRenderPipeline/LayeredLit"
         [HideInInspector] _DoubleSidedConstants("_DoubleSidedConstants", Vector) = (1, 1, -1, 0)
 
         // For layering, due to combinatorial explosion, we only support SSS/Transmission and Standard. We let other case for the shader graph
-        [Enum(Subsurface Scattering and Transmissison, 0, Standard, 1)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
-        [Enum(Both, 0, SSS only, 1, Transmission only, 2)] _SSSAndTransmissionType("SSSandTransmissionType", Int) = 0 // SSSandTransmissionType.Both
+        [Enum(Subsurface Scattering, 0, Standard, 1, Translucent, 5)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
+        [ToggleUI] _TransmissionEnable("_TransmissionEnable", Float) = 1.0
 
         [Enum(None, 0, Vertex displacement, 1, Pixel displacement, 2)] _DisplacementMode("DisplacementMode", Int) = 0
         [ToggleUI] _DisplacementLockObjectScale("displacement lock object scale", Float) = 1.0

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLitTessellation.shader
@@ -259,8 +259,8 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         [HideInInspector] _DoubleSidedConstants("_DoubleSidedConstants", Vector) = (1, 1, -1, 0)
 
         // For layering, due to combinatorial explosion, we only support SSS/Transmission and Standard. We let other case for the shader graph
-        [Enum(Subsurface Scattering and Transmissison, 0, Standard, 1)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
-        [Enum(Both, 0, SSS only, 1, Transmission only, 2)] _SSSAndTransmissionType("SSSandTransmissionType", Int) = 0 // SSSandTransmissionType.Both
+        [Enum(Subsurface Scattering, 0, Standard, 1, Translucent, 5)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
+        [ToggleUI] _TransmissionEnable("_TransmissionEnable", Float) = 1.0
 
         [Enum(None, 0, Tessellation displacement, 3)] _DisplacementMode("DisplacementMode", Int) = 3
         [ToggleUI] _DisplacementLockObjectScale("displacement lock object scale", Float) = 1.0

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.shader
@@ -142,8 +142,8 @@ Shader "HDRenderPipeline/Lit"
         // Following enum should be material feature flags (i.e bitfield), however due to Gbuffer encoding constrain many combination exclude each other
         // so we use this enum as "material ID" which can be interpreted as preset of bitfield of material feature
         // The only material feature flag that can be added in all cases is clear coat
-        [Enum(Subsurface Scattering and Transmissison, 0, Standard, 1, Anisotropy, 2, Iridescence, 3, Specular Color, 4)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
-        [Enum(Both, 0, SSS only, 1, Transmission only, 2)] _SSSAndTransmissionType("SSSandTransmissionType", Int) = 0 // SSSandTransmissionType.Both
+        [Enum(Subsurface Scattering, 0, Standard, 1, Anisotropy, 2, Iridescence, 3, Specular Color, 4, Translucent, 5)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
+        [ToggleUI] _TransmissionEnable("_TransmissionEnable", Float) = 1.0
 
         [Enum(None, 0, Vertex displacement, 1, Pixel displacement, 2)] _DisplacementMode("DisplacementMode", Int) = 0
         [ToggleUI] _DisplacementLockObjectScale("displacement lock object scale", Float) = 1.0

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/LitTessellation.shader
@@ -143,8 +143,8 @@ Shader "HDRenderPipeline/LitTessellation"
         // Following enum should be material feature flags (i.e bitfield), however due to Gbuffer encoding constrain many combination exclude each other
         // so we use this enum as "material ID" which can be interpreted as preset of bitfield of material feature
         // The only material feature flag that can be added in all cases is clear coat
-        [Enum(Subsurface Scattering and Transmissison, 0, Standard, 1, Anisotropy, 2, Iridescence, 3, Specular Color, 4)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
-        [Enum(Both, 0, SSS only, 1, Transmission only, 2)] _SSSAndTransmissionType("SSSandTransmissionType", Int) = 0 // SSSandTransmissionType.Both
+        [Enum(Subsurface Scattering, 0, Standard, 1, Anisotropy, 2, Iridescence, 3, Specular Color, 4, Translucent, 5)] _MaterialID("MaterialId", Int) = 1 // MaterialId.Standard
+        [ToggleUI] _TransmissionEnable("_TransmissionEnable", Float) = 1.0
 
         [Enum(None, 0, Tessellation displacement, 3)] _DisplacementMode("DisplacementMode", Int) = 3
         [ToggleUI] _DisplacementLockObjectScale("displacement lock object scale", Float) = 1.0


### PR DESCRIPTION
This PR update the UI after discussion with ShawnMcLelland.

The Subsurface and transmission material type as well as the subtype are change to the following.

Subsurface scattering material type
with a checkbox for Transmission enable or not

(This match the previous: MaterialId Subsurface and Transmisison + Both or SSS only)

Translucent material type

(This match the previous: MaterialId Subsurface and Transmisison + Transmission only)

