### PR TITLE
Lw/multipass

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightConstantBuffer.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightConstantBuffer.cs
@@ -12,9 +12,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
     {
         public static int _MainLightPosition;
         public static int _MainLightColor;
-        public static int _MainLightDistanceAttenuation;
-        public static int _MainLightSpotDir;
-        public static int _MainLightSpotAttenuation;
         public static int _MainLightCookie;
         public static int _WorldToLight;
 
@@ -26,7 +23,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         public static int _AdditionalLightSpotAttenuation;
     }
 
-    public static class ShadowConstantBuffer
+    public static class DirectionalShadowConstantBuffer
     {
         public static int _WorldToShadow;
         public static int _ShadowData;
@@ -37,5 +34,16 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         public static int _ShadowOffset2;
         public static int _ShadowOffset3;
         public static int _ShadowmapSize;
+    }
+
+    public static class LocalShadowConstantBuffer
+    {
+        public static int _LocalWorldToShadow;
+        public static int _LocalShadowData;
+        public static int _LocalShadowOffset0;
+        public static int _LocalShadowOffset1;
+        public static int _LocalShadowOffset2;
+        public static int _LocalShadowOffset3;
+        public static int _LocalShadowmapSize;
     }
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
@@ -11,64 +11,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         }
     }
 
