### PR TITLE
Various light fix for HD

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineMenuItems.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/HDRenderPipelineMenuItems.cs
@@ -50,7 +50,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
                 else if (add.lightTypeExtent == LightTypeExtent.Line)
                 {
-                    add.areaIntensity = l.intensity / LightUtils.calculateLineLightArea(1.0f, add.shapeWidth);
+                    add.areaIntensity = l.intensity / LightUtils.CalculateLineLightArea(1.0f, add.shapeWidth);
                 }
             }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
@@ -82,7 +82,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             base.OnEnable();
 
             // Get & automatically add additional HD data if not present
-            var lightData = CoreEditorUtils.GetAdditionalData<HDAdditionalLightData>(targets);
+            var lightData = CoreEditorUtils.GetAdditionalData<HDAdditionalLightData>(targets, HDAdditionalLightData.InitDefaultHDAdditionalLightData);
             var shadowData = CoreEditorUtils.GetAdditionalData<AdditionalShadowData>(targets, HDAdditionalShadowData.InitDefaultHDAdditionalShadowData);
             m_SerializedAdditionalLightData = new SerializedObject(lightData);
             m_SerializedAdditionalShadowData = new SerializedObject(shadowData);
@@ -139,6 +139,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_SerializedAdditionalLightData.Update();
             m_SerializedAdditionalShadowData.Update();
 
+            // Disable the default light editor for the release, it is just use for development
+            /*
             // Temporary toggle to go back to the old editor & separated additional datas
             bool useOldInspector = m_AdditionalLightData.useOldInspector.boolValue;
 
@@ -155,6 +157,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 m_SerializedAdditionalLightData.ApplyModifiedProperties();
                 return;
             }
+            */
 
             // New editor
             ApplyAdditionalComponentsVisibility(true);
@@ -305,6 +308,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
+        // Caution: this function must match the one in HDAdditionalLightData.ConvertPhysicalLightIntensityToLightIntensity - any change need to be replicated
         void UpdateLightIntensity()
         {
             switch (m_LightShape)
@@ -330,7 +334,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     break;
 
                 case LightShape.Line:
-                    settings.intensity.floatValue = LightUtils.calculateLineLightArea(m_AdditionalLightData.areaIntensity.floatValue, m_AdditionalLightData.shapeWidth.floatValue);
+                    settings.intensity.floatValue = LightUtils.CalculateLineLightArea(m_AdditionalLightData.areaIntensity.floatValue, m_AdditionalLightData.shapeWidth.floatValue);
                     break;
             }
         }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Light/HDAdditionalLightData.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Light/HDAdditionalLightData.cs
@@ -159,5 +159,49 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 #endif
 
+        // Caution: this function must match the one in HDLightEditor.UpdateLightIntensity - any change need to be replicated
+        public void ConvertPhysicalLightIntensityToLightIntensity()
+        {
+            var light = gameObject.GetComponent<Light>();
+
+            if (lightTypeExtent == LightTypeExtent.Punctual)
+            {
+                switch (light.type)
+                {
+                    case LightType.Directional:
+                        light.intensity = directionalIntensity;
+                        break;
+
+                    case LightType.Point:
+                        light.intensity = LightUtils.ConvertPointLightIntensity(punctualIntensity);
+                        break;
+
+                    case LightType.Spot:
+                        // Spot should used conversion which take into account the angle, and thus the intensity vary with angle.
+                        // This is not easy to manipulate for lighter, so we simply consider any spot light as just occluded point light. So reuse the same code.
+                        light.intensity = LightUtils.ConvertPointLightIntensity(punctualIntensity);
+                        // TODO: What to do with box shape ?
+                        // var spotLightShape = (SpotLightShape)m_AdditionalspotLightShape.enumValueIndex;
+                        break;
+
+                }
+            }
+            else if (lightTypeExtent == LightTypeExtent.Rectangle)
+            {
+                light.intensity = LightUtils.ConvertRectLightIntensity(areaIntensity, shapeWidth, shapeHeight);
+            }
+            else if (lightTypeExtent == LightTypeExtent.Line)
+            {
+                light.intensity = LightUtils.CalculateLineLightArea(areaIntensity, shapeWidth);
+            }
+        }
+
+        // As we have our own default value, we need to initialize the light intensity correctly
+        public static void InitDefaultHDAdditionalLightData(HDAdditionalLightData lightData)
+        {
+            // At first init we need to initialize correctly the default value
+            lightData.ConvertPhysicalLightIntensityToLightIntensity();
+        }
+
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightUtils.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightUtils.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
         // convert intensity (lumen) to nits
-        public static float calculateLineLightArea(float intensity, float lineWidth)
+        public static float CalculateLineLightArea(float intensity, float lineWidth)
         {
             // The area of a cylinder is this:
             // float lineRadius = 0.01f; // 1cm

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionProbeCache.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionProbeCache.cs
@@ -140,13 +140,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 bool formatMismatch = cubeTexture.format != TextureFormat.RGBAHalf; // Temporary RT for convolution is always FP16
                 if (formatMismatch || sizeMismatch)
                 {
+                    // We comment the following warning as they have no impact on the result but spam the console, it is just that we waste offline time and a bit of quality for nothing.
                     if (sizeMismatch)
                     {
-                        Debug.LogWarningFormat("Baked Reflection Probe {0} does not match HDRP Reflection Probe Cache size of {1}. Consider baking it at the same size for better loading performance.", texture.name, m_ProbeSize);
+                        // Debug.LogWarningFormat("Baked Reflection Probe {0} does not match HDRP Reflection Probe Cache size of {1}. Consider baking it at the same size for better loading performance.", texture.name, m_ProbeSize);
                     }
                     else if (cubeTexture.format == TextureFormat.BC6H)
                     {
-                        Debug.LogWarningFormat("Baked Reflection Probe {0} is compressed but the HDRP Reflection Probe Cache is not. Consider removing compression from the input texture for better quality.", texture.name);
+                        // Debug.LogWarningFormat("Baked Reflection Probe {0} is compressed but the HDRP Reflection Probe Cache is not. Consider removing compression from the input texture for better quality.", texture.name);
                     }
                     ConvertTexture(cmd, cubeTexture, m_TempRenderTexture);
                 }


### PR DESCRIPTION
- Light was incorrectly initialize with Physical light unit when adding HDAdditonalLightData
- Hide "toggle light editor"
- Hide warning that spam the console with reflection probe (no impact on result)