### PR TITLE
Add support of bake shadow to area light

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
@@ -231,7 +231,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             using (new EditorGUI.DisabledScope(disabledScope))
             {
                 bool shadowsEnabled = EditorGUILayout.Toggle(CoreEditorUtils.GetContent("Enable Shadows"), settings.shadowsType.enumValueIndex != 0);
-                settings.shadowsType.enumValueIndex = shadowsEnabled ? (int)LightShadows.Hard : (int)LightShadows.None;
+                if (shadowsEnabled)
+                {
+                    settings.shadowsType.enumValueIndex = (m_LightShape == LightShape.Line || m_LightShape == LightShape.Rectangle) ? (int)LightShadows.Soft : (int)LightShadows.Hard;
+                }
+                else
+                {
+                    settings.shadowsType.enumValueIndex = (int)LightShadows.None;
+                }
             }
 
             EditorGUILayout.PropertyField(m_AdditionalLightData.showAdditionalSettings);
@@ -299,9 +306,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     settings.areaSizeX.floatValue = m_AdditionalLightData.shapeWidth.floatValue;
                     settings.areaSizeY.floatValue = m_AdditionalLightData.shapeHeight.floatValue;
                     // Bake shadow aren't supported before 2018.2
-                    #if UNITY_2018_2_OR_NEWER
-                    settings.shadowsType.enumValueIndex = (int)LightShadows.Soft;
-                    #else
+                    #if !UNITY_2018_2_OR_NEWER
                     settings.shadowsType.enumValueIndex = (int)LightShadows.None;
                     #endif
                     break;
@@ -318,9 +323,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     settings.areaSizeX.floatValue = m_AdditionalLightData.shapeWidth.floatValue;
                     settings.areaSizeY.floatValue = k_MinAreaWidth;
                     // Bake shadow aren't supported before 2018.2
-                    #if UNITY_2018_2_OR_NEWER
-                    settings.shadowsType.enumValueIndex = (int)LightShadows.Soft;
-                    #else
+                    #if !UNITY_2018_2_OR_NEWER
                     settings.shadowsType.enumValueIndex = (int)LightShadows.None;
                     #endif
                     break;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
@@ -299,6 +299,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     settings.areaSizeX.floatValue = m_AdditionalLightData.shapeWidth.floatValue;
                     settings.areaSizeY.floatValue = m_AdditionalLightData.shapeHeight.floatValue;
                     // Bake shadow aren't supported before 2018.2
+                    #if UNITY_2018_2_OR_NEWER
                     settings.shadowsType.enumValueIndex = (int)LightShadows.Soft;
                     #else
                     settings.shadowsType.enumValueIndex = (int)LightShadows.None;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/Lighting/HDLightEditor.cs
@@ -221,8 +221,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         void DrawFeatures()
         {
             bool disabledScope = settings.isCompletelyBaked
+                // Bake shadow aren't supported before 2018.2
+                #if !UNITY_2018_2_OR_NEWER
                 || m_LightShape == LightShape.Line
-                || m_LightShape == LightShape.Rectangle;
+                || m_LightShape == LightShape.Rectangle
+                #endif
+                ;
 
             using (new EditorGUI.DisabledScope(disabledScope))
             {
@@ -294,7 +298,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     m_AdditionalLightData.shapeHeight.floatValue = Mathf.Max(m_AdditionalLightData.shapeHeight.floatValue, k_MinAreaWidth);
                     settings.areaSizeX.floatValue = m_AdditionalLightData.shapeWidth.floatValue;
                     settings.areaSizeY.floatValue = m_AdditionalLightData.shapeHeight.floatValue;
+                    // Bake shadow aren't supported before 2018.2
+                    settings.shadowsType.enumValueIndex = (int)LightShadows.Soft;
+                    #else
                     settings.shadowsType.enumValueIndex = (int)LightShadows.None;
+                    #endif
                     break;
 
                 case LightShape.Line:
@@ -308,7 +316,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     // Fake line with a small rectangle in vanilla unity for GI
                     settings.areaSizeX.floatValue = m_AdditionalLightData.shapeWidth.floatValue;
                     settings.areaSizeY.floatValue = k_MinAreaWidth;
+                    // Bake shadow aren't supported before 2018.2
+                    #if UNITY_2018_2_OR_NEWER
+                    settings.shadowsType.enumValueIndex = (int)LightShadows.Soft;
+                    #else
                     settings.shadowsType.enumValueIndex = (int)LightShadows.None;
+                    #endif
                     break;
 
                 case (LightShape)(-1):


### PR DESCRIPTION
This PR enable "enable Shadows" toggle on area light (line, rect) for 2018.2 and default to Soft shadow for these area lights if enabled.