### PR TITLE
Fix for shader include paths for external shaders (not in Asset folder)

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/ShaderPass/DecalSharePass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/ShaderPass/DecalSharePass.hlsl
@@ -13,4 +13,4 @@
 #endif
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitDepthPass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitDepthPass.hlsl
@@ -56,4 +56,4 @@
 #endif
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitDistortionPass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitDistortionPass.hlsl
@@ -59,4 +59,4 @@
 #endif
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitSharePass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitSharePass.hlsl
@@ -37,4 +37,4 @@
 #endif
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitVelocityPass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/ShaderPass/LitVelocityPass.hlsl
@@ -61,4 +61,4 @@
 #endif
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/ShaderPass/StackLitDepthPass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/ShaderPass/StackLitDepthPass.hlsl
@@ -11,4 +11,4 @@
 #endif //..._ALPHATEST_ON
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/ShaderPass/StackLitDistortionPass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/ShaderPass/StackLitDistortionPass.hlsl
@@ -9,4 +9,4 @@
 #define VARYINGS_NEED_TEXCOORD0
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/ShaderPass/StackLitSharePass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/ShaderPass/StackLitSharePass.hlsl
@@ -40,4 +40,4 @@
 #endif
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Unlit/ShaderPass/UnlitDepthPass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Unlit/ShaderPass/UnlitDepthPass.hlsl
@@ -9,4 +9,4 @@
 #endif
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Unlit/ShaderPass/UnlitDistortionPass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Unlit/ShaderPass/UnlitDistortionPass.hlsl
@@ -7,4 +7,4 @@
 #define VARYINGS_NEED_TEXCOORD0
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Unlit/ShaderPass/UnlitSharePass.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Unlit/ShaderPass/UnlitSharePass.hlsl
@@ -17,4 +17,4 @@
 #define VARYINGS_NEED_TEXCOORD0
 
 // This include will define the various Attributes/Varyings structure
-#include "../../ShaderPass/VaryingMesh.hlsl"
+#include "HDRP/ShaderPass/VaryingMesh.hlsl"

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/CameraMotionVectors.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/CameraMotionVectors.shader
@@ -5,11 +5,11 @@ Shader "Hidden/HDRenderPipeline/CameraMotionVectors"
         #pragma target 4.5
 
         #include "CoreRP/ShaderLibrary/Common.hlsl"
-        #include "../ShaderVariables.hlsl"
-        #include "../ShaderPass/FragInputs.hlsl"
-        #include "../ShaderPass/VaryingMesh.hlsl"
-        #include "../ShaderPass/VertMesh.hlsl"
-        #include "../Material/Builtin/BuiltinData.hlsl"
+        #include "HDRP/ShaderVariables.hlsl"
+        #include "HDRP/ShaderPass/FragInputs.hlsl"
+        #include "HDRP/ShaderPass/VaryingMesh.hlsl"
+        #include "HDRP/ShaderPass/VertMesh.hlsl"
+        #include "HDRP/Material/Builtin/BuiltinData.hlsl"
 
         struct Attributes
         {


### PR DESCRIPTION
This pull request is to fix the relative paths written in the shader pass definition files. These files emit the "file not found" error when included from external shaders (e.g. custom shader defined in a user project).