### PR TITLE
Add a minimum value when calculing the height blend factors to avoid …

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/LayeredLit/LayeredLitData.hlsl
@@ -548,7 +548,7 @@ float4 ApplyHeightBlend(float4 heights, float4 blendMask)
 
     // Normalize
     maxHeight = GetMaxHeight(maskedHeights);
-    maskedHeights = maskedHeights / maxHeight.xxxx;
+    maskedHeights = maskedHeights / max(maxHeight.xxxx, 1e-6);
 
     return maskedHeights.yzwx;
 }


### PR DESCRIPTION
…a division by zero when all layers are set to zero in the layer mask map.