### PR TITLE
Upgrade Lightweight shaders and UI to closer match HD and Shader Graph

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/LightweightMaterialUpgrader.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/LightweightMaterialUpgrader.cs
@@ -92,70 +92,90 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
     {
         static public UpgradeParams diffuseOpaque = new UpgradeParams()
         {
-            blendMode = UpgradeBlendMode.Opaque,
+            surfaceType = UpgradeSurfaceType.Opaque,
+            blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.NoSpecular,
             glosinessSource = GlossinessSource.BaseAlpha,
         };
 
         static public UpgradeParams specularOpaque = new UpgradeParams()
         {
-            blendMode = UpgradeBlendMode.Opaque,
+            surfaceType = UpgradeSurfaceType.Opaque,
+            blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.SpecularTextureAndColor,
             glosinessSource = GlossinessSource.BaseAlpha,
         };
 
         static public UpgradeParams diffuseAlpha = new UpgradeParams()
         {
+            surfaceType = UpgradeSurfaceType.Transparent,
             blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.NoSpecular,
             glosinessSource = GlossinessSource.SpecularAlpha,
         };
 
         static public UpgradeParams specularAlpha = new UpgradeParams()
         {
+            surfaceType = UpgradeSurfaceType.Transparent,
             blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.SpecularTextureAndColor,
             glosinessSource = GlossinessSource.SpecularAlpha,
         };
 
         static public UpgradeParams diffuseAlphaCutout = new UpgradeParams()
         {
-            blendMode = UpgradeBlendMode.Cutout,
+            surfaceType = UpgradeSurfaceType.Opaque,
+            blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = true,
             specularSource = SpecularSource.NoSpecular,
             glosinessSource = GlossinessSource.SpecularAlpha,
         };
 
         static public UpgradeParams specularAlphaCutout = new UpgradeParams()
         {
-            blendMode = UpgradeBlendMode.Cutout,
+            surfaceType = UpgradeSurfaceType.Opaque,
+            blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = true,
             specularSource = SpecularSource.SpecularTextureAndColor,
             glosinessSource = GlossinessSource.SpecularAlpha,
         };
 
         static public UpgradeParams diffuseCubemap = new UpgradeParams()
         {
-            blendMode = UpgradeBlendMode.Opaque,
+            surfaceType = UpgradeSurfaceType.Opaque,
+            blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.NoSpecular,
             glosinessSource = GlossinessSource.BaseAlpha,
         };
 
         static public UpgradeParams specularCubemap = new UpgradeParams()
         {
-            blendMode = UpgradeBlendMode.Opaque,
+            surfaceType = UpgradeSurfaceType.Opaque,
+            blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.SpecularTextureAndColor,
             glosinessSource = GlossinessSource.BaseAlpha,
         };
 
         static public UpgradeParams diffuseCubemapAlpha = new UpgradeParams()
         {
+            surfaceType = UpgradeSurfaceType.Transparent,
             blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.NoSpecular,
             glosinessSource = GlossinessSource.BaseAlpha,
         };
 
         static public UpgradeParams specularCubemapAlpha = new UpgradeParams()
         {
+            surfaceType = UpgradeSurfaceType.Transparent,
             blendMode = UpgradeBlendMode.Alpha,
+            alphaClip = false,
             specularSource = SpecularSource.SpecularTextureAndColor,
             glosinessSource = GlossinessSource.BaseAlpha,
         };
@@ -193,7 +213,9 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
         public StandardSimpleLightingUpgrader(string oldShaderName, UpgradeParams upgradeParams)
         {
             RenameShader(oldShaderName, LightweightShaderUtils.GetShaderPath(ShaderPathID.STANDARD_SIMPLE_LIGHTING), UpdateMaterialKeywords);
-            SetFloat("_Mode", (float)upgradeParams.blendMode);
+            SetFloat("_Surface", (float)upgradeParams.surfaceType);
+            SetFloat("_Blend", (float)upgradeParams.blendMode);
+            SetFloat("_AlphaClip", upgradeParams.alphaClip ? 1 : 0);
             SetFloat("_SpecSource", (float)upgradeParams.specularSource);
             SetFloat("_GlossinessSource", (float)upgradeParams.glosinessSource);
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightShaderGUI.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightShaderGUI.cs
@@ -3,12 +3,18 @@ using UnityEngine;
 
 public abstract class LightweightShaderGUI : ShaderGUI
 {
-    public enum BlendMode
+    public enum SurfaceType
     {
         Opaque,
-        Cutout,
-        Fade,   // Old school alpha-blending mode, fresnel does not affect amount of transparency
-        Transparent // Physically plausible transparency mode, implemented as alpha pre-multiply
+        Transparent
+    }
+
+    public enum BlendMode
+    {
+        Alpha,   // Old school alpha-blending mode, fresnel does not affect amount of transparency
+        Premultiply, // Physically plausible transparency mode, implemented as alpha pre-multiply
+        Additive,
+        Multiply
     }
 
     public abstract void FindProperties(MaterialProperty[] props);
@@ -50,53 +56,65 @@ public abstract class LightweightShaderGUI : ShaderGUI
 
     public static void SetupMaterialBlendMode(Material material)
     {
-        BlendMode blendMode = (BlendMode)material.GetFloat("_Mode");
-        switch (blendMode)
+        bool alphaClip = material.GetFloat("_AlphaClip") == 1;
+        if(alphaClip)
+            material.EnableKeyword("_ALPHATEST_ON");
+        else
+            material.DisableKeyword("_ALPHATEST_ON");
+
+        SurfaceType surfaceType = (SurfaceType)material.GetFloat("_Surface");
+        if(surfaceType == SurfaceType.Opaque)
         {
-            case BlendMode.Opaque:
-                material.SetOverrideTag("RenderType", "");
-                material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-                material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                material.SetInt("_ZWrite", 1);
-                material.DisableKeyword("_ALPHATEST_ON");
-                material.DisableKeyword("_ALPHABLEND_ON");
-                material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                material.renderQueue = -1;
-                material.SetShaderPassEnabled("ShadowCaster", true);
-                break;
-            case BlendMode.Cutout:
-                material.SetOverrideTag("RenderType", "TransparentCutout");
-                material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-                material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                material.SetInt("_ZWrite", 1);
-                material.EnableKeyword("_ALPHATEST_ON");
-                material.DisableKeyword("_ALPHABLEND_ON");
-                material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
-                material.SetShaderPassEnabled("ShadowCaster", true);
-                break;
-            case BlendMode.Fade:
-                material.SetOverrideTag("RenderType", "Transparent");
-                material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
-                material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-                material.SetInt("_ZWrite", 0);
-                material.DisableKeyword("_ALPHATEST_ON");
-                material.EnableKeyword("_ALPHABLEND_ON");
-                material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-                material.SetShaderPassEnabled("ShadowCaster", false);
-                break;
-            case BlendMode.Transparent:
-                material.SetOverrideTag("RenderType", "Transparent");
-                material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-                material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-                material.SetInt("_ZWrite", 0);
-                material.DisableKeyword("_ALPHATEST_ON");
-                material.DisableKeyword("_ALPHABLEND_ON");
-                material.EnableKeyword("_ALPHAPREMULTIPLY_ON");
-                material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-                material.SetShaderPassEnabled("ShadowCaster", false);
-                break;
+            material.SetOverrideTag("RenderType", "");
+            material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+            material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+            material.SetInt("_ZWrite", 1);
+            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+            material.renderQueue = -1;
+            material.SetShaderPassEnabled("ShadowCaster", true);
+        }
+        else
+        { 
+            BlendMode blendMode = (BlendMode)material.GetFloat("_Blend");
+            switch (blendMode)
+            {
+                case BlendMode.Alpha:
+                    material.SetOverrideTag("RenderType", "Transparent");
+                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+                    material.SetInt("_ZWrite", 0);
+                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    material.SetShaderPassEnabled("ShadowCaster", false);
+                    break;
+                case BlendMode.Premultiply:
+                    material.SetOverrideTag("RenderType", "Transparent");
+                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+                    material.SetInt("_ZWrite", 0);
+                    material.EnableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    material.SetShaderPassEnabled("ShadowCaster", false);
+                    break;
+                case BlendMode.Additive:
+                    material.SetOverrideTag("RenderType", "Transparent");
+                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                    material.SetInt("_ZWrite", 0);
+                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    material.SetShaderPassEnabled("ShadowCaster", false);
+                    break;
+                case BlendMode.Multiply:
+                    material.SetOverrideTag("RenderType", "Transparent");
+                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.DstColor);
+                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                    material.SetInt("_ZWrite", 0);
+                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    material.SetShaderPassEnabled("ShadowCaster", false);
+                    break;
+            }
         }
     }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightUnlitGUI.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightUnlitGUI.cs
@@ -6,7 +6,17 @@ using UnityEngine.Experimental.Rendering;
 
 public class LightweightUnlitGUI : LightweightShaderGUI
 {
+    public enum UnlitBlendMode
+    {
+        Alpha,   // Old school alpha-blending mode, fresnel does not affect amount of transparency
+        Additive,
+        Multiply
+    }
+
+    private MaterialProperty surfaceTypeProp;
     private MaterialProperty blendModeProp;
+    private MaterialProperty culling;
+    private MaterialProperty alphaClip;
     private MaterialProperty mainTexProp;
     private MaterialProperty mainColorProp;
     private MaterialProperty alphaCutoffProp;
@@ -15,6 +25,9 @@ public class LightweightUnlitGUI : LightweightShaderGUI
 
     private static class Styles
     {
+        public static GUIContent twoSidedLabel = new GUIContent("Two Sided", "Render front and back faces");
+        public static GUIContent alphaClipLabel = new GUIContent("Alpha Clip", "Enable Alpha Clip");
+
         public static GUIContent[] mainTexLabels =
         {
             new GUIContent("MainTex (RGB)", "Base Color"),
@@ -22,16 +35,21 @@ public class LightweightUnlitGUI : LightweightShaderGUI
         };
 
         public static GUIContent normalMapLabel = new GUIContent("Normal Map", "Normal Map");
-        public static readonly string[] blendNames = Enum.GetNames(typeof(UpgradeBlendMode));
+        public static readonly string[] surfaceNames = Enum.GetNames(typeof(SurfaceType));
+        public static readonly string[] blendNames = Enum.GetNames(typeof(UnlitBlendMode));
 
-        public static string renderingModeLabel = "Rendering Mode";
-        public static string alphaCutoffLabel = "Alpha Cutoff";
+        public static string surfaceTypeLabel = "Surface Type";
+        public static string blendingModeLabel = "Blending Mode";
+        public static string clipThresholdLabel = "Clip Threshold";
         public static GUIContent sampleGILabel = new GUIContent("Sample GI", "If enabled GI will be sampled from SH or Lightmap.");
     }
 
     public override void FindProperties(MaterialProperty[] properties)
     {
-        blendModeProp = FindProperty("_Mode", properties);
+        surfaceTypeProp = FindProperty("_Surface", properties);
+        blendModeProp = FindProperty("_Blend", properties);
+        culling = FindProperty("_Cull", properties);
+        alphaClip  = FindProperty("_AlphaClip", properties);
         mainTexProp = FindProperty("_MainTex", properties);
         mainColorProp = FindProperty("_Color", properties);
         alphaCutoffProp = FindProperty("_Cutoff", properties);
@@ -43,15 +61,29 @@ public class LightweightUnlitGUI : LightweightShaderGUI
     {
         EditorGUI.BeginChangeCheck();
         {
-            DoPopup(Styles.renderingModeLabel, blendModeProp, Styles.blendNames);
-            int modeValue = (int)blendModeProp.floatValue;
+            DoPopup(Styles.surfaceTypeLabel, surfaceTypeProp, Styles.surfaceNames);
+            int surfaceTypeValue = (int)surfaceTypeProp.floatValue;
 
-            GUIContent mainTexLabel = Styles.mainTexLabels[Math.Min(modeValue, 1)];
+            if((SurfaceType)surfaceTypeValue == SurfaceType.Transparent)
+                DoPopup(Styles.blendingModeLabel, blendModeProp, Styles.blendNames);
+
+            EditorGUI.BeginChangeCheck();
+            bool twoSidedEnabled = EditorGUILayout.Toggle(Styles.twoSidedLabel, culling.floatValue == 0);
+            if (EditorGUI.EndChangeCheck())
+                culling.floatValue = twoSidedEnabled ? 0 : 2;
+
+            EditorGUI.BeginChangeCheck();
+            bool alphaClipEnabled = EditorGUILayout.Toggle(Styles.alphaClipLabel, alphaClip.floatValue == 1);
+            if (EditorGUI.EndChangeCheck())
+                alphaClip.floatValue = alphaClipEnabled ? 1 : 0;
+
+            GUIContent mainTexLabel = Styles.mainTexLabels[Math.Min(surfaceTypeValue, 1)];
             m_MaterialEditor.TexturePropertySingleLine(mainTexLabel, mainTexProp, mainColorProp);
-            m_MaterialEditor.TextureScaleOffsetProperty(mainTexProp);
 
-            if ((UpgradeBlendMode)modeValue == UpgradeBlendMode.Cutout)
-                m_MaterialEditor.RangeProperty(alphaCutoffProp, Styles.alphaCutoffLabel);
+            if (alphaClipEnabled)
+                m_MaterialEditor.ShaderProperty(alphaCutoffProp, Styles.clipThresholdLabel, MaterialEditor.kMiniTextureFieldLabelIndentLevel + 1);
+
+            m_MaterialEditor.TextureScaleOffsetProperty(mainTexProp);
 
             EditorGUILayout.Space();
             m_MaterialEditor.ShaderProperty(sampleGIProp, Styles.sampleGILabel);
@@ -75,8 +107,59 @@ public class LightweightUnlitGUI : LightweightShaderGUI
     {
         material.shaderKeywords = null;
         bool sampleGI = material.GetFloat("_SampleGI") >= 1.0f;
-        SetupMaterialBlendMode(material);
         CoreUtils.SetKeyword(material, "_SAMPLE_GI", sampleGI);
         CoreUtils.SetKeyword(material, "_NORMAL_MAP", sampleGI && material.GetTexture("_BumpMap"));
+
+        bool alphaClip = material.GetFloat("_AlphaClip") == 1;
+        if(alphaClip)
+            material.EnableKeyword("_ALPHATEST_ON");
+        else
+            material.DisableKeyword("_ALPHATEST_ON");
+
+        SurfaceType surfaceType = (SurfaceType)material.GetFloat("_Surface");
+        if(surfaceType == SurfaceType.Opaque)
+        {
+            material.SetOverrideTag("RenderType", "");
+            material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+            material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+            material.SetInt("_ZWrite", 1);
+            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+            material.renderQueue = -1;
+            material.SetShaderPassEnabled("ShadowCaster", true);
+        }
+        else
+        { 
+            UnlitBlendMode blendMode = (UnlitBlendMode)material.GetFloat("_Blend");
+            switch (blendMode)
+            {
+                case UnlitBlendMode.Alpha:
+                    material.SetOverrideTag("RenderType", "Transparent");
+                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+                    material.SetInt("_ZWrite", 0);
+                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    material.SetShaderPassEnabled("ShadowCaster", false);
+                    break;
+                case UnlitBlendMode.Additive:
+                    material.SetOverrideTag("RenderType", "Transparent");
+                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                    material.SetInt("_ZWrite", 0);
+                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    material.SetShaderPassEnabled("ShadowCaster", false);
+                    break;
+                case UnlitBlendMode.Multiply:
+                    material.SetOverrideTag("RenderType", "Transparent");
+                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.DstColor);
+                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                    material.SetInt("_ZWrite", 0);
+                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    material.SetShaderPassEnabled("ShadowCaster", false);
+                    break;
+            }
+        }
     }
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/UpgradeCommon.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/UpgradeCommon.cs
@@ -1,10 +1,17 @@
 namespace UnityEditor.Experimental.Rendering.LightweightPipeline
 {
-    public enum UpgradeBlendMode
+    public enum UpgradeSurfaceType
     {
         Opaque,
-        Cutout,
-        Alpha
+        Transparent
+    }
+
+    public enum UpgradeBlendMode
+    {
+        Alpha,
+        Premultiply,
+        Additive,
+        Multiply
     }
 
     public enum SpecularSource
@@ -28,7 +35,9 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
 
     public struct UpgradeParams
     {
+        public UpgradeSurfaceType surfaceType;
         public UpgradeBlendMode blendMode;
+        public bool alphaClip;
         public SpecularSource specularSource;
         public GlossinessSource glosinessSource;
     }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassLit.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassLit.hlsl
@@ -130,6 +130,9 @@ half4 LitPassFragmentSimple(LightweightVertexOutput IN) : SV_Target
 
     half alpha = diffuseAlpha.a * _Color.a;
     AlphaDiscard(alpha, _Cutoff);
+#ifdef _ALPHAPREMULTIPLY_ON
+    diffuse *= alpha;
+#endif
 
 #ifdef _NORMALMAP
     half3 normalTS = Normal(uv);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
@@ -44,10 +44,13 @@ Shader "LightweightPipeline/Standard (Physically Based)"
         [Enum(UV0,0,UV1,1)] _UVSec("UV Set for secondary textures", Float) = 0
 
         // Blending state
-        [HideInInspector] _Mode("__mode", Float) = 0.0
+        [HideInInspector] _Surface("__surface", Float) = 0.0
+        [HideInInspector] _Blend("__blend", Float) = 0.0
+        [HideInInspector] _AlphaClip("__clip", Float) = 0.0
         [HideInInspector] _SrcBlend("__src", Float) = 1.0
         [HideInInspector] _DstBlend("__dst", Float) = 0.0
         [HideInInspector] _ZWrite("__zw", Float) = 1.0
+        [HideInInspector] _Cull("__cull", Float) = 2.0
     }
 
     SubShader
@@ -68,6 +71,7 @@ Shader "LightweightPipeline/Standard (Physically Based)"
 
             Blend[_SrcBlend][_DstBlend]
             ZWrite[_ZWrite]
+            Cull[_Cull]
 
             HLSLPROGRAM
             // Required to compile gles 2.0 with standard SRP library
@@ -78,7 +82,8 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             // -------------------------------------
             // Material Keywords
             #pragma shader_feature _NORMALMAP
-            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
+            #pragma shader_feature _ALPHATEST_ON 
+            #pragma shader_feature _ALPHAPREMULTIPLY_ON
             #pragma shader_feature _EMISSION
             #pragma shader_feature _METALLICSPECGLOSSMAP
             #pragma shader_feature _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
@@ -117,6 +122,7 @@ Shader "LightweightPipeline/Standard (Physically Based)"
 
             ZWrite On
             ZTest LEqual
+            Cull[_Cull]
 
             HLSLPROGRAM
             // Required to compile gles 2.0 with standard srp library
@@ -126,7 +132,8 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             // -------------------------------------
             // Material Keywords
             #pragma shader_feature _NORMALMAP
-            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
+            #pragma shader_feature _ALPHATEST_ON 
+            #pragma shader_feature _ALPHAPREMULTIPLY_ON
             #pragma shader_feature _EMISSION
             #pragma shader_feature _METALLICSPECGLOSSMAP
             #pragma shader_feature _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
@@ -162,7 +169,8 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             // -------------------------------------
             // Material Keywords
             #pragma shader_feature _NORMALMAP
-            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
+            #pragma shader_feature _ALPHATEST_ON 
+            #pragma shader_feature _ALPHAPREMULTIPLY_ON
             #pragma shader_feature _EMISSION
             #pragma shader_feature _METALLICSPECGLOSSMAP
             #pragma shader_feature _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
@@ -40,10 +40,13 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
         [Enum(UV0,0,UV1,1)] _UVSec("UV Set for secondary textures", Float) = 0
 
         // Blending state
-        [HideInInspector] _Mode("__mode", Float) = 0.0
+        [HideInInspector] _Surface("__surface", Float) = 0.0
+        [HideInInspector] _Blend("__blend", Float) = 0.0
+        [HideInInspector] _AlphaClip("__clip", Float) = 0.0
         [HideInInspector] _SrcBlend("__src", Float) = 1.0
         [HideInInspector] _DstBlend("__dst", Float) = 0.0
         [HideInInspector] _ZWrite("__zw", Float) = 1.0
+        [HideInInspector] _Cull("__cull", Float) = 2.0
     }
 
     SubShader
@@ -58,6 +61,7 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
             // Use same blending / depth states as Standard shader
             Blend[_SrcBlend][_DstBlend]
             ZWrite[_ZWrite]
+            Cull[_Cull]
 
             HLSLPROGRAM
             // Required to compile gles 2.0 with standard srp library
@@ -66,7 +70,8 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
 
             // -------------------------------------
             // Material Keywords
-            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma shader_feature _ALPHATEST_ON 
+            #pragma shader_feature _ALPHAPREMULTIPLY_ON
             #pragma shader_feature _ _SPECGLOSSMAP _SPECULAR_COLOR
             #pragma shader_feature _ _GLOSSINESS_FROM_BASE_ALPHA
             #pragma shader_feature _NORMALMAP
@@ -100,6 +105,7 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
 
             ZWrite On
             ZTest LEqual
+            Cull[_Cull]
 
             HLSLPROGRAM
             // Required to compile gles 2.0 with standard srp library
@@ -108,7 +114,8 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
             
             // -------------------------------------
             // Material Keywords
-            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma shader_feature _ALPHATEST_ON 
+            #pragma shader_feature _ALPHAPREMULTIPLY_ON
             #pragma shader_feature _ _SPECGLOSSMAP _SPECULAR_COLOR
             #pragma shader_feature _ _GLOSSINESS_FROM_BASE_ALPHA
             #pragma shader_feature _NORMALMAP
@@ -139,7 +146,8 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
 
             // -------------------------------------
             // Material Keywords
-            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma shader_feature _ALPHATEST_ON 
+            #pragma shader_feature _ALPHAPREMULTIPLY_ON
             #pragma shader_feature _ _SPECGLOSSMAP _SPECULAR_COLOR
             #pragma shader_feature _ _GLOSSINESS_FROM_BASE_ALPHA
             #pragma shader_feature _NORMALMAP

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardUnlit.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardUnlit.shader
@@ -9,10 +9,13 @@ Shader "LightweightPipeline/Standard Unlit"
         _BumpMap("Normal Map", 2D) = "bump" {}
 
         // BlendMode
-        [HideInInspector] _Mode("Mode", Float) = 0.0
+        [HideInInspector] _Surface("__surface", Float) = 0.0
+        [HideInInspector] _Blend("__blend", Float) = 0.0
+        [HideInInspector] _AlphaClip("__clip", Float) = 0.0
         [HideInInspector] _SrcBlend("Src", Float) = 1.0
         [HideInInspector] _DstBlend("Dst", Float) = 0.0
         [HideInInspector] _ZWrite("ZWrite", Float) = 1.0
+        [HideInInspector] _Cull("__cull", Float) = 2.0
     }
     SubShader
     {
@@ -21,6 +24,7 @@ Shader "LightweightPipeline/Standard Unlit"
 
         Blend [_SrcBlend][_DstBlend]
         ZWrite [_ZWrite]
+        Cull [_Cull]
 
         Pass
         {
@@ -31,7 +35,7 @@ Shader "LightweightPipeline/Standard Unlit"
             #pragma fragment frag
             #pragma multi_compile_fog
             #pragma shader_feature _SAMPLE_GI
-            #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON
+            #pragma shader_feature _ALPHATEST_ON
             #pragma multi_compile_instancing
 
             // Lighting include is needed because of GI
@@ -91,8 +95,7 @@ Shader "LightweightPipeline/Standard Unlit"
                 half2 uv = IN.uv0AndFogCoord.xy;
                 half4 texColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv);
                 half3 color = texColor.rgb * _Color.rgb;
-                half alpha = texColor.a * _Color.a;
-
+                half alpha = texColor.a * _Color.a;     
                 AlphaDiscard(alpha, _Cutoff);
 
 #if _SAMPLE_GI
@@ -104,12 +107,8 @@ Shader "LightweightPipeline/Standard Unlit"
                 color += SampleGI(IN.lightmapOrVertexSH, normalWS);
 #endif
                 ApplyFog(color, IN.uv0AndFogCoord.z);
-
-#ifdef _ALPHABLEND_ON
+       
                 return half4(color, alpha);
-#else
-                return half4(color, 1.0);
-#endif
             }
             ENDHLSL
         }


### PR DESCRIPTION
- Upgrades to Standard, Simple Standard and Unlit
- Split Rendering Mode into Surface Type and Blending Mode
- Add premultiply option to Simple Standard
- Make Alpha Clip Orthogonal
- Add two sided toggle
- Add Additive and Multiply blend modes
- Rename all blend modes to match HD and SG
- Rename Alpha Cutoff to Clip Threshold
- Remove unused "_ALPHABLEND" keyword
- Split premultiply and clip keywords
- Update material upgrader to reflect changes
- Various shader GUI fixes

Keywords: Adds 1 to Simple, Removes 1 from Unlit, PBR stays the same