### PR TITLE
Fixed TAA only partially working in edit mode

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
@@ -165,8 +165,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 isFirstFrame = false;
             }
 
-            const uint taaFrameCount = 8;
-            taaFrameIndex = taaEnabled ? (uint)Time.renderedFrameCount % taaFrameCount : 0;
+            taaFrameIndex = taaEnabled ? (uint)postProcessLayer.temporalAntialiasing.sampleIndex : 0;
             taaFrameRotation = new Vector2(Mathf.Sin(taaFrameIndex * (0.5f * Mathf.PI)),
                                            Mathf.Cos(taaFrameIndex * (0.5f * Mathf.PI)));
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
@@ -122,7 +122,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             // If TAA is enabled projMatrix will hold a jittered projection matrix. The original,
             // non-jittered projection matrix can be accessed via nonJitteredProjMatrix.
-            bool taaEnabled = Application.isPlaying && camera.cameraType == CameraType.Game &&
+            bool taaEnabled = camera.cameraType == CameraType.Game &&
                 CoreUtils.IsTemporalAntialiasingActive(postProcessLayer);
 
             var nonJitteredCameraProj = camera.projectionMatrix;


### PR DESCRIPTION
4be911b broke TAA in the game view. Unless you entered play mode the projection matrix wouldn't get jittered but TAA would still apply. This fix reverts to the older behavior where you'd see the effect of TAA after a the game view refreshes for a few frames.

Any particular reason why this change was made in the first place? Am I overlooking something?