### PR TITLE
Disable a number of scene view draw modes for LWRP

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+#if UNITY_EDITOR
+using UnityEditor.Experimental.Rendering.LightweightPipeline;
+#endif
 using UnityEngine.Experimental.GlobalIllumination;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.PostProcessing;
@@ -263,6 +266,10 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             CoreUtils.Destroy(m_ErrorMaterial);
             CoreUtils.Destroy(m_CopyDepthMaterial);
             CoreUtils.Destroy(m_BlitMaterial);
+
+#if UNITY_EDITOR
+            SceneViewDrawMode.ResetDrawMode();
+#endif
         }
 
         private void SetRenderingFeatures()
@@ -280,6 +287,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 rendererSupportsReceiveShadows = true,
                 rendererSupportsReflectionProbes = true
             };
+            SceneViewDrawMode.SetupDrawMode();
 #endif
         }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/SceneViewDrawMode.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/SceneViewDrawMode.cs
@@ -1,0 +1,48 @@
+﻿#if UNITY_EDITOR
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityEditor.Experimental.Rendering.LightweightPipeline
+{
+    internal static class SceneViewDrawMode
+    {
+        static bool RejectDrawMode(SceneView.CameraMode cameraMode)
+        {
+            if (cameraMode.drawMode == DrawCameraMode.TexturedWire ||
+                cameraMode.drawMode == DrawCameraMode.ShadowCascades ||
+                cameraMode.drawMode == DrawCameraMode.RenderPaths ||
+                cameraMode.drawMode == DrawCameraMode.AlphaChannel ||
+                cameraMode.drawMode == DrawCameraMode.Overdraw ||
+                cameraMode.drawMode == DrawCameraMode.Mipmaps ||
+                cameraMode.drawMode == DrawCameraMode.SpriteMask ||
+                cameraMode.drawMode == DrawCameraMode.DeferredDiffuse ||
+                cameraMode.drawMode == DrawCameraMode.DeferredSpecular ||
+                cameraMode.drawMode == DrawCameraMode.DeferredSmoothness ||
+                cameraMode.drawMode == DrawCameraMode.DeferredNormal ||
+                cameraMode.drawMode == DrawCameraMode.ValidateAlbedo ||
+                cameraMode.drawMode == DrawCameraMode.ValidateMetalSpecular ||
+                cameraMode.drawMode == DrawCameraMode.ShadowMasks ||
+                cameraMode.drawMode == DrawCameraMode.LightOverlap
+            )
+                return false;
+
+            return true;
+        }
+
+        public static void SetupDrawMode()
+        {
+            ArrayList sceneViewArray = SceneView.sceneViews;
+            foreach (SceneView sceneView in sceneViewArray)
+                sceneView.onValidateCameraMode += RejectDrawMode;
+        }
+
+        public static void ResetDrawMode()
+        {
+            ArrayList sceneViewArray = SceneView.sceneViews;
+            foreach (SceneView sceneView in sceneViewArray)
+                sceneView.onValidateCameraMode -= RejectDrawMode;
+        }
+    }
+}
+#endif

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/SceneViewDrawMode.cs.meta
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/SceneViewDrawMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7255bed85944a04fa68dd4d1d28022a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
As the draw modes haven't been looked at yet in Lightweight pipeline, I'm disabling them so that users cannot access them. 