### PR TITLE
Define REVERSE_ZBUF for Switch platform.

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/ShaderBase.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRP/Lighting/LightLoop/ShaderBase.hlsl
@@ -2,7 +2,7 @@
 #define __SHADERBASE_H__
 
 // can't use UNITY_REVERSED_Z since it's not enabled in compute shaders
-#if !defined(SHADER_API_GLES3) && !defined(SHADER_API_GLCORE)
+#if defined(SHADER_API_SWITCH) || (!defined(SHADER_API_GLES3) && !defined(SHADER_API_GLCORE))
     #define REVERSE_ZBUF
 #endif
 


### PR DESCRIPTION
There is currently a "bug" in the Unity for Switch plugin that incorrectly defines SHADER_API_GLCORE when building Switch shaders. However, Switch uses reversed z implementation, just as the D3D11 and PS4 implementations do on Unity.