### PR TITLE
Add enableVolumetric in the FrameSettings

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Camera/HDCamera.cs
@@ -454,7 +454,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             s_Cleanup.Clear();
         }
 
-        // Look for any camera that hasn't been used in the last frame and remove them for the pool.
+        // Look for any camera that hasn't been used in the last frame and remove them from the pool.
         public static void CleanUnused()
         {
             int frameCheck = Time.frameCount - 1;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
@@ -133,6 +133,7 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUILayout.PropertyField(p.enableSSAO, _.GetContent("Enable SSAO"));
             EditorGUILayout.PropertyField(p.enableSubsurfaceScattering, _.GetContent("Enable Subsurface Scattering"));
             EditorGUILayout.PropertyField(p.enableTransmission, _.GetContent("Enable Transmission"));
+            EditorGUILayout.PropertyField(p.enableVolumetric, _.GetContent("Enable Volumetric"));
             EditorGUILayout.PropertyField(p.enableShadow, _.GetContent("Enable Shadow"));
             EditorGUILayout.PropertyField(p.enableContactShadow, _.GetContent("Enable Contact Shadows"));
             EditorGUILayout.PropertyField(p.enableShadowMask, _.GetContent("Enable Shadow Masks"));

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/FrameSettingsUI.cs
@@ -96,7 +96,6 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUILayout.PropertyField(p.enableMotionVectors, _.GetContent("Enable Motion Vectors"));
             EditorGUILayout.PropertyField(p.enableObjectMotionVectors, _.GetContent("Enable Object Motion Vectors"));
             EditorGUILayout.PropertyField(p.enableDBuffer, _.GetContent("Enable DBuffer"));
-            EditorGUILayout.PropertyField(p.enableAtmosphericScattering, _.GetContent("Enable Atmospheric Scattering"));
             EditorGUILayout.PropertyField(p.enableRoughRefraction, _.GetContent("Enable Rough Refraction"));
             EditorGUILayout.PropertyField(p.enableDistortion, _.GetContent("Enable Distortion"));
             EditorGUILayout.PropertyField(p.enablePostprocess, _.GetContent("Enable Postprocess"));
@@ -133,7 +132,8 @@ namespace UnityEditor.Experimental.Rendering
             EditorGUILayout.PropertyField(p.enableSSAO, _.GetContent("Enable SSAO"));
             EditorGUILayout.PropertyField(p.enableSubsurfaceScattering, _.GetContent("Enable Subsurface Scattering"));
             EditorGUILayout.PropertyField(p.enableTransmission, _.GetContent("Enable Transmission"));
-            EditorGUILayout.PropertyField(p.enableVolumetric, _.GetContent("Enable Volumetric"));
+            EditorGUILayout.PropertyField(p.enableAtmosphericScattering, _.GetContent("Enable Atmospheric Scattering"));
+            EditorGUILayout.PropertyField(p.enableVolumetric, _.GetContent("    Enable Volumetric"));
             EditorGUILayout.PropertyField(p.enableShadow, _.GetContent("Enable Shadow"));
             EditorGUILayout.PropertyField(p.enableContactShadow, _.GetContent("Enable Contact Shadows"));
             EditorGUILayout.PropertyField(p.enableShadowMask, _.GetContent("Enable Shadow Masks"));

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedFrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedFrameSettings.cs
@@ -12,6 +12,7 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty enableSSAO;
         public SerializedProperty enableSubsurfaceScattering;
         public SerializedProperty enableTransmission;
+        public SerializedProperty enableVolumetric;
 
         public SerializedProperty diffuseGlobalDimmer;
         public SerializedProperty specularGlobalDimmer;
@@ -52,6 +53,7 @@ namespace UnityEditor.Experimental.Rendering
             enableSSAO = root.Find((FrameSettings d) => d.enableSSAO);
             enableSubsurfaceScattering = root.Find((FrameSettings d) => d.enableSubsurfaceScattering);
             enableTransmission = root.Find((FrameSettings d) => d.enableTransmission);
+            enableVolumetric = root.Find((FrameSettings d) => d.enableVolumetric);
             diffuseGlobalDimmer = root.Find((FrameSettings d) => d.diffuseGlobalDimmer);
             specularGlobalDimmer = root.Find((FrameSettings d) => d.specularGlobalDimmer);
             enableForwardRenderingOnly = root.Find((FrameSettings d) => d.enableForwardRenderingOnly);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedFrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Editor/RenderLoopSettings/SerializedFrameSettings.cs
@@ -12,6 +12,7 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty enableSSAO;
         public SerializedProperty enableSubsurfaceScattering;
         public SerializedProperty enableTransmission;
+        public SerializedProperty enableAtmosphericScattering;
         public SerializedProperty enableVolumetric;
 
         public SerializedProperty diffuseGlobalDimmer;
@@ -24,7 +25,6 @@ namespace UnityEditor.Experimental.Rendering
         public SerializedProperty enableMotionVectors;
         public SerializedProperty enableObjectMotionVectors;
         public SerializedProperty enableDBuffer;
-        public SerializedProperty enableAtmosphericScattering;
         public SerializedProperty enableRoughRefraction;
         public SerializedProperty enableTransparentPostpass;
         public SerializedProperty enableDistortion;
@@ -53,6 +53,7 @@ namespace UnityEditor.Experimental.Rendering
             enableSSAO = root.Find((FrameSettings d) => d.enableSSAO);
             enableSubsurfaceScattering = root.Find((FrameSettings d) => d.enableSubsurfaceScattering);
             enableTransmission = root.Find((FrameSettings d) => d.enableTransmission);
+            enableAtmosphericScattering = root.Find((FrameSettings d) => d.enableAtmosphericScattering);
             enableVolumetric = root.Find((FrameSettings d) => d.enableVolumetric);
             diffuseGlobalDimmer = root.Find((FrameSettings d) => d.diffuseGlobalDimmer);
             specularGlobalDimmer = root.Find((FrameSettings d) => d.specularGlobalDimmer);
@@ -62,7 +63,6 @@ namespace UnityEditor.Experimental.Rendering
             enableMotionVectors = root.Find((FrameSettings d) => d.enableMotionVectors);
             enableObjectMotionVectors = root.Find((FrameSettings d) => d.enableObjectMotionVectors);
             enableDBuffer = root.Find((FrameSettings d) => d.enableDBuffer);
-            enableAtmosphericScattering = root.Find((FrameSettings d) => d.enableAtmosphericScattering);
             enableRoughRefraction = root.Find((FrameSettings d) => d.enableRoughRefraction);
             enableTransparentPostpass = root.Find((FrameSettings d) => d.enableTransparentPostpass);
             enableDistortion = root.Find((FrameSettings d) => d.enableDistortion);

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/VolumetricLighting.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/VolumetricLighting.cs
@@ -67,6 +67,7 @@ public class VolumetricLightingSystem
 {
     public enum VolumetricLightingPreset
     {
+        Off,
         Normal,
         Ultra,
         Count
@@ -316,6 +317,8 @@ public class VolumetricLightingSystem
                 return 8;
             case VolumetricLightingPreset.Ultra:
                 return 4;
+            case VolumetricLightingPreset.Off:
+                return 0;
             default:
                 Debug.Assert(false, "Encountered an unexpected VolumetricLightingPreset.");
                 return 0;
@@ -330,6 +333,8 @@ public class VolumetricLightingSystem
                 return 64;
             case VolumetricLightingPreset.Ultra:
                 return 128;
+            case VolumetricLightingPreset.Off:
+                return 0;
             default:
                 Debug.Assert(false, "Encountered an unexpected VolumetricLightingPreset.");
                 return 0;

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/VolumetricLighting.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/Volumetrics/VolumetricLighting.cs
@@ -453,7 +453,8 @@ public class VolumetricLightingSystem
             return densityVolumes;
 
         var visualEnvironment = VolumeManager.instance.stack.GetComponent<VisualEnvironment>();
-        if (visualEnvironment.fogType != FogType.Volumetric) return densityVolumes;
+        if (visualEnvironment.fogType != FogType.Volumetric)
+            return densityVolumes;
 
         using (new ProfilingSample(cmd, "Prepare Visible Density Volume List"))
         {
@@ -511,7 +512,8 @@ public class VolumetricLightingSystem
             return;
 
         var visualEnvironment = VolumeManager.instance.stack.GetComponent<VisualEnvironment>();
-        if (visualEnvironment.fogType != FogType.Volumetric) return;
+        if (visualEnvironment.fogType != FogType.Volumetric)
+            return;
 
         using (new ProfilingSample(cmd, "Volume Voxelization"))
         {

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
@@ -17,6 +17,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool enableSSAO = true;
         public bool enableSubsurfaceScattering = true;
         public bool enableTransmission = true;  // Caution: this is only for debug, it doesn't save the cost of Transmission execution
+        public bool enableAtmosphericScattering = true;
         public bool enableVolumetric = true;
 
         // Setup by system
@@ -31,7 +32,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool enableMotionVectors = true; // Enable/disable whole motion vectors pass (Camera + Object).
         public bool enableObjectMotionVectors = true;
         public bool enableDBuffer = true;
-        public bool enableAtmosphericScattering = true;
         public bool enableRoughRefraction = true; // Depends on DepthPyramid - If not enable, just do a copy of the scene color (?) - how to disable rough refraction ?
         public bool enableTransparentPostpass = true;
         public bool enableDistortion = true;
@@ -58,6 +58,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             frameSettings.enableSSAO = this.enableSSAO;
             frameSettings.enableSubsurfaceScattering = this.enableSubsurfaceScattering;
             frameSettings.enableTransmission = this.enableTransmission;
+            frameSettings.enableAtmosphericScattering = this.enableAtmosphericScattering;
             frameSettings.enableVolumetric = this.enableVolumetric;
 
             frameSettings.diffuseGlobalDimmer = this.diffuseGlobalDimmer;
@@ -70,7 +71,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             frameSettings.enableMotionVectors = this.enableMotionVectors;
             frameSettings.enableObjectMotionVectors = this.enableObjectMotionVectors;
             frameSettings.enableDBuffer = this.enableDBuffer;
-            frameSettings.enableAtmosphericScattering = this.enableAtmosphericScattering;
             frameSettings.enableRoughRefraction = this.enableRoughRefraction;
             frameSettings.enableTransparentPostpass = this.enableTransparentPostpass;
             frameSettings.enableDistortion = this.enableDistortion;
@@ -115,7 +115,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             aggregate.enableSSAO = srcFrameSettings.enableSSAO && renderPipelineSettings.supportSSAO;
             aggregate.enableSubsurfaceScattering = camera.cameraType != CameraType.Reflection && srcFrameSettings.enableSubsurfaceScattering && renderPipelineSettings.supportSubsurfaceScattering;
             aggregate.enableTransmission = srcFrameSettings.enableTransmission;
-            aggregate.enableVolumetric = srcFrameSettings.enableVolumetric && renderPipelineSettings.supportVolumetric;
+            aggregate.enableAtmosphericScattering = srcFrameSettings.enableAtmosphericScattering;
+            // We must take care of the scene view fog flags in the editor
+            if (!CoreUtils.IsSceneViewFogEnabled(camera))
+                aggregate.enableAtmosphericScattering = false;
+            // Volumetric are disabled if there is no atmospheric scattering
+            aggregate.enableVolumetric = srcFrameSettings.enableVolumetric && renderPipelineSettings.supportVolumetric && aggregate.enableAtmosphericScattering;
 
             // TODO: Add support of volumetric in planar reflection
             if (camera.cameraType == CameraType.Reflection)
@@ -130,10 +135,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             aggregate.enableMotionVectors = camera.cameraType != CameraType.Reflection && srcFrameSettings.enableMotionVectors && renderPipelineSettings.supportMotionVectors;
             aggregate.enableObjectMotionVectors = camera.cameraType != CameraType.Reflection && srcFrameSettings.enableObjectMotionVectors && renderPipelineSettings.supportMotionVectors;
             aggregate.enableDBuffer = srcFrameSettings.enableDBuffer && renderPipelineSettings.supportDBuffer;
-            aggregate.enableAtmosphericScattering = srcFrameSettings.enableAtmosphericScattering;
-            // We must take care of the scene view fog flags in the editor
-            if (!CoreUtils.IsSceneViewFogEnabled(camera))
-                aggregate.enableAtmosphericScattering = false;
             aggregate.enableRoughRefraction = srcFrameSettings.enableRoughRefraction;
             aggregate.enableTransparentPostpass = srcFrameSettings.enableTransparentPostpass;
             aggregate.enableDistortion = camera.cameraType != CameraType.Reflection && srcFrameSettings.enableDistortion;
@@ -166,17 +167,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 aggregate.enableContactShadows = false;
                 aggregate.enableSSR = false;
                 aggregate.enableSSAO = false;
+                aggregate.enableAtmosphericScattering = false;
+                aggregate.enableVolumetric = false;
                 aggregate.enableTransparentPrepass = false;
                 aggregate.enableMotionVectors = false;
                 aggregate.enableObjectMotionVectors = false;
                 aggregate.enableDBuffer = false;
-                aggregate.enableAtmosphericScattering = false;
                 aggregate.enableTransparentPostpass = false;
                 aggregate.enableDistortion = false;
                 aggregate.enablePostprocess = false;
                 aggregate.enableStereo = false;
                 aggregate.enableShadowMask = false;
-                aggregate.enableVolumetric = false;
             }
 
             LightLoopSettings.InitializeLightLoopSettings(camera, aggregate, renderPipelineSettings, srcFrameSettings, ref aggregate.lightLoopSettings);
@@ -244,7 +245,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         new DebugUI.BoolField { displayName = "Enable Motion Vectors", getter = () => frameSettings.enableMotionVectors, setter = value => frameSettings.enableMotionVectors = value },
                         new DebugUI.BoolField { displayName = "Enable Object Motion Vectors", getter = () => frameSettings.enableObjectMotionVectors, setter = value => frameSettings.enableObjectMotionVectors = value },
                         new DebugUI.BoolField { displayName = "Enable DBuffer", getter = () => frameSettings.enableDBuffer, setter = value => frameSettings.enableDBuffer = value },
-                        new DebugUI.BoolField { displayName = "Enable Atmospheric Scattering", getter = () => frameSettings.enableAtmosphericScattering, setter = value => frameSettings.enableAtmosphericScattering = value },
                         new DebugUI.BoolField { displayName = "Enable Rough Refraction", getter = () => frameSettings.enableRoughRefraction, setter = value => frameSettings.enableRoughRefraction = value },
                         new DebugUI.BoolField { displayName = "Enable Distortion", getter = () => frameSettings.enableDistortion, setter = value => frameSettings.enableDistortion = value },
                         new DebugUI.BoolField { displayName = "Enable Postprocess", getter = () => frameSettings.enablePostprocess, setter = value => frameSettings.enablePostprocess = value },
@@ -280,10 +280,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         new DebugUI.BoolField { displayName = "Enable SSAO", getter = () => frameSettings.enableSSAO, setter = value => frameSettings.enableSSAO = value },
                         new DebugUI.BoolField { displayName = "Enable SubsurfaceScattering", getter = () => frameSettings.enableSubsurfaceScattering, setter = value => frameSettings.enableSubsurfaceScattering = value },
                         new DebugUI.BoolField { displayName = "Enable Transmission", getter = () => frameSettings.enableTransmission, setter = value => frameSettings.enableTransmission = value },
-                        new DebugUI.BoolField { displayName = "Enable volumetric", getter = () => frameSettings.enableVolumetric, setter = value => frameSettings.enableVolumetric = value },
                         new DebugUI.BoolField { displayName = "Enable Shadows", getter = () => frameSettings.enableShadow, setter = value => frameSettings.enableShadow = value },
                         new DebugUI.BoolField { displayName = "Enable Contact Shadows", getter = () => frameSettings.enableContactShadows, setter = value => frameSettings.enableContactShadows = value },
                         new DebugUI.BoolField { displayName = "Enable ShadowMask", getter = () => frameSettings.enableShadowMask, setter = value => frameSettings.enableShadowMask = value },
+                        new DebugUI.BoolField { displayName = "Enable Atmospheric Scattering", getter = () => frameSettings.enableAtmosphericScattering, setter = value => frameSettings.enableAtmosphericScattering = value },
+                        new DebugUI.BoolField { displayName = "    Enable volumetric", getter = () => frameSettings.enableVolumetric, setter = value => frameSettings.enableVolumetric = value },
                     }
                 }
             });

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/RenderPipeline/FrameSettings.cs
@@ -58,6 +58,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             frameSettings.enableSSAO = this.enableSSAO;
             frameSettings.enableSubsurfaceScattering = this.enableSubsurfaceScattering;
             frameSettings.enableTransmission = this.enableTransmission;
