### PR TITLE
Import dependencies

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
@@ -210,7 +210,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             return defines.GetShaderString(2);
         }
 
-        private static bool GenerateShaderPass(UnlitMasterNode masterNode, Pass pass, GenerationMode mode, SurfaceMaterialOptions materialOptions, ShaderGenerator result)
+        private static bool GenerateShaderPass(UnlitMasterNode masterNode, Pass pass, GenerationMode mode, SurfaceMaterialOptions materialOptions, ShaderGenerator result, List<string> sourceAssetDependencyPaths)
         {
             var templateLocation = ShaderGenerator.GetTemplatePath(pass.TemplateName);
             if (!File.Exists(templateLocation))
@@ -218,6 +218,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 // TODO: produce error here
                 return false;
             }
+
+            sourceAssetDependencyPaths.Add(templateLocation);
 
             // grab all of the active nodes
             var activeNodeList = ListPool<INode>.Get();
@@ -394,8 +396,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             return true;
         }
 
-        public string GetSubshader(IMasterNode inMasterNode, GenerationMode mode)
+        public string GetSubshader(IMasterNode inMasterNode, GenerationMode mode, List<string> sourceAssetDependencyPaths = null)
         {
+            if (sourceAssetDependencyPaths != null)
+            {
+                // HDUnlitSubShader.cs
+                sourceAssetDependencyPaths.Add(AssetDatabase.GUIDToAssetPath("292c6a3c80161fa4cb49a9d11d35cbe9"));
+                // HDSubShaderUtilities.cs
+                sourceAssetDependencyPaths.Add(AssetDatabase.GUIDToAssetPath("713ced4e6eef4a44799a4dd59041484b"));
+            }
+
             var masterNode = inMasterNode as UnlitMasterNode;
             var subShader = new ShaderGenerator();
             subShader.AddShaderChunk("SubShader", true);
@@ -416,12 +426,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 //                bool transparent = (masterNode.surfaceType != SurfaceType.Opaque);
                 bool distortionActive = false;
 
-                GenerateShaderPass(masterNode, m_PassDepthOnly, mode, materialOptions, subShader);
-                GenerateShaderPass(masterNode, m_PassForward, mode, materialOptions, subShader);
-                GenerateShaderPass(masterNode, m_PassMETA, mode, materialOptions, subShader);
+                GenerateShaderPass(masterNode, m_PassDepthOnly, mode, materialOptions, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPass(masterNode, m_PassForward, mode, materialOptions, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPass(masterNode, m_PassMETA, mode, materialOptions, subShader, sourceAssetDependencyPaths);
                 if (distortionActive)
                 {
-                    GenerateShaderPass(masterNode, m_PassDistortion, mode, materialOptions, subShader);
+                    GenerateShaderPass(masterNode, m_PassDistortion, mode, materialOptions, subShader, sourceAssetDependencyPaths);
                 }
             }
             subShader.Deindent();

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
@@ -61,12 +61,24 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
             }
         };
 
