### PR TITLE
Fix HD subshader lightmap support

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
@@ -43,6 +43,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 "FragInputs.worldToTangent",
                 "FragInputs.positionWS",
+                "FragInputs.texCoord1",
+                "FragInputs.texCoord2"
             },
             PixelShaderSlots = new List<int>()
             {


### PR DESCRIPTION
This PR adds `texCoord1` and `texCoord2` to required fields in order to fix support for lightmaps in HD subshader. Not entirely sure if these should always be on though, but since the call to `SampleBakedGI` is always there, and it uses the two tex coords, it seems logical to always have these fields required.