### PR TITLE
Lw/shadow optimization

### DIFF
--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightPBRForwardPass.template
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderGraph/lightweightPBRForwardPass.template
@@ -22,6 +22,7 @@ ${ZWrite}
     #pragma multi_compile _ _SHADOWS_ENABLED
     #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
     #pragma multi_compile _ _SHADOWS_SOFT
+    #pragma multi_compile _ _SHADOWS_CASCADES
 
 	// -------------------------------------
     // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/ShaderPreprocessor.cs
@@ -21,6 +21,7 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
         public static readonly ShaderKeyword DirectionalShadows = new ShaderKeyword(LightweightKeywordStrings.DirectionalShadows);
         public static readonly ShaderKeyword LocalShadows = new ShaderKeyword(LightweightKeywordStrings.LocalShadows);
         public static readonly ShaderKeyword SoftShadows = new ShaderKeyword(LightweightKeywordStrings.SoftShadows);
+        public static readonly ShaderKeyword CascadeShadows = new ShaderKeyword(LightweightKeywordStrings.CascadeShadows);
 
         public static readonly ShaderKeyword Lightmap = new ShaderKeyword("LIGHTMAP_ON");
         public static readonly ShaderKeyword DirectionalLightmap = new ShaderKeyword("DIRLIGHTMAP_COMBINED");
@@ -91,10 +92,13 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
 
         bool StripInvalidVariants(ShaderCompilerData compilerData)
         {
-            bool isShadowVariant = compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.DirectionalShadows) ||
-                compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.LocalShadows);
+            bool isDirectionalShadows = compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.DirectionalShadows);
+            bool isShadowVariant = isDirectionalShadows || compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.LocalShadows);
 
-            if (compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.SoftShadows) && !isShadowVariant)
+            if (!isDirectionalShadows && compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.CascadeShadows))
+                return true;
+
+            if (!isShadowVariant && compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.SoftShadows))
                 return true;
 
             if (compilerData.shaderKeywordSet.IsEnabled(LightweightKeyword.VertexLights) &&

--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
@@ -246,7 +246,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             bool supportsScreenSpaceShadows = SystemInfo.graphicsDeviceType != GraphicsDeviceType.OpenGLES2;
 
             shadowData.renderDirectionalShadows = pipelineAsset.supportsDirectionalShadows && hasDirectionalShadowCastingLight;
-            shadowData.requiresScreenSpaceShadowResolve = shadowData.renderDirectionalShadows && supportsScreenSpaceShadows;
+
+            // we resolve shadows in screenspace when cascades are enabled to save ALU as computing cascade index + shadowCoord on fragment is expensive
+            shadowData.requiresScreenSpaceShadowResolve = shadowData.renderDirectionalShadows && supportsScreenSpaceShadows && pipelineAsset.cascadeCount > 1;
             shadowData.directionalLightCascadeCount = (shadowData.requiresScreenSpaceShadowResolve) ? pipelineAsset.cascadeCount : 1;
             shadowData.directionalShadowAtlasWidth = pipelineAsset.directionalShadowAtlasResolution;
             shadowData.directionalShadowAtlasHeight = pipelineAsset.directionalShadowAtlasResolution;

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
@@ -124,12 +124,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 if (success)
                 {
                     shadowQuality = (shadowData.supportsSoftShadows) ? light.shadows : LightShadows.Hard;
-
-                    // In order to avoid shader variants explosion we only do hard shadows when sampling shadowmap in the lit pass.
-                    // GLES2 platform is forced to hard single cascade shadows.
-                    if (!shadowData.requiresScreenSpaceShadowResolve)
-                        shadowQuality = LightShadows.Hard;
-
                     SetupDirectionalShadowReceiverConstants(ref context, cmd, ref shadowData, shadowLight);
                 }
             }

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
@@ -124,7 +124,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 if (success)
                 {
                     shadowQuality = (shadowData.supportsSoftShadows) ? light.shadows : LightShadows.Hard;
-                    SetupDirectionalShadowReceiverConstants(ref context, cmd, ref shadowData, shadowLight);
+                    SetupDirectionalShadowReceiverConstants(cmd, ref shadowData, shadowLight);
                 }
             }
             context.ExecuteCommandBuffer(cmd);
