### PR TITLE
Fixes for visual issues on nodes

### DIFF
--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/EnumControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/EnumControlView.uss
@@ -12,7 +12,7 @@ EnumControlView > EnumField {
 }
 
 EnumControlView > Label {
-    width: 100;
+    width: 94;
     padding-left: 0;
     padding-right: 0;
     padding-top: 0;

--- a/com.unity.shadergraph/Editor/Resources/Styles/MaterialNodeView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/MaterialNodeView.uss
@@ -81,7 +81,6 @@ MaterialNodeView #previewFiller > #expand {
 }
 
 MaterialNodeView #previewFiller > #expand > #icon {
-    align-self: center;
     background-image : resource("GraphView/Nodes/PreviewExpand.png");
     width: 16;
     height: 16;
@@ -118,7 +117,6 @@ MaterialNodeView > #settings-container {
 
 #settings-button {
     width: 16;
-    align-self: center;
     justify-content: center;
     padding-left: 8;
 }


### PR DESCRIPTION
The expand arrow icon was showing all the time.
The Enum control was a tad bit too wide.