+            frameSettings.enableVolumetric = this.enableVolumetric;
 
             frameSettings.diffuseGlobalDimmer = this.diffuseGlobalDimmer;
             frameSettings.specularGlobalDimmer = this.specularGlobalDimmer;
@@ -279,6 +280,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         new DebugUI.BoolField { displayName = "Enable SSAO", getter = () => frameSettings.enableSSAO, setter = value => frameSettings.enableSSAO = value },
                         new DebugUI.BoolField { displayName = "Enable SubsurfaceScattering", getter = () => frameSettings.enableSubsurfaceScattering, setter = value => frameSettings.enableSubsurfaceScattering = value },
                         new DebugUI.BoolField { displayName = "Enable Transmission", getter = () => frameSettings.enableTransmission, setter = value => frameSettings.enableTransmission = value },
+                        new DebugUI.BoolField { displayName = "Enable volumetric", getter = () => frameSettings.enableVolumetric, setter = value => frameSettings.enableVolumetric = value },
                         new DebugUI.BoolField { displayName = "Enable Shadows", getter = () => frameSettings.enableShadow, setter = value => frameSettings.enableShadow = value },
                         new DebugUI.BoolField { displayName = "Enable Contact Shadows", getter = () => frameSettings.enableContactShadows, setter = value => frameSettings.enableContactShadows = value },
                         new DebugUI.BoolField { displayName = "Enable ShadowMask", getter = () => frameSettings.enableShadowMask, setter = value => frameSettings.enableShadowMask = value },

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/AtmosphericScattering/AtmosphericScattering.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/AtmosphericScattering/AtmosphericScattering.cs
@@ -26,13 +26,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public abstract void PushShaderParameters(HDCamera hdCamera, CommandBuffer cmd);
 