-    public class LightComparer : IComparer<VisibleLight>
-    {
-        public Camera CurrCamera { get; set; }
-
-        public int Compare(VisibleLight lhs, VisibleLight rhs)
-        {
-            Light lhsLight = lhs.light;
-            Light rhsLight = rhs.light;
-
-            // Particle Lights have the Light reference set to null
-            // They are at the end of the priority
-            if (lhsLight == null) return 1;
-            if (rhsLight == null) return -1;
-
-            // Prioritize lights marked as important
-            if (lhsLight.renderMode != rhsLight.renderMode)
-            {
-                if (lhsLight.renderMode == LightRenderMode.ForcePixel) return -1;
-                if (rhsLight.renderMode == LightRenderMode.ForcePixel) return 1;
-            }
-
-            // Prioritize Directional Lights
-            if (lhs.lightType != rhs.lightType)
-            {
-                if (lhs.lightType == LightType.Directional) return -1;
-                if (rhs.lightType == LightType.Directional) return 1;
-            }
-
-            // Prioritize Shadows Lights Soft > Hard > None
-            if (lhsLight.shadows != rhsLight.shadows)
-                return (int)rhsLight.shadows - (int)lhsLight.shadows;
-
-            // Prioritize lights with cookies
-            if (lhsLight.cookie != rhsLight.cookie)
-                return (lhsLight.cookie != null) ? -1 : 1;
-
-            // If directional sort by intensity
-            if (lhs.lightType == LightType.Directional)
-            {
-                return (int)(rhsLight.intensity * 100.0f) - (int)(lhsLight.intensity * 100.0f);
-            }
-
-            // Punctual lights are sorted per-object by the engine based on distance to object center + luminance
-            // Here we sort globally the light list per camera distance to fit the closest lights in the global light buffer
-            // Check MAX_VISIBLE_LIGHTS in the LightweightLighting.cginc to see the max global buffer list size
-            int lhsDistance = (int)(SquaredDistanceToCamera(lhsLight.transform.position) * 100.0f);
-            int rhsDistance = (int)(SquaredDistanceToCamera(rhsLight.transform.position) * 100.0f);
-            int result = lhsDistance - rhsDistance;
-            return result;
-        }
-
-        public float SquaredDistanceToCamera(Vector3 lightPos)
-        {
-            Vector3 lightCameraVector = lightPos - CurrCamera.transform.position;
-            return Vector3.Dot(lightCameraVector, lightCameraVector);
-        }
-    }
-
     public class LightEqualityComparer : IEqualityComparer<VisibleLight>
     {
         public bool Equals(VisibleLight x, VisibleLight y)

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Input.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Input.hlsl
@@ -26,9 +26,6 @@ CBUFFER_END
 CBUFFER_START(_PerCamera)
 float4 _MainLightPosition;
 half4 _MainLightColor;
-half4 _MainLightDistanceAttenuation;
-half4 _MainLightSpotDir;
-half4 _MainLightSpotAttenuation;
 float4x4 _WorldToLight;
 
 half4 _AdditionalLightCount;

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
@@ -129,8 +129,8 @@ half4 GetMainLightDirectionAndAttenuation(LightInput lightInput, float3 position
 {
     half4 directionAndAttenuation = GetLightDirectionAndAttenuation(lightInput, positionWS);
 
-    // Cookies are only computed for main light
-    directionAndAttenuation.w *= CookieAttenuation(positionWS);
+    // Cookies disabled for now due to amount of shader variants
+    //directionAndAttenuation.w *= CookieAttenuation(positionWS);
 
     return directionAndAttenuation;
 }
@@ -437,7 +437,7 @@ half3 SubtractDirectMainLightFromLightmap(Light mainLight, half3 normalWS, half3
     // 1) Gives good estimate of illumination as if light would've been shadowed during the bake.
     // We only subtract the main direction light. This is accounted in the contribution term below.
     half shadowStrength = _ShadowData.x;
-    half contributionTerm = saturate(dot(mainLight.direction, normalWS)) * (1.0 - _MainLightPosition.w);
+    half contributionTerm = saturate(dot(mainLight.direction, normalWS));
     half3 lambert = mainLight.color * contributionTerm;
     half3 estimatedLightContributionMaskedByInverseOfShadow = lambert * (1.0 - mainLight.attenuation);
     half3 subtractedLightmap = bakedGI - estimatedLightContributionMaskedByInverseOfShadow;

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
@@ -139,22 +139,13 @@ half4 GetMainLightDirectionAndAttenuation(LightInput lightInput, float3 position
 //                      Light Abstraction                                    //
 ///////////////////////////////////////////////////////////////////////////////
 
-Light GetMainLight(float3 positionWS)
+Light GetMainLight()
 {
-    LightInput lightInput;
-    lightInput.position = _MainLightPosition;
-    lightInput.color = _MainLightColor.rgb;
-    lightInput.distanceAttenuation = _MainLightDistanceAttenuation;
-    lightInput.spotDirection = _MainLightSpotDir;
-    lightInput.spotAttenuation = _MainLightSpotAttenuation;
-
-    half4 directionAndRealtimeAttenuation = GetMainLightDirectionAndAttenuation(lightInput, positionWS);
-
     Light light;
-    light.direction = directionAndRealtimeAttenuation.xyz;
-    light.attenuation = directionAndRealtimeAttenuation.w;
-    light.subtractiveModeAttenuation = lightInput.distanceAttenuation.w;
-    light.color = lightInput.color;
+    light.direction = _MainLightPosition.xyz;
+    light.attenuation = 1.0;
+    light.subtractiveModeAttenuation = _MainLightPosition.w;
+    light.color = _MainLightColor.rgb;
 
     return light;
 }
@@ -539,9 +530,8 @@ half4 LightweightFragmentPBR(InputData inputData, half3 albedo, half metallic, h
     BRDFData brdfData;
     InitializeBRDFData(albedo, metallic, specular, smoothness, alpha, brdfData);
 
-    Light mainLight = GetMainLight(inputData.positionWS);
-
-    mainLight.attenuation *= RealtimeShadowAttenuation(inputData.shadowCoord);
+    Light mainLight = GetMainLight();
+    mainLight.attenuation = RealtimeShadowAttenuation(inputData.shadowCoord, 0.0);
 
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, half4(0, 0, 0, 0));
     half3 color = GlobalIllumination(brdfData, inputData.bakedGI, occlusion, inputData.normalWS, inputData.viewDirectionWS);
@@ -563,8 +553,8 @@ half4 LightweightFragmentPBR(InputData inputData, half3 albedo, half metallic, h
 
 half4 LightweightFragmentBlinnPhong(InputData inputData, half3 diffuse, half4 specularGloss, half shininess, half3 emission, half alpha)
 {
-    Light mainLight = GetMainLight(inputData.positionWS);
-    mainLight.attenuation *= RealtimeShadowAttenuation(inputData.shadowCoord);
+    Light mainLight = GetMainLight();
+    mainLight.attenuation = RealtimeShadowAttenuation(inputData.shadowCoord, 0.0);
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, half4(0, 0, 0, 0));
 
     half3 attenuatedLightColor = mainLight.color * mainLight.attenuation;

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
@@ -550,7 +550,7 @@ half4 LightweightFragmentPBR(InputData inputData, half3 albedo, half metallic, h
     for (int i = 0; i < pixelLightCount; ++i)
     {
         Light light = GetLight(half(i), inputData.positionWS);
-        light.attenuation *= LocalLightRealtimeShadowAttenuation(inputData.shadowCoord, inputData.positionWS);
+        light.attenuation *= LocalLightRealtimeShadowAttenuation(i, inputData.positionWS);
         color += LightingPhysicallyBased(brdfData, light, inputData.normalWS, inputData.viewDirectionWS);
     }
 #endif
@@ -575,7 +575,7 @@ half4 LightweightFragmentBlinnPhong(InputData inputData, half3 diffuse, half4 sp
     for (int i = 0; i < pixelLightCount; ++i)
     {
         Light light = GetLight(half(i), inputData.positionWS);
-        light.attenuation *= LocalLightRealtimeShadowAttenuation(inputData.shadowCoord, inputData.positionWS);
+        light.attenuation *= LocalLightRealtimeShadowAttenuation(i, inputData.positionWS);
         half3 attenuatedLightColor = light.color * light.attenuation;
         diffuseColor += LightingLambert(attenuatedLightColor, light.direction, inputData.normalWS);
         specularColor += LightingSpecular(attenuatedLightColor, light.direction, inputData.normalWS, inputData.viewDirectionWS, specularGloss, shininess);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassLitSimple.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassLitSimple.hlsl
@@ -18,9 +18,8 @@ struct LightweightVertexOutput
 {
     float2 uv                       : TEXCOORD0;
     DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, 1);
-#ifdef _ADDITIONAL_LIGHTS
-    float3 posWS                    : TEXCOORD2;
-#endif
+
+    float4 posWSShininess           : TEXCOORD2;    // xyz: posWS, w: Shininess * 128
 
 #ifdef _NORMALMAP
     half4 normal                    : TEXCOORD3;    // xyz: normal, w: viewDir.x
@@ -44,11 +43,7 @@ struct LightweightVertexOutput
 
 void InitializeInputData(LightweightVertexOutput IN, half3 normalTS, out InputData inputData)
 {
-    inputData = (InputData)0;
-
-#ifdef _ADDITIONAL_LIGHTS
-    inputData.positionWS = IN.posWS;
-#endif
+    inputData.positionWS = IN.posWSShininess.xyz;
 
 #ifdef _NORMALMAP
     half3 viewDir = half3(IN.normal.w, IN.tangent.w, IN.binormal.w);
@@ -73,8 +68,8 @@ void InitializeInputData(LightweightVertexOutput IN, half3 normalTS, out InputDa
 //                  Vertex and Fragment functions                            //
 ///////////////////////////////////////////////////////////////////////////////
 
-// Used in Standard (Physically Based) shader
-LightweightVertexOutput LitPassVertex(LightweightVertexInput v)
+// Used in Standard (Simple Lighting) shader
+LightweightVertexOutput LitPassVertexSimple(LightweightVertexInput v)
 {
     LightweightVertexOutput o = (LightweightVertexOutput)0;
 
@@ -84,10 +79,11 @@ LightweightVertexOutput LitPassVertex(LightweightVertexInput v)
 
     o.uv = TransformMainTextureCoord(v.texcoord);
 
-    float3 posWS = TransformObjectToWorld(v.vertex.xyz);
-    o.clipPos = TransformWorldToHClip(posWS);
+    o.posWSShininess.xyz = TransformObjectToWorld(v.vertex.xyz);
+    o.posWSShininess.w = _Shininess * 128.0;
+    o.clipPos = TransformWorldToHClip(o.posWSShininess.xyz);
 
-    half3 viewDir = VertexViewDirWS(GetCameraPositionWS() - posWS);
+    half3 viewDir = VertexViewDirWS(GetCameraPositionWS() - o.posWSShininess.xyz);
 
 #ifdef _NORMALMAP
     o.normal.w = viewDir.x;
@@ -107,7 +103,7 @@ LightweightVertexOutput LitPassVertex(LightweightVertexInput v)
     OUTPUT_LIGHTMAP_UV(v.lightmapUV, unity_LightmapST, o.lightmapUV);
     OUTPUT_SH(o.normal.xyz, o.vertexSH);
 
-    half3 vertexLight = VertexLighting(posWS, o.normal.xyz);
+    half3 vertexLight = VertexLighting(o.posWSShininess.xyz, o.normal.xyz);
     half fogFactor = ComputeFogFactor(o.clipPos.z);
     o.fogFactorAndVertexLight = half4(fogFactor, vertexLight);
 
@@ -115,32 +111,42 @@ LightweightVertexOutput LitPassVertex(LightweightVertexInput v)
 #if SHADOWS_SCREEN
     o.shadowCoord = ComputeShadowCoord(o.clipPos);
 #else
-    o.shadowCoord = TransformWorldToShadowCoord(posWS);
+    o.shadowCoord = TransformWorldToShadowCoord(o.posWSShininess.xyz);
 #endif
-#endif
-
-#if _ADDITIONAL_LIGHTS
-    o.posWS = posWS;
 #endif
 
     return o;
 }
 
-// Used in Standard (Physically Based) shader
-half4 LitPassFragment(LightweightVertexOutput IN) : SV_Target
+// Used for StandardSimpleLighting shader
+half4 LitPassFragmentSimple(LightweightVertexOutput IN) : SV_Target
 {
     UNITY_SETUP_INSTANCE_ID(IN);
 
-    SurfaceData surfaceData;
-    InitializeStandardLitSurfaceData(IN.uv, surfaceData);
+    float2 uv = IN.uv;
+    half4 diffuseAlpha = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv);
+    half3 diffuse = diffuseAlpha.rgb * _Color.rgb;
+
+    half alpha = diffuseAlpha.a * _Color.a;
+    AlphaDiscard(alpha, _Cutoff);
+#ifdef _ALPHAPREMULTIPLY_ON
+    diffuse *= alpha;
+#endif
+
+#ifdef _NORMALMAP
+    half3 normalTS = Normal(uv);
+#else
+    half3 normalTS = half3(0, 0, 1);
+#endif
+
+    half3 emission = Emission(uv);
+    half4 specularGloss = SpecularGloss(uv, diffuseAlpha.a);
+    half shininess = IN.posWSShininess.w;
 
     InputData inputData;
-    InitializeInputData(IN, surfaceData.normalTS, inputData);
+    InitializeInputData(IN, normalTS, inputData);
 
-    half4 color = LightweightFragmentPBR(inputData, surfaceData.albedo, surfaceData.metallic, surfaceData.specular, surfaceData.smoothness, surfaceData.occlusion, surfaceData.emission, surfaceData.alpha);
-
-    ApplyFog(color.rgb, inputData.fogCoord);
-    return color;
-}
+    return LightweightFragmentBlinnPhong(inputData, diffuse, specularGloss, shininess, emission, alpha);
+};
 
 #endif

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassLitSimple.hlsl.meta
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassLitSimple.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ee447e65526c7db45a978c16b28827a9
+timeCreated: 1488965025
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
@@ -19,7 +19,10 @@ SAMPLER(sampler_ScreenSpaceShadowMap);
 TEXTURE2D_SHADOW(_ShadowMap);
 SAMPLER_CMP(sampler_ShadowMap);
 
-CBUFFER_START(_ShadowBuffer)
+TEXTURE2D_SHADOW(_LocalShadowMapAtlas);
+SAMPLER_CMP(sampler_LocalShadowMapAtlas);
+
+CBUFFER_START(_DirectionalShadowBuffer)
 // Last cascade is initialized with a no-op matrix. It always transforms
 // shadow coord to half(0, 0, NEAR_PLANE). We use this trick to avoid
 // branching since ComputeCascadeIndex can return cascade index = MAX_SHADOW_CASCADES
@@ -34,15 +37,54 @@ half4       _ShadowData;    // (x: shadowStrength)
 float4      _ShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
 CBUFFER_END
 
+CBUFFER_START(_LocalShadowBuffer)
+float4x4    _LocalWorldToShadowAtlas[4];
+half4       _LocalShadowOffset0;
+half4       _LocalShadowOffset1;
+half4       _LocalShadowOffset2;
+half4       _LocalShadowOffset3;
+half4       _LocalShadowData;    // (x: shadowStrength)
+float4      _LocalShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
+CBUFFER_END
+
 #if UNITY_REVERSED_Z
 #define BEYOND_SHADOW_FAR(shadowCoord) shadowCoord.z <= UNITY_RAW_FAR_CLIP_VALUE
 #else
 #define BEYOND_SHADOW_FAR(shadowCoord) shadowCoord.z >= UNITY_RAW_FAR_CLIP_VALUE
 #endif
 
-half GetShadowStrength()
+struct ShadowSamplingData
 {
-    return _ShadowData.x;
+    half shadowStrength;
+    half4 shadowOffset0;
+    half4 shadowOffset1;
+    half4 shadowOffset2;
+    half4 shadowOffset3;
+    half4 shadowmapSize;
+};
+
+ShadowSamplingData GetMainLightShadowSamplingData()
+{
+    ShadowSamplingData shadowSamplingData;
+    shadowSamplingData.shadowStrength = _ShadowData.x;
+    shadowSamplingData.shadowOffset0 = _ShadowOffset0;
+    shadowSamplingData.shadowOffset1 = _ShadowOffset1;
+    shadowSamplingData.shadowOffset2 = _ShadowOffset2;
+    shadowSamplingData.shadowOffset3 = _ShadowOffset3;
+    shadowSamplingData.shadowmapSize = _ShadowmapSize;
+    return shadowSamplingData;
+}
+
+ShadowSamplingData GetLocalLightShadowSamplingData()
+{
+    ShadowSamplingData shadowSamplingData;
+    shadowSamplingData.shadowStrength = _LocalShadowData.x;
+    shadowSamplingData.shadowOffset0 = _LocalShadowOffset0;
+    shadowSamplingData.shadowOffset1 = _LocalShadowOffset1;
+    shadowSamplingData.shadowOffset2 = _LocalShadowOffset2;
+    shadowSamplingData.shadowOffset3 = _LocalShadowOffset3;
+    shadowSamplingData.shadowmapSize = _LocalShadowmapSize;
+    return shadowSamplingData;
 }
 
 inline half SampleScreenSpaceShadowMap(float4 shadowCoord)
@@ -61,9 +103,9 @@ inline half SampleScreenSpaceShadowMap(float4 shadowCoord)
     return attenuation;
 }
 
-inline real SampleShadowmap(float4 shadowCoord, float isPerspectiveProjection = 1.0)
+inline real SampleShadowmap(float4 shadowCoord, TEXTURE2D_SHADOW_ARGS(ShadowMap, sampler_ShadowMap), ShadowSamplingData samplingData, float isMainLight = 0.0)
 {
-    if (isPerspectiveProjection == 0.0)
+    if (isMainLight == 0.0)
         shadowCoord.xyz /= shadowCoord.w;
 
     real attenuation;
@@ -72,57 +114,57 @@ inline real SampleShadowmap(float4 shadowCoord, float isPerspectiveProjection = 
     #ifdef SHADER_API_MOBILE
         // 4-tap hardware comparison
         real4 attenuation4;
-        attenuation4.x = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset0.xyz);
-        attenuation4.y = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset1.xyz);
-        attenuation4.z = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset2.xyz);
-        attenuation4.w = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz + _ShadowOffset3.xyz);
+        attenuation4.x = SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, shadowCoord.xyz + samplingData.shadowOffset0.xyz);
+        attenuation4.y = SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, shadowCoord.xyz + samplingData.shadowOffset1.xyz);
+        attenuation4.z = SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, shadowCoord.xyz + samplingData.shadowOffset2.xyz);
+        attenuation4.w = SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, shadowCoord.xyz + samplingData.shadowOffset3.xyz);
         attenuation = dot(attenuation4, 0.25);
     #else
         #ifdef _SHADOWS_CASCADE //Assume screen space shadows when cascades enabled
             float fetchesWeights[16];
             float2 fetchesUV[16];
-            SampleShadow_ComputeSamples_Tent_7x7(_ShadowmapSize, shadowCoord.xy, fetchesWeights, fetchesUV);
+            SampleShadow_ComputeSamples_Tent_7x7(samplingData.shadowmapSize, shadowCoord.xy, fetchesWeights, fetchesUV);
 
-            attenuation  = fetchesWeights[0]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[0].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[1]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[1].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[2]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[2].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[3]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[3].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[4]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[4].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[5]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[5].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[6]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[6].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[7]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[7].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[8]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[8].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[9]  * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[9].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[10] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[10].xy, shadowCoord.z));
-            attenuation += fetchesWeights[11] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[11].xy, shadowCoord.z));
-            attenuation += fetchesWeights[12] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[12].xy, shadowCoord.z));
-            attenuation += fetchesWeights[13] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[13].xy, shadowCoord.z));
-            attenuation += fetchesWeights[14] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[14].xy, shadowCoord.z));
-            attenuation += fetchesWeights[15] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[15].xy, shadowCoord.z));
+            attenuation  = fetchesWeights[0]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[0].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[1]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[1].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[2]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[2].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[3]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[3].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[4]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[4].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[5]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[5].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[6]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[6].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[7]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[7].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[8]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[8].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[9]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[9].xy,  shadowCoord.z));
+            attenuation += fetchesWeights[10] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[10].xy, shadowCoord.z));
+            attenuation += fetchesWeights[11] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[11].xy, shadowCoord.z));
+            attenuation += fetchesWeights[12] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[12].xy, shadowCoord.z));
+            attenuation += fetchesWeights[13] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[13].xy, shadowCoord.z));
+            attenuation += fetchesWeights[14] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[14].xy, shadowCoord.z));
+            attenuation += fetchesWeights[15] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[15].xy, shadowCoord.z));
         #else
             float fetchesWeights[9];
             float2 fetchesUV[9];
             SampleShadow_ComputeSamples_Tent_5x5(_ShadowmapSize, shadowCoord.xy, fetchesWeights, fetchesUV);
 
