### PR TITLE
LWRP Shadergraph GPU instancing fixes

### DIFF
--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
@@ -239,7 +239,6 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
 
                 foreach (var channel in vertexRequirements.requiresMeshUVs.Distinct())
                     vertexDescriptionInputStruct.AppendLine("half4 {0};", channel.GetUVName());
-                
             }
 
             // -------------------------------------

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
@@ -239,8 +239,7 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
 
                 foreach (var channel in vertexRequirements.requiresMeshUVs.Distinct())
                     vertexDescriptionInputStruct.AppendLine("half4 {0};", channel.GetUVName());
-
-                vertexDescriptionInputStruct.AppendLine("UNITY_VERTEX_INPUT_INSTANCE_ID");
+                
             }
 
             // -------------------------------------

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/LightWeightPBRSubShader.cs
@@ -239,6 +239,8 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
 
                 foreach (var channel in vertexRequirements.requiresMeshUVs.Distinct())
                     vertexDescriptionInputStruct.AppendLine("half4 {0};", channel.GetUVName());
+
+                vertexDescriptionInputStruct.AppendLine("UNITY_VERTEX_INPUT_INSTANCE_ID");
             }
 
             // -------------------------------------

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightPBRExtraPasses.template
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightPBRExtraPasses.template
@@ -32,6 +32,8 @@ ${Graph}
 	{
 	    float2 uv           : TEXCOORD0;
 	    float4 clipPos      : SV_POSITION;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+        UNITY_VERTEX_OUTPUT_STEREO
 	};
 
     // x: global clip space bias, y: normal world space bias
@@ -42,6 +44,8 @@ ${Graph}
 	{
 	    VertexOutput o;
 	    UNITY_SETUP_INSTANCE_ID(v);
+        UNITY_TRANSFER_INSTANCE_ID(v, o);
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
         // Vertex transformations performed by graph
 ${VertexShader}
@@ -77,8 +81,9 @@ ${VertexShaderDescriptionInputs}
 	    return o;
 	}
 
-    half4 ShadowPassFragment() : SV_TARGET
+    half4 ShadowPassFragment(VertexOutput IN) : SV_TARGET
     {
+        UNITY_SETUP_INSTANCE_ID(IN);
         return 0;
     }
 
@@ -120,12 +125,16 @@ ${Graph}
 	{
 	    float2 uv           : TEXCOORD0;
 	    float4 clipPos      : SV_POSITION;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+        UNITY_VERTEX_OUTPUT_STEREO
 	};
 
     VertexOutput vert(GraphVertexInput v)
     {
         VertexOutput o = (VertexOutput)0;
 	    UNITY_SETUP_INSTANCE_ID(v);
+        UNITY_TRANSFER_INSTANCE_ID(v, o);
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
 	    // Vertex transformations performed by graph
 ${VertexShader}
@@ -141,8 +150,9 @@ ${VertexShaderDescriptionInputs}
 	    return o;
     }
 
-    half4 frag() : SV_TARGET
+    half4 frag(VertexOutput IN) : SV_TARGET
     {
+        UNITY_SETUP_INSTANCE_ID(IN);
         return 0;
     }
     ENDHLSL

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightPBRForwardPass.template
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightPBRForwardPass.template
@@ -55,10 +55,16 @@ ${Graph}
 		// Interpolators defined by graph
 ${VertexOutputStruct}
         UNITY_VERTEX_INPUT_INSTANCE_ID
