### PR TITLE
Fixed distortion 1-frame delay

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an error which prevented volumetric lighting from working if no density volumes with 3D textures were present.
 - Fixed issue with color temperature not take correctly into account with static lighting
 - Don't display fog when diffuse lighting, specular lighting, or lux meter debug mode are enabled.
+- Fixed a frame delay on the distortion pass.
 
 ### Added
 - Add option supportDitheringCrossFade on HDRP Asset to allow to remove shader variant during player build if needed

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
@@ -1307,7 +1307,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             using (new ProfilingSample(cmd, "ApplyDistortion", CustomSamplerId.ApplyDistortion.GetSampler()))
             {
-                var colorPyramidRT = hdCamera.GetPreviousFrameRT((int)HDCameraFrameHistoryType.ColorPyramid);
+                var colorPyramidRT = hdCamera.GetCurrentFrameRT((int)HDCameraFrameHistoryType.ColorPyramid);
                 var pyramidScale = m_BufferPyramid.GetPyramidToScreenScale(hdCamera, colorPyramidRT);
 
                 // Need to account for the fact that the gaussian pyramid is actually rendered inside the camera viewport in a square texture so we mutiply by the PyramidToScreen scale


### PR DESCRIPTION
For some reason distortion was using the color pyramid from the previous frame instead of the current one. This PR fixes that, distortion isn't delayed anymore. This should also potentially fix a bunch of weird tests behavior (cc @RemyUnity).