### PR TITLE
UI cleanup for XRGraphicsConfig renderScale/viewportScale

### DIFF
--- a/com.unity.render-pipelines.core/CoreRP/Common/XRGraphicsConfig.cs
+++ b/com.unity.render-pipelines.core/CoreRP/Common/XRGraphicsConfig.cs
@@ -6,7 +6,7 @@ using UnityEngine.Assertions;
 namespace UnityEngine.Experimental.Rendering
 {
     [Serializable]
-    public struct XRGraphicsConfig
+    public class XRGraphicsConfig
     { // XRGConfig stores the desired XR settings for a given SRP asset.
 
         public float renderScale;
@@ -77,7 +77,7 @@ namespace UnityEngine.Experimental.Rendering
                 return false;
 #endif
             }
-        }
+        }        
 
         public static RenderTextureDescriptor eyeTextureDesc
         {

--- a/com.unity.render-pipelines.core/CoreRP/Editor/XRGraphicsConfigDrawer.cs
+++ b/com.unity.render-pipelines.core/CoreRP/Editor/XRGraphicsConfigDrawer.cs
@@ -5,14 +5,9 @@ namespace UnityEngine.Experimental.Rendering
     [CustomPropertyDrawer(typeof(XRGraphicsConfig))]
     public class XRGraphicsConfigDrawer : PropertyDrawer
     {
-        private float k_MinRenderScale = 0.01f;
-        private float k_MaxRenderScale = 4.0f;
         internal class Styles
         {
             public static GUIContent XRSettingsLabel = new GUIContent("XR Config", "Enable XR in Player Settings. Then SetConfig can be used to set this configuration to XRSettings.");
-            public static GUIContent XREnabledLabel = new GUIContent("Enable XR", "Enables stereo rendering");
-            public static GUIContent renderScaleLabel = new GUIContent("Render Scale", "Scales (and reallocates) the camera render target allowing the game to render at a resolution different than native resolution. Can't be modified in play mode.");
-            public static GUIContent viewportScaleLabel = new GUIContent("Viewport Scale", "Scales the section of the render target being rendered. Use for dynamic resolution adjustments.");
             public static GUIContent stereoRenderModeLabel = new GUIContent("Stereo Rendering Mode", "Use Player Settings to select between supported stereo rendering paths for current VR device.");
             public static GUIContent showDeviceViewLabel = new GUIContent("Show Device View", "If possible, mirror the render target of the VR device to the main display.");
             public static GUIContent gameViewRenderModeLabel = new GUIContent("Game View Render Mode", "Select how to reflect stereo display to game view");
@@ -23,8 +18,6 @@ namespace UnityEngine.Experimental.Rendering
         // Draw the property inside the given rect
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var drawRenderScale = property.FindPropertyRelative("renderScale");
-            var drawViewportScale = property.FindPropertyRelative("viewportScale");
             var drawShowDeviceView = property.FindPropertyRelative("showDeviceView");
             var drawGameViewRenderMode = property.FindPropertyRelative("gameViewRenderMode");
             var drawUseOcclusionMesh = property.FindPropertyRelative("useOcclusionMesh");
@@ -33,8 +26,6 @@ namespace UnityEngine.Experimental.Rendering
             EditorGUI.BeginDisabledGroup(!XRGraphicsConfig.tryEnable);
             EditorGUILayout.LabelField(Styles.XRSettingsLabel, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;            
-            drawRenderScale.floatValue = EditorGUILayout.Slider(Styles.renderScaleLabel, drawRenderScale.floatValue, k_MinRenderScale, k_MaxRenderScale);
-            drawViewportScale.floatValue = EditorGUILayout.Slider(Styles.viewportScaleLabel, drawViewportScale.floatValue, k_MinRenderScale, k_MaxRenderScale);
             EditorGUILayout.PropertyField(drawUseOcclusionMesh, Styles.useOcclusionMeshLabel);
             EditorGUILayout.PropertyField(drawOcclusionMaskScale, Styles.occlusionScaleLabel);
             EditorGUILayout.PropertyField(drawShowDeviceView, Styles.showDeviceViewLabel);

--- a/com.unity.render-pipelines.lightweight/LWRP/Data/LightweightPipelineAsset.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Data/LightweightPipelineAsset.cs
@@ -418,6 +418,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         public XRGraphicsConfig savedXRGraphicsConfig
         {
             get { return m_SavedXRConfig; }
+            set { m_SavedXRConfig = value;  }
         }
 
         public void OnBeforeSerialize()

--- a/com.unity.render-pipelines.lightweight/LWRP/Editor/LightweightPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Editor/LightweightPipelineAssetEditor.cs
@@ -17,7 +17,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             public static GUIContent localShadowLabel = new GUIContent("Local Shadows");
             public static GUIContent capabilitiesLabel = new GUIContent("Capabilities");
 
-            public static GUIContent renderScaleLabel = new GUIContent("Render Scale", "Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution. When in VR mode, uses value set in XRGraphicsConfig instead.");
+            public static GUIContent renderScaleLabel = new GUIContent("Render Scale", "Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution.");
 
             public static GUIContent maxPixelLightsLabel = new GUIContent("Pixel Lights",
                     "Controls the amount of pixel lights that run in fragment light loop. Lights are sorted and culled per-object.");
@@ -164,9 +164,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         {
             EditorGUILayout.LabelField(Styles.generalSettingsLabel, EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
-            EditorGUI.BeginDisabledGroup(XRGraphicsConfig.tryEnable); // Begin XR-overridden values
             m_RenderScale.floatValue = EditorGUILayout.Slider(Styles.renderScaleLabel, m_RenderScale.floatValue, k_MinRenderScale, k_MaxRenderScale);
-            EditorGUI.EndDisabledGroup(); // End XR-overridden values
             m_MaxPixelLights.intValue = EditorGUILayout.IntSlider(Styles.maxPixelLightsLabel, m_MaxPixelLights.intValue, 0, k_MaxSupportedPixelLights);
             EditorGUILayout.Space();
 

--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
@@ -61,6 +61,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 Debug.LogWarning("Nested camera rendering is forbidden. If you are calling camera.Render inside OnWillRenderObject callback, use BeginCameraRender callback instead.");
                 return;
             }
+            pipelineAsset.savedXRGraphicsConfig.renderScale = pipelineAsset.renderScale;
+            pipelineAsset.savedXRGraphicsConfig.viewportScale = 1.0f; // Placeholder until viewportScale is all hooked up
             // Apply any changes to XRGConfig prior to this point
             pipelineAsset.savedXRGraphicsConfig.SetConfig();
 


### PR DESCRIPTION
- Removed renderScale slider from XRGraphicsConfigDrawer
- LWRP updated to set XRGraphicsConfig.renderScale = pipelineAsset.renderScale
- XRGraphicsConfig.viewportScale = 1.0f in LWRP until viewportScale implemented