### PR TITLE
HDRenderPipeline: Add support for camera features flags

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
@@ -32,6 +32,18 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             Unlit  // Hard coded path
         };
 
+        public enum ClearColorMode
+        {
+            Sky,
+            BackgroundColor,
+            None
+        };
+
+        public ClearColorMode clearColorMode = ClearColorMode.Sky;
+        [ColorUsage(true, true)]
+        public Color backgroundColorHDR = new Color(0.025f, 0.07f, 0.19f, 0.0f);
+        public bool clearDepth = true;
+
         public RenderingPath    renderingPath;
         [Tooltip("Layer Mask used for the volume interpolation for this camera.")]
         public LayerMask        volumeLayerMask = -1;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
@@ -99,6 +99,42 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // happen, but you never know...
         int m_LastFrameActive;
 
+        public bool clearDepth
+        {
+            get { return m_AdditionalCameraData != null ? m_AdditionalCameraData.clearDepth : camera.clearFlags != CameraClearFlags.Nothing; }
+        }
+
+        public HDAdditionalCameraData.ClearColorMode clearColorMode
+        {
+            get
+            {
+                if (m_AdditionalCameraData != null)
+                {
+                    return m_AdditionalCameraData.clearColorMode;
+                }
+
+                if (camera.clearFlags == CameraClearFlags.Skybox)
+                    return HDAdditionalCameraData.ClearColorMode.Sky;
+                else if (camera.clearFlags == CameraClearFlags.SolidColor)
+                    return HDAdditionalCameraData.ClearColorMode.BackgroundColor;
+                else // None
+                    return HDAdditionalCameraData.ClearColorMode.None;
+            }
+        }
+
+        public Color backgroundColorHDR
+        {
+            get
+            {
+                if (m_AdditionalCameraData != null)
+                {
+                    return m_AdditionalCameraData.backgroundColorHDR;
+                }
+
+                return camera.backgroundColor.linear;
+            }
+        }        
+
         static Dictionary<Camera, HDCamera> s_Cameras = new Dictionary<Camera, HDCamera>();
         static List<Camera> s_Cleanup = new List<Camera>(); // Recycled to reduce GC pressure
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
@@ -131,6 +131,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     return m_AdditionalCameraData.backgroundColorHDR;
                 }
 
+                // The scene view has no additional data so this will correctly pick the editor preference backround color here.
                 return camera.backgroundColor.linear;
             }
         }        

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraUI.cs
@@ -136,7 +136,7 @@ namespace UnityEditor.Experimental.Rendering
 
         static void Drawer_FieldBackgroundColorHDR(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.backgroundColorHDR, _.GetContent("Background Color|The BackgroundColor use to clear screen when selecting BackgrounColor before rendering."));
+            EditorGUILayout.PropertyField(p.backgroundColorHDR, _.GetContent("Background Color|The BackgroundColor used to clear the screen when selecting BackgrounColor before rendering."));
         }
 
         static void Drawer_FieldVolumeLayerMask(HDCameraUI s, SerializedHDCamera p, Editor owner)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraUI.cs
@@ -29,7 +29,9 @@ namespace UnityEditor.Experimental.Rendering
         public static readonly CED.IDrawer[] Inspector = null;
 
         public static readonly CED.IDrawer SectionPrimarySettings = CED.Group(
-            CED.Action(Drawer_FieldBackgroundColor),
+            CED.Action(Drawer_FieldClearColorMode),
+            CED.Action(Drawer_FieldBackgroundColorHDR),
+            CED.Action(Drawer_FieldClearDepth),
             CED.Action(Drawer_FieldCullingMask),
             CED.Action(Drawer_FieldVolumeLayerMask),
             CED.space,
@@ -132,9 +134,9 @@ namespace UnityEditor.Experimental.Rendering
             frameSettingsUI.Update();
         }
 
-        static void Drawer_FieldBackgroundColor(HDCameraUI s, SerializedHDCamera p, Editor owner)
+        static void Drawer_FieldBackgroundColorHDR(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.backgroundColor, _.GetContent("Background Color|The Camera clears the screen to this color before rendering."));
+            EditorGUILayout.PropertyField(p.backgroundColorHDR, _.GetContent("Background Color|The BackgroundColor use to clear screen when selecting BackgrounColor before rendering."));
         }
 
         static void Drawer_FieldVolumeLayerMask(HDCameraUI s, SerializedHDCamera p, Editor owner)
@@ -184,9 +186,19 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUILayout.PropertyField(p.depth, _.GetContent("Depth"));
         }
 
+        static void Drawer_FieldClearColorMode(HDCameraUI s, SerializedHDCamera p, Editor owner)
+        {
+            EditorGUILayout.PropertyField(p.clearColorMode, _.GetContent("Clear Mode|The Camera clears the screen to selected mode."));
+        }
+
         static void Drawer_FieldRenderingPath(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
             EditorGUILayout.PropertyField(p.renderingPath, _.GetContent("Rendering Path"));
+        }
+
+        static void Drawer_FieldClearDepth(HDCameraUI s, SerializedHDCamera p, Editor owner)
+        {
+            EditorGUILayout.PropertyField(p.clearDepth, _.GetContent("ClearDepth|The Camera clears the depth buffer before rendering."));
         }
 
         static void Drawer_FieldRenderTarget(HDCameraUI s, SerializedHDCamera p, Editor owner)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/SerializedHDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/SerializedHDCamera.cs
@@ -8,7 +8,7 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedObject serializedObject;
         public SerializedObject serializedAdditionalDataObject;
 
