### PR TITLE
Hide UI for planar probe mode settings. (issues errors on creation)

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Drawers.cs
@@ -65,7 +65,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     );
 
             Inspector = CED.Group(
-                    SectionProbeModeSettings,
+                    //SectionProbeModeSettings,
                     CED.space,
                     CED.Action((s, d, o) => EditorGUILayout.LabelField(_.GetContent("Proxy Volume"), EditorStyles.boldLabel)),
                     CED.Action(Drawer_FieldProxyVolumeReference),


### PR DESCRIPTION
Remove the UI for planar reflection modes
 - It issues errors when creating a reflection probe
 - This was read only  UI, so hiding it does not update the probe workflow