### PR TITLE
Add spot reflector option to modulate light intensity with spot angle.

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.Styles.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.Styles.cs
@@ -42,7 +42,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             public readonly GUIContent shape = new GUIContent("Type", "Specifies the current type of light. Possible types are Directional, Spot, Point, Rectangle and Line lights.");
             public readonly GUIContent[] shapeNames;
-            public readonly GUIContent spotBackReflector = new GUIContent("Enable light reflector", "Is the light reflected in the back in the spot cone.");
+            public readonly GUIContent enableSpotReflector = new GUIContent("Enable spot reflector", "When true it simulate a spot light with reflector (mean the intensity of the light will be more focus with narrower angle), otherwise light outside of the cone is simply absorbed (mean intensity is constent whatever the size of the cone).");
 
             // Additional shadow data
             public readonly GUIContent shadowResolution = new GUIContent("Resolution", "Controls the rendered resolution of the shadow maps. A higher resolution will increase the fidelity of shadows at the cost of GPU performance and memory usage.");

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.Styles.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.Styles.cs
@@ -42,6 +42,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             public readonly GUIContent shape = new GUIContent("Type", "Specifies the current type of light. Possible types are Directional, Spot, Point, Rectangle and Line lights.");
             public readonly GUIContent[] shapeNames;
+            public readonly GUIContent spotBackReflector = new GUIContent("Enable light reflector", "Is the light reflected in the back in the spot cone.");
 
             // Additional shadow data
             public readonly GUIContent shadowResolution = new GUIContent("Resolution", "Controls the rendered resolution of the shadow maps. A higher resolution will increase the fidelity of shadows at the cost of GPU performance and memory usage.");

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
@@ -366,7 +366,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                             var angleA = settings.spotAngle.floatValue * Mathf.Deg2Rad;
 
                             var halfAngle = angleA * 0.5f; // half of the smallest angle
-                            var length = Mathf.Sin(halfAngle); // half length of the smallest side of the rectangle
+                            var length = Mathf.Tan(halfAngle); // half length of the smallest side of the rectangle
                             length *= aspectRatio; // half length of the bigest side of the rectangle
                             halfAngle = Mathf.Atan(length); // half of the bigest angle
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
@@ -35,6 +35,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public SerializedProperty affectSpecular;
             public SerializedProperty lightTypeExtent;
             public SerializedProperty spotLightShape;
+            public SerializedProperty spotBackReflector;
             public SerializedProperty shapeWidth;
             public SerializedProperty shapeHeight;
             public SerializedProperty aspectRatio;
@@ -114,6 +115,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 affectSpecular = o.Find(x => x.affectSpecular),
                 lightTypeExtent = o.Find(x => x.lightTypeExtent),
                 spotLightShape = o.Find(x => x.spotLightShape),
+                spotBackReflector = o.Find(x => x.spotBackReflector),
                 shapeWidth = o.Find(x => x.shapeWidth),
                 shapeHeight = o.Find(x => x.shapeHeight),
                 aspectRatio = o.Find(x => x.aspectRatio),
@@ -262,12 +264,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     if (spotLightShape == SpotLightShape.Cone)
                     {
                         settings.DrawSpotAngle();
+                        EditorGUILayout.PropertyField(m_AdditionalLightData.spotBackReflector, s_Styles.spotBackReflector);
                         EditorGUILayout.Slider(m_AdditionalLightData.spotInnerPercent, 0f, 100f, s_Styles.spotInnerPercent);
                     }
                     // TODO : replace with angle and ratio
                     else if (spotLightShape == SpotLightShape.Pyramid)
                     {
                         settings.DrawSpotAngle();
+                        EditorGUILayout.PropertyField(m_AdditionalLightData.spotBackReflector, s_Styles.spotBackReflector);
                         EditorGUILayout.Slider(m_AdditionalLightData.aspectRatio, 0.05f, 20.0f, s_Styles.aspectRatioPyramid);
                     }
                     else if (spotLightShape == SpotLightShape.Box)
@@ -344,9 +348,40 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 case LightShape.Spot:
                     // Spot should used conversion which take into account the angle, and thus the intensity vary with angle.
                     // This is not easy to manipulate for lighter, so we simply consider any spot light as just occluded point light. So reuse the same code.
-                    settings.intensity.floatValue = LightUtils.ConvertPointLightIntensity(m_AdditionalLightData.punctualIntensity.floatValue);
-                    // TODO: What to do with box shape ?
-                    // var spotLightShape = (SpotLightShape)m_AdditionalLightData.spotLightShape.enumValueIndex;
+
+                    var spotLightShape = (SpotLightShape)m_AdditionalLightData.spotLightShape.enumValueIndex;
+                    if (spotLightShape == SpotLightShape.Cone)
+                    {
+                        settings.intensity.floatValue = LightUtils.ConvertSpotLightIntensity(m_AdditionalLightData.punctualIntensity.floatValue, settings.spotAngle.floatValue * Mathf.Deg2Rad, m_AdditionalLightData.spotBackReflector.boolValue );
+                    }
+                    else if (spotLightShape == SpotLightShape.Pyramid)
+                    {
+                        if (m_AdditionalLightData.spotBackReflector.boolValue)
+                        {
+                            var aspectRatio = m_AdditionalLightData.aspectRatio.floatValue;
+                            // Since the smallest angles is = to the fov, and we don't care of the angle order, simply make sure the aspect ratio is > 1
+                            if ( aspectRatio < 1f ) aspectRatio = 1f/aspectRatio;
+
+                            var angleA = settings.spotAngle.floatValue * Mathf.Deg2Rad;
+
+                            var halfAngle = angleA * 0.5f;
+                            var length = Mathf.Sin(halfAngle);
+                            length *= aspectRatio;
+                            halfAngle = Mathf.Atan(length);
+
+                            var angleB = halfAngle * 2f;
+
+                            settings.intensity.floatValue = LightUtils.ConvertFrustrumLightIntensity(m_AdditionalLightData.punctualIntensity.floatValue, angleA, angleB );
+                        }
+                        else
+                        {
+                            settings.intensity.floatValue = LightUtils.ConvertPointLightIntensity(m_AdditionalLightData.punctualIntensity.floatValue);
+                        }
+                    }
+                    else // box shape, no conversion implemented for the moment. Should use a fresnel light model.
+                    {
+                        settings.intensity.floatValue = LightUtils.ConvertPointLightIntensity(m_AdditionalLightData.punctualIntensity.floatValue);
+                    }
                     break;
 
                 case LightShape.Rectangle:

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Light/HDAdditionalLightData.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Light/HDAdditionalLightData.cs
@@ -58,7 +58,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public SpotLightShape spotLightShape = SpotLightShape.Cone;
 
         // Only for Spotlight, should be hide for other light
-        public bool spotBackReflector = false;
+        public bool enableSpotReflector = false;
 
         // Only for Rectangle/Line/box projector lights
         public float shapeWidth = 0.5f;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Light/HDAdditionalLightData.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Light/HDAdditionalLightData.cs
@@ -57,6 +57,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // Only for Spotlight, should be hide for other light
         public SpotLightShape spotLightShape = SpotLightShape.Cone;
 
+        // Only for Spotlight, should be hide for other light
+        public bool spotBackReflector = false;
+
         // Only for Rectangle/Line/box projector lights
         public float shapeWidth = 0.5f;
 


### PR DESCRIPTION
Seb, please check the maths for the frustom spot intensity. Calculation seems correct, but visually it doesn't match with cone at 180° angle, where it should be similar.