### PR TITLE
HDRenderPipeline: Fix shader and C# warning + re-arrange lightloop for env

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/Common.hlsl
+++ b/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/Common.hlsl
@@ -831,7 +831,7 @@ float2 GetQuadTexCoord(uint vertexID)
 {
 	uint topBit = vertexID >> 1;
 	uint botBit = (vertexID & 1);
-	float u = topBit; 
+	float u = topBit;
 	float v = (topBit + botBit) & 1; // produces 0 for indices 0,3 and 1 for 1,2
 #if UNITY_UV_STARTS_AT_TOP
 	v = 1.0 - v;
@@ -849,7 +849,7 @@ float4 GetQuadVertexPosition(uint vertexID, float z = UNITY_NEAR_CLIP_VALUE)
 	uint botBit = (vertexID & 1);
 	float x = topBit;
 	float y = 1 - (topBit + botBit) & 1; // produces 1 for indices 0,3 and 0 for 1,2
-	return float4(x, y, z, 1.0); 
+	return float4(x, y, z, 1.0);
 }
 
 #if !defined(SHADER_API_GLES)
@@ -865,7 +865,7 @@ void LODDitheringTransition(uint2 positionSS, float ditherFactor)
 
     // We want to have a symmetry between 0..0.5 ditherFactor and 0.5..1 so no pixels are transparent during the transition
     // this is handled by this test which reverse the pattern
-    // TODO: replace the test (ditherFactor >= 0.5) with (isLod0) to avoid the distracting pattern flip around 0.5.  
+    // TODO: replace the test (ditherFactor >= 0.5) with (isLod0) to avoid the distracting pattern flip around 0.5.
     p = (ditherFactor >= 0.5) ? p : 1 - p;
     clip(ditherFactor - p);
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Debug/DebugDisplay.cs
@@ -77,7 +77,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public static string k_PanelScreenSpaceTracing = "Screen Space Tracing";
 
-        static readonly string[] k_HiZIntersectionKind = { "None", "Depth", "Cell" };
+        //static readonly string[] k_HiZIntersectionKind = { "None", "Depth", "Cell" };
 
         DebugUI.Widget[] m_DebugDisplayStatsItems;
         DebugUI.Widget[] m_DebugMaterialItems;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoopDef.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoopDef.hlsl
@@ -137,7 +137,7 @@ float4 SampleEnv(LightLoopContext lightLoopContext, int index, float3 texCoord, 
 
             color.rgb = SAMPLE_TEXTURE2D_ARRAY_LOD(_Env2DTextures, s_trilinear_clamp_sampler, ndc.xy, index, lod).rgb;
             color.a = any(ndc.xyz < 0) || any(ndc.xyz > 1) ? 0.0 : 1.0;
-            
+
 #ifdef DEBUG_DISPLAY
             if (_DebugLightingMode == DEBUGLIGHTINGMODE_ENVIRONMENT_SAMPLE_COORDINATES)
                 color = float4(ndc.xy, 0, color.a);
@@ -300,4 +300,11 @@ LightData FetchLight(uint start, uint i)
     int j = FetchIndex(start, i);
 
     return _LightDatas[j];
+}
+
+EnvLightData FetchEnvLight(uint start, uint i)
+{
+    int j = FetchIndex(start, i);
+
+    return _EnvLightDatas[j];
 }


### PR DESCRIPTION
Remove some shader warning and C# warning
+ re-arrange environment light loop to be more readable and efficient and match other loop (punctual)