### PR TITLE
Remove PostProcessing dependency from Core

### DIFF
--- a/com.unity.render-pipelines.core/CoreRP/Editor/com.unity.render-pipelines.core.Editor.asmdef
+++ b/com.unity.render-pipelines.core/CoreRP/Editor/com.unity.render-pipelines.core.Editor.asmdef
@@ -1,9 +1,7 @@
 {
     "name": "com.unity.render-pipelines.core.Editor",
     "references": [
-        "com.unity.render-pipelines.core.Runtime",
-        "com.unity.postprocessing.Runtime",
-        "com.unity.postprocessing.Editor"
+        "com.unity.render-pipelines.core.Runtime"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/com.unity.render-pipelines.core/CoreRP/Utilities/CoreUtils.cs
+++ b/com.unity.render-pipelines.core/CoreRP/Utilities/CoreUtils.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.Rendering;
-using UnityEngine.Rendering.PostProcessing;
 
 namespace UnityEngine.Experimental.Rendering
 {
@@ -301,20 +300,6 @@ namespace UnityEngine.Experimental.Rendering
             // we pass the first color target as the depth target. If it has 0 depth bits,
             // no depth target ends up being bound.
             DrawFullScreen(commandBuffer, material, colorBuffers, colorBuffers[0], properties, shaderPassId);
-        }
-
-        // Post-processing misc
-        public static bool IsPostProcessingActive(PostProcessLayer layer)
-        {
-            return layer != null
-                && layer.enabled;
-        }
-
-        public static bool IsTemporalAntialiasingActive(PostProcessLayer layer)
-        {
-            return IsPostProcessingActive(layer)
-                && layer.antialiasingMode == PostProcessLayer.Antialiasing.TemporalAntialiasing
-                && layer.temporalAntialiasing.IsSupported();
         }
 
         // Color space utilities

--- a/com.unity.render-pipelines.core/CoreRP/com.unity.render-pipelines.core.Runtime.asmdef
+++ b/com.unity.render-pipelines.core/CoreRP/com.unity.render-pipelines.core.Runtime.asmdef
@@ -1,8 +1,5 @@
 {
     "name": "com.unity.render-pipelines.core.Runtime",
-    "references": [
-        "com.unity.postprocessing.Runtime"
-    ],
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/com.unity.render-pipelines.core/package.json
+++ b/com.unity.render-pipelines.core/package.json
@@ -3,8 +3,5 @@
     "description": "Core library for Unity render pipelines.",
     "version": "3.0.0-preview",
     "unity": "2018.2",
-    "displayName": "Render Pipeline Core Library",
-    "dependencies": {
-        "com.unity.postprocessing": "2.0.7-preview"
-    }
+    "displayName": "Render Pipeline Core Library"
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Camera/HDCamera.cs
@@ -187,7 +187,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // If TAA is enabled projMatrix will hold a jittered projection matrix. The original,
             // non-jittered projection matrix can be accessed via nonJitteredProjMatrix.
             bool taaEnabled = camera.cameraType == CameraType.Game &&
-                CoreUtils.IsTemporalAntialiasingActive(postProcessLayer) &&
+                HDUtils.IsTemporalAntialiasingActive(postProcessLayer) &&
                 m_frameSettings.enablePostprocess;
 
             var nonJitteredCameraProj = camera.projectionMatrix;

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
@@ -285,7 +285,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_DbufferManager.CreateBuffers();
 
             m_SSSBufferManager.InitSSSBuffers(m_GbufferManager, m_Asset.renderPipelineSettings);
-            m_NormalBufferManager.InitNormalBuffers(m_GbufferManager, m_Asset.renderPipelineSettings);            
+            m_NormalBufferManager.InitNormalBuffers(m_GbufferManager, m_Asset.renderPipelineSettings);
 
             m_CameraColorBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGBHalf, sRGB: false, enableRandomWrite: true, enableMSAA: true, name: "CameraColor");
             m_CameraSssDiffuseLightingBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.RGB111110Float, sRGB: false, enableRandomWrite: true, enableMSAA: true, name: "CameraSSSDiffuseLighting");
@@ -840,7 +840,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     var postProcessLayer = camera.GetComponent<PostProcessLayer>();
 
                     // Disable post process if we enable debug mode or if the post process layer is disabled
-                    if (m_CurrentDebugDisplaySettings.IsDebugDisplayRemovePostprocess() || !CoreUtils.IsPostProcessingActive(postProcessLayer))
+                    if (m_CurrentDebugDisplaySettings.IsDebugDisplayRemovePostprocess() || !HDUtils.IsPostProcessingActive(postProcessLayer))
                     {
                         currentFrameSettings.enablePostprocess = false;
                     }
@@ -1364,7 +1364,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 using (new ProfilingSample(cmd, m_DbufferManager.EnableDBUffer ? "Depth Prepass (deferred) force by DBuffer" : "Depth Prepass (deferred)", CustomSamplerId.DepthPrepass.GetSampler()))
                 {
                     cmd.DisableShaderKeyword("WRITE_NORMAL_BUFFER"); // Note: This only disable the output of normal buffer for Lit shader, not the other shader that don't use multicompile
-                    
+
                     HDUtils.SetRenderTarget(cmd, hdCamera, m_CameraDepthStencilBuffer);
 
                     // First deferred material
@@ -1623,8 +1623,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 else
                 {
                     HDUtils.SetRenderTarget(cmd, hdCamera, m_CameraColorBuffer, m_CameraDepthStencilBuffer);
-                    if ((hdCamera.frameSettings.enableDBuffer) && (DecalSystem.m_DecalDatasCount > 0)) // enable d-buffer flag value is being interpreted more like enable decals in general now that we have clustered                    
-                                                                                                       // decal datas count is 0 if no decals affect transparency             
+                    if ((hdCamera.frameSettings.enableDBuffer) && (DecalSystem.m_DecalDatasCount > 0)) // enable d-buffer flag value is being interpreted more like enable decals in general now that we have clustered
+                                                                                                       // decal datas count is 0 if no decals affect transparency
                     {
                         DecalSystem.instance.SetAtlas(cmd); // for clustered decals
                     }

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDUtils.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.Rendering;
+using UnityEngine.Rendering.PostProcessing;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
@@ -330,6 +331,20 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             var additionalCameraData = camera.GetComponent<HDAdditionalCameraData>();
             return camera.cameraType == CameraType.Preview && ((additionalCameraData == null) || (additionalCameraData && !additionalCameraData.isEditorCameraPreview));
+        }
+
+        // Post-processing misc
+        public static bool IsPostProcessingActive(PostProcessLayer layer)
+        {
+            return layer != null
+                && layer.enabled;
+        }
+
+        public static bool IsTemporalAntialiasingActive(PostProcessLayer layer)
+        {
+            return IsPostProcessingActive(layer)
+                && layer.antialiasingMode == PostProcessLayer.Antialiasing.TemporalAntialiasing
+                && layer.temporalAntialiasing.IsSupported();
         }
     }
 }


### PR DESCRIPTION
The only things that needed the dependency were 2 utility functions used only by HD, so I've moved those to `HDUtils` in the HD package. Marked as api-change because it removes API points from the Core package.