### PR TITLE
Small HDRP fixes

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/ImageBasedLighting.hlsl
+++ b/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/ImageBasedLighting.hlsl
@@ -31,6 +31,11 @@ real PerceptualRoughnessToMipmapLevel(real perceptualRoughness)
     return PerceptualRoughnessToMipmapLevel(perceptualRoughness, UNITY_SPECCUBE_LOD_STEPS);
 }
 
+real PerceptualRoughnessToMipmapLevelFromGaussianConvolution(real perceptualRoughness, uint mipMapCount)
+{
+    return sqrt(perceptualRoughness) * mipMapCount;
+}
+
 // The *accurate* version of the non-linear remapping. It works by
 // approximating the cone of the specular lobe, and then computing the MIP map level
 // which (approximately) covers the footprint of the lobe with a single texel.

--- a/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/ImageBasedLighting.hlsl
+++ b/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/ImageBasedLighting.hlsl
@@ -31,11 +31,6 @@ real PerceptualRoughnessToMipmapLevel(real perceptualRoughness)
     return PerceptualRoughnessToMipmapLevel(perceptualRoughness, UNITY_SPECCUBE_LOD_STEPS);
 }
 
-real PerceptualRoughnessToMipmapLevelFromGaussianConvolution(real perceptualRoughness, uint mipMapCount)
-{
-    return sqrt(perceptualRoughness) * mipMapCount;
-}
-
 // The *accurate* version of the non-linear remapping. It works by
 // approximating the cone of the specular lobe, and then computing the MIP map level
 // which (approximately) covers the footprint of the lobe with a single texel.

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Handles.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Handles.cs
@@ -315,6 +315,10 @@ namespace UnityEditor.Experimental.Rendering
         [DrawGizmo(GizmoType.Selected)]
         static void DrawSelectedGizmo(ReflectionProbe reflectionProbe, GizmoType gizmoType)
         {
+            var e = GetEditorFor(reflectionProbe);
+            if (e == null || !e.sceneViewEditing)
+                return;
+
             var reflectionData = reflectionProbe.GetComponent<HDAdditionalReflectionData>();
 
             Gizmos_Influence(reflectionProbe, reflectionData, null, false);
@@ -328,6 +332,10 @@ namespace UnityEditor.Experimental.Rendering
         [DrawGizmo(GizmoType.NonSelected)]
         static void DrawNonSelectedGizmo(ReflectionProbe reflectionProbe, GizmoType gizmoType)
         {
+            var e = GetEditorFor(reflectionProbe);
+            if (e == null || !e.sceneViewEditing)
+                return;
+                
             var reflectionData = reflectionProbe.GetComponent<HDAdditionalReflectionData>();
             if (reflectionData != null)
                 HDReflectionProbeEditorUtility.ChangeVisibility(reflectionProbe, false);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/Reflection/HDReflectionProbeUI.Drawers.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/Reflection/HDReflectionProbeUI.Drawers.cs
@@ -242,6 +242,17 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUI.showMixedValue = false;
             if (EditorGUI.EndChangeCheck())
                 s.SetShapeTarget(p.influenceShape.intValue);
+
+            if (p.proxyVolumeComponent.objectReferenceValue != null)
+            {
+                var proxy = (ReflectionProxyVolumeComponent)p.proxyVolumeComponent.objectReferenceValue;
+                if ((int)proxy.proxyVolume.shapeType != p.influenceShape.enumValueIndex)
+                    EditorGUILayout.HelpBox(
+                        "Proxy volume and influence volume have different shape types, this is not supported.",
+                        MessageType.Error,
+                        true
+                    );
+            }
         }
 
         static void Drawer_IntensityMultiplier(HDReflectionProbeUI s, SerializedHDReflectionProbe p, Editor owner)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Drawers.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Drawers.cs
@@ -77,6 +77,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     (s, d, o) => d.influenceVolume,
                     InfluenceVolumeUI.SectionFoldoutShape
                 ),
