### PR TITLE
LWRP XR Single-pass Instancing and Multi-view Support

### DIFF
--- a/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/UnityInstancing.hlsl
+++ b/ScriptableRenderPipeline/Core/CoreRP/ShaderLibrary/UnityInstancing.hlsl
@@ -9,7 +9,7 @@
     #define UNITY_SUPPORT_INSTANCING
 #endif
 
-#if defined(SHADER_API_D3D11)
+#if defined(SHADER_API_D3D11) || defined(SHADER_API_GLCORE) || defined(SHADER_API_GLES3)
     #define UNITY_SUPPORT_STEREO_INSTANCING
 #endif
 
@@ -92,8 +92,13 @@
 // - UNITY_TRANSFER_VERTEX_OUTPUT_STEREO    Copy stero target from input struct to output struct. Used in vertex shader.
 // - UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX
 #ifdef UNITY_STEREO_INSTANCING_ENABLED
+#if defined(SHADER_API_GLES3) || defined(SHADER_API_GLCORE)
+    #define DEFAULT_UNITY_VERTEX_OUTPUT_STEREO                          uint stereoTargetEyeIndexSV : SV_RenderTargetArrayIndex; uint stereoTargetEyeIndex : BLENDINDICES0;
+    #define DEFAULT_UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output)       output.stereoTargetEyeIndexSV = unity_StereoEyeIndex; output.stereoTargetEyeIndex = unity_StereoEyeIndex;
+#else
     #define DEFAULT_UNITY_VERTEX_OUTPUT_STEREO                          uint stereoTargetEyeIndex : SV_RenderTargetArrayIndex;
     #define DEFAULT_UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output)       output.stereoTargetEyeIndex = unity_StereoEyeIndex
+#endif
     #define DEFAULT_UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(input, output)  output.stereoTargetEyeIndex = input.stereoTargetEyeIndex;
     #define DEFAULT_UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input) unity_StereoEyeIndex = input.stereoTargetEyeIndex;
 #elif defined(UNITY_STEREO_MULTIVIEW_ENABLED)
@@ -137,9 +142,21 @@
     void UnitySetupInstanceID(uint inputInstanceID)
     {
         #ifdef UNITY_STEREO_INSTANCING_ENABLED
-            // stereo eye index is automatically figured out from the instance ID
-            unity_StereoEyeIndex = inputInstanceID & 0x01;
-            unity_InstanceID = unity_BaseInstanceID + (inputInstanceID >> 1);
+            #if defined(SHADER_API_GLES3)
+                // We must calculate the stereo eye index differently for GLES3
+                // because otherwise,  the unity shader compiler will emit a bitfieldInsert function.
+                // bitfieldInsert requires support for glsl version 400 or later.  Therefore the
+                // generated glsl code will fail to compile on lower end devices.  By changing the
+                // way we calculate the stereo eye index,  we can help the shader compiler to avoid
+                // emitting the bitfieldInsert function and thereby increase the number of devices we
+                // can run stereo instancing on.
+                unity_StereoEyeIndex = round(fmod(inputInstanceID, 2.0));
+                unity_InstanceID = unity_BaseInstanceID + (inputInstanceID >> 1);
+            #else
+                // stereo eye index is automatically figured out from the instance ID
+                unity_StereoEyeIndex = inputInstanceID & 0x01;
+                unity_InstanceID = unity_BaseInstanceID + (inputInstanceID >> 1);
+            #endif
         #else
             unity_InstanceID = inputInstanceID + unity_BaseInstanceID;
         #endif

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -1037,6 +1037,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             }
 
             SetRenderTarget(cmd, colorRT, depthRT, clearFlag);
+            m_CurrCameraColorRT = colorRT;
 
             // If rendering to an intermediate RT we resolve viewport on blit due to offset not being supported
             // while rendering to a RT.

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassDepthOnly.hlsl
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/ShaderLibrary/LightweightPassDepthOnly.hlsl
@@ -14,12 +14,15 @@ struct VertexOutput
 {
     float2 uv           : TEXCOORD0;
     float4 clipPos      : SV_POSITION;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 VertexOutput DepthOnlyVertex(VertexInput v)
 {
     VertexOutput o = (VertexOutput)0;
     UNITY_SETUP_INSTANCE_ID(v);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
     o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
     o.clipPos = TransformObjectToHClip(v.position.xyz);

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightSampling.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightSampling.shader
@@ -12,12 +12,14 @@ Shader "Hidden/LightweightPipeline/Sampling"
     {
         float4 vertex   : POSITION;
         float2 texcoord : TEXCOORD0;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
     };
 
     struct Interpolators
     {
         float4  pos      : SV_POSITION;
         float2  texcoord : TEXCOORD0;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
     };
 
     Interpolators Vertex(VertexInput i)

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightScreenSpaceShadows.shader
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Shaders/LightweightScreenSpaceShadows.shader
@@ -59,12 +59,7 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
         half4 Fragment(Interpolators i) : SV_Target
         {
             UNITY_SETUP_INSTANCE_ID(i);
-#if !defined(UNITY_STEREO_INSTANCING_ENABLED)
-            // Completely unclear why i.stereoTargetEyeIndex doesn't work here, considering
-            // this has to be correct in order for the texture array slices to be rasterized to
-            // We can limit this workaround to stereo instancing for now.
             UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
-#endif
 
 #if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
             float deviceDepth = SAMPLE_TEXTURE2D_ARRAY(_CameraDepthTexture, sampler_CameraDepthTexture, i.texcoord.xy, unity_StereoEyeIndex).r;


### PR DESCRIPTION
Added support for single-pass instancing and multi-view support for XR with LWRP.

Changes Made:
1. Shaders that were not stereo aware now are.
2. Merged in most recent gles single pass instancing support changes that I made for the builtin pipeline.
3. Our shader compiler specifically looks for the global constant buffer to determine if it should add the gles multi-view extension.  So I converted the stereo CBUFFERS to GLOBAL_CBUFFERS which now matches the builtin shaders.
4. Fixed a blitting issue in which we were blitting from the wrong source texture.