### PR TITLE
For opaques use decal diffuse alpha for all channels.

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Decal/DecalData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Decal/DecalData.hlsl
@@ -14,6 +14,7 @@ void GetSurfaceData(float2 texCoordDS, float4x4 decalToWorld, out DecalSurfaceDa
 #if _COLORMAP
 	surfaceData.baseColor = SAMPLE_TEXTURE2D(_BaseColorMap, sampler_BaseColorMap, texCoordDS.xy);
 	surfaceData.baseColor.w *= totalBlend;
+	totalBlend = surfaceData.baseColor.w;	// base alpha affects aall other channels;
 	surfaceData.HTileMask |= DBUFFERHTILEBIT_DIFFUSE;
 #endif
 #if _NORMALMAP

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/LayeredLit/LayeredLitData.hlsl
@@ -759,7 +759,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #endif
 
 #ifndef _DISABLE_DBUFFER
-    AddDecalContribution(posInput, surfaceData);
+    AddDecalContribution(posInput, surfaceData, alpha);
 #endif
 
 #if defined(DEBUG_DISPLAY)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/LitData.hlsl
@@ -220,7 +220,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
 
 #ifndef _DISABLE_DBUFFER
-    AddDecalContribution(posInput, surfaceData);
+    AddDecalContribution(posInput, surfaceData, alpha);
 #endif
 
 #if defined(DEBUG_DISPLAY)


### PR DESCRIPTION
For transparent, if material alpha is less than decal alpha replace it with decal alpha.