-        public string GetSubshader(IMasterNode inMasterNode, GenerationMode mode)
+        public string GetSubshader(IMasterNode inMasterNode, GenerationMode mode, List<string> sourceAssetDependencyPaths = null)
         {
+            if (sourceAssetDependencyPaths != null)
+            {
+                // LightWeightPBRSubShader.cs
+                sourceAssetDependencyPaths.Add(AssetDatabase.GUIDToAssetPath("ca91dbeb78daa054c9bbe15fef76361c"));
+            }
+
             var templatePath = GetTemplatePath("lightweightPBRForwardPass.template");
             var extraPassesTemplatePath = GetTemplatePath("lightweightPBRExtraPasses.template");
             if (!File.Exists(templatePath) || !File.Exists(extraPassesTemplatePath))
                 return string.Empty;
+
+            if (sourceAssetDependencyPaths != null)
+            {
+                sourceAssetDependencyPaths.Add(templatePath);
+                sourceAssetDependencyPaths.Add(extraPassesTemplatePath);
+            }
 
             string forwardTemplate = File.ReadAllText(templatePath);
             string extraTemplate = File.ReadAllText(extraPassesTemplatePath);

--- a/com.unity.shadergraph/Editor/Data/Graphs/IShaderGraph.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/IShaderGraph.cs
@@ -4,7 +4,7 @@ namespace UnityEditor.ShaderGraph
 {
     public interface IShaderGraph
     {
-        string GetShader(string name, GenerationMode mode, out List<PropertyCollector.TextureInfo> configuredTextures);
+        string GetShader(string name, GenerationMode mode, out List<PropertyCollector.TextureInfo> configuredTextures, List<string> sourceAssetDependencyPaths = null);
         void LoadedFromDisk();
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Graphs/MaterialGraph.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/MaterialGraph.cs
@@ -13,9 +13,9 @@ namespace UnityEditor.ShaderGraph
             get { return GetNodes<INode>().OfType<IMasterNode>().FirstOrDefault(); }
         }
 
-        public string GetShader(string name, GenerationMode mode, out List<PropertyCollector.TextureInfo> configuredTextures)
+        public string GetShader(string name, GenerationMode mode, out List<PropertyCollector.TextureInfo> configuredTextures, List<string> sourceAssetDependencyPaths = null)
         {
-            return masterNode.GetShader(mode, name, out configuredTextures);
+            return masterNode.GetShader(mode, name, out configuredTextures, sourceAssetDependencyPaths);
         }
 
         public void LoadedFromDisk()

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/ISubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/ISubShader.cs
@@ -1,11 +1,10 @@
 using System;
-using UnityEditor.Graphing;
-using UnityEngine.Experimental.UIElements;
+using System.Collections.Generic;
 
 namespace UnityEditor.ShaderGraph
 {
     public interface ISubShader
     {
-        string GetSubshader(IMasterNode masterNode, GenerationMode mode);
+        string GetSubshader(IMasterNode masterNode, GenerationMode mode, List<string> sourceAssetDependencyPaths = null);
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -619,5 +619,8 @@ namespace UnityEditor.ShaderGraph
             var slot = FindSlot<MaterialSlot>(slotId);
             return slot != null && owner.GetEdges(slot.slotReference).Any();
         }
+
+        public virtual void GetSourceAssetDependencies(List<string> paths)
+        {}
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/IMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/IMasterNode.cs
@@ -6,7 +6,7 @@ namespace UnityEditor.ShaderGraph
 {
     public interface IMasterNode : INode
     {
-        string GetShader(GenerationMode mode, string name, out List<PropertyCollector.TextureInfo> configuredTextures);
+        string GetShader(GenerationMode mode, string name, out List<PropertyCollector.TextureInfo> configuredTextures, List<string> sourceAssetDependencyPaths = null);
         bool IsPipelineCompatible(IRenderPipeline renderPipeline);
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/MasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/MasterNode.cs
@@ -59,7 +59,7 @@ namespace UnityEditor.ShaderGraph
             Dirty(ModificationScope.Graph);
         }
 
-        public string GetShader(GenerationMode mode, string outputName, out List<PropertyCollector.TextureInfo> configuredTextures)
+        public string GetShader(GenerationMode mode, string outputName, out List<PropertyCollector.TextureInfo> configuredTextures, List<string> sourceAssetDependencyPaths = null)
         {
             var activeNodeList = ListPool<INode>.Get();
             NodeUtils.DepthFirstCollectNodesFromNode(activeNodeList, this);
@@ -84,7 +84,7 @@ namespace UnityEditor.ShaderGraph
                 }
 
                 foreach (var subShader in m_SubShaders)
-                    finalShader.AppendLines(subShader.GetSubshader(this, mode));
+                    finalShader.AppendLines(subShader.GetSubshader(this, mode, sourceAssetDependencyPaths));
 
                 finalShader.AppendLine(@"FallBack ""Hidden/InternalErrorShader""");
             }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
@@ -411,5 +411,17 @@ namespace UnityEditor.ShaderGraph
 
             return referencedGraph.activeNodes.OfType<IMayRequireVertexColor>().Any(x => x.RequiresVertexColor(stageCapability));
         }
+
+        public override void GetSourceAssetDependencies(List<string> paths)
+        {
+            base.GetSourceAssetDependencies(paths);
+            if (subGraphAsset != null)
+            {
+                var assetPath = AssetDatabase.GetAssetPath(subGraphAsset);
+                paths.Add(assetPath);
+                foreach (var dependencyPath in AssetDatabase.GetDependencies(assetPath))
+                    paths.Add(dependencyPath);
+            }
+        }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -148,33 +148,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             graphEditorView = null;
         }
 
-        void UpdateDependantGraphs()
-        {
-            string[] lookFor = new string[] {"Assets"};
-            var guids = AssetDatabase.FindAssets("t:shader", lookFor);
-            foreach (string guid in guids)
-            {
-                if (AssetDatabase.GUIDToAssetPath(guid).ToLower().EndsWith(ShaderGraphImporter.ShaderGraphExtension))
-                {
-                    var path = AssetDatabase.GUIDToAssetPath(guid);
-
-                    var textGraph = File.ReadAllText(path, Encoding.UTF8);
-                    var graph = JsonUtility.FromJson<MaterialGraph>(textGraph);
-                    graph.LoadedFromDisk();
-
-                    foreach (SubGraphNode graphNode in graph.GetNodes<SubGraphNode>())
-                    {
-                        var subpath = AssetDatabase.GetAssetPath(graphNode.subGraphAsset);
-                        var subguid = AssetDatabase.AssetPathToGUID(subpath);
-                        if (subguid == selectedGuid)
-                        {
-                            UpdateShaderGraphOnDisk(path, graph);
-                        }
-                    }
-                }
-            }
-        }
-
         public void PingAsset()
         {
             if (selectedGuid != null)
@@ -430,8 +403,6 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             File.WriteAllText(path, EditorJsonUtility.ToJson(graph, true));
             AssetDatabase.ImportAsset(path);
-
-            UpdateDependantGraphs();
         }
 
         void UpdateShaderGraphOnDisk(string path)

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -64,24 +64,7 @@ Shader ""Hidden/GraphErrorShader2""
             ShaderUtil.ClearShaderErrors(oldShader);
 
         List<PropertyCollector.TextureInfo> configuredTextures;
-        var text = GetShaderText(ctx.assetPath, out configuredTextures);
-        var shader = ShaderUtil.CreateShaderAsset(text);
-
-        EditorMaterialUtility.SetShaderDefaults(
-            shader,
-            configuredTextures.Where(x => x.modifiable).Select(x => x.name).ToArray(),
-            configuredTextures.Where(x => x.modifiable).Select(x => EditorUtility.InstanceIDToObject(x.textureId) as Texture).ToArray());
-        EditorMaterialUtility.SetShaderNonModifiableDefaults(
-            shader,
-            configuredTextures.Where(x => !x.modifiable).Select(x => x.name).ToArray(),
-            configuredTextures.Where(x => !x.modifiable).Select(x => EditorUtility.InstanceIDToObject(x.textureId) as Texture).ToArray());
-
-        ctx.AddObjectToAsset("MainAsset", shader);
-        ctx.SetMainObject(shader);
-    }
-
-    internal static string GetShaderText(string path, out List<PropertyCollector.TextureInfo> configuredTextures)
-    {
+        string path = ctx.assetPath;
         string shaderString = null;
         var shaderName = Path.GetFileNameWithoutExtension(path);
         try
@@ -99,7 +82,21 @@ Shader ""Hidden/GraphErrorShader2""
             configuredTextures = new List<PropertyCollector.TextureInfo>();
             // ignored
         }
