### PR TITLE
Naive hookup for cameraData.renderScale <-> XRSettings.eyeTextureResolutionScale in XR mode

### DIFF
--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
@@ -196,9 +196,24 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             // Discard variations lesser than kRenderScaleThreshold.
             // Scale is only enabled for gameview
-            // XR has it's own scaling mechanism.
-            cameraData.renderScale = (Mathf.Abs(1.0f - pipelineAsset.renderScale) < kRenderScaleThreshold) ? 1.0f : pipelineAsset.renderScale;
-            cameraData.renderScale = (camera.cameraType == CameraType.Game && !cameraData.isStereoEnabled) ? cameraData.renderScale : 1.0f;
+            // XR has its own scaling mechanism.
+
+            if (camera.cameraType == CameraType.Game)
+            {
+                if (cameraData.isStereoEnabled)
+                {
+                    cameraData.renderScale = XRSettings.eyeTextureResolutionScale;
+                }
+                else
+                {
+                    cameraData.renderScale = pipelineAsset.renderScale;
+                }
+            } else
+            {
+                cameraData.renderScale = 1.0f;
+            }
+            
+            cameraData.renderScale = (Mathf.Abs(1.0f - cameraData.renderScale) < kRenderScaleThreshold) ? 1.0f : cameraData.renderScale;
 
             cameraData.requiresDepthTexture = pipelineAsset.supportsCameraDepthTexture || cameraData.postProcessEnabled || cameraData.isSceneViewCamera;
             cameraData.requiresSoftParticles = pipelineAsset.supportsSoftParticles;

--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
@@ -195,21 +195,19 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                                               Math.Abs(cameraRect.width) < 1.0f || Math.Abs(cameraRect.height) < 1.0f));
 
             // Discard variations lesser than kRenderScaleThreshold.
-            // Scale is only enabled for gameview
-            // XR has its own scaling mechanism.
+            // Scale is only enabled for gameview.
+            // In XR mode, grab renderScale from XRSettings instead of SRP asset for now.
+	    // This is just a temporary change pending full integration of XR with SRP
 
             if (camera.cameraType == CameraType.Game)
             {
                 if (cameraData.isStereoEnabled)
                 {
                     cameraData.renderScale = XRSettings.eyeTextureResolutionScale;
-                }
-                else
-                {
+                } else {
                     cameraData.renderScale = pipelineAsset.renderScale;
                 }
-            } else
-            {
+            } else {
                 cameraData.renderScale = 1.0f;
             }
             


### PR DESCRIPTION
In XR mode, cameraData.renderScale = XRSettings.eyeTextureResolutionScale. The functionality of cameraData.renderScale is analogous to XR's eyeTextureResolutionScale: it reallocates a scale*originalTextureSize texture as the render target. 

This simple hookup does not update the SRP asset to reflect the value of eyeTextureResolutionScale. As before, adjusting renderScale in the SRP asset with XR enabled will have no effect on renderScale. 