### PR TITLE
Fixed warnings as requested by Spotlight customer

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/Editor/CoreEditorDrawers.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/Editor/CoreEditorDrawers.cs
@@ -179,7 +179,6 @@ namespace UnityEditor.Experimental.Rendering
             AnimBoolGetter m_IsExpanded;
             string m_Title;
             FoldoutOption m_Options;
-            bool m_Animate;
 
             bool animate { get { return (m_Options & FoldoutOption.Animate) != 0; } }
             bool indent { get { return (m_Options & FoldoutOption.Indent) != 0; } }

--- a/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/GeometricTools.hlsl
+++ b/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/GeometricTools.hlsl
@@ -50,7 +50,7 @@ bool IntersectRayAABB(float3 rayOrigin, float3 rayDirection,
 // This simplified version assume that we care about the result only when we are inside the box
 float IntersectRayAABBSimple(float3 start, float3 dir, float3 boxMin, float3 boxMax)
 {
-    float3 invDir = 1.0 / dir;
+    float3 invDir = rcp(dir);
 
     // Find the ray intersection with box plane
     float3 rbmin = (boxMin - start) * invDir;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/VolumetricLighting.compute
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/VolumetricLighting.compute
@@ -9,6 +9,8 @@
 
 // #pragma enable_d3d11_debug_symbols
 
+#define SHADOW_USE_ONLY_VIEW_BASED_BIASING 1 // We don't use normal biasing as it is not available when doing volumetric
+
 #include "../../ShaderPass/ShaderPass.cs.hlsl"
 #define SHADERPASS SHADERPASS_VOLUMETRIC_LIGHTING
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -90,7 +90,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         private RenderTargetIdentifier m_CopyColorRT;
         private RenderTargetIdentifier m_DepthRT;
         private RenderTargetIdentifier m_CopyDepth;
-        private RenderTargetIdentifier m_Color;
         private float[] m_OpaqueScalerValues = {1.0f, 0.5f, 0.25f, 0.25f};
 
         private float m_RenderScale;

--- a/Tests/GraphicsTests/RenderPipeline/LightweightPipeline/Scenes/011_UnlitSprites/Scripts/Oscilate.cs
+++ b/Tests/GraphicsTests/RenderPipeline/LightweightPipeline/Scenes/011_UnlitSprites/Scripts/Oscilate.cs
@@ -10,7 +10,6 @@ public class Oscilate : MonoBehaviour
 
     private float elapsed;
     Vector3 startPosition;
-    private float time;
 
     void Start()
     {


### PR DESCRIPTION
This PR replace the following close PR: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/1315. It provide proper way to fix the shader warning
+ don't do a zero initialize on PreLightData to better track shader warning issue.