### PR TITLE
Add Distortion Texture functionality

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineAsset.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineAsset.cs
@@ -36,6 +36,13 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         _8x = 8
     }
 
+    public enum TextureScale
+    {
+        Full,
+        Half,
+        Quarter
+    }
+
     public enum DefaultMaterialType
     {
         Standard = 0,
@@ -57,6 +64,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         [SerializeField] private bool m_SupportsVertexLight = false;
         [SerializeField] private bool m_RequireDepthTexture = false;
         [SerializeField] private bool m_RequireSoftParticles = false;
+        [SerializeField] private bool m_RequiresDistortionTexture = false;
+        [SerializeField] private TextureScale m_DistortionTextureScale = TextureScale.Half;
         [SerializeField] private bool m_SupportsHDR = false;
         [SerializeField] private MSAAQuality m_MSAA = MSAAQuality._4x;
         [SerializeField] private float m_RenderScale = 1.0f;
@@ -213,6 +222,17 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             get { return m_RequireSoftParticles; }
         }
 
+        public bool RequireDistortionTexture
+        {
+            get { return m_RequiresDistortionTexture; }
+        }
+
+        public TextureScale DistortionTextureScale
+        {
+            get { return m_DistortionTextureScale; }
+            set { m_DistortionTextureScale = value; }
+        }
+
         public bool SupportsHDR
         {
             get { return m_SupportsHDR; }
@@ -341,6 +361,11 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         public Shader ScreenSpaceShadowShader
         {
             get { return resources != null ? resources.ScreenSpaceShadowShader : null; }
+        }
+
+        public Shader SamplingShader
+        {
+            get { return resources != null ? resources.SamplingShader : null; }
         }
     }
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineResources.asset
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineResources.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   CopyDepthShader: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
   ScreenSpaceShadowShader: {fileID: 4800000, guid: 0f854b35a0cf61a429bd5dcfea30eddd,
     type: 3}
+  SamplingShader: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineResources.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Data/LightweightPipelineResources.cs
@@ -5,4 +5,5 @@ public class LightweightPipelineResources : ScriptableObject
     public Shader BlitShader;
     public Shader CopyDepthShader;
     public Shader ScreenSpaceShadowShader;
+    public Shader SamplingShader;
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/LightweightAssetEditor.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/LightweightAssetEditor.cs
@@ -25,6 +25,10 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             public static GUIContent requireSoftParticles = new GUIContent("Soft Particles", "If enabled the pipeline will enable SOFT_PARTICLES keyword.");
 
+            public static GUIContent requireDistortionTexture = new GUIContent("Distortion Texture", "If enabled the pipeline will copy the screen to texture after opaque objects are drawn. For transparent objects this can be bound in shaders as _CameraDistortionTexture.");
+
+            public static GUIContent distortionTextureScale = new GUIContent("Distortion Scale", "The scale of the original screen size that is used for the distortion texture");
+
             public static GUIContent shadowType = new GUIContent("Type",
                     "Global shadow settings. Options are NO_SHADOW, HARD_SHADOWS and SOFT_SHADOWS.");
 
@@ -50,6 +54,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         }
 
         AnimBool m_ShowSoftParticles = new AnimBool();
+        AnimBool m_ShowDistortionTextureScale = new AnimBool();
+
 
         private int kMaxSupportedPixelLights = 8;
         private float kMinRenderScale = 0.1f;
@@ -59,6 +65,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         private SerializedProperty m_SupportsVertexLightProp;
         private SerializedProperty m_RequireDepthTextureProp;
         private SerializedProperty m_RequireSoftParticlesProp;
+        private SerializedProperty m_RequireDistortionTextureProp;
+        private SerializedProperty m_DistortionTextureScaleProp;
         private SerializedProperty m_ShadowTypeProp;
         private SerializedProperty m_ShadowNearPlaneOffsetProp;
         private SerializedProperty m_ShadowDistanceProp;
@@ -76,6 +84,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             m_SupportsVertexLightProp = serializedObject.FindProperty("m_SupportsVertexLight");
             m_RequireDepthTextureProp = serializedObject.FindProperty("m_RequireDepthTexture");
             m_RequireSoftParticlesProp = serializedObject.FindProperty("m_RequireSoftParticles");
+            m_RequireDistortionTextureProp = serializedObject.FindProperty("m_RequiresDistortionTexture");
+            m_DistortionTextureScaleProp = serializedObject.FindProperty("m_DistortionTextureScale");
             m_ShadowTypeProp = serializedObject.FindProperty("m_ShadowType");
             m_ShadowNearPlaneOffsetProp = serializedObject.FindProperty("m_ShadowNearPlaneOffset");
             m_ShadowDistanceProp = serializedObject.FindProperty("m_ShadowDistance");
@@ -88,16 +98,20 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             m_ShowSoftParticles.valueChanged.AddListener(Repaint);
             m_ShowSoftParticles.value = m_RequireSoftParticlesProp.boolValue;
+            m_ShowDistortionTextureScale.valueChanged.AddListener(Repaint);
+            m_ShowDistortionTextureScale.value = m_DistortionTextureScaleProp.boolValue;
         }
 
         void OnDisable()
         {
             m_ShowSoftParticles.valueChanged.RemoveListener(Repaint);
+            m_ShowDistortionTextureScale.valueChanged.RemoveListener(Repaint);
         }
 
         void UpdateAnimationValues()
         {
             m_ShowSoftParticles.target = m_RequireDepthTextureProp.boolValue;
+            m_ShowDistortionTextureScale.target = m_RequireDistortionTextureProp.boolValue;
         }
 
         void DrawAnimatedProperty(SerializedProperty prop, GUIContent content, AnimBool animation)