-        return shaderString ?? k_ErrorShader.Replace("Hidden/GraphErrorShader2", shaderName);
+
+        var text = shaderString ?? k_ErrorShader.Replace("Hidden/GraphErrorShader2", shaderName);
+        var shader = ShaderUtil.CreateShaderAsset(text);
+
+        EditorMaterialUtility.SetShaderDefaults(
+            shader,
+            configuredTextures.Where(x => x.modifiable).Select(x => x.name).ToArray(),
+            configuredTextures.Where(x => x.modifiable).Select(x => EditorUtility.InstanceIDToObject(x.textureId) as Texture).ToArray());
+        EditorMaterialUtility.SetShaderNonModifiableDefaults(
+            shader,
+            configuredTextures.Where(x => !x.modifiable).Select(x => x.name).ToArray(),
+            configuredTextures.Where(x => !x.modifiable).Select(x => EditorUtility.InstanceIDToObject(x.textureId) as Texture).ToArray());
+
+        ctx.AddObjectToAsset("MainAsset", shader);
+        ctx.SetMainObject(shader);
     }
 }
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -76,7 +76,7 @@ Shader ""Hidden/GraphErrorShader2""
 
             if (!string.IsNullOrEmpty(graph.path))
                 shaderName = graph.path + "/" + shaderName;
-            shaderString = graph.GetShader(shaderName, GenerationMode.ForReals, out configuredTextures);
+            shaderString = graph.GetShader(shaderName, GenerationMode.ForReals, out configuredTextures, sourceAssetDependencyPaths);
 
             foreach (var node in graph.GetNodes<AbstractMaterialNode>())
                 node.GetSourceAssetDependencies(sourceAssetDependencyPaths);

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -9,7 +9,7 @@ using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEditor.ShaderGraph.Drawing;
 
