### PR TITLE
Added a first set of physical settings to HDCamera

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDAdditionalCameraData.cs
@@ -48,6 +48,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [Tooltip("Layer Mask used for the volume interpolation for this camera.")]
         public LayerMask        volumeLayerMask = -1;
 
+        // Physical parameters
+        public float aperture = 8f;
+        public float shutterSpeed = 1f / 200f;
+        public float iso = 400f;
+
         // To be able to turn on/off FrameSettings properties at runtime for debugging purpose without affecting the original one
         // we create a runtime copy (m_ActiveFrameSettings that is used, and any parametrization is done on serialized frameSettings)
         [SerializeField]

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/HDCameraUI.cs
@@ -19,6 +19,7 @@ namespace UnityEditor.Experimental.Rendering
             Inspector = new []
             {
                 SectionPrimarySettings,
+                SectionPhysicalSettings,
                 SectionCaptureSettings,
                 SectionOutputSettings,
                 SectionXRSettings,
@@ -42,6 +43,14 @@ namespace UnityEditor.Experimental.Rendering
             CED.Action(Drawer_FieldRenderingPath),
             CED.space
         );
+
+        public static readonly CED.IDrawer SectionPhysicalSettings = CED.FoldoutGroup(
+            "Physical Settings",
+            (s, p, o) => s.isSectionExpandedPhysicalSettings,
+            FoldoutOption.Indent,
+            CED.Action(Drawer_FieldAperture),
+            CED.Action(Drawer_FieldShutterSpeed),
+            CED.Action(Drawer_FieldIso));
 
         public static readonly CED.IDrawer SectionCaptureSettings = CED.FoldoutGroup(
             "Capture Settings",
@@ -89,18 +98,19 @@ namespace UnityEditor.Experimental.Rendering
         SerializedHDCamera m_SerializedHdCamera;
 
         public AnimBool isSectionExpandedOrthoOptions { get { return m_AnimBools[0]; } }
-        public AnimBool isSectionExpandedCaptureSettings { get { return m_AnimBools[1]; } }
-        public AnimBool isSectionExpandedOutputSettings { get { return m_AnimBools[2]; } }
-        public AnimBool isSectionAvailableRenderLoopSettings { get { return m_AnimBools[3]; } }
-        public AnimBool isSectionExpandedXRSettings { get { return m_AnimBools[4]; } }
-        public AnimBool isSectionAvailableXRSettings { get { return m_AnimBools[5]; } }
+        public AnimBool isSectionExpandedPhysicalSettings { get { return m_AnimBools[1]; } }
+        public AnimBool isSectionExpandedCaptureSettings { get { return m_AnimBools[2]; } }
+        public AnimBool isSectionExpandedOutputSettings { get { return m_AnimBools[3]; } }
+        public AnimBool isSectionAvailableRenderLoopSettings { get { return m_AnimBools[4]; } }
+        public AnimBool isSectionExpandedXRSettings { get { return m_AnimBools[5]; } }
+        public AnimBool isSectionAvailableXRSettings { get { return m_AnimBools[6]; } }
 
         public bool canOverrideRenderLoopSettings { get; set; }
 
         public FrameSettingsUI frameSettingsUI = new FrameSettingsUI();
 
         public HDCameraUI()
-            : base(6)
+            : base(7)
         {
             canOverrideRenderLoopSettings = false;
         }
@@ -174,6 +184,23 @@ namespace UnityEditor.Experimental.Rendering
                 "Clipping Planes",
                 new[] { p.nearClippingPlane, p.farClippingPlane },
                 new[] { _.GetContent("Near|The closest point relative to the camera that drawing will occur."), _.GetContent("Far|The furthest point relative to the camera that drawing will occur.\n") });
+        }
+
+        static void Drawer_FieldAperture(HDCameraUI s, SerializedHDCamera p, Editor owner)
+        {
+            EditorGUILayout.PropertyField(p.aperture, _.GetContent("Aperture"));
+        }
+
+        static void Drawer_FieldShutterSpeed(HDCameraUI s, SerializedHDCamera p, Editor owner)
+        {
+            p.shutterSpeed.floatValue = 1f / p.shutterSpeed.floatValue;
+            EditorGUILayout.PropertyField(p.shutterSpeed, _.GetContent("Shutter Speed (1 / x)"));
+            p.shutterSpeed.floatValue = 1f / p.shutterSpeed.floatValue;
+        }
+
+        static void Drawer_FieldIso(HDCameraUI s, SerializedHDCamera p, Editor owner)
+        {
+            EditorGUILayout.PropertyField(p.iso, _.GetContent("ISO"));
         }
 
         static void Drawer_FieldNormalizedViewPort(HDCameraUI s, SerializedHDCamera p, Editor owner)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/SerializedHDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Camera/SerializedHDCamera.cs
@@ -24,6 +24,10 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty farClippingPlane;
         public SerializedProperty targetEye;
 
+        public SerializedProperty aperture;
+        public SerializedProperty shutterSpeed;
+        public SerializedProperty iso;
+
 #if ENABLE_MULTIPLE_DISPLAYS
         public SerializedProperty targetDisplay;
 #endif
@@ -68,6 +72,9 @@ namespace UnityEditor.Experimental.Rendering
 
             targetEye = serializedObject.FindProperty("m_TargetEye");
 
+            aperture = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.aperture);
+            shutterSpeed = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.shutterSpeed);
+            iso = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.iso);
 
             clearColorMode = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.clearColorMode);
             backgroundColorHDR = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.backgroundColorHDR);


### PR DESCRIPTION
Aperture / Shutter Speed / ISO for now.
For Depth of Field control we'll need Focal Length (which will control FOV or the other way around) and Film size as well as a Priority setting so it can be overridden in Postfx volumes for special cases if needed.