@@ -134,7 +134,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             shadowData.renderedDirectionalShadowQuality = shadowQuality;
         }
 
-        void SetupDirectionalShadowReceiverConstants(ref ScriptableRenderContext context, CommandBuffer cmd, ref ShadowData shadowData, VisibleLight shadowLight)
+        void SetupDirectionalShadowReceiverConstants(CommandBuffer cmd, ref ShadowData shadowData, VisibleLight shadowLight)
         {
             Light light = shadowLight.light;
 

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/ForwardLitPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/ForwardLitPass.cs
@@ -284,6 +284,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.DirectionalShadows, directionalShadowQuality != LightShadows.None);
             CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.LocalShadows, localShadowQuality != LightShadows.None);
             CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.SoftShadows, hasSoftShadows);
+            CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.CascadeShadows, shadowData.directionalLightCascadeCount > 1);
 
             // TODO: Remove this. legacy particles support will be removed from Unity in 2018.3. This should be a shader_feature instead with prop exposed in the Standard particles shader.
             CoreUtils.SetKeyword(cmd, "SOFTPARTICLES_ON", cameraData.requiresSoftParticles);

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/ScreenSpaceShadowResolvePass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/ScreenSpaceShadowResolvePass.cs
@@ -57,7 +57,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         void SetShadowCollectPassKeywords(CommandBuffer cmd, ref ShadowData shadowData)
         {
             CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.SoftShadows, shadowData.renderedDirectionalShadowQuality == LightShadows.Soft);
-            CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.CascadeShadows, shadowData.directionalLightCascadeCount > 1);
         }
     }
 }

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/ScreenSpaceShadowResolvePass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/ScreenSpaceShadowResolvePass.cs
@@ -57,6 +57,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         void SetShadowCollectPassKeywords(CommandBuffer cmd, ref ShadowData shadowData)
         {
             CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.SoftShadows, shadowData.renderedDirectionalShadowQuality == LightShadows.Soft);
+            CoreUtils.SetKeyword(cmd, LightweightKeywordStrings.CascadeShadows, shadowData.directionalLightCascadeCount > 1);
         }
     }
 }

--- a/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
@@ -8,10 +8,10 @@
 #define MAX_SHADOW_CASCADES 4
 
 #ifndef SHADOWS_SCREEN
-#if defined(SHADER_API_GLES) || !defined(_SHADOWS_CASCADE)
-#define SHADOWS_SCREEN 0
-#else
+#if defined(_SHADOWS_ENABLED) && defined(_SHADOWS_CASCADE) && !defined(SHADER_API_GLES)
 #define SHADOWS_SCREEN 1
+#else
+#define SHADOWS_SCREEN 0
 #endif
 #endif
 
@@ -220,7 +220,6 @@ half MainLightRealtimeShadowAttenuation(float4 shadowCoord)
     half shadowStrength = GetMainLightShadowStrength();
     return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_DirectionalShadowmapTexture, sampler_DirectionalShadowmapTexture), shadowSamplingData, shadowStrength);
 #endif
-
 }
 
 half LocalLightRealtimeShadowAttenuation(int lightIndex, float3 positionWS)

--- a/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
@@ -8,7 +8,7 @@
 #define MAX_SHADOW_CASCADES 4
 
 #ifndef SHADOWS_SCREEN
-#ifdef SHADER_API_GLES
+#if defined(SHADER_API_GLES) || !defined(_SHADOWS_CASCADE)
 #define SHADOWS_SCREEN 0
 #else
 #define SHADOWS_SCREEN 1

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
@@ -6,6 +6,10 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
 
         HLSLINCLUDE
 
+        // Note: Screenspace shadow resolve is only performed when shadow cascades are enabled
+        // Shadow cascades require cascade index and shadowCoord to be computed on pixel.
+        #define _SHADOWS_CASCADE
+
         #pragma prefer_hlslcc gles
         #pragma exclude_renderers d3d11_9x
         //Keep compiler quiet about Shadows.hlsl.
