### PR TITLE
Fix issue with framesettings on HDRP Asset and debug windows

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/Debugging/DebugManager.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/Debugging/DebugManager.cs
@@ -9,6 +9,11 @@ namespace UnityEngine.Experimental.Rendering
 
     public sealed partial class DebugManager
     {
+#if UNITY_EDITOR
+        // HACK: Make debug windows work correctly with FrameSettings in Editor
+        public static bool renderPipelineIsRecreated = false;
+#endif
+
         static readonly DebugManager s_Instance = new DebugManager();
         public static DebugManager instance { get { return s_Instance; } }
 

--- a/ScriptableRenderPipeline/Core/CoreRP/Editor/Debugging/DebugWindow.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/Editor/Debugging/DebugWindow.cs
@@ -144,6 +144,11 @@ namespace UnityEditor.Experimental.Rendering
             DebugManager.instance.onSetDirty -= MarkDirty;
             Undo.ClearUndo(m_Settings);
 
+            DestroyWidgetStates();
+        }
+
+        public void DestroyWidgetStates()
+        {
             if (m_WidgetStates != null)
             {
                 // Clear all the states from memory
@@ -282,6 +287,18 @@ namespace UnityEditor.Experimental.Rendering
 
         void Update()
         {
+            // HACK: Make debug windows work correctly with FrameSettings in Editor
+            // When we manipulate the framesettings on HDRenderPipelineAsset, the debug windows is not
+            // refresh, it keep the old state of the runtime framesettings in memory and thus overwrite
+            // our freshly edited value. To ensure debug windows is aware of framesettings change we need to
+            // destroy its internal widget state.
+            if (DebugManager.renderPipelineIsRecreated)
+            {
+                DestroyWidgetStates();
+                DebugManager.renderPipelineIsRecreated = false;
+            }
+            // END HACK
+
             int treeState = DebugManager.instance.GetState();
 
             if (m_DebugTreeState != treeState || m_IsDirty)

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/HDRenderPipeline.cs
@@ -183,6 +183,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public HDRenderPipeline(HDRenderPipelineAsset asset)
         {
+#if UNITY_EDITOR
+            // HACK: Make debug windows work correctly with FrameSettings in Editor
+            DebugManager.renderPipelineIsRecreated = true;
+#endif
+
             m_ValidAPI = true;
 
             if (!SetRenderingFeatures())


### PR DESCRIPTION
When the debug windows is open, the HDRP Asset runtime framesetting are
overwritten by the debug windows settings, whereas it is the debug
windows that should update itself.

@Chman It is a hack for now, we can discuss about how to solve this properly later