### PR TITLE
Fixed an issue where putting Sky Lighting Override mask to "Everythin…

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/GlobalLightLoopSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/GlobalLightLoopSettingsUI.cs
@@ -65,6 +65,10 @@ namespace UnityEditor.Experimental.Rendering
             ++EditorGUI.indentLevel;
             EditorGUILayout.PropertyField(d.skyReflectionSize, _.GetContent("Sky Reflection Size"));
             EditorGUILayout.PropertyField(d.skyLightingOverrideLayerMask, _.GetContent("Sky Lighting Override Mask|This layer mask will define in which layers the sky system will look for sky settings volumes for lighting override"));
+            if(d.skyLightingOverrideLayerMask.intValue == -1)
+            {
+                EditorGUILayout.HelpBox("Be careful, Sky Lighting Override Mask is set to Everything. This is most likely a mistake as it serves no purpose.", MessageType.Warning);
+            }
             --EditorGUI.indentLevel;
         }
     }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -620,11 +620,33 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             }
                             else
                             {
-                                // Temporary hack. For scene view, by default, we don't want to have the lighting override layers in the current sky.
+                                // Temporary hack:
+                                // For scene view, by default, we use the "main" camera volume layer mask if it exists
+                                // Otherwise we just remove the lighting override layers in the current sky to avoid conflicts
                                 // This is arbitrary and should be editable in the scene view somehow.
                                 if (camera.cameraType == CameraType.SceneView)
                                 {
-                                    layerMask = (-1 & ~m_Asset.renderPipelineSettings.lightLoopSettings.skyLightingOverrideLayerMask);
+                                    var mainCamera = Camera.main;
+                                    bool needFallback = true;
+                                    if (mainCamera != null)
+                                    {
+                                        var mainCamAdditionalData = mainCamera.GetComponent<HDAdditionalCameraData>();
+                                        if (mainCamAdditionalData != null)
+                                        {
+                                            layerMask = mainCamAdditionalData.volumeLayerMask;
+                                            needFallback = false;
+                                        }
+                                    }
+                                    
+                                    if (needFallback)
+                                    {
+                                        // If the override layer is "Everything", we fall-back to "Everything" for the current layer mask to avoid issues by having no current layer
+                                        // In practice we should never have "Everything" as an override mask as it does not make sense (a warning is issued in the UI)
+                                        if (m_Asset.renderPipelineSettings.lightLoopSettings.skyLightingOverrideLayerMask == -1)
+                                            layerMask = -1;
+                                        else
+                                            layerMask = (-1 & ~m_Asset.renderPipelineSettings.lightLoopSettings.skyLightingOverrideLayerMask);
+                                    }
                                 }
                             }
                             VolumeManager.instance.Update(camera.transform, layerMask);
@@ -803,7 +825,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             renderContext.ExecuteCommandBuffer(cmd);
                             cmd.Clear();
 
-                            buildGPULightListsCompleteFence = m_LightLoop.BuildGPULightListsAsyncBegin(hdCamera, renderContext, m_CameraDepthStencilBuffer, m_CameraStencilBufferCopy, startFence, m_SkyManager.IsSkyValid());
+                            buildGPULightListsCompleteFence = m_LightLoop.BuildGPULightListsAsyncBegin(hdCamera, renderContext, m_CameraDepthStencilBuffer, m_CameraStencilBufferCopy, startFence, m_SkyManager.IsLightingSkyValid());
                         }
 
                         using (new ProfilingSample(cmd, "Render shadows", CustomSamplerId.RenderShadows.GetSampler()))
@@ -833,7 +855,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         {
                             using (new ProfilingSample(cmd, "Build Light list", CustomSamplerId.BuildLightList.GetSampler()))
                             {
-                                m_LightLoop.BuildGPULightLists(hdCamera, cmd, m_CameraDepthStencilBuffer, m_CameraStencilBufferCopy, m_SkyManager.IsSkyValid());
+                                m_LightLoop.BuildGPULightLists(hdCamera, cmd, m_CameraDepthStencilBuffer, m_CameraStencilBufferCopy, m_SkyManager.IsLightingSkyValid());
                             }
                         }
 
@@ -1675,7 +1697,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     if (hdCamera.clearColorMode == HDAdditionalCameraData.ClearColorMode.BackgroundColor ||
                         // If we want the sky but the sky don't exist, still clear with background color
-                        (hdCamera.clearColorMode == HDAdditionalCameraData.ClearColorMode.Sky && !m_SkyManager.IsSkyValid()) ||
+                        (hdCamera.clearColorMode == HDAdditionalCameraData.ClearColorMode.Sky && !m_SkyManager.IsVisualSkyValid()) ||
                         // Special handling for Preview we force to clear with background color (i.e black)
                         // Note that the sky use in this case is the last one setup. If there is no scene or game, there is no sky use as reflection in the preview
                         hdCamera.camera.cameraType == CameraType.Preview

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyManager.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/SkyManager.cs
@@ -209,11 +209,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_SkyRenderingContext.Cleanup();
         }
 
-        public bool IsSkyValid()
+        public bool IsLightingSkyValid()
         {
             return m_VisualSky.IsValid() || m_LightingOverrideSky.IsValid();
         }
 
+        public bool IsVisualSkyValid()
+        {
+            return m_VisualSky.IsValid();
+        }
 
         void BlitCubemap(CommandBuffer cmd, Cubemap source, RenderTexture dest)
         {
@@ -284,7 +288,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_UpdateRequired = false;
 
             SetGlobalSkyTexture(cmd);
-            if (IsSkyValid())
+            if (IsLightingSkyValid())
             {
                 cmd.SetGlobalInt(HDShaderIDs._EnvLightSkyEnabled, 1);
             }


### PR DESCRIPTION
…g" would cause the scene view background not to be cleared anymore

- Now clearing background only test the validity of the "Visual Sky" (instead of testing also the "Lighting Sky")
- Added a warning if "Everything" is set as a Sky Lighting Override Mask
- Changed the behavior of SceneView wrt to Volume layer mask. Now it uses the mask of the "main camera" if it exists, otherwise we use Everything minus Lighting Override Mask