### PR TITLE
 Disable depth multisample resolve 

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightForwardRenderer.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightForwardRenderer.cs
@@ -312,7 +312,11 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             bool supportsTextureCopy = SystemInfo.copyTextureSupport != CopyTextureSupport.None;
             bool supportsDepthTarget = SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.Depth);
             bool supportsDepthCopy = !msaaEnabledForCamera && (supportsDepthTarget || supportsTextureCopy);
-            bool msaaDepthResolve = msaaEnabledForCamera && SystemInfo.supportsMultisampledTextures != 0;
+
+            // TODO:  We don't have support to highp Texture2DMS currently and this breaks depth precision.
+            // currently disabling it until shader changes kick in.
+            //bool msaaDepthResolve = msaaEnabledForCamera && SystemInfo.supportsMultisampledTextures != 0;
+            bool msaaDepthResolve = false;
             return supportsDepthCopy || msaaDepthResolve;
         }
 


### PR DESCRIPTION
We don't have support to highp Texture2DMS in shader back end.
Currently all Texture2DMS* are declared as lowp in mobile and that causes many depth artifacts.
Disabling multisample depth resolve until we fix the issue.