### PR TITLE
HDRP: StackLit Triplanar - handling of local and world correctly per attribute

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/BaseMaterialUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/BaseMaterialUI.cs
@@ -83,7 +83,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
         }
-         
+
         public class Property : BaseProperty
         {
             public string PropertyName;
@@ -99,7 +99,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 get { return m_MaterialProperty != null; }
             }
-        
+
             public float FloatValue
             {
                 get { return m_MaterialProperty.floatValue; }
@@ -338,6 +338,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 A,
             }
 
+            public enum PlanarSpace
+            {
+                World,
+                Local
+            }
+
             public enum UVMapping
             {
                 UV0,
@@ -358,7 +364,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             public ComboProperty m_UvSetProperty;
 
-            public Property m_LocalOrWorldProperty;
+            public ComboProperty m_LocalOrWorldProperty;
 
             public Property m_ChannelProperty;
 
@@ -384,7 +390,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 m_TextureProperty = new TextureOneLineProperty(parent, propertyName, useConstantAsTint ? constantPropertyName : string.Empty, guiText, toolTip, isMandatory);
 
                 m_UvSetProperty = new ComboProperty(parent, propertyName + "UV", "UV Mapping", Enum.GetNames(typeof(UVMapping)), false);
-                m_LocalOrWorldProperty = new Property(parent, propertyName + "LocalOrWorld", "Local Space", "Whether Planar or Triplanar is using Local or World space.", false);
+                m_LocalOrWorldProperty = new ComboProperty(parent, propertyName + "UVLocal", "Local or world", Enum.GetNames(typeof(PlanarSpace)), false);
 
                 m_ChannelProperty = new ComboProperty(parent, propertyName + "Channel", "Channel", Enum.GetNames(typeof(Channel)), false);
 
@@ -431,12 +437,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                         if (m_TextureProperty.TextureValue != null)
                         {
                             m_UvSetProperty.OnGUI();
-                            m_LocalOrWorldProperty.OnGUI();
                             m_ChannelProperty.OnGUI();
 
                             Parent.m_MaterialEditor.TextureScaleOffsetProperty(m_TextureProperty.m_MaterialProperty);
 
-                            m_LocalOrWorldProperty.OnGUI();
+                            if (m_UvSetProperty.FloatValue >= (float)UVMapping.PlanarXY)
+                            {
+                                m_LocalOrWorldProperty.OnGUI();
+                            }
 
                             if (m_RemapProperty.IsValid)
                             {

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/StackLitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Material/StackLit/StackLitUI.cs
@@ -91,9 +91,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         //protected const string kRefractionModel = "_RefractionModel";
         //protected MaterialProperty refractionSSRayModel = null;
         //protected const string kRefractionSSRayModel = "_RefractionSSRayModel";
-
-        protected MaterialProperty useLocalPlanarMapping = null;
-        protected const string k_UseLocalPlanarMapping = "_UseLocalPlanarMapping";
         #endregion
 
         // Add the properties into an array.
@@ -188,14 +185,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected override void FindMaterialProperties(MaterialProperty[] props)
         {
             //base.FindMaterialProperties(props);
-            useLocalPlanarMapping = FindProperty(k_UseLocalPlanarMapping, props);
             _materialProperties.OnFindProperty(props);
         }
 
         protected override void BaseMaterialPropertiesGUI()
         {
             base.BaseMaterialPropertiesGUI();
-            m_MaterialEditor.ShaderProperty(useLocalPlanarMapping, StylesStackLit.useLocalPlanarMapping);
             _baseMaterialProperties.OnGUI();
         }
 
@@ -334,8 +329,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 requireTriplanar = requireTriplanar || uvIndices[i] == TextureProperty.UVMapping.Triplanar;
             }
 
-            CoreUtils.SetKeyword(material, "_USE_UV2", requireUv2);
-            CoreUtils.SetKeyword(material, "_USE_UV3", requireUv3);
+            //CoreUtils.SetKeyword(material, "_USE_UV2", requireUv2);
+            //CoreUtils.SetKeyword(material, "_USE_UV3", requireUv3);
             CoreUtils.SetKeyword(material, "_USE_TRIPLANAR", requireTriplanar);
         }
     }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLit.shader
@@ -11,12 +11,14 @@ Shader "HDRenderPipeline/StackLit"
         _BaseColorMap("BaseColor Map", 2D) = "white" {}
         [HideInInspector] _BaseColorMapShow("BaseColor Map Show", Float) = 0
         _BaseColorMapUV("BaseColor Map UV", Float) = 0.0
+        _BaseColorMapUVLocal("BaseColorMap UV Local", Float) = 0.0
 
         [HideInInspector] _MetallicMapShow("Metallic Map Show", Float) = 0
         _Metallic("Metallic", Range(0.0, 1.0)) = 0
         _MetallicMap("Metallic Map", 2D) = "black" {}
         _MetallicUseMap("Metallic Use Map", Float) = 0
         _MetallicMapUV("Metallic Map UV", Float) = 0.0
+        _MetallicMapUVLocal("Metallic Map UV Local", Float) = 0.0
         _MetallicMapChannel("Metallic Map Channel", Float) = 0.0
         _MetallicMapChannelMask("Metallic Map Channel Mask", Vector) = (1, 0, 0, 0)
         _MetallicRemap("Metallic Remap", Vector) = (0, 1, 0, 0)