-        public static void PushNeutralShaderParameters(CommandBuffer cmd)
+        public static void PushNeutralShaderParameters(HDCamera hdCamera, CommandBuffer cmd)
         {
             cmd.SetGlobalInt(HDShaderIDs._AtmosphericScatteringType, (int)FogType.None);
 
             // In case volumetric lighting is enabled, we need to make sure that all rendering passes
             // (not just the atmospheric scattering one) receive neutral parameters.
-            if (ShaderConfig.s_VolumetricLightingPreset != 0)
+            if (hdCamera.frameSettings.enableVolumetric)
             {
                 var data = DensityVolumeData.GetNeutralValues();
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/VisualEnvironment.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Sky/VisualEnvironment.cs
@@ -24,7 +24,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             if (!hdCamera.frameSettings.enableAtmosphericScattering)
             {
-                AtmosphericScattering.PushNeutralShaderParameters(cmd);
+                AtmosphericScattering.PushNeutralShaderParameters(hdCamera, cmd);
                 return;
             }
 
@@ -32,7 +32,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 case FogType.None:
                     {
-                        AtmosphericScattering.PushNeutralShaderParameters(cmd);
+                        AtmosphericScattering.PushNeutralShaderParameters(hdCamera, cmd);
                         break;
                     }
                 case FogType.Linear:


### PR DESCRIPTION
This PR introduce enableVolumetric flag
- It check the Framesettings instead of VolumetricPreset of 0 for volumetric to enable/disable the usage.

Note: Currently enableVolumetric have no visible effect but save performance (and display the last result), a second PR will introduce multicompile to disable the effect.