### PR TITLE
Fix shader graph submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = v2
 [submodule "ShaderGraph"]
 	path = ShaderGraph
-	url = git@github.com:Unity-Technologies/ShaderGraph.git
+	url = https://github.com/Unity-Technologies/ShaderGraph


### PR DESCRIPTION
I accidentally added the Shader Graph submodule using SSH URL. This seems to fail if you do not have a GitHub account. 