### PR TITLE
Various Debug Window fixes

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/Debugging/DebugManager.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/Debugging/DebugManager.cs
@@ -42,6 +42,14 @@ namespace UnityEngine.Experimental.Rendering
         {
             get
             {
+                var uiManager = UnityObject.FindObjectOfType<DebugUIHandlerCanvas>();
+
+                // Might be needed to update the reference after domain reload
+                if (uiManager != null)
+                {
+                    m_Root = uiManager.gameObject;
+                }
+
                 return m_Root != null && m_Root.activeInHierarchy;
             }
             set

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.cs
@@ -218,7 +218,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     children =
                     {
-                        new DebugUI.UIntField { displayName = "Shadow Atlas Index", getter = () => lightingDebugSettings.shadowMapIndex, setter = value => lightingDebugSettings.shadowAtlasIndex = value, min = () => 0u, max = () => (uint)(RenderPipelineManager.currentPipeline as HDRenderPipeline).GetShadowAtlasCount() - 1u }
+                        new DebugUI.UIntField { displayName = "Shadow Atlas Index", getter = () => lightingDebugSettings.shadowAtlasIndex, setter = value => lightingDebugSettings.shadowAtlasIndex = value, min = () => 0u, max = () => (uint)(RenderPipelineManager.currentPipeline as HDRenderPipeline).GetShadowAtlasCount() - 1u }
                     }
                 });
             }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/MaterialDebug.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/MaterialDebug.cs
@@ -20,7 +20,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             VertexNormalWS,
             VertexColor,
             VertexColorAlpha,
-            Last,
+            // if you add more values here, fix the first entry of next enum
         };
 
         // Number must be contiguous
@@ -28,13 +28,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public enum DebugViewGbuffer
         {
             None = 0,
-            Depth = DebugViewVarying.Last,
+            Depth = DebugViewVarying.VertexColorAlpha + 1,
             BakeDiffuseLightingWithAlbedoPlusEmissive,
             BakeShadowMask0,
             BakeShadowMask1,
             BakeShadowMask2,
             BakeShadowMask3,
-            Last,
+            // if you add more values here, fix the first entry of next enum
         }
 
         // Number must be contiguous
@@ -42,14 +42,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public enum DebugViewProperties
         {
             None = 0,
-            Tessellation = DebugViewGbuffer.Last,
+            Tessellation = DebugViewGbuffer.BakeShadowMask3 + 1,
             PixelDisplacement,
             VertexDisplacement,
             TessellationDisplacement,
             DepthOffset,
             Lightmap,
             Instancing,
-            Last,
         }
     }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
@@ -107,20 +107,6 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUILayout.PropertyField(p.enablePostprocess, _.GetContent("Enable Postprocess"));
         }
 
-        static void Drawer_SectionRenderingSettings(FrameSettingsUI s, SerializedFrameSettings p, Editor owner)
-        {
-            EditorGUILayout.PropertyField(p.enableForwardRenderingOnly, _.GetContent("Enable Forward Rendering Only"));
-            EditorGUILayout.PropertyField(p.enableDepthPrepassWithDeferredRendering, _.GetContent("Enable Depth Prepass With Deferred Rendering"));
-            EditorGUILayout.PropertyField(p.enableAlphaTestOnlyInDeferredPrepass, _.GetContent("Enable Alpha Test Only In Deferred Prepass"));
-
-            EditorGUILayout.PropertyField(p.enableAsyncCompute, _.GetContent("Enable Async Compute"));
-
-            EditorGUILayout.PropertyField(p.enableOpaqueObjects, _.GetContent("Enable Opaque Objects"));
-            EditorGUILayout.PropertyField(p.enableTransparentObjects, _.GetContent("Enable Transparent Objects"));
-
-            EditorGUILayout.PropertyField(p.enableMSAA, _.GetContent("Enable MSAA"));
-        }
-
         static void Drawer_FieldForwardRenderingOnly(FrameSettingsUI s, SerializedFrameSettings p, Editor owner)
         {
             EditorGUILayout.PropertyField(p.enableForwardRenderingOnly, _.GetContent("Enable Forward Rendering Only"));

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -433,6 +433,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
 #if UNITY_EDITOR
             SceneViewDrawMode.ResetDrawMode();
+            FrameSettings.UnRegisterDebug("Default Camera");
 #endif
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -433,7 +433,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
 #if UNITY_EDITOR
             SceneViewDrawMode.ResetDrawMode();
-            FrameSettings.UnRegisterDebug("Default Camera");
+            FrameSettings.UnRegisterDebug("Scene View");
 #endif
         }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoopSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoopSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
