### PR TITLE
Fixed HD Unlit filepath

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
@@ -212,7 +212,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         private static bool GenerateShaderPass(UnlitMasterNode masterNode, Pass pass, GenerationMode mode, SurfaceMaterialOptions materialOptions, ShaderGenerator result)
         {
-            var templateLocation = ShaderGenerator.GetTemplatePath(pass.TemplateName);
+            var templateLocation = Path.Combine(Path.Combine(Path.Combine(HDEditorUtils.GetHDRenderPipelinePath(), "Editor"), "ShaderGraph"), pass.TemplateName);
             if (!File.Exists(templateLocation))
             {
                 // TODO: produce error here


### PR DESCRIPTION
## Purpose
Fixing the bug on the incorrect filepath for HD unlit graphs.
## Changes

- Fixed the `templateLocation` filepath

## Risks

- n/a