### PR TITLE
Fix HD sub-shaders declaration order

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
@@ -735,9 +735,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 graph.AddShaderChunk("// Shared Graph Properties (uniform inputs)");
                 graph.AddShaderChunk(sharedProperties.GetPropertiesDeclaration(1));
 
-                graph.AddShaderChunk("// Shared Graph Node Functions");
-                graph.AddShaderChunk(graphNodeFunctions.ToString());
-
                 if (vertexActive)
                 {
                     graph.AddShaderChunk("// Vertex Graph Inputs");
@@ -747,10 +744,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     graph.AddShaderChunk("// Vertex Graph Outputs");
                     graph.Indent();
                     graph.AddShaderChunk(vertexGraphOutputs.ToString());
-                    graph.Deindent();
-                    graph.AddShaderChunk("// Vertex Graph Evaluation");
-                    graph.Indent();
-                    graph.AddShaderChunk(vertexGraphEvalFunction.ToString());
                     graph.Deindent();
                 }
 
@@ -762,6 +755,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 graph.Indent();
                 graph.AddShaderChunk(pixelGraphOutputs.ToString());
                 graph.Deindent();
+
+                graph.AddShaderChunk("// Shared Graph Node Functions");
+                graph.AddShaderChunk(graphNodeFunctions.ToString());
+
+                if (vertexActive)
+                {
+                    graph.AddShaderChunk("// Vertex Graph Evaluation");
+                    graph.Indent();
+                    graph.AddShaderChunk(vertexGraphEvalFunction.ToString());
+                    graph.Deindent();
+                }
 
                 graph.AddShaderChunk("// Pixel Graph Evaluation");
                 graph.Indent();

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
@@ -398,9 +398,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 graph.AddShaderChunk("// Shared Graph Properties (uniform inputs)");
                 graph.AddShaderChunk(sharedProperties.GetPropertiesDeclaration(1));
 
-                graph.AddShaderChunk("// Shared Graph Node Functions");
-                graph.AddShaderChunk(graphNodeFunctions.ToString());
-
                 if (vertexActive)
                 {
                     graph.AddShaderChunk("// Vertex Graph Inputs");
@@ -410,10 +407,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     graph.AddShaderChunk("// Vertex Graph Outputs");
                     graph.Indent();
                     graph.AddShaderChunk(vertexGraphOutputs.ToString());
-                    graph.Deindent();
-                    graph.AddShaderChunk("// Vertex Graph Evaluation");
-                    graph.Indent();
-                    graph.AddShaderChunk(vertexGraphEvalFunction.ToString());
                     graph.Deindent();
                 }
 
@@ -425,6 +418,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 graph.Indent();
                 graph.AddShaderChunk(pixelGraphOutputs.ToString());
                 graph.Deindent();
+
+                graph.AddShaderChunk("// Shared Graph Node Functions");
+                graph.AddShaderChunk(graphNodeFunctions.ToString());
+
+                if (vertexActive)
+                {
+                    graph.AddShaderChunk("// Vertex Graph Evaluation");
+                    graph.Indent();
+                    graph.AddShaderChunk(vertexGraphEvalFunction.ToString());
+                    graph.Deindent();
+                }
 
                 graph.AddShaderChunk("// Pixel Graph Evaluation");
                 graph.Indent();


### PR DESCRIPTION
The input and output structs were being declared _after_ the functions that the graph provides. This meant that if any function tried to use the struct it would fail. Sub-graphs uses the struct.