### PR TITLE
Fix warning of LW and OnTileRender OnValidate call

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineAsset.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineAsset.cs
@@ -157,11 +157,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             return new LightweightPipeline(this);
         }
 
-        void OnValidate()
-        {
-            DestroyCreatedInstances();
-        }
-
         private Material GetMaterial(DefaultMaterialType materialType)
         {
 #if UNITY_EDITOR

--- a/TestbedPipelines/OnTileDeferredPipeline/OnTileDeferredRenderPipeline.cs
+++ b/TestbedPipelines/OnTileDeferredPipeline/OnTileDeferredRenderPipeline.cs
@@ -252,9 +252,10 @@ namespace UnityEngine.Experimental.Rendering.OnTileDeferredRenderPipeline
 
 		private Material m_BlitMaterial;
 
-		private void OnValidate()
+		protected override void OnValidate()
 		{
-			Build();
+            base.OnValidate();
+            Build();
 		}
 
 		public void Cleanup()


### PR DESCRIPTION
This PR fix warning of the C# compiler, looks like LW was doing unnecessary call to OnValidate(). OnValidate and DestroyCreateInstance are already handled by the base class.
Add @stramit and @phi-lira for awareness, but merge the PR, seems pretty safe

