### PR TITLE
Add profiling/debugging markers for LWRP cameras

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -299,6 +299,11 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 m_CurrCamera = camera;
                 m_IsOffscreenCamera = m_CurrCamera.targetTexture != null && m_CurrCamera.cameraType != CameraType.SceneView;
 
+                var profilingCmd = CommandBufferPool.Get("");
+                profilingCmd.BeginSample("LightweightPipeline.Render");
+                context.ExecuteCommandBuffer(profilingCmd);
+                CommandBufferPool.Release(profilingCmd);
+
                 ScriptableCullingParameters cullingParameters;
                 if (!CullResults.GetCullingParameters(m_CurrCamera, stereoEnabled, out cullingParameters))
                     continue;
@@ -365,6 +370,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 cmd.ReleaseTemporaryRT(CameraRenderTargetID.depth);
                 cmd.ReleaseTemporaryRT(CameraRenderTargetID.color);
                 cmd.ReleaseTemporaryRT(CameraRenderTargetID.copyColor);
+
+                cmd.EndSample("LightweightPipeline.Render");
+
                 context.ExecuteCommandBuffer(cmd);
                 CommandBufferPool.Release(cmd);
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -299,10 +299,10 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 m_CurrCamera = camera;
                 m_IsOffscreenCamera = m_CurrCamera.targetTexture != null && m_CurrCamera.cameraType != CameraType.SceneView;
 
-                var profilingCmd = CommandBufferPool.Get("");
-                profilingCmd.BeginSample("LightweightPipeline.Render");
-                context.ExecuteCommandBuffer(profilingCmd);
-                CommandBufferPool.Release(profilingCmd);
+                var cmd = CommandBufferPool.Get("");
+                cmd.BeginSample("LightweightPipeline.Render");
+                context.ExecuteCommandBuffer(cmd);
+                cmd.Clear();
 
                 ScriptableCullingParameters cullingParameters;
                 if (!CullResults.GetCullingParameters(m_CurrCamera, stereoEnabled, out cullingParameters))
@@ -359,7 +359,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 ForwardPass(visibleLights, frameRenderingConfiguration, ref context, ref lightData, stereoEnabled);
 
 
-                var cmd = CommandBufferPool.Get("After Camera Render");
+                cmd.name = "After Camera Render";
 #if UNITY_EDITOR
                 if (sceneViewCamera)
                     CopyTexture(cmd, CameraRenderTargetID.depth, BuiltinRenderTextureType.CameraTarget, m_CopyDepthMaterial, true);


### PR DESCRIPTION
Mostly to improve the debugging experience in RenderDoc, but also has the side-effect of helping with other debuggers and the Unity profiler