### PR TITLE
Lw/shadow optimization v2

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - pipeline now uses XRSEttings.eyeTextureResolutionScale as renderScale when in XR 
 
 ### Changed
-- Reduced by 25% frame time in Mali Utgard arch in Overdraw benchmark scene by removing indexing in shadow code and avoiding division for orthographic projection.
+- Optimized shadow rendering in Mali Utgard arch by removing indexing and avoid division on orthographic projections. Frame time reduce 25% on Overdraw benchmark.
+- Removed 7x7 tent filtering when using cascades.
 - Screenspace shadow resolve is not only done when rendering shadow cascades
 
 ### Fixed

--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - pipeline now uses XRSEttings.eyeTextureResolutionScale as renderScale when in XR 
 
 ### Changed
-- Optimized shadow rendering in Mali Utgard arch by removing indexing and avoid division on orthographic projections. Frame time reduce 25% on Overdraw benchmark.
+- Shadow rendering has been optimized for the Mali Utgard architecture by removing indexing and avoiding divisions for orthographic projections. This reduces the frame time by 25% on the Overdraw benchmark.
 - Removed 7x7 tent filtering when using cascades.
 - Screenspace shadow resolve is not only done when rendering shadow cascades
 

--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - pipeline now uses XRSEttings.eyeTextureResolutionScale as renderScale when in XR 
 
 ### Changed
+- Reduced by 25% frame time in Mali Utgard arch in Overdraw benchmark scene by removing indexing in shadow code and avoiding division for orthographic projection.
 - Screenspace shadow resolve is not only done when rendering shadow cascades
 
 ### Fixed

