### PR TITLE
Fix trunk compatibility for TextureArrayControl

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Controls/TextureArrayControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/TextureArrayControl.cs
@@ -47,7 +47,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Texture Change");
             m_PropertyInfo.SetValue(m_Node, evt.newValue, null);
-            Dirty(ChangeType.Repaint);
+            this.MarkDirtyRepaint();
         }
     }
 }


### PR DESCRIPTION
A call to `VisualElement.Dirty(ChangeType)` has snuck in. This is deprecated on trunk.