### PR TITLE
Faster domain reload

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/CoreUtils.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/CoreUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.Rendering;
@@ -335,20 +335,27 @@ namespace UnityEngine.Experimental.Rendering
             }
         }
 
+        static IEnumerable<Type> m_AssemblyTypes;
+
         public static IEnumerable<Type> GetAllAssemblyTypes()
         {
-            return AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(t =>
-                {
-                    // Ugly hack to handle mis-versioned dlls
-                    var innerTypes = new Type[0];
-                    try
+            if (m_AssemblyTypes == null)
+            {
+                m_AssemblyTypes = AppDomain.CurrentDomain.GetAssemblies()
+                    .SelectMany(t =>
                     {
-                        innerTypes = t.GetTypes();
-                    }
-                    catch { }
-                    return innerTypes;
-                });
+                        // Ugly hack to handle mis-versioned dlls
+                        var innerTypes = new Type[0];
+                        try
+                        {
+                            innerTypes = t.GetTypes();
+                        }
+                        catch { }
+                        return innerTypes;
+                    });
+            }
+
+            return m_AssemblyTypes;
         }
 
         public static void Destroy(params UnityObject[] objs)


### PR DESCRIPTION
`GetAllAssemblyTypes` is used in a few places on domain reload and is quite performance-heavy considering the growing number of assemblies & classes in the project. The PR caches its result so it's only done once per domain reload.