@@ -126,6 +140,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             EditorGUILayout.PropertyField(m_SupportsVertexLightProp, Styles.enableVertexLightLabel);
             EditorGUILayout.PropertyField(m_RequireDepthTextureProp, Styles.requireDepthTexture);
             DrawAnimatedProperty(m_RequireSoftParticlesProp, Styles.requireSoftParticles, m_ShowSoftParticles);
+            EditorGUILayout.PropertyField(m_RequireDistortionTextureProp, Styles.requireDistortionTexture);
+            DrawAnimatedProperty(m_DistortionTextureScaleProp, Styles.distortionTextureScale, m_ShowDistortionTextureScale);
             EditorGUILayout.PropertyField(m_HDR, Styles.hdrContent);
             EditorGUILayout.PropertyField(m_MSAA, Styles.msaaContent);
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightSampling.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightSampling.shader
@@ -1,0 +1,112 @@
+Shader "Hidden/LightweightPipeline/Sampling"
+{
+    Properties
+    {
+        _MainTex("Albedo", 2D) = "white" {}
+    }
+
+    HLSLINCLUDE
+    #include "../ShaderLibrary/Core.hlsl"
+
+    struct VertexInput
+    {
+        float4 vertex   : POSITION;
+        float2 texcoord : TEXCOORD0;
+    };
+
+    struct Interpolators
+    {
+        half4  pos      : SV_POSITION;
+        half4  texcoord : TEXCOORD0;
+    };
+
+    Interpolators Vertex(VertexInput i)
+    {
+        Interpolators o;
+        UNITY_SETUP_INSTANCE_ID(i);
+        UNITY_TRANSFER_INSTANCE_ID(i, o);
+
+        o.pos = TransformObjectToHClip(i.vertex.xyz);
+
+        float4 projPos = o.pos * 0.5;
+        projPos.xy = projPos.xy + projPos.w;
+
+        o.texcoord.xy = i.texcoord;
+        o.texcoord.zw = projPos.xy;
+
+        return o;
+    }
+
+    half4 DownsampleBox4Tap(Texture2D tex, SamplerState samplerTex, float2 uv, float2 texelSize, float amount)
+    {
+        float4 d = texelSize.xyxy * float4(-amount, -amount, amount, amount);
+
+        half4 s;
+        s =  (SAMPLE_TEXTURE2D(tex, samplerTex, uv + d.xy));
+        s += (SAMPLE_TEXTURE2D(tex, samplerTex, uv + d.zy));
+        s += (SAMPLE_TEXTURE2D(tex, samplerTex, uv + d.xw));
+        s += (SAMPLE_TEXTURE2D(tex, samplerTex, uv + d.zw));
+
+        return s * (1.0 / 4.0);
+    }
+
+    ENDHLSL
+
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" "RenderPipeline" = "LightweightPipeline"}
+        LOD 100
+
+        // 0 - Downsample - Box filtering
+        Pass
+        {
+            Tags { "LightMode" = "LightweightForward"}
+
+            ZTest Always
+            ZWrite Off
+
+            HLSLPROGRAM
+            // Required to compile gles 2.0 with standard srp library
+            #pragma prefer_hlslcc gles
+            #pragma vertex Vertex
+            #pragma fragment FragBoxDownsample
+
+            TEXTURE2D(_MainTex);
+            SAMPLER(sampler_MainTex);
+            float4 _MainTex_TexelSize;
+
+            half4 FragBoxDownsample(Interpolators i) : SV_Target
+            {
+                half4 col = DownsampleBox4Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy, 1.0);
+                return half4(col.rgb, 1);
+            }
+            ENDHLSL
+        }
+
+        // 1 - 2x Downsample - Box filtering
+        Pass
+        {
+            Tags { "LightMode" = "LightweightForward"}
+
+            ZTest Always
+            ZWrite Off
+
+            HLSLPROGRAM
+            // Required to compile gles 2.0 with standard srp library
+            #pragma prefer_hlslcc gles
+            #pragma vertex Vertex
+            #pragma fragment FragBoxDownsample
+
+            TEXTURE2D(_MainTex);
+            SAMPLER(sampler_MainTex);
+            float4 _MainTex_TexelSize;
+
+            half4 FragBoxDownsample(Interpolators i) : SV_Target
+            {
+                half4 col = DownsampleBox4Tap(TEXTURE2D_PARAM(_MainTex, sampler_MainTex), i.texcoord, _MainTex_TexelSize.xy, 2.0);
+                return half4(col.rgb, 1);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightSampling.shader.meta
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightSampling.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 04c410c9937594faa893a11dceb85f7e
+timeCreated: 1505729520
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Similar to legacy renderer's **Grab Pass** except performed once in the `After Opaque` Pass. Provides functionality for shaders (such as particle shaders) to access the color values of the screen for distortion effects etc using the global texture `_CameraDistortionTexture`.

**Features**
- Get screen color values from `Opaque` pass when rendering in `Transparent` pass.
- Distortion texture can be downsampled to 1/2 or 1/4 using bilinear sampling.

**Changes**
- Add `TextureScale` enum for setting Distortion Texture size.
- Add `Distortion Texture` and `Distortion Scale` fields to Lightweight Asset.
- Add `LightweightSampling.shader` for performing bilinear downsampling.
- Add `LightweightSampling.shader` to Lightweight Resources object.
- Add Distortion render target to pipeline.
- Add Material for `LightweightSampling.shader` to pipeline.
- Add Distortion Pass to copy screen contents to `_CameraDistortionTexture` at the end of `After Opaque` pass.

**Risk**
- None really, apart from that this is my first PR to the render pipeline :D