### PR TITLE
Add Shader Graph repository as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = PostProcessing
 	url = https://github.com/Unity-Technologies/PostProcessing
 	branch = v2
+[submodule "ShaderGraph"]
+	path = ShaderGraph
+	url = git@github.com:Unity-Technologies/ShaderGraph.git

--- a/ScriptableRenderPipeline/Core/package.json
+++ b/ScriptableRenderPipeline/Core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.render-pipelines.core",
     "description": "Core library for Unity render pipelines.",
-    "version": "0.1.29",
+    "version": "0.1.30",
     "unity": "2018.1",
     "dependencies": {
         "com.unity.postprocessing": "0.1.8"

--- a/ScriptableRenderPipeline/HDRenderPipeline/package.json
+++ b/ScriptableRenderPipeline/HDRenderPipeline/package.json
@@ -1,10 +1,10 @@
 {
     "name": "com.unity.render-pipelines.high-definition",
     "description": "HD Render Pipeline for Unity.",
-    "version": "0.1.29",
+    "version": "0.1.30",
     "unity": "2018.1",
     "dependencies": {
         "com.unity.postprocessing": "0.1.8",
-        "com.unity.render-pipelines.core": "0.1.29"
+        "com.unity.render-pipelines.core": "0.1.30"
     }
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/package.json
+++ b/ScriptableRenderPipeline/LightweightPipeline/package.json
@@ -1,10 +1,10 @@
 {
     "name": "com.unity.render-pipelines.lightweight",
     "description": "Lightweight Render Pipeline for Unity.",
-    "version": "0.1.29",
+    "version": "0.1.30",
     "unity": "2018.1",
     "dependencies": {
         "com.unity.postprocessing": "0.1.8",
-        "com.unity.render-pipelines.core": "0.1.29"
+        "com.unity.render-pipelines.core": "0.1.30"
     }
 }

--- a/ScriptableRenderPipeline/master-package.json
+++ b/ScriptableRenderPipeline/master-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.29",
+    "version": "0.1.30",
     "unity": "2018.1",
     "dependencies": {
         "com.unity.postprocessing": "0.1.8"

--- a/ShaderGraph.meta
+++ b/ShaderGraph.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4d536ecfc4cf3c4999d7a81e2d718e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds the Shader Graph repository to this repository as a submodule. The reason for this setup is that we'll be able to move pipeline-specific parts into the pipeline packages.

Note that the package versions of SRP has also been bumped, as we have made a new package version of both Shader Graph and the pipelines.