### PR TITLE
 Added CommandBuffer profiler markers

### DIFF
--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/LightweightPipeline.cs
@@ -94,33 +94,46 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             foreach (Camera camera in cameras)
             {
                 BeginCameraRendering(camera);
-                m_IsCameraRendering = true;
+                string renderCameraTag = "Render " + camera.name;
+                CommandBuffer cmd = CommandBufferPool.Get(renderCameraTag);
+                using (new ProfilingSample(cmd, renderCameraTag))
+                {
+                    m_IsCameraRendering = true;
 
-                CameraData cameraData;
-                InitializeCameraData(camera, out cameraData);
-                SetupPerCameraShaderConstants(cameraData);
+                    CameraData cameraData;
+                    InitializeCameraData(camera, out cameraData);
+                    SetupPerCameraShaderConstants(cameraData);
 
-                ScriptableCullingParameters cullingParameters;
-                if (!CullResults.GetCullingParameters(camera, cameraData.isStereoEnabled, out cullingParameters))
-                    continue;
+                    ScriptableCullingParameters cullingParameters;
+                    if (!CullResults.GetCullingParameters(camera, cameraData.isStereoEnabled, out cullingParameters))
+                    {
+                        CommandBufferPool.Release(cmd);
+                        continue;
+                    }
 
-                cullingParameters.shadowDistance = Mathf.Min(cameraData.maxShadowDistance, camera.farClipPlane);
+                    cullingParameters.shadowDistance = Mathf.Min(cameraData.maxShadowDistance, camera.farClipPlane);
+
+                    context.ExecuteCommandBuffer(cmd);
+                    cmd.Clear();
 
 #if UNITY_EDITOR
-                // Emit scene view UI
-                if (cameraData.isSceneViewCamera)
-                    ScriptableRenderContext.EmitWorldGeometryForSceneView(camera);
+                    // Emit scene view UI
+                    if (cameraData.isSceneViewCamera)
+                        ScriptableRenderContext.EmitWorldGeometryForSceneView(camera);
 #endif
-                CullResults.Cull(ref cullingParameters, context, ref m_CullResults);
-                List<VisibleLight> visibleLights = m_CullResults.visibleLights;
+                    CullResults.Cull(ref cullingParameters, context, ref m_CullResults);
+                    List<VisibleLight> visibleLights = m_CullResults.visibleLights;
 
-                RenderingData renderingData;
-                InitializeRenderingData(ref cameraData, visibleLights, m_Renderer.maxSupportedLocalLightsPerPass, m_Renderer.maxSupportedVertexLights, out renderingData);
-                m_Renderer.Setup(ref context, ref m_CullResults, ref renderingData);
-                m_Renderer.Execute(ref context, ref m_CullResults, ref renderingData);
+                    RenderingData renderingData;
+                    InitializeRenderingData(ref cameraData, visibleLights, m_Renderer.maxSupportedLocalLightsPerPass, m_Renderer.maxSupportedVertexLights, out renderingData);
+                    m_Renderer.Setup(ref context, ref m_CullResults, ref renderingData);
+                    m_Renderer.Execute(ref context, ref m_CullResults, ref renderingData);
+                    
+                    m_IsCameraRendering = false;
+                }
+                context.ExecuteCommandBuffer(cmd);
+                CommandBufferPool.Release(cmd);
                 context.Submit();
-
-                m_IsCameraRendering = false;
             }
         }
 

--- a/ScriptableRenderPipeline/LightweightPipeline/LWRP/Passes/DepthOnlyPass.cs
+++ b/ScriptableRenderPipeline/LightweightPipeline/LWRP/Passes/DepthOnlyPass.cs
@@ -4,8 +4,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 {
     public class DepthOnlyPass : ScriptableRenderPass
     {
-        const string kProfilerTag = "Depth Prepass Setup";
-        const string kCommandBufferTag = "Depth Prepass";
+        const string k_SetupRenderTargetTag = "Setup Render Target";
+        const string k_DepthPrepassTag = "Depth Prepass";
 
         int kDepthBufferBits = 32;
 
@@ -31,8 +31,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
         public override void Execute(ref ScriptableRenderContext context, ref CullResults cullResults, ref RenderingData renderingData)
         {
-            CommandBuffer cmd = CommandBufferPool.Get(kCommandBufferTag);
-            using (new ProfilingSample(cmd, kProfilerTag))
+            CommandBuffer cmd = CommandBufferPool.Get(k_DepthPrepassTag);
+            using (new ProfilingSample(cmd, k_SetupRenderTargetTag))
             {
                 SetRenderTarget(cmd, GetSurface(depthAttachmentHandle), RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store,
                     ClearFlag.Depth, Color.black);


### PR DESCRIPTION
 CommandBuffers are profile markers make it easier to debug frame in FrameDebugger and RenderDoc.
![profilermarkers](https://user-images.githubusercontent.com/7453395/40454244-501658ec-5ee8-11e8-8d7e-0f0c81518f3c.JPG)