-        public SerializedProperty backgroundColor;
+        //public SerializedProperty backgroundColor;
         public SerializedProperty normalizedViewPortRect;
         public SerializedProperty fieldOfView;
         public SerializedProperty orthographic;
@@ -28,7 +28,10 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty targetDisplay;
 #endif
 
+        public SerializedProperty clearColorMode;
+        public SerializedProperty backgroundColorHDR;
         public SerializedProperty renderingPath;
+        public SerializedProperty clearDepth;
         public SerializedProperty volumeLayerMask;
         public SerializedFrameSettings frameSettings;
 
@@ -43,7 +46,7 @@ namespace UnityEditor.Experimental.Rendering
             hideFlags.intValue = (int)HideFlags.HideInInspector;
             serializedAdditionalDataObject.ApplyModifiedProperties();
 
-            backgroundColor = serializedObject.FindProperty("m_BackGroundColor");
+            //backgroundColor = serializedObject.FindProperty("m_BackGroundColor");
             normalizedViewPortRect = serializedObject.FindProperty("m_NormalizedViewPortRect");
             nearClippingPlane = serializedObject.FindProperty("near clip plane");
             farClippingPlane = serializedObject.FindProperty("far clip plane");
@@ -65,7 +68,11 @@ namespace UnityEditor.Experimental.Rendering
 
             targetEye = serializedObject.FindProperty("m_TargetEye");
 
+
+            clearColorMode = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.clearColorMode);
+            backgroundColorHDR = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.backgroundColorHDR);
             renderingPath = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.renderingPath);
+            clearDepth = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.clearDepth);
             volumeLayerMask = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.volumeLayerMask);
             frameSettings = new SerializedFrameSettings(serializedAdditionalDataObject.FindProperty("m_FrameSettings"));
         }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -1655,7 +1655,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     if (hdCamera.clearColorMode == HDAdditionalCameraData.ClearColorMode.BackgroundColor ||
                         // If we want the sky but the sky don't exist, still clear with background color
-                        (hdCamera.clearColorMode == HDAdditionalCameraData.ClearColorMode.Sky && !m_SkyManager.IsSkyValid()))
+                        (hdCamera.clearColorMode == HDAdditionalCameraData.ClearColorMode.Sky && !m_SkyManager.IsSkyValid()) ||
+                        // Special handling for Preview we force to clear with background color (i.e black)
+                        // Note that the sky use in this case is the last one setup. If there is no scene or game, there is no sky use as reflection in the preview
+                        hdCamera.camera.cameraType == CameraType.Preview
+                        )
                     {
                         Color clearColor = hdCamera.backgroundColorHDR;
                         HDUtils.SetRenderTarget(cmd, hdCamera, m_CameraColorBuffer, m_CameraDepthStencilBuffer, ClearFlag.Color, clearColor);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyRenderingContext.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyRenderingContext.cs
@@ -208,21 +208,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             return result;
         }
 
-        public void RenderSky(SkyUpdateContext skyContext, HDCamera camera, Light sunLight, RTHandle colorBuffer, RTHandle depthBuffer, CommandBuffer cmd)
+        public void RenderSky(SkyUpdateContext skyContext, HDCamera hdCamera, Light sunLight, RTHandle colorBuffer, RTHandle depthBuffer, CommandBuffer cmd)
         {
-            if (skyContext.IsValid())
+            if (skyContext.IsValid() && hdCamera.clearColorMode == HDAdditionalCameraData.ClearColorMode.Sky)
             {
                 using (new ProfilingSample(cmd, "Sky Pass"))
                 {
                     m_BuiltinParameters.commandBuffer = cmd;
                     m_BuiltinParameters.sunLight = sunLight;
-                    m_BuiltinParameters.pixelCoordToViewDirMatrix = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(camera.camera.fieldOfView * Mathf.Deg2Rad, camera.screenSize, camera.viewMatrix, false);
-                    m_BuiltinParameters.invViewProjMatrix = camera.viewProjMatrix.inverse;
-                    m_BuiltinParameters.screenSize = camera.screenSize;
-                    m_BuiltinParameters.cameraPosWS = camera.camera.transform.position;
+                    m_BuiltinParameters.pixelCoordToViewDirMatrix = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(hdCamera.camera.fieldOfView * Mathf.Deg2Rad, hdCamera.screenSize, hdCamera.viewMatrix, false);
+                    m_BuiltinParameters.invViewProjMatrix = hdCamera.viewProjMatrix.inverse;
+                    m_BuiltinParameters.screenSize = hdCamera.screenSize;
+                    m_BuiltinParameters.cameraPosWS = hdCamera.camera.transform.position;
                     m_BuiltinParameters.colorBuffer = colorBuffer;
                     m_BuiltinParameters.depthBuffer = depthBuffer;
-                    m_BuiltinParameters.hdCamera = camera;
+                    m_BuiltinParameters.hdCamera = hdCamera;
 
                     skyContext.renderer.SetRenderTargets(m_BuiltinParameters);
                     skyContext.renderer.RenderSky(m_BuiltinParameters, false);


### PR DESCRIPTION
This PR add the support of cameraClearFlagson Camera.
However it doesn't rely on the legacy camera CameraFeatureFlags . This is now handled as this:
- ClearColorMode to select clear mode: Sky, BackgroundColor, None
- The background color have been replaced by an HDR color as HD assume HDR
- If there is no sky the background color is use instead
- If there is no HDAditionnalData, conversion are done from the old cameraClearFlags

@JulienIgnace-Unity This include the black thumbnail for the sky (sky is not rendered when in Preview) as preview camera is Depth mode by default. One problem arrive when there is no sky at all use before the preview, in this case as the preview have no sky, no sky is used for reflection.