-[ScriptedImporter(14, ShaderGraphExtension)]
+[ScriptedImporter(15, ShaderGraphExtension)]
 public class ShaderGraphImporter : ScriptedImporter
 {
     public const string ShaderGraphExtension = "shadergraph";

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -9,7 +9,7 @@ using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEditor.ShaderGraph.Drawing;
 
-[ScriptedImporter(14, ShaderGraphImporter.ShaderGraphExtension)]
+[ScriptedImporter(14, ShaderGraphExtension)]
 public class ShaderGraphImporter : ScriptedImporter
 {
     public const string ShaderGraphExtension = "shadergraph";
@@ -66,6 +66,7 @@ Shader ""Hidden/GraphErrorShader2""
         List<PropertyCollector.TextureInfo> configuredTextures;
         string path = ctx.assetPath;
         string shaderString = null;
+        var sourceAssetDependencyPaths = new List<string>();
         var shaderName = Path.GetFileNameWithoutExtension(path);
         try
         {
@@ -76,6 +77,9 @@ Shader ""Hidden/GraphErrorShader2""
             if (!string.IsNullOrEmpty(graph.path))
                 shaderName = graph.path + "/" + shaderName;
             shaderString = graph.GetShader(shaderName, GenerationMode.ForReals, out configuredTextures);
+
+            foreach (var node in graph.GetNodes<AbstractMaterialNode>())
+                node.GetSourceAssetDependencies(sourceAssetDependencyPaths);
         }
         catch (Exception)
         {
@@ -97,6 +101,9 @@ Shader ""Hidden/GraphErrorShader2""
 
         ctx.AddObjectToAsset("MainAsset", shader);
         ctx.SetMainObject(shader);
+
+        foreach (var sourceAssetDependencyPath in sourceAssetDependencyPaths.Distinct())
+            ctx.DependsOnSourceAsset(sourceAssetDependencyPath);
     }
 }
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-[ScriptedImporter(1, "ShaderSubGraph")]
+[ScriptedImporter(2, "ShaderSubGraph")]
 public class ShaderSubGraphImporter : ScriptedImporter
 {
     public override void OnImportAsset(AssetImportContext ctx)

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEditor.ShaderGraph;
 using UnityEngine;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 [ScriptedImporter(1, "ShaderSubGraph")]
@@ -15,9 +17,17 @@ public class ShaderSubGraphImporter : ScriptedImporter
         if (graph == null)
             return;
 
+        var sourceAssetDependencyPaths = new List<string>();
+        foreach (var node in graph.GetNodes<AbstractMaterialNode>())
+            node.GetSourceAssetDependencies(sourceAssetDependencyPaths);
+
         var graphAsset = ScriptableObject.CreateInstance<MaterialSubGraphAsset>();
         graphAsset.subGraph = graph;
+
         ctx.AddObjectToAsset("MainAsset", graphAsset);
         ctx.SetMainObject(graphAsset);
+
+        foreach (var sourceAssetDependencyPath in sourceAssetDependencyPaths.Distinct())
+            ctx.DependsOnSourceAsset(sourceAssetDependencyPath);
     }
 }


### PR DESCRIPTION
# Problem
If a sub-shader is changed the shader graphs using it does not get re-imported. Typically this will result in shader compilation errors, as the sub-shader was most likely changed for a reason. The same goes for sub-graphs.

# Solution
Adds the ability for a node to specify a list of source asset paths that should trigger re-import when changed. Similarly, a sub-shader can provide an equivalent list during shader generation.

For now, each sub-shader depends on the templates used (these are manually added) as well as _some_ `.cs` files.

Lightweight PBR depends on:
* lightweightPBRForwardPass.template
* lightweightPBRExtraPasses.template
* LightWeightPBRSubShader.cs

Lightweight Unlit depends on:
* lightweightUnlitForwardPass.template
* lightweightUnlitExtraPasses.template
* LightWeightUnlitSubShader.cs

HD PBR depends on:
* HDPBRSubShader.cs
* HDSubShaderUtilities.cs
* Any pass used via `GenerateShaderPass`. I modified it so that it adds the template if it exists.

HD PBR depends on:
* HDUnlitSubShader.cs
* HDSubShaderUtilities.cs
* Any pass used via `GenerateShaderPass`. I modified it so that it adds the template if it exists.

Note that the `*.cs` dependencies are only on that specific file. This means that if something outside of `HDPBRSubShader.cs` changes, but `HDPBRSubShader.cs` itself doesn't, then a re-import is not triggered. I still think this level of tracking is worth it though. We could also do an explicit `VERSION` file and track that.

# Notes
Change log coming soon.