@@ -28,6 +30,7 @@ Shader "HDRenderPipeline/StackLit"
         _SmoothnessAMap("SmoothnessA Map", 2D) = "white" {}
         _SmoothnessAUseMap("SmoothnessA Use Map", Float) = 0
         _SmoothnessAMapUV("SmoothnessA Map UV", Float) = 0.0
+        _SmoothnessAMapUVLocal("_SmoothnessA Map UV Local", Float) = 0.0
         _SmoothnessAMapChannel("SmoothnessA Map Channel", Float) = 0.0
         _SmoothnessAMapChannelMask("SmoothnessA Map Channel Mask", Vector) = (1, 0, 0, 0)
         _SmoothnessARemap("SmoothnessA Remap", Vector)  = (0, 1, 0, 0)
@@ -39,6 +42,7 @@ Shader "HDRenderPipeline/StackLit"
         _SmoothnessBMap("SmoothnessB Map", 2D) = "white" {}
         _SmoothnessBUseMap("SmoothnessB Use Map", Float) = 0
         _SmoothnessBMapUV("SmoothnessB Map UV", Float) = 0.0
+        _SmoothnessAMapUVLocal("_SmoothnessB Map UV Local", Float) = 0.0
         _SmoothnessBMapChannel("SmoothnessB Map Channel", Float) = 0.0
         _SmoothnessBMapChannelMask("SmoothnessB Map Channel Mask", Vector) = (1, 0, 0, 0)
         _SmoothnessBRemap("SmoothnessB Remap", Vector) = (0, 1, 0, 0)
@@ -55,6 +59,7 @@ Shader "HDRenderPipeline/StackLit"
         _EmissiveColor("Emissive Color", Color) = (1, 1, 1)
         _EmissiveColorMap("Emissive Color Map", 2D) = "white" {}
         _EmissiveColorMapUV("Emissive Color Map UV", Range(0.0, 1.0)) = 0
+        _EmissiveColorMapUVLocal("Emissive Color Map UV Local", Float) = 0.0
         _EmissiveIntensity("Emissive Intensity", Float) = 0
         [ToggleUI] _AlbedoAffectEmissive("Albedo Affect Emissive", Float) = 0.0
 
@@ -103,9 +108,6 @@ Shader "HDRenderPipeline/StackLit"
         [ToggleUI]  _AlphaCutoffEnable("Alpha Cutoff Enable", Float) = 0.0
         _AlphaCutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
         _TransparentSortPriority("_TransparentSortPriority", Float) = 0
-
-        // global control
-        [ToggleUI] _UseLocalPlanarMapping("Use Local Planar Mapping", Float) = 0.0
 
         // Stencil state
         [HideInInspector] _StencilRef("_StencilRef", Int) = 2 // StencilLightingUsage.RegularLighting  (fixed at compile time)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/StackLit/StackLitProperties.hlsl
@@ -38,10 +38,12 @@ float4 _BaseColorMap_ST;
 float4 _BaseColorMap_TexelSize;
 float4 _BaseColorMap_MipInfo;
 float _BaseColorMapUV;
+float _BaseColorMapUVLocal;
 
 float _Metallic;
 float _MetallicUseMap;
 float _MetallicMapUV;
+float _MetallicMapUVLocal;
 float4 _MetallicMap_ST;
 float4 _MetallicMap_TexelSize;
 float4 _MetallicMap_MipInfo;
@@ -51,6 +53,7 @@ float4 _MetallicRange;
 float _SmoothnessA;
 float _SmoothnessAUseMap;
 float _SmoothnessAMapUV;
+float _SmoothnessAMapUVLocal;
 float4 _SmoothnessAMap_ST;
 float4 _SmoothnessAMap_TexelSize;
 float4 _SmoothnessAMap_MipInfo;
@@ -59,6 +62,7 @@ float4 _SmoothnessARange;
 float _SmoothnessB;
 float _SmoothnessBUseMap;
 float _SmoothnessBMapUV;
+float _SmoothnessBMapUVLocal;
 float4 _SmoothnessBMap_ST;
 float4 _SmoothnessBMap_TexelSize;
 float4 _SmoothnessBMap_MipInfo;
@@ -77,6 +81,7 @@ float4 _EmissiveColorMap_ST;
 float4 _EmissiveColorMap_TexelSize;
 float4 _EmissiveColorMap_MipInfo;
 float _EmissiveColorMapUV;
+float _EmissiveColorMapUVLocal;
 float _EmissiveIntensity;
 float _AlbedoAffectEmissive;
 
@@ -107,8 +112,6 @@ float _DistortionVectorBias;
 float _DistortionBlurScale;
 float _DistortionBlurRemapMin;
 float _DistortionBlurRemapMax;
-
-float _UseLocalPlanarMapping;
 
 // Caution: C# code in BaseLitUI.cs call LightmapEmissionFlagsProperty() which assume that there is an existing "_EmissionColor"
 // value that exist to identify if the GI emission need to be enabled.


### PR DESCRIPTION
Remove the "global" control of local or world planar, the UI was already there and bind it correctly