@@ -17,8 +18,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         // Setup by system
         public bool isFptlEnabled = true;
-
-        static DebugUI.Widget[] s_DebugEntries;
 
         public void CopyTo(LightLoopSettings lightLoopSettings)
         {
@@ -60,28 +59,24 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             aggregate.isFptlEnabled = !aggregateFrameSettings.enableForwardRenderingOnly || aggregate.enableFptlForForwardOpaque;
         }
 
-        public static void RegisterDebug(string menuName, LightLoopSettings lightLoopSettings)
+        public static void RegisterDebug(LightLoopSettings lightLoopSettings, List<DebugUI.Widget> widgets)
         {
-            s_DebugEntries = new DebugUI.Widget[]
+            widgets.AddRange(new []
             {
-                new DebugUI.BoolField { displayName = "Enable Fptl for Forward Opaque", getter = () => lightLoopSettings.enableFptlForForwardOpaque, setter = value => lightLoopSettings.enableFptlForForwardOpaque = value },
-                new DebugUI.BoolField { displayName = "Enable Tile/Cluster", getter = () => lightLoopSettings.enableTileAndCluster, setter = value => lightLoopSettings.enableTileAndCluster = value },
-                new DebugUI.BoolField { displayName = "Enable Big Tile", getter = () => lightLoopSettings.enableBigTilePrepass, setter = value => lightLoopSettings.enableBigTilePrepass = value },
-                new DebugUI.BoolField { displayName = "Enable Compute Lighting", getter = () => lightLoopSettings.enableComputeLightEvaluation, setter = value => lightLoopSettings.enableComputeLightEvaluation = value },
-                new DebugUI.BoolField { displayName = "Enable Light Classification", getter = () => lightLoopSettings.enableComputeLightVariants, setter = value => lightLoopSettings.enableComputeLightVariants = value },
-                new DebugUI.BoolField { displayName = "Enable Material Classification", getter = () => lightLoopSettings.enableComputeMaterialVariants, setter = value => lightLoopSettings.enableComputeMaterialVariants = value }
-            };
-
-            var panel = DebugManager.instance.GetPanel(menuName, true);
-            panel.children.Add(s_DebugEntries);
-        }
-
-        public static void UnRegisterDebug(string menuName)
-        {
-            var panel = DebugManager.instance.GetPanel(menuName);
-
-            if (panel != null)
-                panel.children.Remove(s_DebugEntries);
+                new DebugUI.Container
+                {
+                    displayName = "Lighting Settings",
+                    children =
+                    {
+                        new DebugUI.BoolField { displayName = "Enable Fptl for Forward Opaque", getter = () => lightLoopSettings.enableFptlForForwardOpaque, setter = value => lightLoopSettings.enableFptlForForwardOpaque = value },
+                        new DebugUI.BoolField { displayName = "Enable Tile/Cluster", getter = () => lightLoopSettings.enableTileAndCluster, setter = value => lightLoopSettings.enableTileAndCluster = value },
+                        new DebugUI.BoolField { displayName = "Enable Big Tile", getter = () => lightLoopSettings.enableBigTilePrepass, setter = value => lightLoopSettings.enableBigTilePrepass = value },
+                        new DebugUI.BoolField { displayName = "Enable Compute Lighting", getter = () => lightLoopSettings.enableComputeLightEvaluation, setter = value => lightLoopSettings.enableComputeLightEvaluation = value },
+                        new DebugUI.BoolField { displayName = "Enable Light Classification", getter = () => lightLoopSettings.enableComputeLightVariants, setter = value => lightLoopSettings.enableComputeLightVariants = value },
+                        new DebugUI.BoolField { displayName = "Enable Material Classification", getter = () => lightLoopSettings.enableComputeMaterialVariants, setter = value => lightLoopSettings.enableComputeMaterialVariants = value }
+                    }
+                }
+            });
         }
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEngine.XR;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
@@ -48,8 +49,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool enableShadowMask = false;
 
         public LightLoopSettings lightLoopSettings = new LightLoopSettings();
