### PR TITLE
 Fixed multiple local shadows.

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -192,7 +192,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             m_MaxLocalLightsShadedPerPass = m_UseComputeBuffer ? kMaxVisibleLocalLights : kMaxNonIndexedLocalLights;
             m_LocalLightIndices = new List<int>(m_MaxLocalLightsShadedPerPass);
 
-            m_ShadowPass = new LightweightShadowPass(m_Asset, m_MaxLocalLightsShadedPerPass);
+            m_ShadowPass = new LightweightShadowPass(m_Asset, kMaxVisibleLocalLights);
 
             // Let engine know we have MSAA on for cases where we support MSAA backbuffer
             if (QualitySettings.antiAliasing != m_Asset.MSAASampleCount)
@@ -707,9 +707,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             {
                 if (visibleLights[i].lightType != LightType.Directional)
                     m_LocalLightIndices.Add(i);
-
-                if (m_LocalLightIndices.Count >= m_MaxLocalLightsShadedPerPass)
-                    break;
             }
 
             // Clear to default all light constant data

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
@@ -38,8 +38,8 @@ float4      _ShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
 CBUFFER_END
 
 CBUFFER_START(_LocalShadowBuffer)
-float4x4    _LocalWorldToShadowAtlas[4];
-half        _LocalShadowStrength[4];
+float4x4    _LocalWorldToShadowAtlas[MAX_VISIBLE_LIGHTS];
+half        _LocalShadowStrength[MAX_VISIBLE_LIGHTS];
 half4       _LocalShadowOffset0;
 half4       _LocalShadowOffset1;
 half4       _LocalShadowOffset2;
@@ -227,7 +227,8 @@ half LocalLightRealtimeShadowAttenuation(int lightIndex, float3 positionWS)
     float4 shadowCoord = mul(_LocalWorldToShadowAtlas[lightIndex], float4(positionWS, 1.0));
     ShadowSamplingData shadowSamplingData = GetLocalLightShadowSamplingData();
     half shadowStrength = GetLocalLightShadowStrenth(lightIndex);
-    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowMapAtlas, sampler_LocalShadowMapAtlas), shadowSamplingData, shadowStrength);
+    half attenuation = SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowMapAtlas, sampler_LocalShadowMapAtlas), shadowSamplingData, shadowStrength);
+    return (shadowStrength > 0.0h) ? attenuation : 1.0h;
 #endif
 }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/Shadows.hlsl
@@ -227,8 +227,7 @@ half LocalLightRealtimeShadowAttenuation(int lightIndex, float3 positionWS)
     float4 shadowCoord = mul(_LocalWorldToShadowAtlas[lightIndex], float4(positionWS, 1.0));
     ShadowSamplingData shadowSamplingData = GetLocalLightShadowSamplingData();
     half shadowStrength = GetLocalLightShadowStrenth(lightIndex);
-    half attenuation = SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowMapAtlas, sampler_LocalShadowMapAtlas), shadowSamplingData, shadowStrength);
-    return (shadowStrength > 0.0h) ? attenuation : 1.0h;
+    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowMapAtlas, sampler_LocalShadowMapAtlas), shadowSamplingData, shadowStrength);
 #endif
 }
 


### PR DESCRIPTION
 Fixes per-object local shadows. We use shadow strength value to decide if shadow is enabled for a particular light. Due to perobject indices we have to setup shadow buffer for all visible lights. 

As a next step we need to convert all light and shadow buffers to ComputeBuffer for platforms that support it and remove the MAX_VISIBLE_LIGHTS cap. 