### PR TITLE
Fixed Y-flip in LW when a camera is rendering to a RT

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -1449,7 +1449,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             m_PostProcessRenderContext.sourceFormat = m_ColorFormat;
             m_PostProcessRenderContext.destination = dest;
             m_PostProcessRenderContext.command = cmd;
-            m_PostProcessRenderContext.flip = true;
+            m_PostProcessRenderContext.flip = m_CurrCamera.targetTexture == null;
 
             if (opaqueOnly)
             {


### PR DESCRIPTION
Refer to [this issue](https://github.com/Unity-Technologies/PostProcessing/issues/523). Also applies to HD, separate PR coming.