-
-        static DebugUI.Widget[] s_DebugEntries;
 
         public void CopyTo(FrameSettings frameSettings)
         {
@@ -219,53 +218,73 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public static void RegisterDebug(string menuName, FrameSettings frameSettings)
         {
-            s_DebugEntries = new DebugUI.Widget[]
+            List<DebugUI.Widget> widgets = new List<DebugUI.Widget>();
+            widgets.AddRange(
+            new DebugUI.Widget[]
             {
-                new DebugUI.BoolField { displayName = "Enable Shadows", getter = () => frameSettings.enableShadow, setter = value => frameSettings.enableShadow = value },
-                new DebugUI.BoolField { displayName = "Enable Contact Shadows", getter = () => frameSettings.enableContactShadows, setter = value => frameSettings.enableContactShadows = value },
-                new DebugUI.BoolField { displayName = "Enable SSR", getter = () => frameSettings.enableSSR, setter = value => frameSettings.enableSSR = value },
-                new DebugUI.BoolField { displayName = "Enable SSAO", getter = () => frameSettings.enableSSAO, setter = value => frameSettings.enableSSAO = value },
-                new DebugUI.BoolField { displayName = "Enable SubsurfaceScattering", getter = () => frameSettings.enableSubsurfaceScattering, setter = value => frameSettings.enableSubsurfaceScattering = value },
-                new DebugUI.BoolField { displayName = "Enable Transmission", getter = () => frameSettings.enableTransmission, setter = value => frameSettings.enableTransmission = value },
+                new DebugUI.Container
+                {
+                    displayName = "Rendering Passes",
+                    children =
+                    {
+                        new DebugUI.BoolField { displayName = "Enable Transparent Prepass", getter = () => frameSettings.enableTransparentPrepass, setter = value => frameSettings.enableTransparentPrepass = value },
+                        new DebugUI.BoolField { displayName = "Enable Transparent Postpass", getter = () => frameSettings.enableTransparentPostpass, setter = value => frameSettings.enableTransparentPostpass = value },
+                        new DebugUI.BoolField { displayName = "Enable Motion Vectors", getter = () => frameSettings.enableMotionVectors, setter = value => frameSettings.enableMotionVectors = value },
+                        new DebugUI.BoolField { displayName = "Enable Object Motion Vectors", getter = () => frameSettings.enableObjectMotionVectors, setter = value => frameSettings.enableObjectMotionVectors = value },
+                        new DebugUI.BoolField { displayName = "Enable DBuffer", getter = () => frameSettings.enableDBuffer, setter = value => frameSettings.enableDBuffer = value },
+                        new DebugUI.BoolField { displayName = "Enable Atmospheric Scattering", getter = () => frameSettings.enableAtmosphericScattering, setter = value => frameSettings.enableAtmosphericScattering = value },
+                        new DebugUI.BoolField { displayName = "Enable Rough Refraction", getter = () => frameSettings.enableRoughRefraction, setter = value => frameSettings.enableRoughRefraction = value },
+                        new DebugUI.BoolField { displayName = "Enable Distortion", getter = () => frameSettings.enableDistortion, setter = value => frameSettings.enableDistortion = value },
+                        new DebugUI.BoolField { displayName = "Enable Postprocess", getter = () => frameSettings.enablePostprocess, setter = value => frameSettings.enablePostprocess = value },
+                    }
+                },
+                new DebugUI.Container
+                {
+                    displayName = "Rendering Settings",
+                    children =
+                    {
+                        new DebugUI.BoolField { displayName = "Forward Only", getter = () => frameSettings.enableForwardRenderingOnly, setter = value => frameSettings.enableForwardRenderingOnly = value },
+                        new DebugUI.BoolField { displayName = "Deferred Depth Prepass", getter = () => frameSettings.enableDepthPrepassWithDeferredRendering, setter = value => frameSettings.enableDepthPrepassWithDeferredRendering = value },
+                        new DebugUI.BoolField { displayName = "Deferred Depth Prepass ATest Only", getter = () => frameSettings.enableAlphaTestOnlyInDeferredPrepass, setter = value => frameSettings.enableAlphaTestOnlyInDeferredPrepass = value },
+                        new DebugUI.BoolField { displayName = "Enable Async Compute", getter = () => frameSettings.enableAsyncCompute, setter = value => frameSettings.enableAsyncCompute = value },
+                        new DebugUI.BoolField { displayName = "Enable Opaque Objects", getter = () => frameSettings.enableOpaqueObjects, setter = value => frameSettings.enableOpaqueObjects = value },
+                        new DebugUI.BoolField { displayName = "Enable Transparent Objects", getter = () => frameSettings.enableTransparentObjects, setter = value => frameSettings.enableTransparentObjects = value },
+                        new DebugUI.BoolField { displayName = "Enable MSAA", getter = () => frameSettings.enableMSAA, setter = value => frameSettings.enableMSAA = value },
+                    }
+                },
+                new DebugUI.Container
+                {
+                    displayName = "XR Settings",
+                    children =
+                    {
+                        new DebugUI.BoolField { displayName = "Enable Stereo Rendering", getter = () => frameSettings.enableStereo, setter = value => frameSettings.enableStereo = value }
+                    }
+                },
+                new DebugUI.Container
+                {
+                    displayName = "Lighting Settings",
+                    children =
+                    {
+                        new DebugUI.BoolField { displayName = "Enable SSR", getter = () => frameSettings.enableSSR, setter = value => frameSettings.enableSSR = value },
+                        new DebugUI.BoolField { displayName = "Enable SSAO", getter = () => frameSettings.enableSSAO, setter = value => frameSettings.enableSSAO = value },
+                        new DebugUI.BoolField { displayName = "Enable SubsurfaceScattering", getter = () => frameSettings.enableSubsurfaceScattering, setter = value => frameSettings.enableSubsurfaceScattering = value },
+                        new DebugUI.BoolField { displayName = "Enable Transmission", getter = () => frameSettings.enableTransmission, setter = value => frameSettings.enableTransmission = value },
+                        new DebugUI.BoolField { displayName = "Enable Shadows", getter = () => frameSettings.enableShadow, setter = value => frameSettings.enableShadow = value },
+                        new DebugUI.BoolField { displayName = "Enable Contact Shadows", getter = () => frameSettings.enableContactShadows, setter = value => frameSettings.enableContactShadows = value },
+                        new DebugUI.BoolField { displayName = "Enable ShadowMask", getter = () => frameSettings.enableShadowMask, setter = value => frameSettings.enableShadowMask = value },
+                    }
+                }
+            });
 
-                new DebugUI.BoolField { displayName = "Forward Only", getter = () => frameSettings.enableForwardRenderingOnly, setter = value => frameSettings.enableForwardRenderingOnly = value },
-                new DebugUI.BoolField { displayName = "Deferred Depth Prepass", getter = () => frameSettings.enableDepthPrepassWithDeferredRendering, setter = value => frameSettings.enableDepthPrepassWithDeferredRendering = value },
-                new DebugUI.BoolField { displayName = "Deferred Depth Prepass ATest Only", getter = () => frameSettings.enableAlphaTestOnlyInDeferredPrepass, setter = value => frameSettings.enableAlphaTestOnlyInDeferredPrepass = value },
-
-                new DebugUI.BoolField { displayName = "Enable Transparent Prepass", getter = () => frameSettings.enableTransparentPrepass, setter = value => frameSettings.enableTransparentPrepass = value },
-                new DebugUI.BoolField { displayName = "Enable Motion Vectors", getter = () => frameSettings.enableMotionVectors, setter = value => frameSettings.enableMotionVectors = value },
-                new DebugUI.BoolField { displayName = "Enable Object Motion Vectors", getter = () => frameSettings.enableObjectMotionVectors, setter = value => frameSettings.enableObjectMotionVectors = value },
-                new DebugUI.BoolField { displayName = "Enable DBuffer", getter = () => frameSettings.enableDBuffer, setter = value => frameSettings.enableDBuffer = value },
-                new DebugUI.BoolField { displayName = "Enable Atmospheric Scattering", getter = () => frameSettings.enableAtmosphericScattering, setter = value => frameSettings.enableAtmosphericScattering = value },
-                new DebugUI.BoolField { displayName = "Enable Rough Refraction", getter = () => frameSettings.enableRoughRefraction, setter = value => frameSettings.enableRoughRefraction = value },
-                new DebugUI.BoolField { displayName = "Enable Transparent Postpass", getter = () => frameSettings.enableTransparentPostpass, setter = value => frameSettings.enableTransparentPostpass = value },
-                new DebugUI.BoolField { displayName = "Enable Distortion", getter = () => frameSettings.enableDistortion, setter = value => frameSettings.enableDistortion = value },
-                new DebugUI.BoolField { displayName = "Enable Postprocess", getter = () => frameSettings.enablePostprocess, setter = value => frameSettings.enablePostprocess = value },
-
-                new DebugUI.BoolField { displayName = "Enable Stereo Rendering", getter = () => frameSettings.enableStereo, setter = value => frameSettings.enableStereo = value },
-                new DebugUI.BoolField { displayName = "Enable Async Compute", getter = () => frameSettings.enableAsyncCompute, setter = value => frameSettings.enableAsyncCompute = value },
-
-                new DebugUI.BoolField { displayName = "Enable Opaque Objects", getter = () => frameSettings.enableOpaqueObjects, setter = value => frameSettings.enableOpaqueObjects = value },
-                new DebugUI.BoolField { displayName = "Enable Transparent Objects", getter = () => frameSettings.enableTransparentObjects, setter = value => frameSettings.enableTransparentObjects = value },
-
-                new DebugUI.BoolField { displayName = "Enable MSAA", getter = () => frameSettings.enableMSAA, setter = value => frameSettings.enableMSAA = value },
-                new DebugUI.BoolField { displayName = "Enable ShadowMask", getter = () => frameSettings.enableShadowMask, setter = value => frameSettings.enableShadowMask = value },
-            };
+            LightLoopSettings.RegisterDebug(frameSettings.lightLoopSettings, widgets);
 
             var panel = DebugManager.instance.GetPanel(menuName, true);
-            panel.children.Add(s_DebugEntries);
-
-            LightLoopSettings.RegisterDebug(menuName, frameSettings.lightLoopSettings);
-       }
+            panel.children.Add(widgets.ToArray());
+        }
 
         public static void UnRegisterDebug(string menuName)
         {
-            var panel = DebugManager.instance.GetPanel(menuName);
-
-            if (panel != null)
-                panel.children.Remove(s_DebugEntries);
-
-            LightLoopSettings.UnRegisterDebug(menuName);
+            DebugManager.instance.RemovePanel(menuName);
         }
     }
 }


### PR DESCRIPTION
- Fixed Shadow Atlas index.
- Fixed DebugManager.instance.displayRuntimeUI breaking after domain reload
- Removed wrong "Last" entries in material debug.
- Fixed Frame Settings debug not being removed correctly on camera disable.
- Frame Settings debug layout is now the same as the regular UI.