-            attenuation  = fetchesWeights[0] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[0].xy, shadowCoord.z));
-            attenuation += fetchesWeights[1] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[1].xy, shadowCoord.z));
-            attenuation += fetchesWeights[2] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[2].xy, shadowCoord.z));
-            attenuation += fetchesWeights[3] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[3].xy, shadowCoord.z));
-            attenuation += fetchesWeights[4] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[4].xy, shadowCoord.z));
-            attenuation += fetchesWeights[5] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[5].xy, shadowCoord.z));
-            attenuation += fetchesWeights[6] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[6].xy, shadowCoord.z));
-            attenuation += fetchesWeights[7] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[7].xy, shadowCoord.z));
-            attenuation += fetchesWeights[8] * SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, float3(fetchesUV[8].xy, shadowCoord.z));
+            attenuation  = fetchesWeights[0] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[0].xy, shadowCoord.z));
+            attenuation += fetchesWeights[1] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[1].xy, shadowCoord.z));
+            attenuation += fetchesWeights[2] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[2].xy, shadowCoord.z));
+            attenuation += fetchesWeights[3] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[3].xy, shadowCoord.z));
+            attenuation += fetchesWeights[4] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[4].xy, shadowCoord.z));
+            attenuation += fetchesWeights[5] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[5].xy, shadowCoord.z));
+            attenuation += fetchesWeights[6] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[6].xy, shadowCoord.z));
+            attenuation += fetchesWeights[7] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[7].xy, shadowCoord.z));
+            attenuation += fetchesWeights[8] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[8].xy, shadowCoord.z));
         #endif
     #endif
 #else
     // 1-tap hardware comparison
