### PR TITLE
New StackLit forward only material: Can serve as a basic template for…

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd74f5e99c8fb6d4086471ff874e0ba2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/StackLitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/StackLitUI.cs
@@ -1,0 +1,101 @@
+using System;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+
+namespace UnityEditor.Experimental.Rendering.HDPipeline
+{
+    class StackLitGUI : BaseUnlitGUI
+    {
+        protected static class Styles
+        {
+            public static string InputsText = "Inputs";
+
+            public static GUIContent baseColorText = new GUIContent("Base Color + Opacity", "Albedo (RGB) and Opacity (A)");
+
+            public static GUIContent emissiveText = new GUIContent("Emissive Color", "Emissive");
+            public static GUIContent emissiveIntensityText = new GUIContent("Emissive Intensity", "Emissive");
+            public static GUIContent albedoAffectEmissiveText = new GUIContent("Albedo Affect Emissive", "Specifies whether or not the emissive color is multiplied by the albedo.");
+			
+        }
+
+
+        protected MaterialProperty baseColor = null;
+        protected const string kBaseColor = "_BaseColor";
+        protected MaterialProperty baseColorMap = null;
+        protected const string kBaseColorMap = "_BaseColorMap";
+
+        protected MaterialProperty emissiveColor = null;
+        protected const string kEmissiveColor = "_EmissiveColor";
+        protected MaterialProperty emissiveColorMap = null;
+        protected const string kEmissiveColorMap = "_EmissiveColorMap";
+        protected MaterialProperty emissiveIntensity = null;
+        protected const string kEmissiveIntensity = "_EmissiveIntensity";
+        protected MaterialProperty albedoAffectEmissive = null;
+        protected const string kAlbedoAffectEmissive = "_AlbedoAffectEmissive";
+		
+
+        override protected void FindMaterialProperties(MaterialProperty[] props)
+        {
+            baseColor = FindProperty(kBaseColor, props);
+            baseColorMap = FindProperty(kBaseColorMap, props);
+
+            emissiveColor = FindProperty(kEmissiveColor, props);
+            emissiveColorMap = FindProperty(kEmissiveColorMap, props);
+            emissiveIntensity = FindProperty(kEmissiveIntensity, props);
+            albedoAffectEmissive = FindProperty(kAlbedoAffectEmissive, props);
+        }
+
+        protected override void MaterialPropertiesGUI(Material material)
+        {
+            EditorGUILayout.LabelField(Styles.InputsText, EditorStyles.boldLabel);
+
+            m_MaterialEditor.TexturePropertySingleLine(Styles.baseColorText, baseColorMap, baseColor);
+            m_MaterialEditor.TextureScaleOffsetProperty(baseColorMap);
+
+            m_MaterialEditor.TexturePropertySingleLine(Styles.emissiveText, emissiveColorMap, emissiveColor);
+            m_MaterialEditor.TextureScaleOffsetProperty(emissiveColorMap);
+            m_MaterialEditor.ShaderProperty(emissiveIntensity, Styles.emissiveIntensityText);
+            m_MaterialEditor.ShaderProperty(albedoAffectEmissive, Styles.albedoAffectEmissiveText);
+
+            var surfaceTypeValue = (SurfaceType)surfaceType.floatValue;
+            if (surfaceTypeValue == SurfaceType.Transparent)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField(StylesBaseUnlit.TransparencyInputsText, EditorStyles.boldLabel);
+                ++EditorGUI.indentLevel;
+
+                DoDistortionInputsGUI();
+
+                --EditorGUI.indentLevel;
+            }
+        }
+
+        protected override void MaterialPropertiesAdvanceGUI(Material material)
+        {
+        }
+
+        protected override void VertexAnimationPropertiesGUI()
+        {
+
+        }
+
+        protected override bool ShouldEmissionBeEnabled(Material mat)
+        {
+            return mat.GetFloat(kEmissiveIntensity) > 0.0f;
+        }
+
+        protected override void SetupMaterialKeywordsAndPassInternal(Material material)
+        {
+            SetupMaterialKeywordsAndPass(material);
+        }
+
+        // All Setup Keyword functions must be static. It allow to create script to automatically update the shaders with a script if code change
+        static public void SetupMaterialKeywordsAndPass(Material material)
+        {
+            SetupBaseUnlitKeywords(material);
+            SetupBaseUnlitMaterialPass(material);
+
+            CoreUtils.SetKeyword(material, "_EMISSIVE_COLOR_MAP", material.GetTexture(kEmissiveColorMap));
+        }
+    }
+} // namespace UnityEditor

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/StackLitUI.cs.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/StackLitUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1299689b419a58340b4da4d67c678769
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Material.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Material.hlsl
@@ -135,6 +135,8 @@ void UpdateLightingHierarchyWeights(inout float hierarchyWeight, inout float wei
 #include "Lit/Lit.hlsl"
 #elif defined(UNITY_MATERIAL_UNLIT)
 #include "Unlit/Unlit.hlsl"
+#elif defined(UNITY_MATERIAL_STACKLIT)
+#include "StackLit/StackLit.hlsl"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86c95bf966685564ba869d965bb5efe0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9fd26622ba7766c4f9285e0cd3f8199c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDepthPass.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDepthPass.hlsl
@@ -1,0 +1,14 @@
+#ifndef SHADERPASS
+#error Undefine_SHADERPASS
+#endif
+
+// NEWLITTODO : Handling of TESSELATION, DISPLACEMENT, WIND
+
+#ifdef _ALPHATEST_ON
+#define ATTRIBUTES_NEED_TEXCOORD0
+
+#define VARYINGS_NEED_TEXCOORD0
+#endif //..._ALPHATEST_ON
+
+// This include will define the various Attributes/Varyings structure
+#include "../../ShaderPass/VaryingMesh.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDepthPass.hlsl.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDepthPass.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 60c153442d48a7f45a551c0808637155
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDistortionPass.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDistortionPass.hlsl
@@ -1,0 +1,12 @@
+#ifndef SHADERPASS
+#error Undefine_SHADERPASS
+#endif
+
+// NEWLITTODO : Handling of TESSELATION, DISPLACEMENT, HEIGHTMAP, WIND
+
+#define ATTRIBUTES_NEED_TEXCOORD0
+
+#define VARYINGS_NEED_TEXCOORD0
+
+// This include will define the various Attributes/Varyings structure
+#include "../../ShaderPass/VaryingMesh.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDistortionPass.hlsl.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitDistortionPass.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e9ce97cf6b6d6304fac625fa22747b2f
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitSharePass.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitSharePass.hlsl
@@ -1,0 +1,43 @@
+#ifndef SHADERPASS
+#error Undefine_SHADERPASS
+#endif
+
+// NOTE: Copied from LitSharePass.hlsl, we will need most of this, but at first, vs the unlit, we have 
+// diffuse lighting, and also consider the _DOUBLESIDED_ON option.
+
+// This first set of define allow to say which attributes will be use by the mesh in the vertex and domain shader (for tesselation)
+
+// Attributes
+#define ATTRIBUTES_NEED_NORMAL
+#define ATTRIBUTES_NEED_TANGENT // Always present as we require it also in case of anisotropic lighting
+#define ATTRIBUTES_NEED_TEXCOORD0
+#define ATTRIBUTES_NEED_TEXCOORD1
+#define ATTRIBUTES_NEED_COLOR
+
+#if defined(_REQUIRE_UV2) || defined(_REQUIRE_UV3) || defined(DYNAMICLIGHTMAP_ON) || defined(DEBUG_DISPLAY) || (SHADERPASS == SHADERPASS_LIGHT_TRANSPORT)
+#define ATTRIBUTES_NEED_TEXCOORD2
+#endif
+#if defined(_REQUIRE_UV3) || defined(DEBUG_DISPLAY)
+#define ATTRIBUTES_NEED_TEXCOORD3
+#endif
+
+// Varying - Use for pixel shader
+// This second set of define allow to say which varyings will be output in the vertex (no more tesselation)
+#define VARYINGS_NEED_POSITION_WS
+#define VARYINGS_NEED_TANGENT_TO_WORLD
+#define VARYINGS_NEED_TEXCOORD0
+#define VARYINGS_NEED_TEXCOORD1
+#ifdef ATTRIBUTES_NEED_TEXCOORD2
+#define VARYINGS_NEED_TEXCOORD2
+#endif
+#ifdef ATTRIBUTES_NEED_TEXCOORD3
+#define VARYINGS_NEED_TEXCOORD3
+#endif
+#define VARYINGS_NEED_COLOR
+
+#ifdef _DOUBLESIDED_ON
+#define VARYINGS_NEED_CULLFACE
+#endif
+
+// This include will define the various Attributes/Varyings structure
+#include "../../ShaderPass/VaryingMesh.hlsl"

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitSharePass.hlsl.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/ShaderPass/StackLitSharePass.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8950ba3f99538d5489ffd15903311678
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using System;
+
+//-----------------------------------------------------------------------------
+// structure definition
+//-----------------------------------------------------------------------------
+namespace UnityEngine.Experimental.Rendering.HDPipeline
+{
+    public class StackLit : RenderPipelineMaterial
+    {
+        //-----------------------------------------------------------------------------
+        // SurfaceData
+        //-----------------------------------------------------------------------------
+
+        // Main structure that store the user data (i.e user input of master node in material graph)
+        [GenerateHLSL(PackingRules.Exact, false, true, 1300)]
+        public struct SurfaceData
+        {
+            // Standard
+            [SurfaceDataAttributes("Base Color", false, true)]
+            public Vector3 baseColor;
+            
+            [SurfaceDataAttributes(new string[]{"Normal", "Normal View Space"}, true)]
+            public Vector3 normalWS;
+        };
+
+        //-----------------------------------------------------------------------------
+        // BSDFData
+        //-----------------------------------------------------------------------------
+
+        [GenerateHLSL(PackingRules.Exact, false, true, 1400)]
+        public struct BSDFData
+        {
+            [SurfaceDataAttributes("", false, true)]
+            public Vector3 diffuseColor;
+            
+            [SurfaceDataAttributes(new string[] { "Normal WS", "Normal View Space" }, true)]
+            public Vector3 normalWS;
+        };
+    }
+}

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs.hlsl
@@ -1,0 +1,78 @@
+//
+// This file was automatically generated. Please don't edit by hand.
+//
+
+#ifndef STACKLIT_CS_HLSL
+#define STACKLIT_CS_HLSL
+//
+// UnityEngine.Experimental.Rendering.HDPipeline.StackLit+SurfaceData:  static fields
+//
+#define DEBUGVIEW_STACKLIT_SURFACEDATA_BASE_COLOR (1300)
+#define DEBUGVIEW_STACKLIT_SURFACEDATA_NORMAL (1301)
+#define DEBUGVIEW_STACKLIT_SURFACEDATA_NORMAL_VIEW_SPACE (1302)
+
+//
+// UnityEngine.Experimental.Rendering.HDPipeline.StackLit+BSDFData:  static fields
+//
+#define DEBUGVIEW_STACKLIT_BSDFDATA_DIFFUSE_COLOR (1400)
+#define DEBUGVIEW_STACKLIT_BSDFDATA_NORMAL_WS (1401)
+#define DEBUGVIEW_STACKLIT_BSDFDATA_NORMAL_VIEW_SPACE (1402)
+
+// Generated from UnityEngine.Experimental.Rendering.HDPipeline.StackLit+SurfaceData
+// PackingRules = Exact
+struct SurfaceData
+{
+    float3 baseColor;
+    float3 normalWS;
+};
+
+// Generated from UnityEngine.Experimental.Rendering.HDPipeline.StackLit+BSDFData
+// PackingRules = Exact
+struct BSDFData
+{
+    float3 diffuseColor;
+    float3 normalWS;
+};
+
+//
+// Debug functions
+//
+void GetGeneratedSurfaceDataDebug(uint paramId, SurfaceData surfacedata, inout float3 result, inout bool needLinearToSRGB)
+{
+    switch (paramId)
+    {
+        case DEBUGVIEW_STACKLIT_SURFACEDATA_BASE_COLOR:
+            result = surfacedata.baseColor;
+            needLinearToSRGB = true;
+            break;
+        case DEBUGVIEW_STACKLIT_SURFACEDATA_NORMAL:
+            result = surfacedata.normalWS * 0.5 + 0.5;
+            break;
+        case DEBUGVIEW_STACKLIT_SURFACEDATA_NORMAL_VIEW_SPACE:
+            result = surfacedata.normalWS * 0.5 + 0.5;
+            break;
+    }
+}
+
+//
+// Debug functions
+//
+void GetGeneratedBSDFDataDebug(uint paramId, BSDFData bsdfdata, inout float3 result, inout bool needLinearToSRGB)
+{
+    switch (paramId)
+    {
+        case DEBUGVIEW_STACKLIT_BSDFDATA_DIFFUSE_COLOR:
+            result = bsdfdata.diffuseColor;
+            needLinearToSRGB = true;
+            break;
+        case DEBUGVIEW_STACKLIT_BSDFDATA_NORMAL_WS:
+            result = bsdfdata.normalWS * 0.5 + 0.5;
+            break;
+        case DEBUGVIEW_STACKLIT_BSDFDATA_NORMAL_VIEW_SPACE:
+            result = bsdfdata.normalWS * 0.5 + 0.5;
+            break;
+    }
+}
+
+
+#endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs.hlsl.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e9689279fece92a43a07134408146db1
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c791362c2eaa3a94c807d88c81a53119
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.hlsl
@@ -1,0 +1,544 @@
+//-----------------------------------------------------------------------------
+// SurfaceData and BSDFData
+//-----------------------------------------------------------------------------
+// SurfaceData is defined in StackLit.cs which generates StackLit.cs.hlsl
+#include "StackLit.cs.hlsl"
+//#include "../SubsurfaceScattering/SubsurfaceScattering.hlsl"
+//#include "CoreRP/ShaderLibrary/VolumeRendering.hlsl"
+
+//NEWLITTODO : wireup CBUFFERs for ambientocclusion, and other uniforms and samplers used: 
+//
+// We need this for AO, Depth/Color pyramids, LTC lights data, FGD pre-integrated data.
+//
+// Also add options at the top of this file, see Lit.hlsl.
+
+
+// This function is use to help with debugging and must be implemented by any lit material
+// Implementer must take into account what are the current override component and
+// adjust SurfaceData properties accordingdly
+void ApplyDebugToSurfaceData(float3x3 worldToTangent, inout SurfaceData surfaceData)
+{
+#ifdef DEBUG_DISPLAY
+    // NOTE: THe _Debug* uniforms come from /HDRP/Debug/DebugDisplay.hlsl
+
+    // Override value if requested by user
+    // this can be use also in case of debug lighting mode like diffuse only
+    bool overrideAlbedo = _DebugLightingAlbedo.x != 0.0;
+    bool overrideSmoothness = _DebugLightingSmoothness.x != 0.0;
+    bool overrideNormal = _DebugLightingNormal.x != 0.0;
+
+    if (overrideAlbedo)
+    {
+        float3 overrideAlbedoValue = _DebugLightingAlbedo.yzw;
+        surfaceData.baseColor = overrideAlbedoValue;
+    }
+
+    if (overrideSmoothness)
+    {
+        //NEWLITTODO
+        //float overrideSmoothnessValue = _DebugLightingSmoothness.y;
+        //surfaceData.perceptualSmoothness = overrideSmoothnessValue;
+    }
+
+    if (overrideNormal)
+    {
+        surfaceData.normalWS = worldToTangent[2];
+    }
+#endif
+}
+
+// This function is similar to ApplyDebugToSurfaceData but for BSDFData
+//
+// NOTE: 
+//
+// This will be available and used in ShaderPassForward.hlsl since in StackLit.shader, 
+// just before including the core code of the pass (ShaderPassForward.hlsl) we include 
+// Material.hlsl (or Lighting.hlsl which includes it) which in turn includes us, 
+// StackLit.shader, via the #if defined(UNITY_MATERIAL_*) glue mechanism.
+//
+void ApplyDebugToBSDFData(inout BSDFData bsdfData)
+{
+#ifdef DEBUG_DISPLAY
+    // Override value if requested by user
+    // this can be use also in case of debug lighting mode like specular only
+    
+    //NEWLITTODO
+    //bool overrideSpecularColor = _DebugLightingSpecularColor.x != 0.0;
+
+    //if (overrideSpecularColor)
+    //{
+    //   float3 overrideSpecularColor = _DebugLightingSpecularColor.yzw;
+    //    bsdfData.fresnel0 = overrideSpecularColor;
+    //}
+#endif
+}
+
+//-----------------------------------------------------------------------------
+// conversion function for forward
+//-----------------------------------------------------------------------------
+
+BSDFData ConvertSurfaceDataToBSDFData(SurfaceData surfaceData)
+{
+    BSDFData bsdfData;
+    ZERO_INITIALIZE(BSDFData, bsdfData);
+    
+    // NEWLITTODO: will be much more involved obviously, and use metallic, etc.
+    bsdfData.diffuseColor = surfaceData.baseColor;
+    bsdfData.normalWS = surfaceData.normalWS;
+
+    ApplyDebugToBSDFData(bsdfData);
+    return bsdfData;
+}
+
+//-----------------------------------------------------------------------------
+// Debug method (use to display values)
+//-----------------------------------------------------------------------------
+
+void GetSurfaceDataDebug(uint paramId, SurfaceData surfaceData, inout float3 result, inout bool needLinearToSRGB)
+{
+    GetGeneratedSurfaceDataDebug(paramId, surfaceData, result, needLinearToSRGB);
+    //NEWLITTODO
+}
+
+void GetBSDFDataDebug(uint paramId, BSDFData bsdfData, inout float3 result, inout bool needLinearToSRGB)
+{
+    GetGeneratedBSDFDataDebug(paramId, bsdfData, result, needLinearToSRGB);
+    //NEWLITTODO
+}
+
+
+//-----------------------------------------------------------------------------
+// PreLightData 
+// 
+// Make sure we respect naming conventions to reuse ShaderPassForward as is,
+// ie struct (even if opaque to the ShaderPassForward) name is PreLightData,
+// GetPreLightData prototype.
+//-----------------------------------------------------------------------------
+
+// Precomputed lighting data to send to the various lighting functions
+struct PreLightData
+{
+    float NdotV;                     // Could be negative due to normal mapping, use ClampNdotV()
+    //NEWLITTODO
+};
+
+PreLightData GetPreLightData(float3 V, PositionInputs posInput, inout BSDFData bsdfData)
+{
+    PreLightData preLightData;
+    ZERO_INITIALIZE(PreLightData, preLightData);
+
+    float3 N = bsdfData.normalWS;
+    preLightData.NdotV = dot(N, V);
+
+    float NdotV = ClampNdotV(preLightData.NdotV);
+
+
+    return preLightData;
+}
+
+//-----------------------------------------------------------------------------
+// bake lighting function
+//-----------------------------------------------------------------------------
+
+//
+// GetBakedDiffuseLighting will be called from ShaderPassForward.hlsl.
+//
+// GetBakedDiffuseLighting function compute the bake lighting + emissive color to be store in emissive buffer (Deferred case)
+// In forward it must be add to the final contribution.
+// This function require the 3 structure surfaceData, builtinData, bsdfData because it may require both the engine side data, and data that will not be store inside the gbuffer.
+float3 GetBakedDiffuseLighting(SurfaceData surfaceData, BuiltinData builtinData, BSDFData bsdfData, PreLightData preLightData)
+{
+    //NEWLITTODO
+
+#ifdef DEBUG_DISPLAY
+    if (_DebugLightingMode == DEBUGLIGHTINGMODE_LUX_METER)
+    {
+        // The lighting in SH or lightmap is assume to contain bounced light only (i.e no direct lighting), and is divide by PI (i.e Lambert is apply), so multiply by PI here to get back the illuminance
+        return builtinData.bakeDiffuseLighting * PI;
+    }
+#endif
+    //NEWLITTODO
+    // Premultiply bake diffuse lighting information with DisneyDiffuse pre-integration
+    //return builtinData.bakeDiffuseLighting * preLightData.diffuseFGD * surfaceData.ambientOcclusion * bsdfData.diffuseColor + builtinData.emissiveColor;
+    return builtinData.bakeDiffuseLighting * bsdfData.diffuseColor; //...todo, just to return something for now, .bakeDiffuseLighting is bogus for now anyway.
+}
+
+
+//-----------------------------------------------------------------------------
+// light transport functions
+//-----------------------------------------------------------------------------
+
+LightTransportData GetLightTransportData(SurfaceData surfaceData, BuiltinData builtinData, BSDFData bsdfData)
+{
+    LightTransportData lightTransportData;
+
+    // diffuseColor for lightmapping should basically be diffuse color.
+    // But rough metals (black diffuse) still scatter quite a lot of light around, so
+    // we want to take some of that into account too.
+
+    //NEWLITTODO
+    //float roughness = PerceptualRoughnessToRoughness(bsdfData.perceptualRoughness);
+    //lightTransportData.diffuseColor = bsdfData.diffuseColor + bsdfData.fresnel0 * roughness * 0.5 * surfaceData.metallic;
+    lightTransportData.diffuseColor = bsdfData.diffuseColor;
+    lightTransportData.emissiveColor = builtinData.emissiveColor;
+
+    return lightTransportData;
+}
+
+//-----------------------------------------------------------------------------
+// LightLoop related function (Only include if required)
+// HAS_LIGHTLOOP is define in Lighting.hlsl
+//-----------------------------------------------------------------------------
+
+#ifdef HAS_LIGHTLOOP
+
+#ifndef _SURFACE_TYPE_TRANSPARENT
+// For /Lighting/LightEvaluation.hlsl:
+#define USE_DEFERRED_DIRECTIONAL_SHADOWS // Deferred shadows are always enabled for opaque objects
+#endif
+
+#include "../../Lighting/LightEvaluation.hlsl"
+#include "../../Lighting/Reflection/VolumeProjection.hlsl"
+
+//-----------------------------------------------------------------------------
+// Lighting structure for light accumulation
+//-----------------------------------------------------------------------------
+
+// These structure allow to accumulate lighting accross the Lit material
+// AggregateLighting is init to zero and transfer to EvaluateBSDF, but the LightLoop can't access its content.
+//
+// In fact, all structures here are opaque but used by LightLoop.hlsl.
+// The Accumulate* functions are also used by LightLoop to accumulate the contributions of lights.
+//
+struct DirectLighting
+{
+    float3 diffuse;
+    float3 specular;
+};
+
+struct IndirectLighting
+{
+    float3 specularReflected;
+    float3 specularTransmitted;
+};
+
+struct AggregateLighting
+{
+    DirectLighting   direct;
+    IndirectLighting indirect;
+};
+
+void AccumulateDirectLighting(DirectLighting src, inout AggregateLighting dst)
+{
+    dst.direct.diffuse += src.diffuse;
+    dst.direct.specular += src.specular;
+}
+
+void AccumulateIndirectLighting(IndirectLighting src, inout AggregateLighting dst)
+{
+    dst.indirect.specularReflected += src.specularReflected;
+    dst.indirect.specularTransmitted += src.specularTransmitted;
+}
+
+//-----------------------------------------------------------------------------
+// BSDF share between directional light, punctual light and area light (reference)
+//-----------------------------------------------------------------------------
+
+// NEWLITTODO
+
+// This function apply BSDF. Assumes that NdotL is positive.
+void BSDF(  float3 V, float3 L, float NdotL, float3 positionWS, PreLightData preLightData, BSDFData bsdfData,
+            out float3 diffuseLighting,
+            out float3 specularLighting)
+{
+    float  diffuseTerm = Lambert();
+
+    // We don't multiply by 'bsdfData.diffuseColor' here. It's done only once in PostEvaluateBSDF().
+    diffuseLighting = diffuseTerm;
+    specularLighting = float3(0.0, 0.0, 0.0);
+}
+
+//-----------------------------------------------------------------------------
+// EvaluateBSDF_Directional
+//-----------------------------------------------------------------------------
+
+DirectLighting EvaluateBSDF_Directional(LightLoopContext lightLoopContext,
+                                        float3 V, PositionInputs posInput, PreLightData preLightData,
+                                        DirectionalLightData lightData, BSDFData bsdfData,
+                                        BakeLightingData bakeLightingData)
+{
+    DirectLighting lighting;
+    ZERO_INITIALIZE(DirectLighting, lighting);
+
+    float3 N     = bsdfData.normalWS;
+    float3 L     = -lightData.forward; // Lights point backward in Unity
+    //float  NdotV = ClampNdotV(preLightData.NdotV);
+    float  NdotL = dot(N, L);
+    //float  LdotV = dot(L, V);
+
+    // color and attenuation are outputted  by EvaluateLight: 
+    float3 color;
+    float attenuation;
+    EvaluateLight_Directional(lightLoopContext, posInput, lightData, bakeLightingData, N, L, color, attenuation);
+
+    float intensity = max(0, attenuation * NdotL); // Warning: attenuation can be greater than 1 due to the inverse square attenuation (when position is close to light)
+
+    // Note: We use NdotL here to early out, but in case of clear coat this is not correct. But we are ok with this
+    UNITY_BRANCH if (intensity > 0.0)
+    {
+        BSDF(V, L, NdotL, posInput.positionWS, preLightData, bsdfData, lighting.diffuse, lighting.specular);
+
+        lighting.diffuse  *= intensity * lightData.diffuseScale;
+        lighting.specular *= intensity * lightData.specularScale;
+    }
+
+    // NEWLITTODO: Mixed thickness, transmission
+    
+    // Save ALU by applying light and cookie colors only once.
+    lighting.diffuse  *= color;
+    lighting.specular *= color;
+
+#ifdef DEBUG_DISPLAY
+    if (_DebugLightingMode == DEBUGLIGHTINGMODE_LUX_METER)
+    {
+        // Only lighting, not BSDF
+        lighting.diffuse = color * intensity * lightData.diffuseScale;
+    }
+#endif
+
+    return lighting;
+}
+
+//-----------------------------------------------------------------------------
+// EvaluateBSDF_Punctual (supports spot, point and projector lights)
+//-----------------------------------------------------------------------------
+
+DirectLighting EvaluateBSDF_Punctual(LightLoopContext lightLoopContext,
+                                     float3 V, PositionInputs posInput,
+                                     PreLightData preLightData, LightData lightData, BSDFData bsdfData, BakeLightingData bakeLightingData)
+{
+    DirectLighting lighting;
+    ZERO_INITIALIZE(DirectLighting, lighting);
+
+    float3 lightToSample = posInput.positionWS - lightData.positionWS;
+    int    lightType     = lightData.lightType;
+
+    float3 L;
+    float4 distances; // {d, d^2, 1/d, d_proj}
+    distances.w = dot(lightToSample, lightData.forward);
+
+    if (lightType == GPULIGHTTYPE_PROJECTOR_BOX)
+    {
+        L = -lightData.forward;
+        distances.xyz = 1; // No distance or angle attenuation
+    }
+    else
+    {
+        float3 unL     = -lightToSample;
+        float  distSq  = dot(unL, unL);
+        float  distRcp = rsqrt(distSq);
+        float  dist    = distSq * distRcp;
+
+        L = unL * distRcp;
+        distances.xyz = float3(dist, distSq, distRcp);
+    }
+
+    float3 N     = bsdfData.normalWS;
+    float  NdotV = ClampNdotV(preLightData.NdotV);
+    float  NdotL = dot(N, L);
+    float  LdotV = dot(L, V);
+
+    // NEWLITTODO: mixedThickness, transmission
+    
+    float3 color;
+    float attenuation;
+    EvaluateLight_Punctual(lightLoopContext, posInput, lightData, bakeLightingData, N, L,
+                           lightToSample, distances, color, attenuation);
+
+
+    float intensity = max(0, attenuation * NdotL); // Warning: attenuation can be greater than 1 due to the inverse square attenuation (when position is close to light)
+
+    // Note: We use NdotL here to early out, but in case of clear coat this is not correct. But we are ok with this
+    UNITY_BRANCH if (intensity > 0.0)
+    {
+        // Simulate a sphere light with this hack
+        // Note that it is not correct with our pre-computation of PartLambdaV (mean if we disable the optimization we will not have the
+        // same result) but we don't care as it is a hack anyway
+        
+        //NEWLITTODO: Do we want this hack in stacklit ? Yes we have area lights, but cheap and not much maintenance to leave it here.
+        // For now no roughness anyways.
+        
+        //bsdfData.coatRoughness = max(bsdfData.coatRoughness, lightData.minRoughness);
+        //bsdfData.roughnessT = max(bsdfData.roughnessT, lightData.minRoughness);
+        //bsdfData.roughnessB = max(bsdfData.roughnessB, lightData.minRoughness);
+
+        BSDF(V, L, NdotL, posInput.positionWS, preLightData, bsdfData, lighting.diffuse, lighting.specular);
+
+        lighting.diffuse  *= intensity * lightData.diffuseScale;
+        lighting.specular *= intensity * lightData.specularScale;
+    }
+
+    //NEWLITTODO : transmission
+    
+
+    // Save ALU by applying light and cookie colors only once.
+    lighting.diffuse  *= color;
+    lighting.specular *= color;
+
+#ifdef DEBUG_DISPLAY
+    if (_DebugLightingMode == DEBUGLIGHTINGMODE_LUX_METER)
+    {
+        // Only lighting, not BSDF
+        lighting.diffuse = color * intensity * lightData.diffuseScale;
+    }
+#endif
+
+    return lighting;
+}
+
+// NEWLITTODO: For a refence rendering option for area light, like LIT_DISPLAY_REFERENCE_AREA option in eg EvaluateBSDF_<area light type> : 
+//#include "LitReference.hlsl"
+
+//-----------------------------------------------------------------------------
+// EvaluateBSDF_Line - Approximation with Linearly Transformed Cosines
+//-----------------------------------------------------------------------------
+
+DirectLighting EvaluateBSDF_Line(   LightLoopContext lightLoopContext,
+                                    float3 V, PositionInputs posInput,
+                                    PreLightData preLightData, LightData lightData, BSDFData bsdfData, BakeLightingData bakeLightingData)
+{
+    DirectLighting lighting;
+    ZERO_INITIALIZE(DirectLighting, lighting);
+    
+    //NEWLITTODO
+
+    return lighting;
+}
+
+//-----------------------------------------------------------------------------
+// EvaluateBSDF_Area - Approximation with Linearly Transformed Cosines
+//-----------------------------------------------------------------------------
+
+// #define ELLIPSOIDAL_ATTENUATION
+
+DirectLighting EvaluateBSDF_Rect(   LightLoopContext lightLoopContext,
+                                    float3 V, PositionInputs posInput,
+                                    PreLightData preLightData, LightData lightData, BSDFData bsdfData, BakeLightingData bakeLightingData)
+{
+    DirectLighting lighting;
+    ZERO_INITIALIZE(DirectLighting, lighting);
+
+    //NEWLITTODO
+
+    return lighting;
+}
+
+DirectLighting EvaluateBSDF_Area(LightLoopContext lightLoopContext,
+    float3 V, PositionInputs posInput,
+    PreLightData preLightData, LightData lightData,
+    BSDFData bsdfData, BakeLightingData bakeLightingData)
+{
+    if (lightData.lightType == GPULIGHTTYPE_LINE)
+    {
+        return EvaluateBSDF_Line(lightLoopContext, V, posInput, preLightData, lightData, bsdfData, bakeLightingData);
+    }
+    else
+    {
+        return EvaluateBSDF_Rect(lightLoopContext, V, posInput, preLightData, lightData, bsdfData, bakeLightingData);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// EvaluateBSDF_SSLighting for screen space lighting
+// ----------------------------------------------------------------------------
+
+IndirectLighting EvaluateBSDF_SSLighting(LightLoopContext lightLoopContext,
+                                            float3 V, PositionInputs posInput,
+                                            PreLightData preLightData, BSDFData bsdfData,
+                                            EnvLightData envLightData,
+                                            int GPUImageBasedLightingType,
+                                            inout float hierarchyWeight)
+{
+    IndirectLighting lighting;
+    ZERO_INITIALIZE(IndirectLighting, lighting);
+    
+    //NEWLITTODO
+
+    return lighting;
+}
+
+//-----------------------------------------------------------------------------
+// EvaluateBSDF_Env
+// ----------------------------------------------------------------------------
+
+// _preIntegratedFGD and _CubemapLD are unique for each BRDF
+IndirectLighting EvaluateBSDF_Env(  LightLoopContext lightLoopContext,
+                                    float3 V, PositionInputs posInput,
+                                    PreLightData preLightData, EnvLightData lightData, BSDFData bsdfData,
+                                    int influenceShapeType, int GPUImageBasedLightingType,
+                                    inout float hierarchyWeight)
+{
+    IndirectLighting lighting;
+    ZERO_INITIALIZE(IndirectLighting, lighting);
+
+    //NEWLITTODO
+
+    return lighting;
+}
+
+//-----------------------------------------------------------------------------
+// PostEvaluateBSDF
+// ----------------------------------------------------------------------------
+
+void PostEvaluateBSDF(  LightLoopContext lightLoopContext,
+                        float3 V, PositionInputs posInput,
+                        PreLightData preLightData, BSDFData bsdfData, BakeLightingData bakeLightingData, AggregateLighting lighting,
+                        out float3 diffuseLighting, out float3 specularLighting)
+{
+    // Apply the albedo to the direct diffuse lighting and that's about it.
+    // diffuse lighting has already had the albedo applied in GetBakedDiffuseLighting().
+    diffuseLighting = bsdfData.diffuseColor * lighting.direct.diffuse + bakeLightingData.bakeDiffuseLighting;
+    specularLighting = lighting.direct.specular; // should be 0 for now.
+
+#ifdef DEBUG_DISPLAY
+
+    if (_DebugLightingMode == DEBUGLIGHTINGMODE_LUX_METER)
+    {
+        diffuseLighting = lighting.direct.diffuse + bakeLightingData.bakeDiffuseLighting;
+    }
+    else if (_DebugLightingMode == DEBUGLIGHTINGMODE_INDIRECT_DIFFUSE_OCCLUSION_FROM_SSAO)
+    {
+        // NEWLITTODO
+        //diffuseLighting = indirectAmbientOcclusion;
+        specularLighting = float3(0.0, 0.0, 0.0); // Disable specular lighting
+    }
+    else if (_DebugLightingMode == DEBUGLIGHTINGMODE_INDIRECT_SPECULAR_OCCLUSION_FROM_SSAO)
+    {
+        // NEWLITTODO
+        //diffuseLighting = specularOcclusion;
+        specularLighting = float3(0.0, 0.0, 0.0); // Disable specular lighting
+    }
+    #if GTAO_MULTIBOUNCE_APPROX
+    else if (_DebugLightingMode == DEBUGLIGHTINGMODE_INDIRECT_DIFFUSE_GTAO_FROM_SSAO)
+    {
+        // NEWLITTODO
+        //diffuseLighting = GTAOMultiBounce(indirectAmbientOcclusion, bsdfData.diffuseColor);
+        specularLighting = float3(0.0, 0.0, 0.0); // Disable specular lighting
+    }
+    else if (_DebugLightingMode == DEBUGLIGHTINGMODE_INDIRECT_SPECULAR_GTAO_FROM_SSAO)
+    {
+        // NEWLITTODO
+        //diffuseLighting = GTAOMultiBounce(specularOcclusion, bsdfData.fresnel0);
+        specularLighting = float3(0.0, 0.0, 0.0); // Disable specular lighting
+    }
+    #endif
+    else if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)
+    {
+        // NEWLITTODO    
+        //diffuseLighting = bsdfData.diffuseColor;
+        specularLighting = float3(0.0, 0.0, 0.0); // Disable specular lighting
+    }
+#endif
+}
+
+#endif // #ifdef HAS_LIGHTLOOP

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.hlsl.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 03326c2e6dae9c549bcbb37408fb9cd2
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.shader
@@ -1,0 +1,300 @@
+Shader "HDRenderPipeline/StackLit"
+{
+    Properties
+    {
+        // Following set of parameters represent the parameters node inside the MaterialGraph.
+        // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
+
+        // Reminder. Color here are in linear but the UI (color picker) do the conversion sRGB to linear
+        // Be careful, do not change the name here to _Color. It will conflict with the "fake" parameters (see end of properties) required for GI.
+        _BaseColor("BaseColor", Color) = (1,1,1,1)
+        _BaseColorMap("BaseColorMap", 2D) = "white" {}
+
+        _EmissiveColor("EmissiveColor", Color) = (1, 1, 1)
+        _EmissiveColorMap("EmissiveColorMap", 2D) = "white" {}
+        _EmissiveIntensity("EmissiveIntensity", Float) = 0
+        [ToggleUI] _AlbedoAffectEmissive("Albedo Affect Emissive", Float) = 0.0
+
+        _DistortionVectorMap("DistortionVectorMap", 2D) = "black" {}
+        [ToggleUI] _DistortionEnable("Enable Distortion", Float) = 0.0
+        [ToggleUI] _DistortionOnly("Distortion Only", Float) = 0.0
+        [ToggleUI] _DistortionDepthTest("Distortion Depth Test Enable", Float) = 1.0
+        [Enum(Add, 0, Multiply, 1)] _DistortionBlendMode("Distortion Blend Mode", Int) = 0
+        [HideInInspector] _DistortionSrcBlend("Distortion Blend Src", Int) = 0
+        [HideInInspector] _DistortionDstBlend("Distortion Blend Dst", Int) = 0
+        [HideInInspector] _DistortionBlurSrcBlend("Distortion Blur Blend Src", Int) = 0
+        [HideInInspector] _DistortionBlurDstBlend("Distortion Blur Blend Dst", Int) = 0
+        [HideInInspector] _DistortionBlurBlendMode("Distortion Blur Blend Mode", Int) = 0
+        _DistortionScale("Distortion Scale", Float) = 1
+        _DistortionVectorScale("Distortion Vector Scale", Float) = 2
+        _DistortionVectorBias("Distortion Vector Bias", Float) = -1
+        _DistortionBlurScale("Distortion Blur Scale", Float) = 1
+        _DistortionBlurRemapMin("DistortionBlurRemapMin", Float) = 0.0
+        _DistortionBlurRemapMax("DistortionBlurRemapMax", Float) = 1.0
+
+        // Transparency
+        [ToggleUI] _PreRefractionPass("PreRefractionPass", Float) = 0.0
+
+        [ToggleUI]  _AlphaCutoffEnable("Alpha Cutoff Enable", Float) = 0.0
+        _AlphaCutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+        _TransparentSortPriority("_TransparentSortPriority", Float) = 0
+
+
+        // Stencil state
+        [HideInInspector] _StencilRef("_StencilRef", Int) = 2 // StencilLightingUsage.RegularLighting  (fixed at compile time)
+        [HideInInspector] _StencilWriteMask("_StencilWriteMask", Int) = 7 // StencilMask.Lighting  (fixed at compile time)
+        [HideInInspector] _StencilRefMV("_StencilRefMV", Int) = 128 // StencilLightingUsage.RegularLighting  (fixed at compile time)
+        [HideInInspector] _StencilWriteMaskMV("_StencilWriteMaskMV", Int) = 128 // StencilMask.ObjectsVelocity  (fixed at compile time)
+
+        // Blending state
+        [HideInInspector] _SurfaceType("__surfacetype", Float) = 0.0
+        [HideInInspector] _BlendMode("__blendmode", Float) = 0.0
+        [HideInInspector] _SrcBlend("__src", Float) = 1.0
+        [HideInInspector] _DstBlend("__dst", Float) = 0.0
+        [HideInInspector] _ZWrite("__zw", Float) = 1.0
+        [HideInInspector] _CullMode("__cullmode", Float) = 2.0
+        [HideInInspector] _CullModeForward("__cullmodeForward", Float) = 2.0 // This mode is dedicated to Forward to correctly handle backface then front face rendering thin transparent
+        [HideInInspector] _ZTestDepthEqualForOpaque("_ZTestDepthEqualForOpaque", Int) = 4 // Less equal
+        [HideInInspector] _ZTestModeDistortion("_ZTestModeDistortion", Int) = 8
+
+
+        [ToggleUI] _EnableFogOnTransparent("Enable Fog", Float) = 1.0
+        [ToggleUI] _EnableBlendModePreserveSpecularLighting("Enable Blend Mode Preserve Specular Lighting", Float) = 1.0
+        
+        [ToggleUI] _DoubleSidedEnable("Double sided enable", Float) = 0.0
+        [Enum(Flip, 0, Mirror, 1, None, 2)] _DoubleSidedNormalMode("Double sided normal mode", Float) = 1 // This is for the editor only, see BaseLitUI.cs: _DoubleSidedConstants will be set based on the mode.
+        [HideInInspector] _DoubleSidedConstants("_DoubleSidedConstants", Vector) = (1, 1, -1, 0)
+
+        // Caution: C# code in BaseLitUI.cs call LightmapEmissionFlagsProperty() which assume that there is an existing "_EmissionColor"
+        // value that exist to identify if the GI emission need to be enabled.
+        // In our case we don't use such a mechanism but need to keep the code quiet. We declare the value and always enable it.
+        // TODO: Fix the code in legacy unity so we can customize the beahvior for GI
+        _EmissionColor("Color", Color) = (1, 1, 1)
+
+        // HACK: GI Baking system relies on some properties existing in the shader ("_MainTex", "_Cutoff" and "_Color") for opacity handling, so we need to store our version of those parameters in the hard-coded name the GI baking system recognizes.
+        _MainTex("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (1,1,1,1)
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+    }
+
+    HLSLINCLUDE
+
+    #pragma target 4.5
+    #pragma only_renderers d3d11 ps4 xboxone vulkan metal
+
+    //-------------------------------------------------------------------------------------
+    // Variant
+    //-------------------------------------------------------------------------------------
+
+    #pragma shader_feature _ALPHATEST_ON
+    #pragma shader_feature _DOUBLESIDED_ON
+    
+    
+    #pragma shader_feature _EMISSIVE_COLOR_MAP
+
+    // Keyword for transparent
+    #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
+    #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
+    #pragma shader_feature _BLENDMODE_PRESERVE_SPECULAR_LIGHTING // easily handled in material.hlsl, so adding this already.
+    #pragma shader_feature _ENABLE_FOG_ON_TRANSPARENT
+    
+    //enable GPU instancing support
+    #pragma multi_compile_instancing
+
+    //-------------------------------------------------------------------------------------
+    // Define
+    //-------------------------------------------------------------------------------------
+
+    #define UNITY_MATERIAL_STACKLIT // Need to be define before including Material.hlsl
+
+    //-------------------------------------------------------------------------------------
+    // Include
+    //-------------------------------------------------------------------------------------
+
+    #include "CoreRP/ShaderLibrary/Common.hlsl"
+    #include "../../ShaderPass/FragInputs.hlsl"
+    #include "../../ShaderPass/ShaderPass.cs.hlsl"
+
+    //-------------------------------------------------------------------------------------
+    // variable declaration
+    //-------------------------------------------------------------------------------------
+
+    #include "../../Material/StackLit/StackLitProperties.hlsl"
+
+    // All our shaders use same name for entry point
+    #pragma vertex Vert
+    #pragma fragment Frag
+
+    ENDHLSL
+
+    SubShader
+    {
+        // This tags allow to use the shader replacement features
+        Tags{ "RenderPipeline" = "HDRenderPipeline" "RenderType" = "HDStackLitShader" }
+
+        // Caution: The outline selection in the editor use the vertex shader/hull/domain shader of the first pass declare. So it should not be the meta pass.
+
+        Pass
+        {
+            Name "Depth prepass"
+            Tags{ "LightMode" = "DepthForwardOnly" }
+
+            Cull[_CullMode]
+
+            ZWrite On
+
+            HLSLPROGRAM
+
+            #define SHADERPASS SHADERPASS_DEPTH_ONLY
+            #include "../../ShaderVariables.hlsl"
+            #include "../../Material/Material.hlsl"
+            #include "ShaderPass/StackLitDepthPass.hlsl"
+            #include "StackLitData.hlsl"
+            #include "../../ShaderPass/ShaderPassDepthOnly.hlsl"
+
+            ENDHLSL
+        }
+
+        // Extracts information for lightmapping, GI (emission, albedo, ...)
+        // This pass it not used during regular rendering.
+        Pass
+        {
+            Name "META"
+            Tags{ "LightMode" = "Meta" }
+
+            Cull Off
+
+            HLSLPROGRAM
+
+            // Lightmap memo
+            // DYNAMICLIGHTMAP_ON is used when we have an "enlighten lightmap" ie a lightmap updated at runtime by enlighten.This lightmap contain indirect lighting from realtime lights and realtime emissive material.Offline baked lighting(from baked material / light,
+            // both direct and indirect lighting) will hand up in the "regular" lightmap->LIGHTMAP_ON.
+
+            #define SHADERPASS SHADERPASS_LIGHT_TRANSPORT
+            #include "../../ShaderVariables.hlsl"
+            #include "../../Material/Material.hlsl"
+            #include "ShaderPass/StackLitSharePass.hlsl"
+            #include "StackLitData.hlsl"
+            #include "../../ShaderPass/ShaderPassLightTransport.hlsl"
+
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags{ "LightMode" = "ShadowCaster" }
+
+            Cull[_CullMode]
+
+            ZClip [_ZClip]
+            ZWrite On
+            ZTest LEqual
+
+            ColorMask 0
+
+            HLSLPROGRAM
+
+            #define SHADERPASS SHADERPASS_SHADOWS
+            #define USE_LEGACY_UNITY_MATRIX_VARIABLES
+            #include "../../ShaderVariables.hlsl"
+            #include "../../Material/Material.hlsl"
+
+            #include "ShaderPass/StackLitDepthPass.hlsl"
+            #include "StackLitData.hlsl"
+            #include "../../ShaderPass/ShaderPassDepthOnly.hlsl"
+
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "Distortion" // Name is not used
+            Tags { "LightMode" = "DistortionVectors" } // This will be only for transparent object based on the RenderQueue index
+
+            Blend [_DistortionSrcBlend] [_DistortionDstBlend], [_DistortionBlurSrcBlend] [_DistortionBlurDstBlend]
+            BlendOp Add, [_DistortionBlurBlendOp]
+            ZTest [_ZTestModeDistortion]
+            ZWrite off
+            Cull [_CullMode]
+
+            HLSLPROGRAM
+
+            #define SHADERPASS SHADERPASS_DISTORTION
+            #include "../../ShaderVariables.hlsl"
+            #include "../../Material/Material.hlsl"
+            #include "ShaderPass/StackLitDistortionPass.hlsl"
+            #include "StackLitData.hlsl"
+            #include "../../ShaderPass/ShaderPassDistortion.hlsl"
+
+            ENDHLSL
+        }
+
+        // StackLit shader always render in forward
+        Pass
+        {
+            Name "Forward" // Name is not used
+            Tags { "LightMode" = "ForwardOnly" }
+
+            Stencil
+            {
+                WriteMask [_StencilWriteMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
+
+            Blend [_SrcBlend] [_DstBlend]
+            // In case of forward we want to have depth equal for opaque mesh
+            ZTest [_ZTestDepthEqualForOpaque]
+            ZWrite [_ZWrite]
+            Cull [_CullModeForward]
+            //
+            // NOTE: For _CullModeForward, see BaseLitUI and the handling of TransparentBackfaceEnable: 
+            // Basically, we need to use it to support a TransparentBackface pass before this pass
+            // (and it should be placed just before this one) for separate backface and frontface rendering,
+            // eg for "hair shader style" approximate sorting, see eg Thorsten Scheuermann writeups on this:
+            // http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.607.1272&rep=rep1&type=pdf
+            // http://amd-dev.wpengine.netdna-cdn.com/wordpress/media/2012/10/Scheuermann_HairSketchSlides.pdf
+            // http://web.engr.oregonstate.edu/~mjb/cs519/Projects/Papers/HairRendering.pdf
+            //
+            // See Lit.shader and the order of the passes after a DistortionVectors, we have: 
+            // TransparentDepthPrepass, TransparentBackface, Forward, TransparentDepthPostpass
+
+            HLSLPROGRAM
+
+            #pragma multi_compile _ DEBUG_DISPLAY
+            //NEWLITTODO
+            //#pragma multi_compile _ LIGHTMAP_ON
+            //#pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            //#pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            //#pragma multi_compile _ SHADOWS_SHADOWMASK
+
+            // #include "../../Lighting/Forward.hlsl" : nothing left in there.
+            //#pragma multi_compile LIGHTLOOP_SINGLE_PASS LIGHTLOOP_TILE_PASS
+            #define LIGHTLOOP_TILE_PASS
+            #pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST
+
+            #define SHADERPASS SHADERPASS_FORWARD
+            // In case of opaque we don't want to perform the alpha test, it is done in depth prepass and we use depth equal for ztest (setup from UI)
+            #ifndef _SURFACE_TYPE_TRANSPARENT
+                #define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST
+            #endif
+            #include "../../ShaderVariables.hlsl"
+            #ifdef DEBUG_DISPLAY
+            #include "../../Debug/DebugDisplay.hlsl"
+            #endif
+            #include "../../Lighting/Lighting.hlsl"
+            //...this will include #include "../../Material/Material.hlsl" but also LightLoop which the forward pass directly uses.
+
+            #include "ShaderPass/StackLitSharePass.hlsl"
+            #include "StackLitData.hlsl"
+            #include "../../ShaderPass/ShaderPassForward.hlsl"
+
+            ENDHLSL
+        }
+
+    }
+
+    CustomEditor "Experimental.Rendering.HDPipeline.StackLitGUI"
+}

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.shader.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3a796817b9614b347895c0e8db89b63a
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitData.hlsl
@@ -1,0 +1,71 @@
+//-------------------------------------------------------------------------------------
+// Fill SurfaceData/Builtin data function
+//-------------------------------------------------------------------------------------
+#include "../MaterialUtilities.hlsl"
+
+void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
+{
+    ApplyDoubleSidedFlipOrMirror(input); // Apply double sided flip on the vertex normal
+    
+    // NEWLITTODO: 
+    // For now, just use the interpolated vertex normal. This has been normalized in the initial fragment interpolators unpacking.
+    // Eventually, we want to share all the LitData LayerTexCoord (and surface gradient frame + uv, planar, triplanar, etc.) logic, also
+    // spread in LitDataIndividualLayer and LitDataMeshModification.
+    surfaceData.normalWS = input.worldToTangent[2].xyz;
+    
+    float2 baseColorMapUv = TRANSFORM_TEX(input.texCoord0, _BaseColorMap);
+    surfaceData.baseColor = SAMPLE_TEXTURE2D(_BaseColorMap, sampler_BaseColorMap, baseColorMapUv).rgb * _BaseColor.rgb;
+    float alpha = SAMPLE_TEXTURE2D(_BaseColorMap, sampler_BaseColorMap, baseColorMapUv).a * _BaseColor.a;
+
+#ifdef _ALPHATEST_ON
+    //NEWLITTODO: Once we include those passes in the main StackLit.shader, add handling of CUTOFF_TRANSPARENT_DEPTH_PREPASS and _POSTPASS
+    // and the related properties (in the .shader) and uniforms (in the StackLitProperties file) _AlphaCutoffPrepass, _AlphaCutoffPostpass
+    DoAlphaTest(alpha, _AlphaCutoff);
+#endif
+
+#if defined(DEBUG_DISPLAY)
+    if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)
+    {
+        surfaceData.color = GetTextureDataDebug(_DebugMipMapMode, baseColorMapUv, _BaseColorMap, _BaseColorMap_TexelSize, _BaseColorMap_MipInfo, surfaceData.color);
+    }
+#endif
+
+    // Builtin Data
+    // NEWLITTODO: for all BuiltinData, might need to just refactor and use a comon function like that 
+    // contained in LitBuiltinData.hlsl
+
+    builtinData.opacity = alpha;
+
+    builtinData.bakeDiffuseLighting = float3(0.0, 0.0, 0.0);
+
+    // Emissive Intensity is only use here, but is part of BuiltinData to enforce UI parameters as we want the users to fill one color and one intensity
+    builtinData.emissiveIntensity = _EmissiveIntensity;
+    builtinData.emissiveColor = _EmissiveColor * builtinData.emissiveIntensity * lerp(float3(1.0, 1.0, 1.0), surfaceData.baseColor.rgb, _AlbedoAffectEmissive);
+
+
+#ifdef _EMISSIVE_COLOR_MAP
+    builtinData.emissiveColor *= SAMPLE_TEXTURE2D(_EmissiveColorMap, sampler_EmissiveColorMap, TRANSFORM_TEX(input.texCoord0, _EmissiveColorMap)).rgb;
+#endif
+
+    builtinData.velocity = float2(0.0, 0.0);
+
+    
+    //NEWLITTODO: shader feature SHADOWS_SHADOWMASK not there yet. 
+    builtinData.shadowMask0 = 0.0;
+    builtinData.shadowMask1 = 0.0;
+    builtinData.shadowMask2 = 0.0;
+    builtinData.shadowMask3 = 0.0;
+
+#if (SHADERPASS == SHADERPASS_DISTORTION) || defined(DEBUG_DISPLAY)
+    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb;
+    distortion.rg = distortion.rg * _DistortionVectorScale.xx + _DistortionVectorBias.xx;
+    builtinData.distortion = distortion.rg * _DistortionScale;
+    builtinData.distortionBlur = clamp(distortion.b * _DistortionBlurScale, 0.0, 1.0) * (_DistortionBlurRemapMax - _DistortionBlurRemapMin) + _DistortionBlurRemapMin;
+#else
+    builtinData.distortion = float2(0.0, 0.0);
+    builtinData.distortionBlur = 0.0;
+#endif
+
+    builtinData.depthOffset = 0.0;
+
+}

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitData.hlsl.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitData.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3a7c3981c91d6d448ae2b9830a62386f
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitProperties.hlsl
@@ -1,0 +1,45 @@
+// ===========================================================================
+//                              WARNING:
+// On PS4, texture/sampler declarations need to be outside of CBuffers
+// Otherwise those parameters are not bound correctly at runtime.
+// ===========================================================================
+TEXTURE2D(_DistortionVectorMap);
+SAMPLER(sampler_DistortionVectorMap);
+
+TEXTURE2D(_EmissiveColorMap);
+SAMPLER(sampler_EmissiveColorMap);
+
+TEXTURE2D(_BaseColorMap);
+SAMPLER(sampler_BaseColorMap);
+
+
+CBUFFER_START(UnityPerMaterial)
+
+float4 _BaseColor;
+float4 _BaseColorMap_ST;
+float4 _BaseColorMap_TexelSize;
+float4 _BaseColorMap_MipInfo;
+
+float3 _EmissiveColor;
+float4 _EmissiveColorMap_ST;
+float _EmissiveIntensity;
+float _AlbedoAffectEmissive;
+
+float _AlphaCutoff;
+float4 _DoubleSidedConstants;
+
+float _DistortionScale;
+float _DistortionVectorScale;
+float _DistortionVectorBias;
+float _DistortionBlurScale;
+float _DistortionBlurRemapMin;
+float _DistortionBlurRemapMax;
+
+
+// Caution: C# code in BaseLitUI.cs call LightmapEmissionFlagsProperty() which assume that there is an existing "_EmissionColor"
+// value that exist to identify if the GI emission need to be enabled.
+// In our case we don't use such a mechanism but need to keep the code quiet. We declare the value and always enable it.
+// TODO: Fix the code in legacy unity so we can customize the behavior for GI
+float3 _EmissionColor;
+
+CBUFFER_END

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitProperties.hlsl.meta
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitProperties.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 11f90969f030f4a4186577bf302f41d3
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
… a new lit material creation with a different lighting code path glued in material.hlsl.

Only supports base unlit material parameters with the addition of : analytical lights with a diffuse lambert BSDF, interpolated geometric normal and double sided option.