### PR TITLE
Fix a compile warning in GraphEditorView

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -27,8 +27,6 @@ namespace UnityEditor.ShaderGraph.Drawing
         MaterialGraphView m_GraphView;
         MasterPreviewView m_MasterPreviewView;
 
-        private EditorWindow m_EditorWindow;
-
         AbstractMaterialGraph m_Graph;
         PreviewManager m_PreviewManager;
         SearchWindowProvider m_SearchWindowProvider;
@@ -63,7 +61,6 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             m_Graph = graph;
             AddStyleSheetPath("Styles/GraphEditorView");
-            m_EditorWindow = editorWindow;
             previewManager = new PreviewManager(graph);
 
             string serializedWindowLayout = EditorUserSettings.GetConfigValue(k_FloatingWindowsLayoutKey);


### PR DESCRIPTION
This PR fixes a compile warning in GraphEditorView. Most likely someone removed the last use of the field, but then didn't remove the field.