### PR TITLE
Backport/shadow backports

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -447,6 +447,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             // stereo functionality, we use the screen-space shadow map as the source (until we have
             // a better solution).
             // An alternative would be DrawProcedural, but that would require further changes in the shader.
+            cmd.SetRenderTarget(m_ScreenSpaceShadowMapRT);
+            cmd.ClearRenderTarget(true, true, Color.white);
             cmd.Blit(m_ScreenSpaceShadowMapRT, m_ScreenSpaceShadowMapRT, m_ScreenSpaceShadowsMaterial);
 
             StartStereoRendering(ref context, frameRenderingConfiguration);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
@@ -119,10 +119,8 @@ inline real SampleShadowmap(float4 shadowCoord)
     attenuation = SAMPLE_TEXTURE2D_SHADOW(_ShadowMap, sampler_ShadowMap, shadowCoord.xyz);
 #endif
 
-#if SHADER_HINT_NICE_QUALITY
     // Apply shadow strength
     attenuation = LerpWhiteTo(attenuation, GetShadowStrength());
-#endif
 
     // Shadow coords that fall out of the light frustum volume must always return attenuation 1.0
     return BEYOND_SHADOW_FAR(shadowCoord) ? 1.0 : attenuation;


### PR DESCRIPTION
Backport of the following individual changes:
  - Shadow Strength should always be computed. 
  - Clear of screen shadow occlusion texture to avoid tile LOAD in mobile.