### PR TITLE
LWRP - Disable stereo on cams that don't have both target eyes enabled

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -298,7 +298,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 RenderPipeline.BeginCameraRendering(camera);
 
                 bool sceneViewCamera = camera.cameraType == CameraType.SceneView;
-                bool stereoEnabled = XRSettings.isDeviceActive && !sceneViewCamera;
+                bool stereoEnabled = XRSettings.isDeviceActive && !sceneViewCamera && (camera.stereoTargetEye == StereoTargetEyeMask.Both);
                 m_CurrCamera = camera;
                 m_IsOffscreenCamera = m_CurrCamera.targetTexture != null && m_CurrCamera.cameraType != CameraType.SceneView;
 


### PR DESCRIPTION
Pretty simple change, was a mistake to omit.  Mirrors logic in HDRP FrameSettings

Associated with Issue #1017 