+                CED.Action(Drawer_DifferentShapeError),
                 SectionFoldoutInfluenceSettings,
                 SectionFoldoutCaptureSettings,
                 CED.Select(
@@ -110,6 +111,19 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             // EditorGUILayout.PropertyField(d.captureMirrorPlaneLocalPosition, _.GetContent("Plane Position"));
             // EditorGUILayout.PropertyField(d.captureMirrorPlaneLocalNormal, _.GetContent("Plane Normal"));
+        }
+
+        static void Drawer_DifferentShapeError(PlanarReflectionProbeUI s, SerializedPlanarReflectionProbe d, Editor o)
+        {
+            var proxy = d.proxyVolumeReference.objectReferenceValue as ReflectionProxyVolumeComponent;
+            if (proxy != null && (int)proxy.proxyVolume.shapeType != d.influenceVolume.shapeType.enumValueIndex)
+            {
+                EditorGUILayout.HelpBox(
+                    "Proxy volume and influence volume have different shape types, this is not supported.",
+                    MessageType.Error,
+                    true
+                );
+            }
         }
 
         static void Drawer_SectionCaptureSettings(PlanarReflectionProbeUI s, SerializedPlanarReflectionProbe d, Editor o)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -761,9 +761,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     continue;
                 }
 
-                if (camera.cameraType != CameraType.Reflection)
-                    // TODO: Render only visible probes
-                    ReflectionSystem.RenderAllRealtimeViewerDependentProbesFor(ReflectionProbeType.PlanarReflection, camera);
+                if (camera.cameraType != CameraType.Reflection
+                    // Planar probes rendering is not currently supported for orthographic camera
+                    // Avoid rendering to prevent error log spamming
+                    && !camera.orthographic)
+                        // TODO: Render only visible probes
+                        ReflectionSystem.RenderAllRealtimeViewerDependentProbesFor(ReflectionProbeType.PlanarReflection, camera);
 
                 // Init material if needed
                 // TODO: this should be move outside of the camera loop but we have no command buffer, ask details to Tim or Julien to do this

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipelineAsset.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipelineAsset.cs
@@ -78,7 +78,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 return new ReflectionSystemParameters
                 {
-                    maxPlanarReflectionProbes = renderPipelineSettings.lightLoopSettings.planarReflectionProbeCacheSize,
+                    maxPlanarReflectionProbePerRender = renderPipelineSettings.lightLoopSettings.planarReflectionProbeCacheSize,
+                    maxActivePlanarReflectionProbe = 512,
                     planarReflectionProbeSize = renderPipelineSettings.lightLoopSettings.planarReflectionTextureSize
                 };
             }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipelineAsset.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipelineAsset.cs
