### PR TITLE
Lw/fix shadow tile initialization

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -127,7 +127,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
         private CameraComparer m_CameraComparer = new CameraComparer();
 
-        private Mesh m_BlitQuad;
         private Material m_BlitMaterial;
         private Material m_CopyDepthMaterial;
         private Material m_ErrorMaterial;
@@ -195,7 +194,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             Shader.globalRenderPipeline = "LightweightPipeline";
 
-            m_BlitQuad = LightweightUtils.CreateQuadMesh(false);
             m_BlitMaterial = CoreUtils.CreateEngineMaterial(m_Asset.BlitShader);
             m_CopyDepthMaterial = CoreUtils.CreateEngineMaterial(m_Asset.CopyDepthShader);
             m_SamplingMaterial = CoreUtils.CreateEngineMaterial(m_Asset.SamplingShader);
@@ -1127,13 +1125,12 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             }
             else
             {
-                if (m_BlitQuad == null)
-                    m_BlitQuad = LightweightUtils.CreateQuadMesh(false);
-
+                // Viewport doesn't work when rendering to an RT
+                // We have to manually blit by rendering a fullscreen quad
                 SetRenderTarget(cmd, destRT);
                 cmd.SetViewProjectionMatrices(Matrix4x4.identity, Matrix4x4.identity);
                 cmd.SetViewport(m_CurrCamera.pixelRect);
-                cmd.DrawMesh(m_BlitQuad, Matrix4x4.identity, material);
+                LightweightUtils.DrawFullScreen(cmd, m_BlitMaterial);
             }
         }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
@@ -65,7 +65,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         public static void DrawFullScreen(CommandBuffer commandBuffer, Material material,
             MaterialPropertyBlock properties = null, int shaderPassId = 0)
         {
-            commandBuffer.DrawMesh(fullscreenMesh, Matrix4x4.identity, material, 0, 0, properties);
+            commandBuffer.DrawMesh(fullscreenMesh, Matrix4x4.identity, material, 0, shaderPassId, properties);
         }
 
         public static void StartStereoRendering(Camera camera, ref ScriptableRenderContext context, FrameRenderingConfiguration renderingConfiguration)

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine.Rendering;
 
 namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 {
@@ -27,6 +28,46 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
     public static class LightweightUtils
     {
+        static Mesh s_FullscreenMesh = null;
+        public static Mesh fullscreenMesh
+        {
+            get
+            {
+                if (s_FullscreenMesh != null)
+                    return s_FullscreenMesh;
+
+                float topV = 1.0f;
+                float bottomV = 0.0f;
+
+                Mesh mesh = new Mesh {name = "Fullscreen Quad"};
+                mesh.SetVertices(new List<Vector3>
+                {
+                    new Vector3(-1.0f, -1.0f, 0.0f),
+                    new Vector3(-1.0f,  1.0f, 0.0f),
+                    new Vector3( 1.0f, -1.0f, 0.0f),
+                    new Vector3( 1.0f,  1.0f, 0.0f)
+                });
+
+                mesh.SetUVs(0, new List<Vector2>
+                {
+                    new Vector2(0.0f, bottomV),
+                    new Vector2(0.0f, topV),
+                    new Vector2(1.0f, bottomV),
+                    new Vector2(1.0f, topV)
+                });
+
+                mesh.SetIndices(new[] { 0, 1, 2, 2, 1, 3 }, MeshTopology.Triangles, 0, false);
+                mesh.UploadMeshData(true);
+                return mesh;
+            }
+        }
+
+        public static void DrawFullScreen(CommandBuffer commandBuffer, Material material,
+            MaterialPropertyBlock properties = null, int shaderPassId = 0)
+        {
+            commandBuffer.DrawMesh(fullscreenMesh, Matrix4x4.identity, material, 0, 0, properties);
+        }
+
         public static void StartStereoRendering(Camera camera, ref ScriptableRenderContext context, FrameRenderingConfiguration renderingConfiguration)
         {
             if (HasFlag(renderingConfiguration, FrameRenderingConfiguration.Stereo))
@@ -101,41 +142,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         public static bool HasFlag(FrameRenderingConfiguration mask, FrameRenderingConfiguration flag)
         {
             return (mask & flag) != 0;
-        }
-
-        public static Mesh CreateQuadMesh(bool uvStartsAtTop)
-        {
-            float topV, bottomV;
-            if (uvStartsAtTop)
-            {
-                topV = 0.0f;
-                bottomV = 1.0f;
-            }
-            else
-            {
-                topV = 1.0f;
-                bottomV = 0.0f;
-            }
-
-            Mesh mesh = new Mesh();
-            mesh.vertices = new Vector3[]
-            {
-                new Vector3(-1.0f, -1.0f, 0.0f),
-                new Vector3(-1.0f,  1.0f, 0.0f),
-                new Vector3(1.0f, -1.0f, 0.0f),
-                new Vector3(1.0f,  1.0f, 0.0f)
-            };
-
-            mesh.uv = new Vector2[]
-            {
-                new Vector2(0.0f, bottomV),
-                new Vector2(0.0f, topV),
-                new Vector2(1.0f, bottomV),
-                new Vector2(1.0f, topV)
-            };
-
-            mesh.triangles = new int[] { 0, 1, 2, 2, 1, 3 };
-            return mesh;
         }
     }
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightShadowPass.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightShadowPass.cs
@@ -202,6 +202,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             // stereo functionality, we use the screen-space shadow map as the source (until we have
             // a better solution).
             // An alternative would be DrawProcedural, but that would require further changes in the shader.
+            cmd.SetRenderTarget(m_ScreenSpaceShadowmapTexture);
+            cmd.ClearRenderTarget(true, true, Color.white);
             cmd.Blit(m_ScreenSpaceShadowmapTexture, m_ScreenSpaceShadowmapTexture, m_ScreenSpaceShadowsMaterial);
 
             LightweightUtils.StartStereoRendering(camera, ref context, frameRenderingConfiguration);


### PR DESCRIPTION
 - Added Clear to Screenspace shadow occlusion texture to avoid Tile LOAD
 - Moved BlitQuad to a static mesh in LightweightUtils