### PR TITLE
Added Sample Texture 2D LOD Node

### DIFF
--- a/com.unity.shadergraph/.data/texture_2d_lod_node.PNG
+++ b/com.unity.shadergraph/.data/texture_2d_lod_node.PNG
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b262d71d68d478f6b6c3dc3086451a764e065b8608a65104e17cb8aefefa5f76
+size 238646

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -28,6 +28,12 @@ You can now change the path of Shader Graphs and Sub Graphs. When you change the
 
 This adds gradient functionality via two new nodes. The Sample Gradient node samples a gradient given a Time parameter. You can define this gradient on the Gradient slot control view. The Gradient Asset node defines a gradient that can be sampled by multiple Sample Gradient nodes using different Time parameters.
 
+### Texture 2D LOD node
+
+![](.data/texture_2d_lod_node.png)
+
+This adds a new node for LOD functionality on a Texture 2D Sample. Sample Texture 2D LOD uses the exact same input and output slots as Sample Texture 2D, but also includes an input for 
+LOD changes via a Vector1 slot. 
 
 ### Show generated code
 

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -32,8 +32,7 @@ This adds gradient functionality via two new nodes. The Sample Gradient node sam
 
 ![](.data/texture_2d_lod_node.png)
 
-This adds a new node for LOD functionality on a Texture 2D Sample. Sample Texture 2D LOD uses the exact same input and output slots as Sample Texture 2D, but also includes an input for 
-LOD changes via a Vector1 slot. 
+This adds a new node for LOD functionality on a Texture 2D Sample. Sample Texture 2D LOD uses the exact same input and output slots as Sample Texture 2D, but also includes an input for level of detail adjustments via a Vector1 slot. 
 
 ### Show generated code
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
@@ -1,0 +1,120 @@
+using System.Linq;
+using UnityEngine;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph.Drawing.Controls;
+
+namespace UnityEditor.ShaderGraph
+{
+    
+    [Title("Input", "Texture", "Sample Texture 2D LOD")]
+    public class SampleTexture2DLODNode : AbstractMaterialNode, IGeneratesBodyCode, IMayRequireMeshUV
+    {
+        public const int OutputSlotRGBAId = 0;
+        public const int OutputSlotRId = 5;
+        public const int OutputSlotGId = 6;
+        public const int OutputSlotBId = 7;
+        public const int OutputSlotAId = 8;
+        public const int TextureInputId = 1;
+        public const int UVInput = 2;
+        public const int SamplerInput = 3;
+        public const int LODInput = 4;
+
+        const string kOutputSlotRGBAName = "RGBA";
+        const string kOutputSlotRName = "R";
+        const string kOutputSlotGName = "G";
+        const string kOutputSlotBName = "B";
+        const string kOutputSlotAName = "A";
+        const string kTextureInputName = "Texture";
+        const string kUVInputName = "UV";
+        const string kSamplerInputName = "Sampler";
+        const string kLODInputName = "LOD";
+
+        public override bool hasPreview { get { return true; } }
+
+        public SampleTexture2DLODNode()
+        {
+            name = "Sample Texture 2D LOD";
+            UpdateNodeAfterDeserialization();
+        }
+
+        public override string documentationURL
+        {
+            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/Sample-Texture-2D-LOD-Node"; }
+        }
+
+        [SerializeField]
+        private TextureType m_TextureType = TextureType.Default;
+
+        [EnumControl("Type")]
+        public TextureType textureType
+        {
+            get { return m_TextureType; }
+            set
+            {
+                if (m_TextureType == value)
+                    return;
+
+                m_TextureType = value;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        public sealed override void UpdateNodeAfterDeserialization()
+        {
+            AddSlot(new Vector4MaterialSlot(OutputSlotRGBAId, kOutputSlotRGBAName, kOutputSlotRGBAName, SlotType.Output, Vector4.zero, ShaderStageCapability.Fragment));
+            AddSlot(new Vector1MaterialSlot(OutputSlotRId, kOutputSlotRName, kOutputSlotRName, SlotType.Output, 0, ShaderStageCapability.Fragment));
+            AddSlot(new Vector1MaterialSlot(OutputSlotGId, kOutputSlotGName, kOutputSlotGName, SlotType.Output, 0, ShaderStageCapability.Fragment));
+            AddSlot(new Vector1MaterialSlot(OutputSlotBId, kOutputSlotBName, kOutputSlotBName, SlotType.Output, 0, ShaderStageCapability.Fragment));
+            AddSlot(new Vector1MaterialSlot(OutputSlotAId, kOutputSlotAName, kOutputSlotAName, SlotType.Output, 0, ShaderStageCapability.Fragment));
+            AddSlot(new Texture2DInputMaterialSlot(TextureInputId, kTextureInputName, kTextureInputName));
+            AddSlot(new UVMaterialSlot(UVInput, kUVInputName, kUVInputName, UVChannel.UV0));
+            AddSlot(new SamplerStateMaterialSlot(SamplerInput, kSamplerInputName, kSamplerInputName, SlotType.Input));
+            AddSlot(new Vector1MaterialSlot(LODInput, kLODInputName, kLODInputName, SlotType.Input, 0));
+            RemoveSlotsNameNotMatching(new[] { OutputSlotRGBAId, OutputSlotRId, OutputSlotGId, OutputSlotBId, OutputSlotAId, TextureInputId, UVInput, SamplerInput, LODInput });
+        }
+
+        // Node generations
+        public virtual void GenerateNodeCode(ShaderGenerator visitor, GenerationMode generationMode)
+        {
+            var uvName = GetSlotValue(UVInput, generationMode);
+
+            //Sampler input slot
+            var samplerSlot = FindInputSlot<MaterialSlot>(SamplerInput);
+            var edgesSampler = owner.GetEdges(samplerSlot.slotReference);
+
+            var lodSlot = GetSlotValue(LODInput, generationMode);
+
+            var id = GetSlotValue(TextureInputId, generationMode);
+            
+            var result = string.Format("{0}4 {1} = SAMPLE_TEXTURE2D_LOD({2}, {3}, {4}, {5});"
+                    , precision
+                    , GetVariableNameForSlot(OutputSlotRGBAId)
+                    , id
+                    , edgesSampler.Any() ? GetSlotValue(SamplerInput, generationMode) : "sampler" + id
+                    , uvName
+                    , lodSlot);
+
+            visitor.AddShaderChunk(result, true);
+
+            if (textureType == TextureType.Normal)
+                visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
+
+            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.r;", precision, GetVariableNameForSlot(OutputSlotRId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
+            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.g;", precision, GetVariableNameForSlot(OutputSlotGId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
+            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.b;", precision, GetVariableNameForSlot(OutputSlotBId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
+            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.a;", precision, GetVariableNameForSlot(OutputSlotAId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
+        }
+
+        public bool RequiresMeshUV(UVChannel channel, ShaderStageCapability stageCapability)
+        {
+            s_TempSlots.Clear();
+            GetInputSlots(s_TempSlots);
+            foreach (var slot in s_TempSlots)
+            {
+                if (slot.RequiresMeshUV(channel))
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
@@ -61,11 +61,11 @@ namespace UnityEditor.ShaderGraph
 
         public sealed override void UpdateNodeAfterDeserialization()
         {
-            AddSlot(new Vector4MaterialSlot(OutputSlotRGBAId, kOutputSlotRGBAName, kOutputSlotRGBAName, SlotType.Output, Vector4.zero, ShaderStageCapability.Fragment));
-            AddSlot(new Vector1MaterialSlot(OutputSlotRId, kOutputSlotRName, kOutputSlotRName, SlotType.Output, 0, ShaderStageCapability.Fragment));
-            AddSlot(new Vector1MaterialSlot(OutputSlotGId, kOutputSlotGName, kOutputSlotGName, SlotType.Output, 0, ShaderStageCapability.Fragment));
-            AddSlot(new Vector1MaterialSlot(OutputSlotBId, kOutputSlotBName, kOutputSlotBName, SlotType.Output, 0, ShaderStageCapability.Fragment));
-            AddSlot(new Vector1MaterialSlot(OutputSlotAId, kOutputSlotAName, kOutputSlotAName, SlotType.Output, 0, ShaderStageCapability.Fragment));
+            AddSlot(new Vector4MaterialSlot(OutputSlotRGBAId, kOutputSlotRGBAName, kOutputSlotRGBAName, SlotType.Output, Vector4.zero, ShaderStageCapability.All));
+            AddSlot(new Vector1MaterialSlot(OutputSlotRId, kOutputSlotRName, kOutputSlotRName, SlotType.Output, 0, ShaderStageCapability.All));
+            AddSlot(new Vector1MaterialSlot(OutputSlotGId, kOutputSlotGName, kOutputSlotGName, SlotType.Output, 0, ShaderStageCapability.All));
+            AddSlot(new Vector1MaterialSlot(OutputSlotBId, kOutputSlotBName, kOutputSlotBName, SlotType.Output, 0, ShaderStageCapability.All));
+            AddSlot(new Vector1MaterialSlot(OutputSlotAId, kOutputSlotAName, kOutputSlotAName, SlotType.Output, 0, ShaderStageCapability.All));
             AddSlot(new Texture2DInputMaterialSlot(TextureInputId, kTextureInputName, kTextureInputName));
             AddSlot(new UVMaterialSlot(UVInput, kUVInputName, kUVInputName, UVChannel.UV0));
             AddSlot(new SamplerStateMaterialSlot(SamplerInput, kSamplerInputName, kSamplerInputName, SlotType.Input));

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs.meta
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64b637768540cce4f83b9b10cdcacd23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![texture_2d_lod_node](https://user-images.githubusercontent.com/39529353/40684843-66ebfbd6-6347-11e8-924c-ea0d0cfbbecc.PNG)

# Added Sample Texture 2D LOD Node

## Purpose
This adds a new node for LOD functionality on a Texture 2D Sample. Sample Texture 2D LOD uses the exact same input and output slots as Sample Texture 2D, but also includes an input for 
LOD changes via a Vector1 slot.

## Changes

- Adds `Sample Texture 2D Node` to node library.

## Risks

- n/a