### PR TITLE
Fixed a leak in the decal system

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/TextureCache.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/TextureCache.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine;
 using System.Collections.Generic;
 using UnityEngine.Rendering;
 #if UNITY_EDITOR
@@ -52,7 +51,7 @@ namespace UnityEngine.Experimental.Rendering
 
         public void Release()
         {
-            Texture.DestroyImmediate(m_Cache);      // do I need this?
+            CoreUtils.Destroy(m_Cache);
         }
     }
 
@@ -136,6 +135,7 @@ namespace UnityEngine.Experimental.Rendering
                 {
                     m_CubeMipLevelPropName = Shader.PropertyToID("_cubeMipLvl");
                     m_cubeSrcTexPropName = Shader.PropertyToID("_srcCubeTexture");
+
                 }
             }
             else
@@ -156,16 +156,16 @@ namespace UnityEngine.Experimental.Rendering
         {
             if (m_CacheNoCubeArray)
             {
-                Texture.DestroyImmediate(m_CacheNoCubeArray);
+                CoreUtils.Destroy(m_CacheNoCubeArray);
                 for (int m = 0; m < m_NumPanoMipLevels; m++)
                 {
                     m_StagingRTs[m].Release();
                 }
                 m_StagingRTs = null;
-                if (m_CubeBlitMaterial) Material.DestroyImmediate(m_CubeBlitMaterial);
+                CoreUtils.Destroy(m_CubeBlitMaterial);
             }
-            if (m_Cache)
-                Texture.DestroyImmediate(m_Cache);
+
+            CoreUtils.Destroy(m_Cache);
         }
 
         private void TransferToPanoCache(CommandBuffer cmd, int sliceIndex, Texture texture)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Decal/DecalSystem.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Decal/DecalSystem.cs
@@ -65,7 +65,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // Core\CoreRP\ShaderLibrary\UnityInstancing.hlsl
         // #if defined(SHADER_API_VULKAN) && defined(SHADER_API_MOBILE)
         //      #define UNITY_INSTANCED_ARRAY_SIZE  250
-        private const int kDrawIndexedBatchSize = 250; 
+        private const int kDrawIndexedBatchSize = 250;
 
         // cube mesh bounds for decal
         static Vector4 kMin = new Vector4(-0.5f, -1.0f, -0.5f, 1.0f);
@@ -96,7 +96,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_DiffuseTexture = m_Material.GetTexture("_BaseColorMap");
                 m_NormalTexture = m_Material.GetTexture("_NormalMap");
                 m_MaskTexture = m_Material.GetTexture("_MaskMap");
-                m_Blend = m_Material.GetFloat("_DecalBlend");                
+                m_Blend = m_Material.GetFloat("_DecalBlend");
             }
 
             public DecalSet(Material material)
@@ -302,13 +302,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         normalToWorldBatch[instanceCount].m23 = m_NormalTexIndex;
                         normalToWorldBatch[instanceCount].m33 = m_MaskTexIndex;
 
-                        
-                        // clustered forward data                        
-                        m_DecalDatas[m_DecalDatasCount].worldToDecal = decalToWorldBatch[instanceCount].inverse; 
+
+                        // clustered forward data
+                        m_DecalDatas[m_DecalDatasCount].worldToDecal = decalToWorldBatch[instanceCount].inverse;
                         m_DecalDatas[m_DecalDatasCount].normalToWorld = normalToWorldBatch[instanceCount];
                         GetDecalVolumeDataAndBound(decalToWorldBatch[instanceCount], worldToView);
                         m_DecalDatasCount++;
-                        
+
                         instanceCount++;
                         if (instanceCount == kDrawIndexedBatchSize)
                         {
@@ -384,7 +384,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 InitializeMaterialValues(); // refresh in case they changed in the UI
                 UpdateTextureCache(cmd);
             }
-      
+
             public void RenderIntoDBuffer(CommandBuffer cmd)
             {
                 if(m_NumResults == 0)
@@ -402,9 +402,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     m_PropertyBlock.SetMatrixArray(HDShaderIDs._NormalToWorldID, m_NormalToWorld[batchIndex]);
                     cmd.DrawMeshInstanced(m_DecalMesh, 0, KeyMaterial, 0, m_DecalToWorld[batchIndex], totalToDraw, m_PropertyBlock);
-                }                
+                }
             }
-           
+
             public Material KeyMaterial
             {
                 get
@@ -442,7 +442,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             private int m_NormalTexIndex = -1;
             private int m_MaskTexIndex = -1;
         }
-        
+
         public void AddDecal(DecalProjectorComponent decal)
         {
 			if (decal.CullIndex != DecalProjectorComponent.kInvalidIndex) //do not add the same decal more than once
@@ -528,7 +528,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             foreach (var pair in m_DecalSets)
             {
                 pair.Value.RenderIntoDBuffer(cmd);
-            }            
+            }
         }
 
         public void SetAtlas(CommandBuffer cmd)
@@ -547,7 +547,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void CreateDrawData()
         {
-            m_DecalDatasCount = 0;           
+            m_DecalDatasCount = 0;
             // reallocate if needed
             if (m_DecalsVisibleThisFrame > m_DecalDatas.Length)
             {
@@ -560,6 +560,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 pair.Value.CreateDrawData();
             }
+        }
+
+        public void Cleanup()
+        {
+            m_DecalAtlas.Release();
+            CoreUtils.Destroy(m_DecalMesh);
         }
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -396,6 +396,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // For debugging
             MousePositionDebug.instance.Cleanup();
 
+            DecalSystem.instance.Cleanup();
+
             m_MaterialList.ForEach(material => material.Cleanup());
 
             CoreUtils.Destroy(m_CopyStencilForNoLighting);


### PR DESCRIPTION
The decal system wasn't releasing any of its allocated resources, resulting in ~180MB of leaked memory on each domain reload.