### PR TITLE
 Added fog exp back to lw.

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -1177,19 +1177,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             CoreUtils.SetKeyword(cmd, "_MIXED_LIGHTING_SUBTRACTIVE", m_MixedLightingSetup == MixedLightingSetup.Subtractive);
             CoreUtils.SetKeyword(cmd, "_VERTEX_LIGHTS", vertexLightsCount > 0);
             CoreUtils.SetKeyword(cmd, "SOFTPARTICLES_ON", m_RequireDepthTexture && m_Asset.RequireSoftParticles);
-
-            bool linearFogModeEnabled = false;
-            bool exponentialFogModeEnabled = false;
-            if (RenderSettings.fog)
-            {
-                if (RenderSettings.fogMode == FogMode.Linear)
-                    linearFogModeEnabled = true;
-                else
-                    exponentialFogModeEnabled = true;
-            }
-
-            CoreUtils.SetKeyword(cmd, "FOG_LINEAR", linearFogModeEnabled);
-            CoreUtils.SetKeyword(cmd, "FOG_EXP2", exponentialFogModeEnabled);
         }
 
         private void SetShadowCollectPassKeywords(CommandBuffer cmd, VisibleLight shadowLight, ref LightData lightData)

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Core.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Core.hlsl
@@ -124,7 +124,7 @@ half ComputeFogFactor(float z)
     // factor = (end-z)/(end-start) = z * (-1/(end-start)) + (end/(end-start))
     float fogFactor = saturate(clipZ_01 * unity_FogParams.z + unity_FogParams.w);
     return half(fogFactor);
-#elif defined(FOG_EXP2)
+#elif defined(FOG_EXP) || defined(FOG_EXP2)
     // factor = exp(-(density*z)^2)
     // -density * z computed at vertex
     return half(unity_FogParams.x * clipZ_01);
@@ -135,8 +135,12 @@ half ComputeFogFactor(float z)
 
 void ApplyFogColor(inout half3 color, half3 fogColor, half fogFactor)
 {
-#if defined (FOG_LINEAR) || defined(FOG_EXP2)
-#if defined(FOG_EXP2)
+#if defined(FOG_LINEAR) || defined(FOG_EXP) || defined(FOG_EXP2)
+#if defined(FOG_EXP)
+    // factor = exp(-density*z)
+    // fogFactor = density*z compute at vertex
+    fogFactor = saturate(exp2(-fogFactor));
+#elif defined(FOG_EXP2)
     // factor = exp(-(density*z)^2)
     // fogFactor = density*z compute at vertex
     fogFactor = saturate(exp2(-fogFactor*fogFactor));

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
@@ -98,7 +98,7 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS
             #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
-            #pragma multi_compile _ FOG_LINEAR FOG_EXP2
+            #pragma multi_compile_fog
 
             // -------------------------------------
             // Unity defined keywords

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
@@ -82,7 +82,7 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS
             #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
-            #pragma multi_compile _ FOG_LINEAR FOG_EXP2
+            #pragma multi_compile_fog
 
             // -------------------------------------
             // Unity defined keywords

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardTerrain.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardTerrain.shader
@@ -46,7 +46,7 @@ Shader "LightweightPipeline/Standard Terrain"
             #pragma multi_compile _ _ADDITIONAL_LIGHTS
             #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
-            #pragma multi_compile _ FOG_LINEAR FOG_EXP2
+            #pragma multi_compile_fog
 
             // -------------------------------------
             // Unity defined keywords


### PR DESCRIPTION
 Crunching fog exp and exp2 modes into one causes issues that make the exp mode be stripped from the build. We added it back to lightweight. 