### PR TITLE
 Stripped invalid variants.

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderPreprocessor.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Editor/ShaderPreprocessor.cs
@@ -74,6 +74,26 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
             return false;
         }
 
+        bool StripInvalidVariants(ShaderCompilerData compilerData)
+        {
+            bool isShadowVariant = compilerData.shaderKeywordSet.IsEnabled(LightweightKeywords.DirectionalShadows) ||
+                compilerData.shaderKeywordSet.IsEnabled(LightweightKeywords.LocalShadows);
+
+            if (compilerData.shaderKeywordSet.IsEnabled(LightweightKeywords.SoftShadows) && !isShadowVariant)
+                return true;
+
+            if (compilerData.shaderKeywordSet.IsEnabled(LightweightKeywords.VertexLights) &&
+                !compilerData.shaderKeywordSet.IsEnabled(LightweightKeywords.AdditionalLights))
+                return true;
+
+            // Note: LWRP doesn't support Dynamic Lightmap.
+            if (compilerData.shaderKeywordSet.IsEnabled(LightweightKeywords.DirectionalLightmap) &&
+                !compilerData.shaderKeywordSet.IsEnabled(LightweightKeywords.Lightmap))
+                return true;
+
+            return false;
+        }
+
         bool StripUnused(PipelineCapabilities capabilities, Shader shader, ShaderSnippetData snippetData, ShaderCompilerData compilerData)
         {
             if (StripUnusedShader(capabilities, shader))
@@ -83,6 +103,9 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
                 return true;
 
             if (StripUnusedVariant(capabilities, compilerData))
+                return true;
+
+            if (StripInvalidVariants(compilerData))
                 return true;
 
             return false;

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineCore.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipelineCore.cs
@@ -31,6 +31,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         public static readonly ShaderKeyword DirectionalShadows = new ShaderKeyword(DirectionalShadowsText);
         public static readonly ShaderKeyword LocalShadows = new ShaderKeyword(LocalShadowsText);
         public static readonly ShaderKeyword SoftShadows = new ShaderKeyword(SoftShadowsText);
+
+        public static readonly ShaderKeyword Lightmap = new ShaderKeyword("LIGHTMAP_ON");
+        public static readonly ShaderKeyword DirectionalLightmap = new ShaderKeyword("DIRLIGHTMAP_COMBINED");
     }
 
     public partial class LightweightPipeline


### PR DESCRIPTION
Stripped 57.25% variants in Standard Shader due to being invalid variants.
Standard shader with minimum pipeline capabilities (single directional light - no shadows) has now only   2.08% surviving variants.