-    attenuation = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz);
+    attenuation = SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, shadowCoord.xyz);
 #endif
 
 #if SHADER_HINT_NICE_QUALITY
     // Apply shadow strength
-    attenuation = LerpWhiteTo(attenuation, GetShadowStrength());
+    attenuation = LerpWhiteTo(attenuation, samplingData.shadowStrength);
 #endif
 
     // Shadow coords that fall out of the light frustum volume must always return attenuation 1.0
@@ -160,19 +202,27 @@ float4 ComputeShadowCoord(float4 clipPos)
     return ComputeScreenPos(clipPos);
 }
 
-half RealtimeShadowAttenuation(float4 shadowCoord, float isPerspectiveProjection = 1.0)
+half MainLightRealtimeShadowAttenuation(float4 shadowCoord)
 {
-#ifndef _SHADOWS_ENABLED
-    return 1.0h;
-#endif
-
-#if defined(NO_SHADOWS)
+#if defined(NO_SHADOWS) || !defined(_SHADOWS_ENABLED)
     return 1.0h;
 #elif SHADOWS_SCREEN
     return SampleScreenSpaceShadowMap(shadowCoord);
 #else
+    ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
+    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_ShadowMap, sampler_ShadowMap), shadowSamplingData, 1.0);
+#endif
 
