### PR TITLE
Allow to assign any RenderPipelineAsset easily.

### DIFF
--- a/com.unity.render-pipelines.core/CoreRP/Editor/RenderPipelineAssetHandler.cs
+++ b/com.unity.render-pipelines.core/CoreRP/Editor/RenderPipelineAssetHandler.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Experimental.Rendering;
+using UnityEditor;
+using UnityEditor.Callbacks;
+
+public class RenderPipelineAssetHandler
+{
+        // Assign RenderPipeline Asset on double click
+        [OnOpenAssetAttribute()]
+        public static bool OpenAsset(int instanceID, int line)
+        {
+			Object obj = EditorUtility.InstanceIDToObject(instanceID);
+
+			RenderPipelineAsset rpAsset = obj as RenderPipelineAsset;
+			if (rpAsset != null)
+			{
+				GraphicsSettings.renderPipelineAsset = rpAsset;
+				return true;
+			}
+            return false; // we did not handle the open
+        }
+}

--- a/com.unity.render-pipelines.core/CoreRP/Editor/RenderPipelineAssetHandler.cs.meta
+++ b/com.unity.render-pipelines.core/CoreRP/Editor/RenderPipelineAssetHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1433650c3d1bb2043a21d46e674e783a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When double clicking (or open action) on the asset file in the project view.