@@ -78,7 +78,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 return new ReflectionSystemParameters
                 {
-                    maxPlanarReflectionProbePerRender = renderPipelineSettings.lightLoopSettings.planarReflectionProbeCacheSize,
+                    maxPlanarReflectionProbePerCamera = renderPipelineSettings.lightLoopSettings.planarReflectionProbeCacheSize,
                     maxActivePlanarReflectionProbe = 512,
                     planarReflectionProbeSize = renderPipelineSettings.lightLoopSettings.planarReflectionTextureSize
                 };

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoopDef.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/LightLoopDef.hlsl
@@ -106,6 +106,9 @@ float3 SampleCookieCube(LightLoopContext lightLoopContext, float3 coord, int ind
 #define SINGLE_PASS_CONTEXT_SAMPLE_REFLECTION_PROBES 0
 #define SINGLE_PASS_CONTEXT_SAMPLE_SKY 1
 
+bool IsEnvIndexCubemap(int index)   { return (index & 1) == ENVCACHETYPE_CUBEMAP; }
+bool IsEnvIndexTexture2D(int index) { return (index & 1) == ENVCACHETYPE_TEXTURE2D; }
+
 // Note: index is whatever the lighting architecture want, it can contain information like in which texture to sample (in case we have a compressed BC6H texture and an uncompressed for real time reflection ?)
 // EnvIndex can also be use to fetch in another array of struct (to  atlas information etc...).
 // Cubemap      : texCoord = direction vector

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionProbeCullResults.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionProbeCullResults.cs
@@ -15,12 +15,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         internal ReflectionProbeCullResults(ReflectionSystemParameters parameters)
         {
-            Assert.IsTrue(parameters.maxPlanarReflectionProbePerRender >= 0, "Maximum number of planar reflection probe must be positive");
+            Assert.IsTrue(parameters.maxPlanarReflectionProbePerCamera >= 0, "Maximum number of planar reflection probe must be positive");
 
             visiblePlanarReflectionProbeCount = 0;
 
-            m_PlanarReflectionProbeIndices = new int[parameters.maxPlanarReflectionProbePerRender];
-            m_VisiblePlanarReflectionProbes = new PlanarReflectionProbe[parameters.maxPlanarReflectionProbePerRender];
+            m_PlanarReflectionProbeIndices = new int[parameters.maxPlanarReflectionProbePerCamera];
+            m_VisiblePlanarReflectionProbes = new PlanarReflectionProbe[parameters.maxPlanarReflectionProbePerCamera];
         }
 
         public void CullPlanarReflectionProbes(CullingGroup cullingGroup, PlanarReflectionProbe[] planarReflectionProbes)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionProbeCullResults.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionProbeCullResults.cs
@@ -15,12 +15,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         internal ReflectionProbeCullResults(ReflectionSystemParameters parameters)
         {
-            Assert.IsTrue(parameters.maxPlanarReflectionProbes >= 0, "Maximum number of planar reflection probe must be positive");
+            Assert.IsTrue(parameters.maxPlanarReflectionProbePerRender >= 0, "Maximum number of planar reflection probe must be positive");
 
             visiblePlanarReflectionProbeCount = 0;
 
-            m_PlanarReflectionProbeIndices = new int[parameters.maxPlanarReflectionProbes];
-            m_VisiblePlanarReflectionProbes = new PlanarReflectionProbe[parameters.maxPlanarReflectionProbes];
+            m_PlanarReflectionProbeIndices = new int[parameters.maxPlanarReflectionProbePerRender];
+            m_VisiblePlanarReflectionProbes = new PlanarReflectionProbe[parameters.maxPlanarReflectionProbePerRender];
         }
 
         public void CullPlanarReflectionProbes(CullingGroup cullingGroup, PlanarReflectionProbe[] planarReflectionProbes)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionSystemInternal.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionSystemInternal.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline.Internal
             m_PlanarReflectionProbeBounds = new Dictionary<PlanarReflectionProbe, BoundingSphere>(parameters.maxActivePlanarReflectionProbe);
             m_PlanarReflectionProbesArray = new PlanarReflectionProbe[parameters.maxActivePlanarReflectionProbe];
             m_PlanarReflectionProbeBoundsArray = new BoundingSphere[parameters.maxActivePlanarReflectionProbe];
-            m_PlanarReflectionProbe_RealtimeUpdate_WorkArray = new PlanarReflectionProbe[parameters.maxPlanarReflectionProbePerRender];
+            m_PlanarReflectionProbe_RealtimeUpdate_WorkArray = new PlanarReflectionProbe[parameters.maxPlanarReflectionProbePerCamera];
 
             // Persistent collections
             m_PlanarReflectionProbes = new HashSet<PlanarReflectionProbe>();

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionSystemParameters.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionSystemParameters.cs
@@ -1,16 +1,30 @@
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
+    /// <summary>
+    /// Holds settings for the reflection system.
+    /// </summary>
     public struct ReflectionSystemParameters
     {
         public static ReflectionSystemParameters Default = new ReflectionSystemParameters
         {
-            maxPlanarReflectionProbePerRender = 512,
+            maxPlanarReflectionProbePerCamera = 128,
             maxActivePlanarReflectionProbe = 512,
             planarReflectionProbeSize = 128
         };
 
-        public int maxPlanarReflectionProbePerRender;
+        /// <summary>
+        /// Maximum number of planar reflection that can be found in a cull result.
+        /// </summary>
+        public int maxPlanarReflectionProbePerCamera;
+
+        /// <summary>
+        /// Maximum number of active planar reflection in the world.
+        /// </summary>
         public int maxActivePlanarReflectionProbe;
+
+        /// <summary>
+        /// Size of the planar probe textures.
+        /// </summary>
         public int planarReflectionProbeSize;
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionSystemParameters.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Reflection/ReflectionSystemParameters.cs
@@ -4,11 +4,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     {
         public static ReflectionSystemParameters Default = new ReflectionSystemParameters
         {
-            maxPlanarReflectionProbes = 512,
+            maxPlanarReflectionProbePerRender = 512,
+            maxActivePlanarReflectionProbe = 512,
             planarReflectionProbeSize = 128
         };
 
-        public int maxPlanarReflectionProbes;
+        public int maxPlanarReflectionProbePerRender;
+        public int maxActivePlanarReflectionProbe;
         public int planarReflectionProbeSize;
     }
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Material/Lit/Lit.hlsl
@@ -1017,7 +1017,7 @@ PreLightData GetPreLightData(float3 V, PositionInputs posInput, inout BSDFData b
     preLightData.transparentTransmittance = exp(-bsdfData.absorptionCoefficient * refraction.dist);
     // Empirical remap to try to match a bit the refraction probe blurring for the fallback
     // Use IblPerceptualRoughness so we can handle approx of clear coat.
-    preLightData.transparentSSMipLevel = PerceptualRoughnessToMipmapLevelFromGaussianConvolution(preLightData.iblPerceptualRoughness, uint(_ColorPyramidScale.z));
+    preLightData.transparentSSMipLevel = pow(preLightData.iblPerceptualRoughness, 1.3) * uint(max(_ColorPyramidScale.z - 1, 0));
 #endif
 
     return preLightData;
@@ -1921,7 +1921,8 @@ IndirectLighting EvaluateBSDF_Env(  LightLoopContext lightLoopContext,
     // Specific case for Texture2Ds, their convolution is a gaussian one and not a GGX one.
     // So we use another roughness mip mapping.
     if (IsEnvIndexTexture2D(lightData.envIndex))
-        iblMipLevel = PerceptualRoughnessToMipmapLevelFromGaussianConvolution(preLightData.iblPerceptualRoughness, uint(_ColorPyramidScale.z));
+        // Empirical remapping
+        iblMipLevel = pow(preLightData.iblPerceptualRoughness, 0.8) * uint(max(_ColorPyramidScale.z - 1, 0));
 
     float4 preLD = SampleEnv(lightLoopContext, lightData.envIndex, R, iblMipLevel);
     weight *= preLD.a; // Used by planar reflection to discard pixel

--- a/Tests/UTF_Suites_HDRP/Resources/HDRP_Deferred.asset
+++ b/Tests/UTF_Suites_HDRP/Resources/HDRP_Deferred.asset
@@ -20,128 +20,128 @@ MonoBehaviour:
   - groupName: 1xMaterials
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
       scene: {fileID: 102900000, guid: 7fe3f9e94b4355641ba1534c54d5c356, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
       scene: {fileID: 102900000, guid: a6e4a81e1988f24459f57a881905a465, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
       scene: {fileID: 102900000, guid: 27d04b0368c7fef4eb423d76cc0e48dc, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
       scene: {fileID: 102900000, guid: 51392325eef9416439dc126a37256e6f, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
       scene: {fileID: 102900000, guid: 653861b0fa3627049a20abf379b1258f, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
       scene: {fileID: 102900000, guid: e86a25d7e98b1c74199eaa8dbcc2cd01, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
       scene: {fileID: 102900000, guid: bc3f6030b835ecd4c800561f9ff1af15, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
       scene: {fileID: 102900000, guid: 530aef5d08a1569479cc65b219b8f9fb, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
       scene: {fileID: 102900000, guid: fc3cc4c68d873e64ca12fcfc828d7ee4, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
       scene: {fileID: 102900000, guid: ac4701d765fa26b4f83d2fb9ed6b3c08, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
       scene: {fileID: 102900000, guid: 40bca98d8a50ec14182c423a91470550, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
       scene: {fileID: 102900000, guid: 54145926a6315654b9e70a75a4b050ef, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
       scene: {fileID: 102900000, guid: 5f5bca2466b2a1d48ae818180ef308fb, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
       scene: {fileID: 102900000, guid: 722bdd4c5dac1f145acd795543fae598, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
       scene: {fileID: 102900000, guid: f465136a9ac4cb1429a4a1761d07c3c3, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
       scene: {fileID: 102900000, guid: 201c29a239df4c74ea9e1ab47082abea, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
       scene: {fileID: 102900000, guid: 0277520b19264c24eac3041bd22ae564, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
       scene: {fileID: 102900000, guid: 6f2bc3028f3daba46ab0447a3e25ebc6, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
@@ -149,93 +149,93 @@ MonoBehaviour:
   - groupName: 2xLighting
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
       scene: {fileID: 102900000, guid: 09baf18a7e1f6584f86675e6a2141c66, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
       scene: {fileID: 102900000, guid: bcbb964f739039045b7958a9b1489657, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
       scene: {fileID: 102900000, guid: ac9787fadf0b4ed4391bee6ba1d8e213, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
       scene: {fileID: 102900000, guid: 9f03abfd8e9cc614c89458cbdb208e7c, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
       scene: {fileID: 102900000, guid: 8747b43f8bcf2b44cbc3ece373da65a9, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
       scene: {fileID: 102900000, guid: b8f49ca9a12abb4468116e9422139e63, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
       scene: {fileID: 102900000, guid: d8cfa4fd9319d2444b3bf6dd836ffe31, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
       scene: {fileID: 102900000, guid: d485acf0535eb4b42a9a3847f4a8274a, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
       scene: {fileID: 102900000, guid: 9b3132db666b3ae48aa17349ab100118, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
       scene: {fileID: 102900000, guid: 359ded33a047fd540b5e19a98547f5e2, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2206_ProbeRoughness.unity
       scene: {fileID: 102900000, guid: fde2b1b0825ef5f40a0e5069afcca848, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2206_ProbeRoughness.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
-      run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
+      run: 0
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
       scene: {fileID: 102900000, guid: 1029947770f955b4290bbdd8b641f7f1, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
       scene: {fileID: 102900000, guid: 3f6529c22f7d2ca46814b2e7afd04ef9, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
@@ -243,65 +243,65 @@ MonoBehaviour:
   - groupName: 3xDebugView
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
       scene: {fileID: 102900000, guid: 21522d96110c8dd41ab353d89fd740c3, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
       scene: {fileID: 102900000, guid: 5fd66b494b9e057498e551fea7ab02fd, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
       scene: {fileID: 102900000, guid: 32624e48cd276b5418513150e7abd682, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
       scene: {fileID: 102900000, guid: b8bed96a3181ffe49b8e54bc9a3c7687, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
       scene: {fileID: 102900000, guid: 55881ec59ae8d414cb8a77aa120a45ed, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
       scene: {fileID: 102900000, guid: 0225322b58c79bb4d87afeb169e0d119, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
       scene: {fileID: 102900000, guid: 01e6660110220214782d0ebf364fe7c9, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
       scene: {fileID: 102900000, guid: fabc53a9f87e8784580b4e75dc067ca3, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
       scene: {fileID: 102900000, guid: a5fb429214e9b2a4f8b3d258c0585630, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
@@ -309,18 +309,18 @@ MonoBehaviour:
   - groupName: 9xOther
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
       scene: {fileID: 102900000, guid: a27cb5a638892574f99eb333bb3c7722, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
       scene: {fileID: 102900000, guid: 7f93d4b757746d44a82005f71f597384, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-  suiteVersion: 3
+  suiteVersion: 8

--- a/Tests/UTF_Suites_HDRP/Resources/HDRP_Deferred.asset
+++ b/Tests/UTF_Suites_HDRP/Resources/HDRP_Deferred.asset
@@ -16,11 +16,6 @@ MonoBehaviour:
   defaultTestSettings: {fileID: 0}
   defaultRenderPipeline: {fileID: 11400000, guid: d7fe5f39d2c099a4ea1f1f610af309d7,
     type: 2}
-  alternateSettings:
-  - renderPipeline: {fileID: 11400000, guid: e0b837a0b8013cb4380a2f1286170857, type: 2}
-    testSettings: {fileID: 0}
-  - renderPipeline: {fileID: 11400000, guid: ae88914339ad0504eaca3f858706b8ad, type: 2}
-    testSettings: {fileID: 0}
   groups:
   - groupName: 1xMaterials
     renderPipelineOverride: {fileID: 0}
@@ -224,6 +219,13 @@ MonoBehaviour:
       minimumUnityVersion: 4
       platforms: -1
       run: 0
+    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      scene: {fileID: 102900000, guid: fde2b1b0825ef5f40a0e5069afcca848, type: 3}
+      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      testTypes: 2
+      minimumUnityVersion: 4
+      platforms: -1
+      run: 1
     - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
       scene: {fileID: 102900000, guid: 1029947770f955b4290bbdd8b641f7f1, type: 3}
       scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
@@ -321,4 +323,4 @@ MonoBehaviour:
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-  suiteVersion: 2
+  suiteVersion: 3

--- a/Tests/UTF_Suites_HDRP/Resources/HDRP_Forward.asset
+++ b/Tests/UTF_Suites_HDRP/Resources/HDRP_Forward.asset
@@ -20,128 +20,128 @@ MonoBehaviour:
   - groupName: 1xMaterials
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
       scene: {fileID: 102900000, guid: 7fe3f9e94b4355641ba1534c54d5c356, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1101_Unlit.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
       scene: {fileID: 102900000, guid: a6e4a81e1988f24459f57a881905a465, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1102_Unlit_Distortion.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
       scene: {fileID: 102900000, guid: 27d04b0368c7fef4eb423d76cc0e48dc, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1103_Unlit_Distortion_DepthTest.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
       scene: {fileID: 102900000, guid: 51392325eef9416439dc126a37256e6f, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1201_Lit_Features.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
       scene: {fileID: 102900000, guid: 653861b0fa3627049a20abf379b1258f, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1202_Lit_DoubleSideNormalMode.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
       scene: {fileID: 102900000, guid: e86a25d7e98b1c74199eaa8dbcc2cd01, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1203_Lit_Transparent.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
       scene: {fileID: 102900000, guid: bc3f6030b835ecd4c800561f9ff1af15, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1204_Lit_Transparent_Fog.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
       scene: {fileID: 102900000, guid: 530aef5d08a1569479cc65b219b8f9fb, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1205_Lit_Transparent_Refraction.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
       scene: {fileID: 102900000, guid: fc3cc4c68d873e64ca12fcfc828d7ee4, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1206_Lit_Transparent_Distortion.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
       scene: {fileID: 102900000, guid: ac4701d765fa26b4f83d2fb9ed6b3c08, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1207_Lit_Displacement.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
       scene: {fileID: 102900000, guid: 40bca98d8a50ec14182c423a91470550, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1208_Lit_Displacement_POM.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
       scene: {fileID: 102900000, guid: 54145926a6315654b9e70a75a4b050ef, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1209_Lit_Displacement_Vertex.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
       scene: {fileID: 102900000, guid: 5f5bca2466b2a1d48ae818180ef308fb, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1210_Lit_BentNormal.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
       scene: {fileID: 102900000, guid: 722bdd4c5dac1f145acd795543fae598, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1211_Lit_Details.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
       scene: {fileID: 102900000, guid: f465136a9ac4cb1429a4a1761d07c3c3, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1212_Lit_Emission.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
       scene: {fileID: 102900000, guid: 201c29a239df4c74ea9e1ab47082abea, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1301_SubSurfaceScattering.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
       scene: {fileID: 102900000, guid: 0277520b19264c24eac3041bd22ae564, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1302_SSS_MaxRadius.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
       scene: {fileID: 102900000, guid: 6f2bc3028f3daba46ab0447a3e25ebc6, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/1x_Materials/1303_SSS_Pre-Post.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
@@ -149,93 +149,93 @@ MonoBehaviour:
   - groupName: 2xLighting
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
       scene: {fileID: 102900000, guid: 09baf18a7e1f6584f86675e6a2141c66, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2001_Dynamic_Directional.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
       scene: {fileID: 102900000, guid: bcbb964f739039045b7958a9b1489657, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2002_Dynamic_Mix.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
       scene: {fileID: 102900000, guid: ac9787fadf0b4ed4391bee6ba1d8e213, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2003_Light_Parameters.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
       scene: {fileID: 102900000, guid: 9f03abfd8e9cc614c89458cbdb208e7c, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2004_AnimatedCookie.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
       scene: {fileID: 102900000, guid: 8747b43f8bcf2b44cbc3ece373da65a9, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2101_GI_Metapass.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
       scene: {fileID: 102900000, guid: b8f49ca9a12abb4468116e9422139e63, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2102_GI_Emission.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
       scene: {fileID: 102900000, guid: d8cfa4fd9319d2444b3bf6dd836ffe31, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2103_BakeMixed.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
       scene: {fileID: 102900000, guid: d485acf0535eb4b42a9a3847f4a8274a, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2201_ReflectionProbes_Priority.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
       scene: {fileID: 102900000, guid: 9b3132db666b3ae48aa17349ab100118, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2202_ReflectionProbes_Volume.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
       scene: {fileID: 102900000, guid: 359ded33a047fd540b5e19a98547f5e2, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2203_PlanarProbes.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2206_ProbeRoughness.unity
       scene: {fileID: 102900000, guid: fde2b1b0825ef5f40a0e5069afcca848, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2206_ProbeRoughness.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
-      run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
+      run: 0
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
       scene: {fileID: 102900000, guid: 1029947770f955b4290bbdd8b641f7f1, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
       scene: {fileID: 102900000, guid: 3f6529c22f7d2ca46814b2e7afd04ef9, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
@@ -243,65 +243,65 @@ MonoBehaviour:
   - groupName: 3xDebugView
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
       scene: {fileID: 102900000, guid: 21522d96110c8dd41ab353d89fd740c3, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3001_DebugView.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
       scene: {fileID: 102900000, guid: 5fd66b494b9e057498e551fea7ab02fd, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3002_ObjectMotionVector.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
       scene: {fileID: 102900000, guid: 32624e48cd276b5418513150e7abd682, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3003_CameraMotionVector_TranslateX.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
       scene: {fileID: 102900000, guid: b8bed96a3181ffe49b8e54bc9a3c7687, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3004_CameraMotionVector_TranslateY.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
       scene: {fileID: 102900000, guid: 55881ec59ae8d414cb8a77aa120a45ed, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3005_CameraMotionVector_TranslateZ.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
       scene: {fileID: 102900000, guid: 0225322b58c79bb4d87afeb169e0d119, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3006_CameraMotionVector_RotateX.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
       scene: {fileID: 102900000, guid: 01e6660110220214782d0ebf364fe7c9, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3007_CameraMotionVector_RotateY.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
       scene: {fileID: 102900000, guid: fabc53a9f87e8784580b4e75dc067ca3, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3008_CameraMotionVector_RotateZ.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
       scene: {fileID: 102900000, guid: a5fb429214e9b2a4f8b3d258c0585630, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/3x_DebugView/3009_CameraMotionVector_FOV.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
@@ -309,18 +309,18 @@ MonoBehaviour:
   - groupName: 9xOther
     renderPipelineOverride: {fileID: 0}
     tests:
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
       scene: {fileID: 102900000, guid: a27cb5a638892574f99eb333bb3c7722, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9001_Decals.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 1
-    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
+    - name: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
       scene: {fileID: 102900000, guid: 7f93d4b757746d44a82005f71f597384, type: 3}
-      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
+      scenePath: Assets/ScriptableRenderPipeline/Tests/UTF_Tests_HDRP/Scenes/9x_Other/9002_Deferred-and-Forward.unity
       testTypes: 2
       minimumUnityVersion: 4
       platforms: -1
       run: 0
-  suiteVersion: 2
+  suiteVersion: 4

--- a/Tests/UTF_Suites_HDRP/Resources/HDRP_Forward.asset
+++ b/Tests/UTF_Suites_HDRP/Resources/HDRP_Forward.asset
@@ -16,7 +16,6 @@ MonoBehaviour:
   defaultTestSettings: {fileID: 0}
   defaultRenderPipeline: {fileID: 11400000, guid: d206727e1fcd98842b54b98db4dfce28,
     type: 2}
-  alternateSettings: []
   groups:
   - groupName: 1xMaterials
     renderPipelineOverride: {fileID: 0}
@@ -220,6 +219,13 @@ MonoBehaviour:
       minimumUnityVersion: 4
       platforms: -1
       run: 0
+    - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      scene: {fileID: 102900000, guid: fde2b1b0825ef5f40a0e5069afcca848, type: 3}
+      scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2401_Light_on_Tesselation.unity
+      testTypes: 2
+      minimumUnityVersion: 4
+      platforms: -1
+      run: 1
     - name: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity
       scene: {fileID: 102900000, guid: 1029947770f955b4290bbdd8b641f7f1, type: 3}
       scenePath: Assets/SRP/Tests/UTF_Tests_HDRP/Scenes/2x_Lighting/2301_Shadow_Mask.unity


### PR DESCRIPTION
- Fixed log error when using the ReflectionProbe component without HDRP
- Added a warning when using different shape for influence and proxy volume for reflection/planar probes
- Use two limits for max number of active planar probe and max planar probe during a rendering
- Remapped rougness to mip level for refraction and planar probes (empirical)
- Disabled planar probe rendering for orthographic cameras
- Fixed pyramid computation error