### PR TITLE
Improved volume UI & styling

### DIFF
--- a/ScriptableRenderPipeline/Core/CHANGELOG.md
+++ b/ScriptableRenderPipeline/Core/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Improvements
+- Improved volume UI & styling
+
 ### Changed
- - Moved root files into folders for easier maintenance
+- Moved root files into folders for easier maintenance
 
 ## [0.1.6] - 2018-xx-yy
 

--- a/ScriptableRenderPipeline/Core/CoreRP/Editor/CoreEditorStyles.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/Editor/CoreEditorStyles.cs
@@ -7,12 +7,13 @@ namespace UnityEditor.Experimental.Rendering
         public static readonly GUIStyle smallTickbox;
         public static readonly GUIStyle miniLabelButton;
 
-        public static readonly Texture2D paneOptionsIconDark;
-        public static readonly Texture2D paneOptionsIconLight;
+        static readonly Texture2D paneOptionsIconDark;
+        static readonly Texture2D paneOptionsIconLight;
+        public static Texture2D paneOptionsIcon { get { return EditorGUIUtility.isProSkin ? paneOptionsIconDark : paneOptionsIconLight; } }
 
         static CoreEditorStyles()
         {
-            smallTickbox = new GUIStyle("ShurikenCheckMark");
+            smallTickbox = new GUIStyle("ShurikenToggle");
 
             var transparentTexture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
             transparentTexture.SetPixel(0, 0, Color.clear);

--- a/ScriptableRenderPipeline/Core/CoreRP/Editor/CoreEditorUtils.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/Editor/CoreEditorUtils.cs
@@ -169,10 +169,16 @@ namespace UnityEditor.Experimental.Rendering
             var backgroundRect = GUILayoutUtility.GetRect(1f, 17f);
 
             var labelRect = backgroundRect;
-            labelRect.xMin += 16f;
+            labelRect.xMin += 32f;
             labelRect.xMax -= 20f;
 
+            var foldoutRect = backgroundRect;
+            foldoutRect.y += 1f;
+            foldoutRect.width = 13f;
+            foldoutRect.height = 13f;
+
             var toggleRect = backgroundRect;
+            toggleRect.x += 16f;
             toggleRect.y += 2f;
             toggleRect.width = 13f;
             toggleRect.height = 13f;
@@ -189,16 +195,18 @@ namespace UnityEditor.Experimental.Rendering
             using (new EditorGUI.DisabledScope(!activeField.boolValue))
                 EditorGUI.LabelField(labelRect, GetContent(title), EditorStyles.boldLabel);
 
+            // Foldout
+            group.serializedObject.Update();
+            group.isExpanded = GUI.Toggle(foldoutRect, group.isExpanded, GUIContent.none, EditorStyles.foldout);
+            group.serializedObject.ApplyModifiedProperties();
+
             // Active checkbox
             activeField.serializedObject.Update();
             activeField.boolValue = GUI.Toggle(toggleRect, activeField.boolValue, GUIContent.none, CoreEditorStyles.smallTickbox);
             activeField.serializedObject.ApplyModifiedProperties();
 
             // Context menu
-            var menuIcon = EditorGUIUtility.isProSkin
-                ? CoreEditorStyles.paneOptionsIconDark
-                : CoreEditorStyles.paneOptionsIconLight;
-
+            var menuIcon = CoreEditorStyles.paneOptionsIcon;
             var menuRect = new Rect(labelRect.xMax + 4f, labelRect.y + 4f, menuIcon.width, menuIcon.height);
 
             if (contextAction != null)

--- a/ScriptableRenderPipeline/Core/CoreRP/Editor/Volume/VolumeComponentEditor.cs
+++ b/ScriptableRenderPipeline/Core/CoreRP/Editor/Volume/VolumeComponentEditor.cs
@@ -254,11 +254,7 @@ namespace UnityEditor.Experimental.Rendering
         {
             var overrideRect = GUILayoutUtility.GetRect(17f, 17f, GUILayout.ExpandWidth(false));
             overrideRect.yMin += 4f;
-
-            var oldColor = GUI.color;
-            GUI.color = new Color(0.6f, 0.6f, 0.6f, 0.75f);
             property.overrideState.boolValue = GUI.Toggle(overrideRect, property.overrideState.boolValue, CoreEditorUtils.GetContent("|Override this setting for this volume."), CoreEditorStyles.smallTickbox);
-            GUI.color = oldColor;
         }
     }
 }


### PR DESCRIPTION
Following popular user requests and general UX guidelines, I made the volume UI a bit more intuitive and easier to understand for newcomers.

Before / After

![image](https://user-images.githubusercontent.com/849090/40424167-057e0eae-5e95-11e8-9d15-d78d2482a7a2.png)

Changed the checkbox style & added a foldout icon to the left to keep it consistent with the rest of Unity.

Can be backported to 2018.1 (cc @sebastienlagarde).