### PR TITLE
Add macro to show error when using unity_ObjectToWorld/unity_WorldToO…

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRPass.template
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRPass.template
@@ -233,8 +233,8 @@ ${Graph}
             ZERO_INITIALIZE(SurfaceDescriptionInputs, output);
 
             $SurfaceDescriptionInputs.WorldSpaceNormal:          output.WorldSpaceNormal =            normalize(input.worldToTangent[2].xyz);
-            $SurfaceDescriptionInputs.ObjectSpaceNormal:         output.ObjectSpaceNormal =           mul(output.WorldSpaceNormal, (float3x3) unity_ObjectToWorld);      // transposed multiplication by inverse matrix to handle normal scale
-            $SurfaceDescriptionInputs.ViewSpaceNormal:           output.ViewSpaceNormal =             mul(output.WorldSpaceNormal, (float3x3) UNITY_MATRIX_I_V);         // transposed multiplication by inverse matrix to handle normal scale
+            $SurfaceDescriptionInputs.ObjectSpaceNormal:         output.ObjectSpaceNormal =           mul(output.WorldSpaceNormal, (float3x3) UNITY_MATRIX_M);      // transposed multiplication by inverse matrix to handle normal scale
+            $SurfaceDescriptionInputs.ViewSpaceNormal:           output.ViewSpaceNormal =             mul(output.WorldSpaceNormal, (float3x3) UNITY_MATRIX_I_V);    // transposed multiplication by inverse matrix to handle normal scale
             $SurfaceDescriptionInputs.TangentSpaceNormal:        output.TangentSpaceNormal =          float3(0.0f, 0.0f, 1.0f);
             $SurfaceDescriptionInputs.WorldSpaceTangent:         output.WorldSpaceTangent =           input.worldToTangent[0].xyz;
             $SurfaceDescriptionInputs.ObjectSpaceTangent:        output.ObjectSpaceTangent =          TransformWorldToObjectDir(output.WorldSpaceTangent);

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitPassForward.template
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitPassForward.template
@@ -222,8 +222,8 @@ ${Graph}
             ZERO_INITIALIZE(SurfaceDescriptionInputs, output);
 
             $SurfaceDescriptionInputs.WorldSpaceNormal:          output.WorldSpaceNormal =            normalize(input.worldToTangent[2].xyz);
-            $SurfaceDescriptionInputs.ObjectSpaceNormal:         output.ObjectSpaceNormal =           mul(output.WorldSpaceNormal, (float3x3) unity_ObjectToWorld);      // transposed multiplication by inverse matrix to handle normal scale
-            $SurfaceDescriptionInputs.ViewSpaceNormal:           output.ViewSpaceNormal =             mul(output.WorldSpaceNormal, (float3x3) UNITY_MATRIX_I_V);         // transposed multiplication by inverse matrix to handle normal scale
+            $SurfaceDescriptionInputs.ObjectSpaceNormal:         output.ObjectSpaceNormal =           mul(output.WorldSpaceNormal, (float3x3) UNITY_MATRIX_M);      // transposed multiplication by inverse matrix to handle normal scale
+            $SurfaceDescriptionInputs.ViewSpaceNormal:           output.ViewSpaceNormal =             mul(output.WorldSpaceNormal, (float3x3) UNITY_MATRIX_I_V);    // transposed multiplication by inverse matrix to handle normal scale
             $SurfaceDescriptionInputs.TangentSpaceNormal:        output.TangentSpaceNormal =          float3(0.0f, 0.0f, 1.0f);
             $SurfaceDescriptionInputs.WorldSpaceTangent:         output.WorldSpaceTangent =           input.worldToTangent[0].xyz;
             $SurfaceDescriptionInputs.ObjectSpaceTangent:        output.ObjectSpaceTangent =          TransformWorldToObjectDir(output.WorldSpaceTangent);

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderVariables.hlsl
@@ -359,12 +359,24 @@ float4x4 ApplyCameraTranslationToInverseMatrix(float4x4 inverseModelMatrix)
 #endif
 }
 
+// Define Model Matrix Macro
+// Note: In order to be able to define our macro to forbid usage of unity_ObjectToWorld/unity_WorldToObject
+// We need to declare inline function. Using uniform directly mean they are expand with the macro
+float4x4 GetUnityObjectToWorld() { return unity_ObjectToWorld; }
+float4x4 GetUnityWorldToObject() { return unity_WorldToObject; }
+
+#define UNITY_MATRIX_M     ApplyCameraTranslationToMatrix(GetUnityObjectToWorld())
+#define UNITY_MATRIX_I_M   ApplyCameraTranslationToInverseMatrix(GetUnityWorldToObject())
+
+#define unity_ObjectToWorld Use_Macro_UNITY_MATRIX_M_instead_of_unity_ObjectToWorld
+#define unity_WorldToObject Use_Macro_UNITY_MATRIX_I_M_instead_of_unity_WorldToObject
+
+// Define View/Projection matrix macro
 #ifdef USE_LEGACY_UNITY_MATRIX_VARIABLES
     #include "ShaderVariablesMatrixDefsLegacyUnity.hlsl"
 #else
     #include "ShaderVariablesMatrixDefsHDCamera.hlsl"
 #endif
-
 
 // This define allow to tell to unity instancing that we will use our camera relative functions (ApplyCameraTranslationToMatrix and  ApplyCameraTranslationToInverseMatrix) for the model view matrix
 #define MODIFY_MATRIX_FOR_CAMERA_RELATIVE_RENDERING

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderVariablesMatrixDefsHDCamera.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderVariablesMatrixDefsHDCamera.hlsl
@@ -5,9 +5,6 @@
 #ifndef UNITY_SHADER_VARIABLES_MATRIX_DEFS_HDCAMERA_INCLUDED
 #define UNITY_SHADER_VARIABLES_MATRIX_DEFS_HDCAMERA_INCLUDED
 
-#define UNITY_MATRIX_M     ApplyCameraTranslationToMatrix(unity_ObjectToWorld)
-#define UNITY_MATRIX_I_M   ApplyCameraTranslationToInverseMatrix(unity_WorldToObject)
-
 #if defined(USING_STEREO_MATRICES)
 
 #define UNITY_MATRIX_V     _ViewMatrixStereo[unity_StereoEyeIndex]

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderVariablesMatrixDefsLegacyUnity.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderVariablesMatrixDefsLegacyUnity.hlsl
@@ -5,8 +5,6 @@
 #ifndef UNITY_SHADER_VARIABLES_MATRIX_DEFS_LEGACY_UNITY_INCLUDED
 #define UNITY_SHADER_VARIABLES_MATRIX_DEFS_LEGACY_UNITY_INCLUDED
 
-#define UNITY_MATRIX_M     ApplyCameraTranslationToMatrix(unity_ObjectToWorld)
-#define UNITY_MATRIX_I_M   ApplyCameraTranslationToInverseMatrix(unity_WorldToObject)
 #define UNITY_MATRIX_V     unity_MatrixV
 #define UNITY_MATRIX_I_V   unity_MatrixInvV
 #define UNITY_MATRIX_P     OptimizeProjectionMatrix(glstate_matrix_projection)


### PR DESCRIPTION
unity_ObjectToWorld/unity_WorldToObject must not be use as it doesn't handle camera-relative rendering