-    return SampleShadowmap(shadowCoord, isPerspectiveProjection);
+}
+
+half LocalLightRealtimeShadowAttenuation(int lightIndex, float3 positionWS)
+{
+#if defined(NO_SHADOWS) || !defined(_LOCAL_SHADOWS_ENABLED)
+    return 1.0h;
+#else
+    float4 shadowCoord = mul(_LocalWorldToShadowAtlas[lightIndex], float4(positionWS, 1.0));
+    ShadowSamplingData shadowSamplingData = GetLocalLightShadowSamplingData();
+    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowMapAtlas, sampler_LocalShadowMapAtlas), shadowSamplingData, 0.0);
 #endif
 }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
@@ -61,9 +61,10 @@ inline half SampleScreenSpaceShadowMap(float4 shadowCoord)
     return attenuation;
 }
 
-inline real SampleShadowmap(float4 shadowCoord)
+inline real SampleShadowmap(float4 shadowCoord, float isPerspectiveProjection = 1.0)
 {
-    shadowCoord.xyz /= shadowCoord.w;
+    if (isPerspectiveProjection == 0.0)
+        shadowCoord.xyz /= shadowCoord.w;
 
     real attenuation;
 
@@ -159,7 +160,7 @@ float4 ComputeShadowCoord(float4 clipPos)
     return ComputeScreenPos(clipPos);
 }
 
