### PR TITLE
API validation improvement

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -165,7 +165,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         RTHandle                        m_DebugColorPickerBuffer;
         RTHandle                        m_DebugFullScreenTempBuffer;
         bool                            m_FullScreenDebugPushed;
-        bool                            m_NoRendering; // False by default mean we render normally, true mean we don't render anything
+        bool                            m_ValidAPI; // False by default mean we render normally, true mean we don't render anything
 
         public Material GetBlitMaterial() { return m_Blit; }
 
@@ -173,7 +173,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public HDRenderPipeline(HDRenderPipelineAsset asset)
         {
-            SetRenderingFeatures();
+            m_ValidAPI = true;
+
+            if (!SetRenderingFeatures())
+            {
+                m_ValidAPI = false;
+
+                return ;
+            }            
 
             m_Asset = asset;
             m_GPUCopy = new GPUCopy(asset.renderPipelineResources.copyChannelCS);
@@ -322,7 +329,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
 
-        void SetRenderingFeatures()
+        bool SetRenderingFeatures()
         {
             // Set subshader pipeline tag
             Shader.globalRenderPipeline = "HDRenderPipeline";
@@ -354,13 +361,20 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 Debug.LogError("High Definition Render Pipeline doesn't support Gamma mode, change to Linear mode");
             }
 #endif
-            m_NoRendering = false;
 
             if (!IsSupportedPlatform())
             {
                 Debug.LogError("Platform " + SystemInfo.operatingSystem + " with device " + SystemInfo.graphicsDeviceType.ToString() + " is not supported, no rendering will occur");
-                m_NoRendering = true;
+
+#if UNITY_EDITOR
+                foreach (UnityEditor.SceneView sv in Resources.FindObjectsOfTypeAll(typeof(UnityEditor.SceneView)))
+                    sv.ShowNotification(new GUIContent("Platform " + SystemInfo.operatingSystem + " with device " + SystemInfo.graphicsDeviceType.ToString() + " is not supported, no rendering will occur"));
+#endif                
+
+                return false;
             }
+
+            return true;
         }
 
         bool IsSupportedPlatform()
@@ -446,6 +460,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public override void Dispose()
         {
+            UnsetRenderingFeatures();
+
+            if (!m_ValidAPI)
+                return ;
+
             base.Dispose();
 
             m_DebugDisplaySettings.UnregisterDebug();
@@ -477,8 +496,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_IBLFilterGGX.Cleanup();
 
             DestroyRenderTextures();
-
-            UnsetRenderingFeatures();
 
 #if UNITY_EDITOR
             SceneViewDrawMode.ResetDrawMode();
@@ -585,7 +602,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         ReflectionProbeCullResults m_ReflectionProbeCullResults;
         public override void Render(ScriptableRenderContext renderContext, Camera[] cameras)
         {
-            if (m_NoRendering)
+            if (!m_ValidAPI)
                 return;
 
             base.Render(renderContext, cameras);


### PR DESCRIPTION
With this PR, there is now a notification on SceneView about not supporting a particular API + remove various error from the log.

Note: To work perfectly, we need to be able to detect API change, this should be handled in C++, at API change we should recreate the HDRenderPipeline. As currently it is not the case we have no way to detect API change and once you get nothing rendering due to API unsupported you need to remove the asset and assign it again we settings a new working API