--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightConstantBuffer.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightConstantBuffer.cs
@@ -31,7 +31,10 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
     {
         public static int _WorldToShadow;
         public static int _ShadowData;
-        public static int _DirShadowSplitSpheres;
+        public static int _DirShadowSplitSpheres0;
+        public static int _DirShadowSplitSpheres1;
+        public static int _DirShadowSplitSpheres2;
+        public static int _DirShadowSplitSpheres3;
         public static int _DirShadowSplitSphereRadii;
         public static int _ShadowOffset0;
         public static int _ShadowOffset1;

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
@@ -28,7 +28,10 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             DirectionalShadowConstantBuffer._WorldToShadow = Shader.PropertyToID("_WorldToShadow");
             DirectionalShadowConstantBuffer._ShadowData = Shader.PropertyToID("_ShadowData");
-            DirectionalShadowConstantBuffer._DirShadowSplitSpheres = Shader.PropertyToID("_DirShadowSplitSpheres");
+            DirectionalShadowConstantBuffer._DirShadowSplitSpheres0 = Shader.PropertyToID("_DirShadowSplitSpheres0");
+            DirectionalShadowConstantBuffer._DirShadowSplitSpheres1 = Shader.PropertyToID("_DirShadowSplitSpheres1");
+            DirectionalShadowConstantBuffer._DirShadowSplitSpheres2 = Shader.PropertyToID("_DirShadowSplitSpheres2");
+            DirectionalShadowConstantBuffer._DirShadowSplitSpheres3 = Shader.PropertyToID("_DirShadowSplitSpheres3");
             DirectionalShadowConstantBuffer._DirShadowSplitSphereRadii = Shader.PropertyToID("_DirShadowSplitSphereRadii");
             DirectionalShadowConstantBuffer._ShadowOffset0 = Shader.PropertyToID("_ShadowOffset0");
             DirectionalShadowConstantBuffer._ShadowOffset1 = Shader.PropertyToID("_ShadowOffset1");
@@ -154,9 +157,15 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             float invHalfShadowAtlasWidth = 0.5f * invShadowAtlasWidth;
             float invHalfShadowAtlasHeight = 0.5f * invShadowAtlasHeight;
             cmd.SetGlobalTexture(RenderTargetHandles.DirectionalShadowmap, m_DirectionalShadowmapTexture);
-            cmd.SetGlobalMatrixArray(DirectionalShadowConstantBuffer._WorldToShadow, m_DirectionalShadowMatrices);
+            if (shadowData.directionalLightCascadeCount > 1)
+                cmd.SetGlobalMatrixArray(DirectionalShadowConstantBuffer._WorldToShadow, m_DirectionalShadowMatrices);
+            else
+                cmd.SetGlobalMatrix(DirectionalShadowConstantBuffer._WorldToShadow, m_DirectionalShadowMatrices[0]);
             cmd.SetGlobalVector(DirectionalShadowConstantBuffer._ShadowData, new Vector4(light.shadowStrength, 0.0f, 0.0f, 0.0f));
-            cmd.SetGlobalVectorArray(DirectionalShadowConstantBuffer._DirShadowSplitSpheres, m_CascadeSplitDistances);
+            cmd.SetGlobalVector(DirectionalShadowConstantBuffer._DirShadowSplitSpheres0, m_CascadeSplitDistances[0]);
+            cmd.SetGlobalVector(DirectionalShadowConstantBuffer._DirShadowSplitSpheres0, m_CascadeSplitDistances[1]);
+            cmd.SetGlobalVector(DirectionalShadowConstantBuffer._DirShadowSplitSpheres0, m_CascadeSplitDistances[2]);
+            cmd.SetGlobalVector(DirectionalShadowConstantBuffer._DirShadowSplitSpheres0, m_CascadeSplitDistances[3]);
             cmd.SetGlobalVector(DirectionalShadowConstantBuffer._DirShadowSplitSphereRadii, new Vector4(m_CascadeSplitDistances[0].w, m_CascadeSplitDistances[1].w, m_CascadeSplitDistances[2].w, m_CascadeSplitDistances[3].w));
             cmd.SetGlobalVector(DirectionalShadowConstantBuffer._ShadowOffset0, new Vector4(-invHalfShadowAtlasWidth, -invHalfShadowAtlasHeight, 0.0f, 0.0f));
             cmd.SetGlobalVector(DirectionalShadowConstantBuffer._ShadowOffset1, new Vector4(invHalfShadowAtlasWidth, -invHalfShadowAtlasHeight, 0.0f, 0.0f));

--- a/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
@@ -28,8 +28,15 @@ CBUFFER_START(_DirectionalShadowBuffer)
 // Last cascade is initialized with a no-op matrix. It always transforms
 // shadow coord to half(0, 0, NEAR_PLANE). We use this trick to avoid
 // branching since ComputeCascadeIndex can return cascade index = MAX_SHADOW_CASCADES
+#ifdef _SHADOWS_CASCADE
 float4x4    _WorldToShadow[MAX_SHADOW_CASCADES + 1];
-float4      _DirShadowSplitSpheres[MAX_SHADOW_CASCADES];
+#else
+float4x4    _WorldToShadow;
+#endif
+float4      _DirShadowSplitSpheres0;
+float4      _DirShadowSplitSpheres1;
+float4      _DirShadowSplitSpheres2;
+float4      _DirShadowSplitSpheres3;
 float4      _DirShadowSplitSphereRadii;
 half4       _ShadowOffset0;
 half4       _ShadowOffset1;
@@ -112,9 +119,11 @@ half SampleScreenSpaceShadowMap(float4 shadowCoord)
     return attenuation;
 }
 