-half RealtimeShadowAttenuation(float4 shadowCoord)
+half RealtimeShadowAttenuation(float4 shadowCoord, float isPerspectiveProjection = 1.0)
 {
 #ifndef _SHADOWS_ENABLED
     return 1.0h;
@@ -171,7 +172,7 @@ half RealtimeShadowAttenuation(float4 shadowCoord)
     return SampleScreenSpaceShadowMap(shadowCoord);
 #else
 
-    return SampleShadowmap(shadowCoord);
+    return SampleShadowmap(shadowCoord, isPerspectiveProjection);
 #endif
 }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
@@ -215,14 +215,15 @@ half MainLightRealtimeShadowAttenuation(float4 shadowCoord)
 
 }
 
-half LocalLightRealtimeShadowAttenuation(int lightIndex, float3 positionWS)
+half LocalLightRealtimeShadowAttenuation(int lightIndex, half castShadows, float3 positionWS)
 {
 #if defined(NO_SHADOWS) || !defined(_LOCAL_SHADOWS_ENABLED)
     return 1.0h;
 #else
     float4 shadowCoord = mul(_LocalWorldToShadowAtlas[lightIndex], float4(positionWS, 1.0));
     ShadowSamplingData shadowSamplingData = GetLocalLightShadowSamplingData();
-    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowMapAtlas, sampler_LocalShadowMapAtlas), shadowSamplingData, 0.0);
+    half attenuation = SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowMapAtlas, sampler_LocalShadowMapAtlas), shadowSamplingData, 0.0);
+    return (castShadows < 1.0h) ? 1.0h : attenuation;
 #endif
 }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightScreenSpaceShadows.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightScreenSpaceShadows.shader
