### PR TITLE
LWRP XR Single Pass Instancing Shadow Fixes

### DIFF
--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightForwardRenderer.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightForwardRenderer.cs
@@ -164,6 +164,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             SetupPerObjectLightIndices(ref cullResults, ref renderingData.lightData);
             RenderTextureDescriptor baseDescriptor = CreateRTDesc(ref renderingData.cameraData);
+            RenderTextureDescriptor shadowDescriptor = baseDescriptor;
+            shadowDescriptor.dimension = TextureDimension.Tex2D;
 
             bool requiresCameraDepth = renderingData.cameraData.requiresDepthTexture;
             bool requiresDepthPrepass = renderingData.shadowData.requiresScreenSpaceShadowResolve ||
@@ -178,13 +180,13 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             if (renderingData.shadowData.renderDirectionalShadows)
             {
-                EnqueuePass(cmd, RenderPassHandles.DirectionalShadows, baseDescriptor);
+                EnqueuePass(cmd, RenderPassHandles.DirectionalShadows, shadowDescriptor);
                 if (renderingData.shadowData.requiresScreenSpaceShadowResolve)
                     EnqueuePass(cmd, RenderPassHandles.ScreenSpaceShadowResolve, baseDescriptor, new[] {RenderTargetHandles.ScreenSpaceShadowmap});
             }
 
             if (renderingData.shadowData.renderLocalShadows)
-                EnqueuePass(cmd, RenderPassHandles.LocalShadows, baseDescriptor);
+                EnqueuePass(cmd, RenderPassHandles.LocalShadows, shadowDescriptor);
 
             bool requiresDepthAttachment = requiresCameraDepth && !requiresDepthPrepass;
             bool requiresColorAttachment = RequiresColorAttachment(ref renderingData.cameraData, baseDescriptor) || requiresDepthAttachment;

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
@@ -34,7 +34,6 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
         {
             half4  pos      : SV_POSITION;
             half4  texcoord : TEXCOORD0;
-            UNITY_VERTEX_INPUT_INSTANCE_ID
             UNITY_VERTEX_OUTPUT_STEREO
         };
 
@@ -42,7 +41,6 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
         {
             Interpolators o;
             UNITY_SETUP_INSTANCE_ID(i);
-            UNITY_TRANSFER_INSTANCE_ID(i, o);
             UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
             o.pos = TransformObjectToHClip(i.vertex.xyz);
@@ -58,7 +56,6 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
 
         half4 Fragment(Interpolators i) : SV_Target
         {
-            UNITY_SETUP_INSTANCE_ID(i);
             UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
 
 #if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)


### PR DESCRIPTION
After the LWRP refactor, both directional and local shadows were broken for XR when using Single Pass Instancing.  This commit fixes those issues.