### PR TITLE
Compatibility with Toggle changes in core Unity

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardFieldPropertyView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardFieldPropertyView.cs
@@ -28,11 +28,12 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_Graph = graph;
             m_Property = property;
 
-            m_ExposedToogle = new Toggle(() =>
-                {
-                    property.generatePropertyBlock = m_ExposedToogle.value;
-                    DirtyNodes(ModificationScope.Graph);
-                });
+            m_ExposedToogle = new Toggle();
+            m_ExposedToogle.OnToggleChanged(evt =>
+            {
+                property.generatePropertyBlock = evt.newValue;
+                DirtyNodes(ModificationScope.Graph);
+            });
             m_ExposedToogle.value = property.generatePropertyBlock;
             AddRow("Exposed", m_ExposedToogle);
 
@@ -284,12 +285,13 @@ namespace UnityEditor.ShaderGraph.Drawing
             else if (property is BooleanShaderProperty)
             {
                 var booleanProperty = (BooleanShaderProperty)property;
-                Action onBooleanChanged = () =>
+                EventCallback<ChangeEvent<bool>> onBooleanChanged = evt =>
                     {
-                        booleanProperty.value = !booleanProperty.value;
+                        booleanProperty.value = evt.newValue;
                         DirtyNodes();
                     };
-                var field = new Toggle(onBooleanChanged);
+                var field = new Toggle();
+                field.OnToggleChanged(onBooleanChanged);
                 field.value = booleanProperty.value;
                 AddRow("Default", field);
             }

--- a/com.unity.shadergraph/Editor/Drawing/Controls/ToggleControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/ToggleControl.cs
@@ -63,8 +63,8 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
             var panel = new VisualElement { name = "togglePanel" };
             if (!string.IsNullOrEmpty(label))
                 panel.Add(new Label(label));
-            Action changedToggle = () => { OnChangeToggle(); };
-            m_Toggle = new UnityEngine.Experimental.UIElements.Toggle(changedToggle);
+            m_Toggle = new Toggle();
+            m_Toggle.OnToggleChanged(OnChangeToggle);
             m_Toggle.SetEnabled(value.isEnabled);
             m_Toggle.value = value.isOn;
             panel.Add(m_Toggle);
@@ -82,11 +82,11 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
             }
         }
 
-        void OnChangeToggle()
+        void OnChangeToggle(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Toggle Change");
             var value = (ToggleData)m_PropertyInfo.GetValue(m_Node, null);
-            value.isOn = !value.isOn;
+            value.isOn = evt.newValue;
             m_PropertyInfo.SetValue(m_Node, value, null);
             this.MarkDirtyRepaint();
         }

--- a/com.unity.shadergraph/Editor/Drawing/Views/PBRSettingsView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/PBRSettingsView.cs
@@ -47,10 +47,10 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             ps.Add(new PropertyRow(new Label("Two Sided")), (row) =>
                 {
-                    row.Add(new Toggle(null), (toggle) =>
+                    row.Add(new Toggle(), (toggle) =>
                     {
                         toggle.value = m_Node.twoSided.isOn;
-                        toggle.OnToggle(ChangeTwoSided);
+                        toggle.OnToggleChanged(ChangeTwoSided);
                     });
                 });
 
@@ -84,11 +84,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_Node.alphaMode = (AlphaMode)evt.newValue;
         }
 
-        void ChangeTwoSided()
+        void ChangeTwoSided(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Two Sided Change");
             ToggleData td = m_Node.twoSided;
-            td.isOn ^= true;
+            td.isOn = evt.newValue;
             m_Node.twoSided = td;
         }
     }

--- a/com.unity.shadergraph/Editor/Drawing/Views/Slots/BooleanSlotControlView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/Slots/BooleanSlotControlView.cs
@@ -13,16 +13,16 @@ namespace UnityEditor.ShaderGraph.Drawing.Slots
         {
             AddStyleSheetPath("Styles/Controls/BooleanSlotControlView");
             m_Slot = slot;
-            Action changedToggle = () => { OnChangeToggle(); };
-            var toggleField = new UnityEngine.Experimental.UIElements.Toggle(changedToggle);
+            var toggleField = new Toggle();
+            toggleField.OnToggleChanged(OnChangeToggle);
             Add(toggleField);
         }
 
-        void OnChangeToggle()
+        void OnChangeToggle(ChangeEvent<bool> evt)
         {
             m_Slot.owner.owner.owner.RegisterCompleteObjectUndo("Toggle Change");
             var value = m_Slot.value;
-            value = !value;
+            value = evt.newValue;
             m_Slot.value = value;
             m_Slot.owner.Dirty(ModificationScope.Node);
         }

--- a/com.unity.shadergraph/Editor/Drawing/Views/UnlitSettingsView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/UnlitSettingsView.cs
@@ -38,10 +38,10 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             ps.Add(new PropertyRow(new Label("Two Sided")), (row) =>
                 {
-                    row.Add(new Toggle(null), (toggle) =>
+                    row.Add(new Toggle(), (toggle) =>
                     {
                         toggle.value = m_Node.twoSided.isOn;
-                        toggle.OnToggle(ChangeTwoSided);
+                        toggle.OnToggleChanged(ChangeTwoSided);
                     });
                 });
 
@@ -66,11 +66,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_Node.alphaMode = (AlphaMode)evt.newValue;
         }
 
-        void ChangeTwoSided()
+        void ChangeTwoSided(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Two Sided Change");
             ToggleData td = m_Node.twoSided;
-            td.isOn ^= true;
+            td.isOn = evt.newValue;
             m_Node.twoSided = td;
         }
     }

--- a/com.unity.shadergraph/Editor/Util/CompatibilityExtensions.cs
+++ b/com.unity.shadergraph/Editor/Util/CompatibilityExtensions.cs
@@ -37,6 +37,15 @@ namespace UnityEditor.ShaderGraph.Drawing
             element.ReleaseMouseCapture();
         }
 #endif
+
+        public static void OnToggleChanged(this Toggle toggle, EventCallback<ChangeEvent<bool>> callback)
+        {
+#if UNITY_2018_3_OR_NEWER
+            toggle.OnValueChanged(callback);
+#else
+            toggle.OnToggle(() => callback(ChangeEvent<bool>.GetPooled(!toggle.value, toggle.value)));
+#endif
+        }
     }
 
     static class TrickleDownEnum


### PR DESCRIPTION
Fix core changes to UIElements Toggle with compatibility layer. This means that as long as this compatibility layer lives, **no one** may use `OnValueChanged` on `Toggle` instances.