### PR TITLE
RC bugfixes

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightStandardGUI.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightStandardGUI.cs
@@ -45,7 +45,7 @@ namespace UnityEditor
 
         private MaterialProperty albedoColor;
         private MaterialProperty albedoMap;
-        
+
         private MaterialProperty smoothness;
         private MaterialProperty smoothnessScale;
         private MaterialProperty smoothnessMapChannel;
@@ -71,7 +71,7 @@ namespace UnityEditor
             workflowMode = FindProperty("_WorkflowMode", properties);
             albedoColor = FindProperty("_Color", properties);
             albedoMap = FindProperty("_MainTex", properties);
-            
+
             smoothness = FindProperty("_Glossiness", properties);
             smoothnessScale = FindProperty("_GlossMapScale", properties, false);
             smoothnessMapChannel = FindProperty("_SmoothnessTextureChannel", properties, false);
@@ -106,10 +106,9 @@ namespace UnityEditor
             // Detect any changes to the material
             EditorGUI.BeginChangeCheck();
             {
+                DoPopup(Styles.workflowModeText, workflowMode, Styles.workflowNames);
                 base.ShaderPropertiesGUI(material);
                 GUILayout.Label(Styles.surfaceProperties, EditorStyles.boldLabel);
-
-                DoPopup(Styles.workflowModeText, workflowMode, Styles.workflowNames);
 
                 DoAlbedoArea();
                 DoMetallicSpecularArea();

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightStandardParticlesShaderGUI.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightStandardParticlesShaderGUI.cs
@@ -121,8 +121,8 @@ namespace UnityEditor
             metallicMap = FindProperty("_MetallicGlossMap", props, false);
             metallic = FindProperty("_Metallic", props, false);
             smoothness = FindProperty("_Glossiness", props, false);
-            bumpScale = FindProperty("_BumpScale", props);
-            bumpMap = FindProperty("_BumpMap", props);
+            bumpScale = FindProperty("_BumpScale", props, false);
+            bumpMap = FindProperty("_BumpMap", props, false);
             emissionEnabled = FindProperty("_EmissionEnabled", props);
             emissionColorForRendering = FindProperty("_EmissionColor", props);
             emissionMap = FindProperty("_EmissionMap", props);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightStandardSimpleLightingGUI.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightStandardSimpleLightingGUI.cs
@@ -7,13 +7,8 @@ using UnityEngine.Experimental.Rendering;
 public class LightweightStandardSimpleLightingGUI : LightweightShaderGUI
 {
     private const float kMinShininessValue = 0.01f;
-    private MaterialProperty surfaceTypeProp;
-    private MaterialProperty blendModeProp;
-    private MaterialProperty culling;
-    private MaterialProperty alphaClip;
     private MaterialProperty albedoMapProp;
     private MaterialProperty albedoColorProp;
-    private MaterialProperty alphaThresholdProp;
     private MaterialProperty specularSourceProp;
     private MaterialProperty glossinessSourceProp;
     private MaterialProperty specularGlossMapProp;
@@ -25,9 +20,6 @@ public class LightweightStandardSimpleLightingGUI : LightweightShaderGUI
 
     private static class Styles
     {
-        public static GUIContent twoSidedLabel = new GUIContent("Two Sided", "Render front and back faces");
-        public static GUIContent alphaClipLabel = new GUIContent("Alpha Clip", "Enable Alpha Clip");
-
         public static GUIContent[] albedoGlosinessLabels =
         {
             new GUIContent("Base (RGB) Glossiness (A)", "Base Color (RGB) and Glossiness (A)"),
@@ -46,34 +38,25 @@ public class LightweightStandardSimpleLightingGUI : LightweightShaderGUI
         public static GUIContent normalMapText = new GUIContent("Normal Map", "Normal Map");
         public static GUIContent emissionMapLabel = new GUIContent("Emission Map", "Emission Map");
 
-        public static readonly string[] surfaceNames = Enum.GetNames(typeof(SurfaceType));
-        public static readonly string[] blendNames = Enum.GetNames(typeof(UpgradeBlendMode));
         public static readonly string[] glossinessSourceNames = Enum.GetNames(typeof(GlossinessSource));
 
-        public static string surfaceTypeLabel = "Surface Type";
-        public static string blendingModeLabel = "Blending Mode";
+        public static string surfaceProperties = "Surface Properties";
         public static string specularSourceLabel = "Specular";
         public static string glossinessSourceLabel = "Glossiness Source";
         public static string glossinessSource = "Glossiness Source";
         public static string albedoColorLabel = "Base Color";
         public static string albedoMapAlphaLabel = "Base(RGB) Alpha(A)";
         public static string albedoMapGlossinessLabel = "Base(RGB) Glossiness (A)";
-        public static string clipThresholdLabel = "Clip Threshold";
         public static string shininessLabel = "Shininess";
         public static string normalMapLabel = "Normal map";
         public static string emissionColorLabel = "Emission Color";
-        public static string advancedText = "Advanced Options";
     }
 
     public override void FindProperties(MaterialProperty[] properties)
     {
-        surfaceTypeProp = FindProperty("_Surface", properties);
-        blendModeProp = FindProperty("_Blend", properties);
-        culling = FindProperty("_Cull", properties);
-        alphaClip  = FindProperty("_AlphaClip", properties);
+        base.FindProperties(properties);
         albedoMapProp = FindProperty("_MainTex", properties);
         albedoColorProp = FindProperty("_Color", properties);
-        alphaThresholdProp = FindProperty("_Cutoff", properties);
         specularSourceProp = FindProperty("_SpecSource", properties);
         glossinessSourceProp = FindProperty("_GlossinessSource", properties);
         specularGlossMapProp = FindProperty("_SpecGlossMap", properties);
@@ -88,6 +71,8 @@ public class LightweightStandardSimpleLightingGUI : LightweightShaderGUI
     {
         EditorGUI.BeginChangeCheck();
         {
+            base.ShaderPropertiesGUI(material);
+            GUILayout.Label(Styles.surfaceProperties, EditorStyles.boldLabel);
             DoSurfaceArea();
             DoSpecular();
 
@@ -101,20 +86,15 @@ public class LightweightStandardSimpleLightingGUI : LightweightShaderGUI
             m_MaterialEditor.TextureScaleOffsetProperty(albedoMapProp);
             if (EditorGUI.EndChangeCheck())
                 emissionMapProp.textureScaleAndOffset = albedoMapProp.textureScaleAndOffset; // Apply the main texture scale and offset to the emission texture as well, for Enlighten's sake
-
-            GUILayout.Label(Styles.advancedText, EditorStyles.boldLabel);
-            EditorGUI.indentLevel++;
-            m_MaterialEditor.EnableInstancingField();
-            EditorGUI.indentLevel--;
         }
+
         if (EditorGUI.EndChangeCheck())
         {
             foreach (var obj in blendModeProp.targets)
                 MaterialChanged((Material)obj);
         }
 
-        EditorGUILayout.Space();
-        EditorGUILayout.Space();
+        DoMaterialRenderingOptions();
     }
 
     public override void MaterialChanged(Material material)
@@ -180,38 +160,14 @@ public class LightweightStandardSimpleLightingGUI : LightweightShaderGUI
     private bool RequiresAlpha()
     {
         SurfaceType surfaceType = (SurfaceType) surfaceTypeProp.floatValue;
-        return alphaClip.floatValue > 0.0f || surfaceType == SurfaceType.Transparent;
+        return alphaClipProp.floatValue > 0.0f || surfaceType == SurfaceType.Transparent;
     }
 
     private void DoSurfaceArea()
     {
-        int surfaceTypeValue = (int)surfaceTypeProp.floatValue;
-        EditorGUI.BeginChangeCheck();
-        surfaceTypeValue = EditorGUILayout.Popup(Styles.surfaceTypeLabel, surfaceTypeValue, Styles.surfaceNames);
-        if (EditorGUI.EndChangeCheck())
-            surfaceTypeProp.floatValue = surfaceTypeValue;
-
-        if((SurfaceType)surfaceTypeValue == SurfaceType.Transparent)
-        {
-            int blendModeValue = (int)blendModeProp.floatValue;
-            EditorGUI.BeginChangeCheck();
-            blendModeValue = EditorGUILayout.Popup(Styles.blendingModeLabel, blendModeValue, Styles.blendNames);
-            if (EditorGUI.EndChangeCheck())
-                blendModeProp.floatValue = blendModeValue;
-        }
-
-        EditorGUI.BeginChangeCheck();
-        bool twoSidedEnabled = EditorGUILayout.Toggle(Styles.twoSidedLabel, culling.floatValue == 0);
-        if (EditorGUI.EndChangeCheck())
-            culling.floatValue = twoSidedEnabled ? 0 : 2;
-
-        EditorGUI.BeginChangeCheck();
-        bool alphaClipEnabled = EditorGUILayout.Toggle(Styles.alphaClipLabel, alphaClip.floatValue == 1);
-        if (EditorGUI.EndChangeCheck())
-            alphaClip.floatValue = alphaClipEnabled ? 1 : 0;
-
         EditorGUILayout.Space();
 
+        int surfaceTypeValue = (int)surfaceTypeProp.floatValue;
         if ((SurfaceType)surfaceTypeValue == SurfaceType.Opaque)
         {
             int glossSource = (int)glossinessSourceProp.floatValue;
@@ -222,8 +178,6 @@ public class LightweightStandardSimpleLightingGUI : LightweightShaderGUI
         {
             m_MaterialEditor.TexturePropertySingleLine(Styles.albedoAlphaLabel, albedoMapProp, albedoColorProp);
         }
-        if (alphaClipEnabled)
-            m_MaterialEditor.ShaderProperty(alphaThresholdProp, Styles.clipThresholdLabel, MaterialEditor.kMiniTextureFieldLabelIndentLevel + 1);
     }
 
     private void DoSpecular()

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightUnlitGUI.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightUnlitGUI.cs
@@ -1,55 +1,32 @@
 using System;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Experimental.Rendering.LightweightPipeline;
 using UnityEngine.Experimental.Rendering;
 
 public class LightweightUnlitGUI : LightweightShaderGUI
 {
-    public enum UnlitBlendMode
-    {
-        Alpha,   // Old school alpha-blending mode, fresnel does not affect amount of transparency
-        Additive,
-        Multiply
-    }
-
-    private MaterialProperty surfaceTypeProp;
-    private MaterialProperty blendModeProp;
-    private MaterialProperty culling;
-    private MaterialProperty alphaClip;
     private MaterialProperty mainTexProp;
     private MaterialProperty mainColorProp;
-    private MaterialProperty alphaCutoffProp;
     private MaterialProperty sampleGIProp;
     private MaterialProperty bumpMap;
 
     private static class Styles
     {
-        public static GUIContent twoSidedLabel = new GUIContent("Two Sided", "Render front and back faces");
-        public static GUIContent alphaClipLabel = new GUIContent("Alpha Clip", "Enable Alpha Clip");
-
         public static GUIContent[] mainTexLabels =
         {
             new GUIContent("MainTex (RGB)", "Base Color"),
             new GUIContent("MainTex (RGB) Alpha (A)", "Base Color and Alpha")
         };
 
+        public static string surfaceProperties = "Surface Properties";
         public static GUIContent normalMapLabel = new GUIContent("Normal Map", "Normal Map");
-        public static readonly string[] surfaceNames = Enum.GetNames(typeof(SurfaceType));
-        public static readonly string[] blendNames = Enum.GetNames(typeof(UnlitBlendMode));
-
-        public static string surfaceTypeLabel = "Surface Type";
-        public static string blendingModeLabel = "Blending Mode";
-        public static string clipThresholdLabel = "Clip Threshold";
         public static GUIContent sampleGILabel = new GUIContent("Sample GI", "If enabled GI will be sampled from SH or Lightmap.");
     }
 
     public override void FindProperties(MaterialProperty[] properties)
     {
-        surfaceTypeProp = FindProperty("_Surface", properties);
-        blendModeProp = FindProperty("_Blend", properties);
-        culling = FindProperty("_Cull", properties);
-        alphaClip  = FindProperty("_AlphaClip", properties);
+        base.FindProperties(properties);
+        alphaClipProp  = FindProperty("_AlphaClip", properties);
         mainTexProp = FindProperty("_MainTex", properties);
         mainColorProp = FindProperty("_Color", properties);
         alphaCutoffProp = FindProperty("_Cutoff", properties);
@@ -61,37 +38,18 @@ public class LightweightUnlitGUI : LightweightShaderGUI
     {
         EditorGUI.BeginChangeCheck();
         {
-            DoPopup(Styles.surfaceTypeLabel, surfaceTypeProp, Styles.surfaceNames);
+            base.ShaderPropertiesGUI(material);
+            GUILayout.Label(Styles.surfaceProperties, EditorStyles.boldLabel);
             int surfaceTypeValue = (int)surfaceTypeProp.floatValue;
-
-            if((SurfaceType)surfaceTypeValue == SurfaceType.Transparent)
-                DoPopup(Styles.blendingModeLabel, blendModeProp, Styles.blendNames);
-
-            EditorGUI.BeginChangeCheck();
-            bool twoSidedEnabled = EditorGUILayout.Toggle(Styles.twoSidedLabel, culling.floatValue == 0);
-            if (EditorGUI.EndChangeCheck())
-                culling.floatValue = twoSidedEnabled ? 0 : 2;
-
-            EditorGUI.BeginChangeCheck();
-            bool alphaClipEnabled = EditorGUILayout.Toggle(Styles.alphaClipLabel, alphaClip.floatValue == 1);
-            if (EditorGUI.EndChangeCheck())
-                alphaClip.floatValue = alphaClipEnabled ? 1 : 0;
-
             GUIContent mainTexLabel = Styles.mainTexLabels[Math.Min(surfaceTypeValue, 1)];
             m_MaterialEditor.TexturePropertySingleLine(mainTexLabel, mainTexProp, mainColorProp);
-
-            if (alphaClipEnabled)
-                m_MaterialEditor.ShaderProperty(alphaCutoffProp, Styles.clipThresholdLabel, MaterialEditor.kMiniTextureFieldLabelIndentLevel + 1);
-
-            m_MaterialEditor.TextureScaleOffsetProperty(mainTexProp);
-
+            
             EditorGUILayout.Space();
             m_MaterialEditor.ShaderProperty(sampleGIProp, Styles.sampleGILabel);
             if (sampleGIProp.floatValue >= 1.0)
                 m_MaterialEditor.TexturePropertySingleLine(Styles.normalMapLabel, bumpMap);
 
-            EditorGUILayout.Space();
-            EditorGUILayout.Space();
+            m_MaterialEditor.TextureScaleOffsetProperty(mainTexProp);
         }
         if (EditorGUI.EndChangeCheck())
         {
@@ -99,67 +57,20 @@ public class LightweightUnlitGUI : LightweightShaderGUI
                 MaterialChanged((Material)target);
         }
 
-        EditorGUILayout.Space();
-        EditorGUILayout.Space();
+        DoMaterialRenderingOptions();
     }
 
     public override void MaterialChanged(Material material)
     {
         material.shaderKeywords = null;
+        SetupMaterialBlendMode(material);
+        SetMaterialKeywords(material);
+    }
+
+    static void SetMaterialKeywords(Material material)
+    {
         bool sampleGI = material.GetFloat("_SampleGI") >= 1.0f;
         CoreUtils.SetKeyword(material, "_SAMPLE_GI", sampleGI);
         CoreUtils.SetKeyword(material, "_NORMAL_MAP", sampleGI && material.GetTexture("_BumpMap"));
-
-        bool alphaClip = material.GetFloat("_AlphaClip") == 1;
-        if(alphaClip)
-            material.EnableKeyword("_ALPHATEST_ON");
-        else
-            material.DisableKeyword("_ALPHATEST_ON");
-
-        SurfaceType surfaceType = (SurfaceType)material.GetFloat("_Surface");
-        if(surfaceType == SurfaceType.Opaque)
-        {
-            material.SetOverrideTag("RenderType", "");
-            material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-            material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-            material.SetInt("_ZWrite", 1);
-            material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-            material.renderQueue = -1;
-            material.SetShaderPassEnabled("ShadowCaster", true);
-        }
-        else
-        { 
-            UnlitBlendMode blendMode = (UnlitBlendMode)material.GetFloat("_Blend");
-            switch (blendMode)
-            {
-                case UnlitBlendMode.Alpha:
-                    material.SetOverrideTag("RenderType", "Transparent");
-                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
-                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-                    material.SetInt("_ZWrite", 0);
-                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-                    material.SetShaderPassEnabled("ShadowCaster", false);
-                    break;
-                case UnlitBlendMode.Additive:
-                    material.SetOverrideTag("RenderType", "Transparent");
-                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.One);
-                    material.SetInt("_ZWrite", 0);
-                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-                    material.SetShaderPassEnabled("ShadowCaster", false);
-                    break;
-                case UnlitBlendMode.Multiply:
-                    material.SetOverrideTag("RenderType", "Transparent");
-                    material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.DstColor);
-                    material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                    material.SetInt("_ZWrite", 0);
-                    material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
-                    material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-                    material.SetShaderPassEnabled("ShadowCaster", false);
-                    break;
-            }
-        }
     }
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightUnlitGUI.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderGUI/LightweightUnlitGUI.cs
@@ -26,10 +26,8 @@ public class LightweightUnlitGUI : LightweightShaderGUI
     public override void FindProperties(MaterialProperty[] properties)
     {
         base.FindProperties(properties);
-        alphaClipProp  = FindProperty("_AlphaClip", properties);
         mainTexProp = FindProperty("_MainTex", properties);
         mainColorProp = FindProperty("_Color", properties);
-        alphaCutoffProp = FindProperty("_Cutoff", properties);
         sampleGIProp = FindProperty("_SampleGI", properties, false);
         bumpMap = FindProperty("_BumpMap", properties, false);
     }
@@ -41,9 +39,11 @@ public class LightweightUnlitGUI : LightweightShaderGUI
             base.ShaderPropertiesGUI(material);
             GUILayout.Label(Styles.surfaceProperties, EditorStyles.boldLabel);
             int surfaceTypeValue = (int)surfaceTypeProp.floatValue;
+            if (alphaClipProp.floatValue >= 1.0f)
+                surfaceTypeValue = 1;
             GUIContent mainTexLabel = Styles.mainTexLabels[Math.Min(surfaceTypeValue, 1)];
             m_MaterialEditor.TexturePropertySingleLine(mainTexLabel, mainTexProp, mainColorProp);
-            
+
             EditorGUILayout.Space();
             m_MaterialEditor.ShaderProperty(sampleGIProp, Styles.sampleGILabel);
             if (sampleGIProp.floatValue >= 1.0)

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Materials/Lightweight-Default.mat
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Materials/Lightweight-Default.mat
@@ -67,7 +67,10 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
     - _BumpScale: 1
+    - _Cull: 2
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
@@ -85,10 +88,11 @@ Material:
     - _SpecSource: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _Surface: 0
     - _UVSec: 0
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 1, g: 1, b: 1, a: 1}

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Materials/Lightweight-StandardSimpleLighting.mat
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Materials/Lightweight-StandardSimpleLighting.mat
@@ -55,7 +55,10 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
     - _BumpScale: 1
+    - _Cull: 2
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
@@ -71,6 +74,7 @@ Material:
     - _SpecSource: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _Surface: 0
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Lighting.hlsl
@@ -396,18 +396,9 @@ half3 SampleLightmap(float2 lightmapUV, half3 normalWS)
 // If lightmap: sampleData.xy = lightmapUV
 // If probe: sampleData.xyz = L2 SH terms
 #ifdef LIGHTMAP_ON
-#define SAMPLE_GI(lmName, shName, normalWSName) SampleGI(lmName, normalWSName)
-half3 SampleGI(float2 sampleData, half3 normalWS)
-{
-    return SampleLightmap(sampleData, normalWS);
-}
+#define SAMPLE_GI(lmName, shName, normalWSName) SampleLightmap(lmName, normalWSName)
 #else
-#define SAMPLE_GI(lmName, shName, normalWSName) SampleGI(shName, normalWSName)
-half3 SampleGI(half3 sampleData, half3 normalWS)
-{
-    // If lightmap is not enabled we sample GI from SH
-    return SampleSHPixel(sampleData, normalWS);
-}
+#define SAMPLE_GI(lmName, shName, normalWSName) SampleSHPixel(shName, normalWSName)
 #endif
 
 half3 GlossyEnvironmentReflection(half3 reflectVector, half perceptualRoughness, half occlusion)

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Particles.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Particles.hlsl
@@ -231,7 +231,7 @@ half AlphaBlendAndTest(half alpha, half cutoff)
 #else
     half result = 1.0h;
 #endif
-    AlphaDiscard(result, cutoff, 0.0001h);
+    AlphaDiscard(alpha, cutoff, 0.0001h);
 
     return result;
 }

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Particles.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Particles.hlsl
@@ -199,7 +199,7 @@ half3 SampleEmission(VertexOutputLit IN, half3 emissionColor, TEXTURE2D_ARGS(emi
 
 half4 SampleAlbedo(VertexOutputLit IN, TEXTURE2D_ARGS(albedoMap, sampler_albedoMap))
 {
-    half4 albedo = readTexture(TEXTURE2D_PARAM(albedoMap, sampler_albedoMap), IN) * IN.color;
+    half4 albedo = readTexture(TEXTURE2D_PARAM(albedoMap, sampler_albedoMap), IN) * _Color;
 
     // No distortion Support
     fragColorMode(IN);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/ParticlesPBR.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/ParticlesPBR.hlsl
@@ -26,8 +26,8 @@ void InitializeSurfaceData(VertexOutputLit IN, out SurfaceData surfaceData)
     surfaceData.smoothness = metallicGloss.g;
     surfaceData.occlusion = 1.0;
 
+    surfaceData.albedo = AlphaModulate(surfaceData.albedo, albedo.a);
     surfaceData.alpha = AlphaBlendAndTest(albedo.a, _Cutoff);
-    surfaceData.albedo = AlphaModulate(surfaceData.albedo, surfaceData.alpha);
 }
 
 #endif // LIGHTWEIGHT_PARTICLES_PBR_INCLUDED

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticles.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticles.shader
@@ -80,12 +80,15 @@ Shader "LightweightPipeline/Particles/Standard (Physically Based)"
                 VertexOutputLit o;
                 OUTPUT_NORMAL(v, o);
 
-                o.color = v.color * _Color;
                 o.posWS.xyz = TransformObjectToWorld(v.vertex.xyz).xyz;
                 o.posWS.w = ComputeFogFactor(o.clipPos.z);
                 o.clipPos = TransformWorldToHClip(o.posWS.xyz);
                 o.viewDirShininess.xyz = VertexViewDirWS(GetCameraPositionWS() - o.posWS.xyz);
                 o.viewDirShininess.w = 0.0;
+                o.color = v.color;
+
+                // TODO: Instancing
+                // vertColor(v.color);
                 vertTexcoord(v, o);
                 vertFading(o, o.posWS, o.clipPos);
                 return o;

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticlesSimpleLighting.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticlesSimpleLighting.shader
@@ -92,12 +92,15 @@ Shader "LightweightPipeline/Particles/Standard (Simple Lighting)"
 
                 OUTPUT_NORMAL(v, o);
 
-                o.color = v.color * _Color;
                 o.posWS.xyz = TransformObjectToWorld(v.vertex.xyz).xyz;
                 o.posWS.w = ComputeFogFactor(o.clipPos.z);
                 o.clipPos = TransformWorldToHClip(o.posWS.xyz);
                 o.viewDirShininess.xyz = VertexViewDirWS(GetCameraPositionWS() - o.posWS.xyz);
                 o.viewDirShininess.w = _Shininess * 128.0h;
+                o.color = v.color;
+
+                // TODO: Instancing
+                // vertColor(o.color);
                 vertTexcoord(v, o);
                 vertFading(o, o.posWS, o.clipPos);
                 return o;
@@ -106,8 +109,8 @@ Shader "LightweightPipeline/Particles/Standard (Simple Lighting)"
             half4 ParticlesLitFragment(VertexOutputLit IN) : SV_Target
             {
                 half4 albedo = SampleAlbedo(IN, TEXTURE2D_PARAM(_MainTex, sampler_MainTex));
+                half3 diffuse = AlphaModulate(albedo.rgb, albedo.a);
                 half alpha = AlphaBlendAndTest(albedo.a, _Cutoff);
-                half3 diffuse = AlphaModulate(albedo.rgb, alpha);
                 half3 normalTS = SampleNormalTS(IN, TEXTURE2D_PARAM(_BumpMap, sampler_BumpMap));
                 half3 emission = SampleEmission(IN, _EmissionColor.rgb, TEXTURE2D_PARAM(_EmissionMap, sampler_EmissionMap));
                 half4 specularGloss = SampleSpecularGloss(IN, albedo.a, _SpecColor, TEXTURE2D_PARAM(_SpecGlossMap, sampler_SpecGlossMap));

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticlesUnlit.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticlesUnlit.shader
@@ -88,12 +88,11 @@ Shader "LightweightPipeline/Particles/Standard Unlit"
                 half4 fragParticleUnlit(VertexOutputLit IN) : SV_Target
                 {
                     half4 albedo = SampleAlbedo(IN, TEXTURE2D_PARAM(_MainTex, sampler_MainTex));
+                    half3 diffuse = AlphaModulate(albedo.rgb, albedo.a);
                     half alpha = AlphaBlendAndTest(albedo.a, _Cutoff);
                     half3 emission = SampleEmission(IN, _EmissionColor.rgb, TEXTURE2D_PARAM(_EmissionMap, sampler_EmissionMap));
-                    half3 diffuse = AlphaModulate(albedo.rgb, alpha);
-
+                    
                     half3 result = diffuse + emission;
-
                     half fogFactor = IN.posWS.w;
                     ApplyFogColor(result, half3(0, 0, 0), fogFactor);
                     return half4(result, alpha);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticlesUnlit.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardParticlesUnlit.shader
@@ -76,9 +76,10 @@ Shader "LightweightPipeline/Particles/Standard Unlit"
                     o.posWS.xyz = TransformObjectToWorld(v.vertex.xyz);
                     o.posWS.w = ComputeFogFactor(o.clipPos.z);
                     o.clipPos = TransformWorldToHClip(o.posWS.xyz);
-                    o.color = v.color * _Color;
+                    o.color = v.color;
 
-                    vertColor(o.color);
+                    // TODO: Instancing
+                    //vertColor(o.color);
                     vertTexcoord(v, o);
                     vertFading(o, o.posWS, o.clipPos);
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardUnlit.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardUnlit.shader
@@ -19,7 +19,7 @@ Shader "LightweightPipeline/Standard Unlit"
     }
     SubShader
     {
-        Tags { "RenderType" = "Opaque" "IgnoreProjectors" = "True" "RenderPipeline" = "LightweightPipeline" "IgnoreProjector" = "True"}
+        Tags { "RenderType" = "Opaque" "IgnoreProjectors" = "True" "RenderPipeline" = "LightweightPipeline" }
         LOD 100
 
         Blend [_SrcBlend][_DstBlend]
@@ -35,15 +35,16 @@ Shader "LightweightPipeline/Standard Unlit"
 
             #pragma vertex vert
             #pragma fragment frag
-            #pragma multi_compile_fog
             #pragma shader_feature _SAMPLE_GI
             #pragma shader_feature _ALPHATEST_ON
-            #pragma multi_compile_instancing
+            #pragma shader_feature _ALPHAPREMULTIPLY_ON
 
             // -------------------------------------
             // Unity defined keywords
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
             #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile_fog
+            #pragma multi_compile_instancing
 
             // Lighting include is needed because of GI
             #include "LWRP/ShaderLibrary/Lighting.hlsl"
@@ -105,6 +106,11 @@ Shader "LightweightPipeline/Standard Unlit"
                 half3 color = texColor.rgb * _Color.rgb;
                 half alpha = texColor.a * _Color.a;
                 AlphaDiscard(alpha, _Cutoff);
+
+#ifdef _ALPHAPREMULTIPLY_ON
+                color *= alpha;
+#endif
+
 
 #if _SAMPLE_GI
     #if _NORMALMAP

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardUnlit.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightStandardUnlit.shader
@@ -64,7 +64,7 @@ Shader "LightweightPipeline/Standard Unlit"
             {
                 float3 uv0AndFogCoord           : TEXCOORD0; // xy: uv0, z: fogCoord
 #if _SAMPLE_GI
-                float4 lightmapOrVertexSH       : TEXCOORD1;
+                DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, 1);
                 half3 normal                    : TEXCOORD2;
     #if _NORMALMAP
                 half3 tangent                   : TEXCOORD3;
@@ -91,8 +91,8 @@ Shader "LightweightPipeline/Standard Unlit"
 
 #if _SAMPLE_GI
                 OUTPUT_NORMAL(v, o);
-                OUTPUT_LIGHTMAP_UV(v.lightmapUV, unity_LightmapST, o.lightmapOrVertexSH.xy);
-                OUTPUT_SH(o.normal, o.lightmapOrVertexSH);
+                OUTPUT_LIGHTMAP_UV(v.lightmapUV, unity_LightmapST, o.lightmapUV);
+                OUTPUT_SH(o.normal, o.vertexSH);
 #endif
                 return o;
             }
@@ -118,7 +118,7 @@ Shader "LightweightPipeline/Standard Unlit"
     #else
                 half3 normalWS = normalize(IN.normal);
     #endif
-                color *= SampleGI(IN.lightmapOrVertexSH, normalWS);
+                color += SAMPLE_GI(IN.lightmapUV, IN.vertexSH, normalWS);
 #endif
                 ApplyFog(color, IN.uv0AndFogCoord.z);
 


### PR DESCRIPTION
 - Fixed GI in Standard Unlit shader
 - Fixed null reference in particles UI
 - Fixed standard particles cutout, alpha modulate and color modes
 - Updated LW standard material to have midgrey albedo color
 - Moved shader UI common code to LightweightShaderGUI
 - Standard PBR, Simple Lighting and Unlit shaders all support same rendering options (SurfaceType, BlendModes, Two Sides and Alpha Clip + threshold)

 Note: We have to discuss some of these shader UIs. BlendModes currently is dependent on surface being transparent which doesn't make sense IMO. Plus we have some weird cases that if you want transparent reflections you have to set blend mode as PREMULTIPLY.