@@ -14,10 +18,6 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
         #include "CoreRP/ShaderLibrary/ImageBasedLighting.hlsl"
         #include "LWRP/ShaderLibrary/Core.hlsl"
         #include "LWRP/ShaderLibrary/Shadows.hlsl"
-
-        // Note: Screenspace shadow resolve is only performed when shadow cascades are enabled
-        // Shadow cascades require cascade index and shadowCoord to be computed on pixel.
-        #define _SHADOWS_CASCADE
 
 #if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
         TEXTURE2D_ARRAY_FLOAT(_CameraDepthTexture);
@@ -77,7 +77,7 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
             float3 wpos = mul(unity_CameraToWorld, float4(vpos, 1)).xyz;
 
             //Fetch shadow coordinates for cascade.
-            float4 coords  = TransformWorldToShadowCoord(wpos);
+            float4 coords = TransformWorldToShadowCoord(wpos);
 
             // Screenspace shadowmap is only used for directional lights which use orthogonal projection.
             ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
@@ -15,6 +15,10 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
         #include "LWRP/ShaderLibrary/Core.hlsl"
         #include "LWRP/ShaderLibrary/Shadows.hlsl"
 
+        // Note: Screenspace shadow resolve is only performed when shadow cascades are enabled
+        // Shadow cascades require cascade index and shadowCoord to be computed on pixel.
+        #define _SHADOWS_CASCADE
+
 #if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
         TEXTURE2D_ARRAY_FLOAT(_CameraDepthTexture);
 #else
@@ -92,7 +96,6 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
 
             HLSLPROGRAM
             #pragma multi_compile _ _SHADOWS_SOFT
-            #pragma multi_compile _ _SHADOWS_CASCADE
 
             #pragma vertex   Vertex
             #pragma fragment Fragment

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightStandard.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightStandard.shader
@@ -103,7 +103,7 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
-            #pragma multi_compile _ _SHADOWS_CASCADES
+            #pragma multi_compile _ _SHADOWS_CASCADE
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightStandard.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightStandard.shader
@@ -103,6 +103,7 @@ Shader "LightweightPipeline/Standard (Physically Based)"
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _SHADOWS_CASCADES
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightStandardSimpleLighting.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightStandardSimpleLighting.shader
@@ -87,6 +87,7 @@ Shader "LightweightPipeline/Standard (Simple Lighting)"
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _SHADOWS_CASCADE
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightStandardTerrain.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightStandardTerrain.shader
@@ -54,6 +54,7 @@ Shader "LightweightPipeline/Terrain/Standard Terrain"
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _SHADOWS_CASCADE
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightStandardTerrainAddPass.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightStandardTerrainAddPass.shader
@@ -52,6 +52,7 @@ Shader "Hidden/LightweightPipeline/Terrain/Standard Terrain Add Pass"
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _SHADOWS_CASCADE
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightStandardTerrainBase.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightStandardTerrainBase.shader
@@ -41,6 +41,7 @@ Shader "Hidden/LightweightPipeline/Terrain/Standard Terrain Base"
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _SHADOWS_CASCADE
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightWavingGrass.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightWavingGrass.shader
@@ -32,6 +32,7 @@ Shader "Hidden/TerrainEngine/Details/WavingDoublePass" // Has to override the in
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _SHADOWS_CASCADE
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightWavingGrassBillboard.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/Terrain/LightweightWavingGrassBillboard.shader
@@ -32,6 +32,7 @@ Shader "Hidden/TerrainEngine/Details/BillboardWavingDoublePass" // Has to overri
             #pragma multi_compile _ _SHADOWS_ENABLED
             #pragma multi_compile _ _LOCAL_SHADOWS_ENABLED
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _SHADOWS_CASCADE
 
             // -------------------------------------
             // Unity defined keywords


### PR DESCRIPTION
- Screenspace shadow shadows are now only done if shadows cascades are selected. The reason we still kept it is because it's expensive to compute cascade index + shadowCoord on fragment. 

- Cascades are always disabled on GLES2