### PR TITLE
fix texture/sampler naming scheme for WIND_SETTINGS_Tex*

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/Wind.hlsl
+++ b/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/Wind.hlsl
@@ -1,7 +1,7 @@
 // TODO: no global variable or resource declarations in the Shader Library. Functions and macros only!
-TEXTURE2D(WIND_SETTINGS_TexNoise);
+TEXTURE2D(_WIND_SETTINGS_TexNoise);
 SAMPLER(sampler_WIND_SETTINGS_TexNoise);
-TEXTURE2D(WIND_SETTINGS_TexGust);
+TEXTURE2D(_WIND_SETTINGS_TexGust);
 SAMPLER(sampler_WIND_SETTINGS_TexGust);
 
 float4  WIND_SETTINGS_WorldDirectionAndSpeed;
@@ -37,12 +37,12 @@ struct WindData
 
 float3 texNoise(float3 worldPos, float LOD)
 {
-    return SAMPLE_TEXTURE2D_LOD(WIND_SETTINGS_TexNoise, sampler_WIND_SETTINGS_TexNoise, worldPos.xz, LOD).xyz -0.5;
+    return SAMPLE_TEXTURE2D_LOD(_WIND_SETTINGS_TexNoise, sampler_WIND_SETTINGS_TexNoise, worldPos.xz, LOD).xyz -0.5;
 }
 
 float texGust(float3 worldPos, float LOD)
 {
-    return SAMPLE_TEXTURE2D_LOD(WIND_SETTINGS_TexGust, sampler_WIND_SETTINGS_TexGust, worldPos.xz, LOD).x;
+    return SAMPLE_TEXTURE2D_LOD(_WIND_SETTINGS_TexGust, sampler_WIND_SETTINGS_TexGust, worldPos.xz, LOD).x;
 }
 
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Wind/ShaderWindSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Wind/ShaderWindSettings.cs
@@ -53,8 +53,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void ApplySettings()
         {
-            Shader.SetGlobalTexture("WIND_SETTINGS_TexNoise", NoiseTexture);
-            Shader.SetGlobalTexture("WIND_SETTINGS_TexGust", GustMaskTexture);
+            Shader.SetGlobalTexture("_WIND_SETTINGS_TexNoise", NoiseTexture);
+            Shader.SetGlobalTexture("_WIND_SETTINGS_TexGust", GustMaskTexture);
             Shader.SetGlobalVector("WIND_SETTINGS_WorldDirectionAndSpeed", GetDirectionAndSpeed());
             Shader.SetGlobalFloat("WIND_SETTINGS_FlexNoiseScale", 1.0f / Mathf.Max(0.01f, FlexNoiseWorldSize));
             Shader.SetGlobalFloat("WIND_SETTINGS_ShiverNoiseScale", 1.0f / Mathf.Max(0.01f, ShiverNoiseWorldSize));


### PR DESCRIPTION
fixes pixelized trees issue with Fontainebleau on metal, probably on some other platforms too

-Set 2D Texture "WIND_SETTINGS_TexNoise" to slot 0 sampler slot -1
-Set 2D Texture "WIND_SETTINGS_TexGust" to slot 1 sampler slot -1
+Set 2D Texture "WIND_SETTINGS_TexNoise" to slot 0
+Set 2D Texture "WIND_SETTINGS_TexGust" to slot 1
