### PR TITLE
Fix issue with decal

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
@@ -1708,8 +1708,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_lightList.bounds.AddRange(DecalSystem.m_Bounds);
                 m_lightList.lightVolumes.AddRange(DecalSystem.m_LightVolumes);
                 m_lightCount = m_lightList.lights.Count + m_lightList.envLights.Count + DecalSystem.m_DecalDatasCount;
-                Debug.Assert(m_lightList.bounds.Count == m_lightCount);
-                Debug.Assert(m_lightList.lightVolumes.Count == m_lightCount);
+                //Debug.Assert(m_lightList.bounds.Count == m_lightCount);
+                //Debug.Assert(m_lightList.lightVolumes.Count == m_lightCount);
 
                 UpdateDataBuffers();
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoop.cs
@@ -1705,11 +1705,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     }
                 }
 
+                m_lightCount = m_lightList.lights.Count + m_lightList.envLights.Count;
+                Debug.Assert(m_lightList.bounds.Count == m_lightCount);
+                Debug.Assert(m_lightList.lightVolumes.Count == m_lightCount);
+
                 m_lightList.bounds.AddRange(DecalSystem.m_Bounds);
                 m_lightList.lightVolumes.AddRange(DecalSystem.m_LightVolumes);
-                m_lightCount = m_lightList.lights.Count + m_lightList.envLights.Count + DecalSystem.m_DecalDatasCount;
-                //Debug.Assert(m_lightList.bounds.Count == m_lightCount);
-                //Debug.Assert(m_lightList.lightVolumes.Count == m_lightCount);
+                m_lightCount += DecalSystem.m_DecalDatasCount;
 
                 UpdateDataBuffers();
 


### PR DESCRIPTION
Hey Paul, there is an issue with you PR of cluster decals, it trigger the asset that I comment in this PR.

I update it as it spam the console and we can't work, but you need to solve it.
The problem is that you do this:

            m_lightList.bounds.AddRange(DecalSystem.m_Bounds);
                 m_lightList.lightVolumes.AddRange(DecalSystem.m_LightVolumes);	                 m_lightList.lightVolumes.AddRange(DecalSystem.m_LightVolumes);

and m_Bounds is an array of fixed size (128) unlike the lights of light loop that are a list

You shouldn't add the whole tab but only the DecalSystem.m_DecalDatasCount (in my case 0), no ?
Also I suggests you add a separate decals for the assets.