-real SampleShadowmap(float4 shadowCoord, TEXTURE2D_SHADOW_ARGS(ShadowMap, sampler_ShadowMap), ShadowSamplingData samplingData, half shadowStrength)
+real SampleShadowmap(float4 shadowCoord, TEXTURE2D_SHADOW_ARGS(ShadowMap, sampler_ShadowMap), ShadowSamplingData samplingData, half shadowStrength, bool isPerspectiveProjection = true)
 {
-    shadowCoord.xyz /= shadowCoord.w;
+    // Compiler will optimize this branch away as long as isPerspectiveProjection is known at runtime
+    if (isPerspectiveProjection)
+        shadowCoord.xyz /= shadowCoord.w;
 
     real attenuation;
 
@@ -128,42 +137,19 @@ real SampleShadowmap(float4 shadowCoord, TEXTURE2D_SHADOW_ARGS(ShadowMap, sample
         attenuation4.w = SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, shadowCoord.xyz + samplingData.shadowOffset3.xyz);
         attenuation = dot(attenuation4, 0.25);
     #else
-        #ifdef _SHADOWS_CASCADE //Assume screen space shadows when cascades enabled
-            float fetchesWeights[16];
-            float2 fetchesUV[16];
-            SampleShadow_ComputeSamples_Tent_7x7(samplingData.shadowmapSize, shadowCoord.xy, fetchesWeights, fetchesUV);
+        float fetchesWeights[9];
+        float2 fetchesUV[9];
+        SampleShadow_ComputeSamples_Tent_5x5(samplingData.shadowmapSize, shadowCoord.xy, fetchesWeights, fetchesUV);
 
-            attenuation  = fetchesWeights[0]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[0].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[1]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[1].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[2]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[2].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[3]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[3].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[4]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[4].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[5]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[5].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[6]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[6].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[7]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[7].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[8]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[8].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[9]  * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[9].xy,  shadowCoord.z));
-            attenuation += fetchesWeights[10] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[10].xy, shadowCoord.z));
-            attenuation += fetchesWeights[11] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[11].xy, shadowCoord.z));
-            attenuation += fetchesWeights[12] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[12].xy, shadowCoord.z));
-            attenuation += fetchesWeights[13] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[13].xy, shadowCoord.z));
-            attenuation += fetchesWeights[14] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[14].xy, shadowCoord.z));
-            attenuation += fetchesWeights[15] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[15].xy, shadowCoord.z));
-        #else
-            float fetchesWeights[9];
-            float2 fetchesUV[9];
-            SampleShadow_ComputeSamples_Tent_5x5(samplingData.shadowmapSize, shadowCoord.xy, fetchesWeights, fetchesUV);
-
-            attenuation  = fetchesWeights[0] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[0].xy, shadowCoord.z));
-            attenuation += fetchesWeights[1] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[1].xy, shadowCoord.z));
-            attenuation += fetchesWeights[2] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[2].xy, shadowCoord.z));
-            attenuation += fetchesWeights[3] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[3].xy, shadowCoord.z));
-            attenuation += fetchesWeights[4] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[4].xy, shadowCoord.z));
-            attenuation += fetchesWeights[5] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[5].xy, shadowCoord.z));
-            attenuation += fetchesWeights[6] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[6].xy, shadowCoord.z));
-            attenuation += fetchesWeights[7] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[7].xy, shadowCoord.z));
-            attenuation += fetchesWeights[8] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[8].xy, shadowCoord.z));
-        #endif
+        attenuation  = fetchesWeights[0] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[0].xy, shadowCoord.z));
+        attenuation += fetchesWeights[1] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[1].xy, shadowCoord.z));
+        attenuation += fetchesWeights[2] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[2].xy, shadowCoord.z));
+        attenuation += fetchesWeights[3] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[3].xy, shadowCoord.z));
+        attenuation += fetchesWeights[4] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[4].xy, shadowCoord.z));
+        attenuation += fetchesWeights[5] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[5].xy, shadowCoord.z));
+        attenuation += fetchesWeights[6] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[6].xy, shadowCoord.z));
+        attenuation += fetchesWeights[7] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[7].xy, shadowCoord.z));
+        attenuation += fetchesWeights[8] * SAMPLE_TEXTURE2D_SHADOW(ShadowMap, sampler_ShadowMap, float3(fetchesUV[8].xy, shadowCoord.z));
     #endif
 #else
     // 1-tap hardware comparison
