### PR TITLE
Fix up lightmapping shader variants.

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
@@ -100,7 +100,8 @@ Shader "LightweightPipeline/Standard (Physically Based)"
 
             // -------------------------------------
             // Unity defined keywords
-            #pragma multi_compile _ DIRLIGHTMAP_COMBINED LIGHTMAP_ON
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
 
             //--------------------------------------
             // GPU Instancing

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
@@ -84,7 +84,8 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
 
             // -------------------------------------
             // Unity defined keywords
-            #pragma multi_compile _ DIRLIGHTMAP_COMBINED LIGHTMAP_ON
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
 
             //--------------------------------------
             // GPU Instancing

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardTerrain.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardTerrain.shader
@@ -50,10 +50,12 @@ Shader "LightweightPipeline/Standard Terrain"
             #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             #pragma multi_compile _ FOG_LINEAR FOG_EXP2
-
+            
             // -------------------------------------
             // Unity defined keywords
-            #pragma multi_compile _ DIRLIGHTMAP_COMBINED LIGHTMAP_ON
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+
             #pragma multi_compile __ _TERRAIN_NORMAL_MAP
 
             // LW doesn't support dynamic GI. So we save 30% shader variants if we assume


### PR DESCRIPTION
Using only one multi compile has an issue where the other variant can be stripped which breaks lightmap UV's on baked objects.