### PR TITLE
Fixed Y-flip in HD when a camera is rendering to a RT

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -1591,7 +1591,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 context.command = cmd;
                 context.camera = hdcamera.camera;
                 context.sourceFormat = RenderTextureFormat.ARGBHalf;
-                context.flip = true;
+                context.flip = hdcamera.camera.targetTexture == null;
 
                 layer.Render(context);
             }


### PR DESCRIPTION
Refer to [this issue](https://github.com/Unity-Technologies/PostProcessing/issues/523). Also applies to LW, separate PR coming.