@@ -179,10 +165,10 @@ real SampleShadowmap(float4 shadowCoord, TEXTURE2D_SHADOW_ARGS(ShadowMap, sample
 half ComputeCascadeIndex(float3 positionWS)
 {
     // TODO: profile if there's a performance improvement if we avoid indexing here
-    float3 fromCenter0 = positionWS.xyz - _DirShadowSplitSpheres[0].xyz;
-    float3 fromCenter1 = positionWS.xyz - _DirShadowSplitSpheres[1].xyz;
-    float3 fromCenter2 = positionWS.xyz - _DirShadowSplitSpheres[2].xyz;
-    float3 fromCenter3 = positionWS.xyz - _DirShadowSplitSpheres[3].xyz;
+    float3 fromCenter0 = positionWS - _DirShadowSplitSpheres0.xyz;
+    float3 fromCenter1 = positionWS - _DirShadowSplitSpheres1.xyz;
+    float3 fromCenter2 = positionWS - _DirShadowSplitSpheres2.xyz;
+    float3 fromCenter3 = positionWS - _DirShadowSplitSpheres3.xyz;
     float4 distances2 = float4(dot(fromCenter0, fromCenter0), dot(fromCenter1, fromCenter1), dot(fromCenter2, fromCenter2), dot(fromCenter3, fromCenter3));
 
     half4 weights = half4(distances2 < _DirShadowSplitSphereRadii);
@@ -197,7 +183,7 @@ float4 TransformWorldToShadowCoord(float3 positionWS)
     half cascadeIndex = ComputeCascadeIndex(positionWS);
     return mul(_WorldToShadow[cascadeIndex], float4(positionWS, 1.0));
 #else
-    return mul(_WorldToShadow[0], float4(positionWS, 1.0));
+    return mul(_WorldToShadow, float4(positionWS, 1.0));
 #endif
 }
 
@@ -218,7 +204,7 @@ half MainLightRealtimeShadowAttenuation(float4 shadowCoord)
 #else
     ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
     half shadowStrength = GetMainLightShadowStrength();
-    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_DirectionalShadowmapTexture, sampler_DirectionalShadowmapTexture), shadowSamplingData, shadowStrength);
+    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_DirectionalShadowmapTexture, sampler_DirectionalShadowmapTexture), shadowSamplingData, shadowStrength, false);
 #endif
 }
 
@@ -230,7 +216,7 @@ half LocalLightRealtimeShadowAttenuation(int lightIndex, float3 positionWS)
     float4 shadowCoord = mul(_LocalWorldToShadowAtlas[lightIndex], float4(positionWS, 1.0));
     ShadowSamplingData shadowSamplingData = GetLocalLightShadowSamplingData();
     half shadowStrength = GetLocalLightShadowStrenth(lightIndex);
-    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowmapTexture, sampler_LocalShadowmapTexture), shadowSamplingData, shadowStrength);
+    return SampleShadowmap(shadowCoord, TEXTURE2D_PARAM(_LocalShadowmapTexture, sampler_LocalShadowmapTexture), shadowSamplingData, shadowStrength, true);
 #endif
 }
 

--- a/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
@@ -121,7 +121,7 @@ half SampleScreenSpaceShadowMap(float4 shadowCoord)
 
 real SampleShadowmap(float4 shadowCoord, TEXTURE2D_SHADOW_ARGS(ShadowMap, sampler_ShadowMap), ShadowSamplingData samplingData, half shadowStrength, bool isPerspectiveProjection = true)
 {
-    // Compiler will optimize this branch away as long as isPerspectiveProjection is known at runtime
+    // Compiler will optimize this branch away as long as isPerspectiveProjection is known at compile time
     if (isPerspectiveProjection)
         shadowCoord.xyz /= shadowCoord.w;
 

--- a/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
+++ b/com.unity.render-pipelines.lightweight/LWRP/Shaders/LightweightScreenSpaceShadows.shader
@@ -82,7 +82,7 @@ Shader "Hidden/LightweightPipeline/ScreenSpaceShadows"
             // Screenspace shadowmap is only used for directional lights which use orthogonal projection.
             ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
             half shadowStrength = GetMainLightShadowStrength();
-            return SampleShadowmap(coords, TEXTURE2D_PARAM(_DirectionalShadowmapTexture, sampler_DirectionalShadowmapTexture), shadowSamplingData, shadowStrength);
+            return SampleShadowmap(coords, TEXTURE2D_PARAM(_DirectionalShadowmapTexture, sampler_DirectionalShadowmapTexture), shadowSamplingData, shadowStrength, false);
         }
 
         ENDHLSL


### PR DESCRIPTION
 - Optimized shadow rendering for Mali Utgard arch by removing indexing and division in orthographic projections.
 - Removed 7x7 tent filtering. This was only happening when cascades were enabled and we resolve cascades in screenspace that later is sampled with bilinear filter.