@@ -83,7 +83,8 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
             float4 coords  = TransformWorldToShadowCoord(wpos);
 
             // Screenspace shadowmap is only used for directional lights which use orthogonal projection.
-            return SampleShadowmap(coords, 0.0);
+            ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
+            return SampleShadowmap(coords, TEXTURE2D_PARAM(_ShadowMap, sampler_ShadowMap), shadowSamplingData, 1.0);
         }
 
         ENDHLSL

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightScreenSpaceShadows.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightScreenSpaceShadows.shader
@@ -82,7 +82,8 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
             //Fetch shadow coordinates for cascade.
             float4 coords  = TransformWorldToShadowCoord(wpos);
 
-            return SampleShadowmap(coords);
+            // Screenspace shadowmap is only used for directional lights which use orthogonal projection.
+            return SampleShadowmap(coords, 0.0);
         }
 
         ENDHLSL

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandard.shader
@@ -99,6 +99,7 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             #pragma multi_compile _ _SHADOWS_ENABLED
+            #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
 
             // -------------------------------------
             // Unity defined keywords

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
@@ -97,7 +97,7 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
             #pragma vertex LitPassVertexSimple
             #pragma fragment LitPassFragmentSimple
             #define BUMP_SCALE_NOT_SUPPORTED 1
-            #include "LWRP/ShaderLibrary/LightweightPassLit.hlsl"
+            #include "LWRP/ShaderLibrary/LightweightPassLitSimple.hlsl"
             ENDHLSL
         }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardSimpleLighting.shader
@@ -83,6 +83,7 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
             #pragma multi_compile _ _VERTEX_LIGHTS
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             #pragma multi_compile _ _SHADOWS_ENABLED
+            #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
 
             // -------------------------------------
             // Unity defined keywords


### PR DESCRIPTION
- Fixed material upgrader softlocks editor
 - Fixed issue that material upgrader causing material upgrader to proceed even by clicking on dialog x button
 - Fixed issue that renderscale was not being applied to screenspace shadow occlusion texture
 - Added _ScaledScreenParams shader property to access camera scaled size
 - Excluded d3d11_9x from shader targets as we don't support it anymore
 - Fixed warning in Particles PBS shader
 - Added depth pass to Standard Unlit shader