### PR TITLE
Rename SpotCookieSize to CookieSize

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/TextureCache.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/TextureCache.cs
@@ -336,7 +336,7 @@ namespace UnityEngine.Experimental.Rendering
 
         // In case the texture content with which we update the cache is not the input texture, we need to provide the right update count.
         public void UpdateSlice(CommandBuffer cmd, int sliceIndex, Texture content, uint textureHash)
-                {
+        {
             // transfer new slice to sliceIndex from source texture
             SetSliceHash(sliceIndex, textureHash);
             TransferToSlice(cmd, sliceIndex, content);
@@ -351,7 +351,7 @@ namespace UnityEngine.Experimental.Rendering
         public void UpdateSlice(CommandBuffer cmd, int sliceIndex, Texture content)
         {
             UpdateSlice(cmd, sliceIndex, content, GetTextureHash(content));
-                }
+        }
 
         public int FetchSlice(CommandBuffer cmd, Texture texture, bool forceReinject=false)
         {

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/GlobalLightLoopSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/GlobalLightLoopSettingsUI.cs
@@ -34,10 +34,10 @@ namespace UnityEditor.Experimental.Rendering
         {
             EditorGUILayout.LabelField(_.GetContent("Cookies"), EditorStyles.boldLabel);
             ++EditorGUI.indentLevel;
+            EditorGUILayout.PropertyField(d.cookieSize, _.GetContent("Cookie Size"));
             EditorGUILayout.PropertyField(d.cookieTexArraySize, _.GetContent("Texture Array Size"));
-            EditorGUILayout.PropertyField(d.cubeCookieTexArraySize, _.GetContent("Cubemap Array Size"));
             EditorGUILayout.PropertyField(d.pointCookieSize, _.GetContent("Point Cookie Size"));
-            EditorGUILayout.PropertyField(d.spotCookieSize, _.GetContent("Spot Cookie Size"));
+            EditorGUILayout.PropertyField(d.cubeCookieTexArraySize, _.GetContent("Cubemap Array Size"));
             --EditorGUI.indentLevel;
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedGlobalLightLoopSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedGlobalLightLoopSettings.cs
@@ -6,7 +6,7 @@ namespace UnityEditor.Experimental.Rendering
     {
         public SerializedProperty root;
 
-        public SerializedProperty spotCookieSize;
+        public SerializedProperty cookieSize;
         public SerializedProperty cookieTexArraySize;
         public SerializedProperty pointCookieSize;
         public SerializedProperty cubeCookieTexArraySize;
@@ -24,7 +24,7 @@ namespace UnityEditor.Experimental.Rendering
         {
             this.root = root;
 
-            spotCookieSize = root.Find((GlobalLightLoopSettings s) => s.spotCookieSize);
+            cookieSize = root.Find((GlobalLightLoopSettings s) => s.cookieSize);
             cookieTexArraySize = root.Find((GlobalLightLoopSettings s) => s.cookieTexArraySize);
             pointCookieSize = root.Find((GlobalLightLoopSettings s) => s.pointCookieSize);
             cubeCookieTexArraySize = root.Find((GlobalLightLoopSettings s) => s.cubeCookieTexArraySize);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/GlobalLightLoopSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/GlobalLightLoopSettings.cs
@@ -11,9 +11,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     [Serializable]
     public class GlobalLightLoopSettings
     {
-        public int spotCookieSize = 128;
+        public int cookieSize = 128;
         public int cookieTexArraySize = 16;
-        public int pointCookieSize = 512;
+        public int pointCookieSize = 128;
         public int cubeCookieTexArraySize = 16;
 
         public int reflectionProbeCacheSize = 4;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
@@ -478,7 +478,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             GlobalLightLoopSettings gLightLoopSettings = hdAsset.GetRenderPipelineSettings().lightLoopSettings;
             m_CookieTexArray = new TextureCache2D();
-            m_CookieTexArray.AllocTextureArray(gLightLoopSettings.cookieTexArraySize, gLightLoopSettings.spotCookieSize, gLightLoopSettings.spotCookieSize, TextureFormat.RGBA32, true);
+            m_CookieTexArray.AllocTextureArray(gLightLoopSettings.cookieTexArraySize, gLightLoopSettings.cookieSize, gLightLoopSettings.cookieSize, TextureFormat.RGBA32, true);
             m_CubeCookieTexArray = new TextureCacheCubemap();
             m_CubeCookieTexArray.AllocTextureArray(gLightLoopSettings.cubeCookieTexArraySize, gLightLoopSettings.pointCookieSize, TextureFormat.RGBA32, true);
 


### PR DESCRIPTION
This PR rename Spot Cookie Size => Cookie size as it apply to both directional light and spot.