### PR TITLE
Fix default textures

### DIFF
--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -9,7 +9,7 @@ using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEditor.ShaderGraph.Drawing;
 
-[ScriptedImporter(13, ShaderGraphImporter.ShaderGraphExtension)]
+[ScriptedImporter(14, ShaderGraphImporter.ShaderGraphExtension)]
 public class ShaderGraphImporter : ScriptedImporter
 {
     public const string ShaderGraphExtension = "shadergraph";

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -96,9 +96,9 @@ Shader ""Hidden/GraphErrorShader2""
         }
         catch (Exception)
         {
+            configuredTextures = new List<PropertyCollector.TextureInfo>();
             // ignored
         }
-        configuredTextures = new List<PropertyCollector.TextureInfo>();
         return shaderString ?? k_ErrorShader.Replace("Hidden/GraphErrorShader2", shaderName);
     }
 }


### PR DESCRIPTION
This PR fixes a bug causing default textures to not be applied to materials using a Shader Graph. Note that this bug is not present in 1.1.9-preview, and so the change log doesn't need any updates.