+    	UNITY_VERTEX_OUTPUT_STEREO
     };
 
     GraphVertexOutput vert (GraphVertexInput v)
 	{
+		GraphVertexOutput o = (GraphVertexOutput)0;
+        UNITY_SETUP_INSTANCE_ID(v);
+    	UNITY_TRANSFER_INSTANCE_ID(v, o);
+		UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
 		// Vertex transformations performed by graph
 ${VertexShader}
 		VertexDescriptionInputs vdi = (VertexDescriptionInputs)0;
@@ -67,11 +73,6 @@ ${VertexShader}
 ${VertexShaderDescriptionInputs}
 	    VertexDescription vd = PopulateVertexData(vdi);
 		v.vertex.xyz = vd.Position;
-
-        GraphVertexOutput o = (GraphVertexOutput)0;
-
-        UNITY_SETUP_INSTANCE_ID(v);
-    	UNITY_TRANSFER_INSTANCE_ID(v, o);
 
 		// Vertex shader outputs defined by graph
 ${VertexShaderOutputs}

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightUnlitExtraPasses.template
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightUnlitExtraPasses.template
@@ -32,6 +32,8 @@ ${Graph}
     {
         float2 uv           : TEXCOORD0;
         float4 clipPos      : SV_POSITION;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+        UNITY_VERTEX_OUTPUT_STEREO
     };
 
     // x: global clip space bias, y: normal world space bias
@@ -42,6 +44,8 @@ ${Graph}
     {
         VertexOutput o;
         UNITY_SETUP_INSTANCE_ID(v);
+        UNITY_TRANSFER_INSTANCE_ID(v, o);
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
         // Vertex transformations performed by graph
 ${VertexShader}
@@ -77,8 +81,9 @@ ${VertexShaderDescriptionInputs}
         return o;
     }
 
-    half4 ShadowPassFragment() : SV_TARGET
+    half4 ShadowPassFragment(VertexOutput IN) : SV_TARGET
     {
+        UNITY_SETUP_INSTANCE_ID(IN);
         return 0;
     }
 
@@ -120,12 +125,16 @@ ${Graph}
     {
         float2 uv           : TEXCOORD0;
         float4 clipPos      : SV_POSITION;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+        UNITY_VERTEX_OUTPUT_STEREO
     };
 
     VertexOutput vert(GraphVertexInput v)
     {
         VertexOutput o = (VertexOutput)0;
         UNITY_SETUP_INSTANCE_ID(v);
+        UNITY_TRANSFER_INSTANCE_ID(v, o);
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
         // Vertex transformations performed by graph
 ${VertexShader}
@@ -141,8 +150,9 @@ ${VertexShaderDescriptionInputs}
         return o;
     }
 
-    half4 frag() : SV_TARGET
+    half4 frag(VertexOutput IN) : SV_TARGET
     {
+        UNITY_SETUP_INSTANCE_ID(IN);
         return 0;
     }
     ENDHLSL

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightUnlitPass.template
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightUnlitPass.template
@@ -47,10 +47,16 @@ ${Graph}
         // Interpolators defined by graph
 ${VertexOutputStruct}
         UNITY_VERTEX_INPUT_INSTANCE_ID
+        UNITY_VERTEX_OUTPUT_STEREO
     };
 
     GraphVertexOutput vert (GraphVertexInput v)
     {
+        GraphVertexOutput o = (GraphVertexOutput)0;
+        UNITY_SETUP_INSTANCE_ID(v);
+        UNITY_TRANSFER_INSTANCE_ID(v, o);
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
         // Vertex transformations performed by graph
 ${VertexShader}
         VertexDescriptionInputs vdi = (VertexDescriptionInputs)0;
@@ -59,11 +65,6 @@ ${VertexShader}
 ${VertexShaderDescriptionInputs}
         VertexDescription vd = PopulateVertexData(vdi);
         v.vertex.xyz = vd.Position;
-        
-        GraphVertexOutput o = (GraphVertexOutput)0;
-        
-        UNITY_SETUP_INSTANCE_ID(v);
-        UNITY_TRANSFER_INSTANCE_ID(v, o);
 
         o.position = TransformObjectToHClip(v.vertex.xyz);
         // Vertex shader outputs defined by graph


### PR DESCRIPTION
GPU Instancing work on LWRP shadergraph shaders. Before meshes could get confused as to which information to access when instanced, this caused meshes receiving the incorrect matrices, etc. Also added some additional stereo macros and some future work for the fragment passes once they get full graph support.
-Fixed placement of main passes instancing setup
-Added missing stereo instancing macros
-Added missing fragment Instancing ID for future work in shadow/depth passes