### PR TITLE
Refactor reflectionprobe 0 : make probes common ancestor

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Handles.cs
@@ -92,8 +92,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 Handles.matrix = m;
             }
 
-            if (d.proxyVolumeReference != null)
-                ReflectionProxyVolumeComponentUI.DrawHandles_EditNone(s.reflectionProxyVolume, d.proxyVolumeReference);
+            if (d.proxyVolume != null)
+                ReflectionProxyVolumeComponentUI.DrawHandles_EditNone(s.reflectionProxyVolume, d.proxyVolume);
         }
 
         [DrawGizmo(GizmoType.Selected)]
@@ -146,8 +146,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
 
-            if (d.proxyVolumeReference != null)
-                ReflectionProxyVolumeComponentUI.DrawGizmos_EditNone(s.reflectionProxyVolume, d.proxyVolumeReference);
+            if (d.proxyVolume != null)
+                ReflectionProxyVolumeComponentUI.DrawGizmos_EditNone(s.reflectionProxyVolume, d.proxyVolume);
 
             var showFrustrum = s.showCaptureHandles
                 || EditMode.editMode == EditCenter;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/SerializedHDReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/SerializedHDReflectionProbe.cs
@@ -133,7 +133,7 @@ namespace UnityEditor.Experimental.Rendering
                 Apply();
             }
 
-            proxyVolumeComponent = addso.Find((HDAdditionalReflectionData d) => d.proxyVolumeComponent);
+            proxyVolumeComponent = addso.Find((HDAdditionalReflectionData d) => d.proxyVolume);
         }
 
         public void Update()

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/SerializedPlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/SerializedPlanarReflectionProbe.cs
@@ -47,7 +47,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             this.serializedObject = serializedObject;
 
-            proxyVolumeReference = serializedObject.Find((PlanarReflectionProbe p) => p.proxyVolumeReference);
+            proxyVolumeReference = serializedObject.Find((PlanarReflectionProbe p) => p.proxyVolume);
             influenceVolume = new SerializedInfluenceVolume(serializedObject.Find((PlanarReflectionProbe p) => p.influenceVolume));
 
             captureLocalPosition = serializedObject.Find((PlanarReflectionProbe p) => p.captureLocalPosition);
@@ -75,7 +75,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             var objs = new List<Object>();
             for (var i = 0; i < serializedObject.targetObjects.Length; i++)
             {
-                var p = ((PlanarReflectionProbe)serializedObject.targetObjects[i]).proxyVolumeReference;
+                var p = ((PlanarReflectionProbe)serializedObject.targetObjects[i]).proxyVolume;
                 if (p != null)
                     objs.Add(p);
             }
@@ -100,7 +100,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 var proxyVolumeTargets = reflectionProxyVolume.serializedObject.targetObjects;
                 for (var i = 0; i < serializedObject.targetObjects.Length; i++)
                 {
-                    if (proxyVolumeTargets[i] != ((PlanarReflectionProbe)serializedObject.targetObjects[i]).proxyVolumeReference)
+                    if (proxyVolumeTargets[i] != ((PlanarReflectionProbe)serializedObject.targetObjects[i]).proxyVolume)
                     {
                         updateProxyVolume = true;
                         break;

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
@@ -42,8 +42,6 @@ namespace UnityEngine.Experimental.Rendering
         [SerializeField] private float editorSimplifiedModeBlendNormalDistance;
         [SerializeField] private bool editorAdvancedModeEnabled;
 
-        public ReflectionProxyVolumeComponent proxyVolumeComponent;
-
         public Vector3 boxBlendCenterOffset { get { return (blendDistanceNegative - blendDistancePositive) * 0.5f; } }
         public Vector3 boxBlendSizeOffset { get { return -(blendDistancePositive + blendDistanceNegative); } }
         public Vector3 boxBlendNormalCenterOffset { get { return (blendNormalDistanceNegative - blendNormalDistancePositive) * 0.5f; } }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
@@ -5,7 +5,7 @@ using System;
 namespace UnityEngine.Experimental.Rendering
 {
     [RequireComponent(typeof(ReflectionProbe))]
-    public class HDAdditionalReflectionData : MonoBehaviour, ISerializationCallbackReceiver
+    public class HDAdditionalReflectionData : HDProbe, ISerializationCallbackReceiver
     {
         [HideInInspector]
         const int currentVersion = 1;

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
@@ -14,8 +14,6 @@ namespace UnityEngine.Experimental.Rendering
         int m_Version;
 
         public ShapeType influenceShape;
-        [FormerlySerializedAsAttribute("dimmer")]
-        public float multiplier = 1.0f;
         [Range(0.0f, 1.0f)]
         public float weight = 1.0f;
         public float influenceSphereRadius = 3.0f;

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
@@ -81,6 +81,7 @@ namespace UnityEngine.Experimental.Rendering
         void MigrateToHDProbeChild()
         {
             mode = legacyProbe.mode;
+            refreshMode = legacyProbe.refreshMode;
             m_Version = 2;
             OnAfterDeserialize();   //continue migrating if needed
         }
@@ -91,6 +92,15 @@ namespace UnityEngine.Experimental.Rendering
             {
                 base.mode = value;
                 legacyProbe.mode = value; //ensure compatibility till we capture without the legacy component
+            }
+        }
+
+        public override ReflectionProbeRefreshMode refreshMode
+        {
+            set
+            {
+                base.refreshMode = value;
+                legacyProbe.refreshMode = value; //ensure compatibility till we capture without the legacy component
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDAdditionalReflectionData.cs
@@ -14,8 +14,6 @@ namespace UnityEngine.Experimental.Rendering
         int m_Version;
 
         public ShapeType influenceShape;
-        [Range(0.0f, 1.0f)]
-        public float weight = 1.0f;
         public float influenceSphereRadius = 3.0f;
         public float sphereReprojectionVolumeRadius = 1.0f;
         public bool useSeparateProjectionVolume = false;

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
@@ -8,6 +8,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [SerializeField, FormerlySerializedAs("proxyVolumeComponent"), FormerlySerializedAs("m_ProxyVolumeReference")]
         ReflectionProxyVolumeComponent m_ProxyVolume = null;
 
+        [SerializeField, FormerlySerializedAsAttribute("dimmer"), FormerlySerializedAsAttribute("m_Dimmer"), FormerlySerializedAsAttribute("multiplier")]
+        float m_Multiplier = 1.0f;
+
         public ReflectionProxyVolumeComponent proxyVolume { get { return m_ProxyVolume; } }
+        public float multiplier { get { return m_Multiplier; } }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
@@ -11,7 +11,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [SerializeField, FormerlySerializedAsAttribute("dimmer"), FormerlySerializedAsAttribute("m_Dimmer"), FormerlySerializedAsAttribute("multiplier")]
         float m_Multiplier = 1.0f;
 
+        [SerializeField, FormerlySerializedAsAttribute("weight")]
+        [Range(0.0f, 1.0f)]
+        float m_Weight = 1.0f;
+
         public ReflectionProxyVolumeComponent proxyVolume { get { return m_ProxyVolume; } }
         public float multiplier { get { return m_Multiplier; } }
+        public float weight { get { return m_Weight; } }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Rendering;
 using UnityEngine.Serialization;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
@@ -15,8 +16,16 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [Range(0.0f, 1.0f)]
         float m_Weight = 1.0f;
 
+        [SerializeField]
+        ReflectionProbeMode m_Mode = ReflectionProbeMode.Baked;
+
         public ReflectionProxyVolumeComponent proxyVolume { get { return m_ProxyVolume; } }
         public float multiplier { get { return m_Multiplier; } }
         public float weight { get { return m_Weight; } }
+        public virtual ReflectionProbeMode mode
+        {
+            get { return m_Mode; }
+            set { m_Mode = value; }
+        }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
@@ -1,9 +1,13 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
     public abstract class HDProbe : MonoBehaviour
     {
+        [SerializeField, FormerlySerializedAs("proxyVolumeComponent"), FormerlySerializedAs("m_ProxyVolumeReference")]
+        ReflectionProxyVolumeComponent m_ProxyVolume = null;
 
+        public ReflectionProxyVolumeComponent proxyVolume { get { return m_ProxyVolume; } }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
@@ -18,6 +18,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         [SerializeField]
         ReflectionProbeMode m_Mode = ReflectionProbeMode.Baked;
+        [SerializeField]
+        ReflectionProbeRefreshMode m_RefreshMode = ReflectionProbeRefreshMode.OnAwake;
 
         public ReflectionProxyVolumeComponent proxyVolume { get { return m_ProxyVolume; } }
         public float multiplier { get { return m_Multiplier; } }
@@ -26,6 +28,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get { return m_Mode; }
             set { m_Mode = value; }
+        }
+        public virtual ReflectionProbeRefreshMode refreshMode
+        {
+            get { return m_RefreshMode; }
+            set { m_RefreshMode = value; }
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace UnityEngine.Experimental.Rendering.HDPipeline
+{
+    public abstract class HDProbe : MonoBehaviour
+    {
+
+    }
+}

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs
@@ -11,7 +11,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         [SerializeField, FormerlySerializedAsAttribute("dimmer"), FormerlySerializedAsAttribute("m_Dimmer"), FormerlySerializedAsAttribute("multiplier")]
         float m_Multiplier = 1.0f;
-
         [SerializeField, FormerlySerializedAsAttribute("weight")]
         [Range(0.0f, 1.0f)]
         float m_Weight = 1.0f;
@@ -21,14 +20,23 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [SerializeField]
         ReflectionProbeRefreshMode m_RefreshMode = ReflectionProbeRefreshMode.OnAwake;
 
+        /// <summary>ProxyVolume currently used by this probe.</summary>
         public ReflectionProxyVolumeComponent proxyVolume { get { return m_ProxyVolume; } }
+
+        /// <summary>Multiplier factor of reflection (non PBR parameter).</summary>
         public float multiplier { get { return m_Multiplier; } }
+
+        /// <summary>Weight for blending amongst probes (non PBR parameter).</summary>
         public float weight { get { return m_Weight; } }
+
+        /// <summary>The capture mode.</summary>
         public virtual ReflectionProbeMode mode
         {
             get { return m_Mode; }
             set { m_Mode = value; }
         }
+
+        /// <summary>Refreshing rate of the capture for Realtime capture mode.</summary>
         public virtual ReflectionProbeRefreshMode refreshMode
         {
             get { return m_RefreshMode; }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs.meta
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/HDProbe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 843017cb1cb3fa441a28e5a674bfea8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
@@ -5,7 +5,7 @@ using System;
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
     [ExecuteInEditMode]
-    public class PlanarReflectionProbe : MonoBehaviour, ISerializationCallbackReceiver
+    public class PlanarReflectionProbe : HDProbe, ISerializationCallbackReceiver
     {
         [HideInInspector]
         const int currentVersion = 1;

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
@@ -24,9 +24,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [SerializeField]
         Vector3 m_CaptureLocalPosition;
         [SerializeField]
-        [FormerlySerializedAsAttribute("m_Dimmer")]
-        float m_Multiplier = 1.0f;
-        [SerializeField]
         [Range(0.0f, 1.0f)]
         float m_Weight = 1.0f;
         [SerializeField]
@@ -82,7 +79,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public Bounds bounds { get { return m_InfluenceVolume.GetBoundsAt(transform); } }
         public Vector3 captureLocalPosition { get { return m_CaptureLocalPosition; } set { m_CaptureLocalPosition = value; } }
         public float weight { get { return m_Weight; } }
-        public float multiplier { get { return m_Multiplier; } }
         public ReflectionProbeMode mode { get { return m_Mode; } }
         public Matrix4x4 influenceToWorld
         {

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
@@ -20,8 +20,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
-        ReflectionProxyVolumeComponent m_ProxyVolumeReference = null;
-        [SerializeField]
         InfluenceVolume m_InfluenceVolume = new InfluenceVolume();
         [SerializeField]
         Vector3 m_CaptureLocalPosition;
@@ -62,7 +60,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool overrideFieldOfView { get { return m_OverrideFieldOfView; } }
         public float fieldOfViewOverride { get { return m_FieldOfViewOverride; } }
 
-        public ReflectionProxyVolumeComponent proxyVolumeReference { get { return m_ProxyVolumeReference; } }
         public InfluenceVolume influenceVolume { get { return m_InfluenceVolume; } }
         public BoundingSphere boundingSphere { get { return m_InfluenceVolume.GetBoundingSphereAt(transform); } }
 
@@ -126,8 +123,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                return m_ProxyVolumeReference != null
-                    ? m_ProxyVolumeReference.transform.localToWorldMatrix
+                return proxyVolume != null
+                    ? proxyVolume.transform.localToWorldMatrix
                     : influenceToWorld;
             }
         }
@@ -135,8 +132,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                return m_ProxyVolumeReference != null
-                    ? m_ProxyVolumeReference.proxyVolume.shapeType
+                return proxyVolume != null
+                    ? proxyVolume.proxyVolume.shapeType
                     : influenceVolume.shapeType;
             }
         }
@@ -144,12 +141,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                return m_ProxyVolumeReference != null
-                    ? m_ProxyVolumeReference.proxyVolume.extents
+                return proxyVolume != null
+                    ? proxyVolume.proxyVolume.extents
                     : influenceVolume.boxBaseSize;
             }
         }
-        public bool infiniteProjection { get { return m_ProxyVolumeReference != null && m_ProxyVolumeReference.proxyVolume.infiniteProjection; } }
+        public bool infiniteProjection { get { return proxyVolume != null && proxyVolume.proxyVolume.infiniteProjection; } }
 
         public bool useMirrorPlane
         {

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
@@ -24,9 +24,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [SerializeField]
         Vector3 m_CaptureLocalPosition;
         [SerializeField]
-        [Range(0.0f, 1.0f)]
-        float m_Weight = 1.0f;
-        [SerializeField]
         ReflectionProbeMode m_Mode = ReflectionProbeMode.Baked;
         [SerializeField]
         ReflectionProbeRefreshMode m_RefreshMode = ReflectionProbeRefreshMode.OnAwake;
@@ -78,7 +75,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
         public Bounds bounds { get { return m_InfluenceVolume.GetBoundsAt(transform); } }
         public Vector3 captureLocalPosition { get { return m_CaptureLocalPosition; } set { m_CaptureLocalPosition = value; } }
-        public float weight { get { return m_Weight; } }
         public ReflectionProbeMode mode { get { return m_Mode; } }
         public Matrix4x4 influenceToWorld
         {

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
@@ -24,8 +24,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [SerializeField]
         Vector3 m_CaptureLocalPosition;
         [SerializeField]
-        ReflectionProbeRefreshMode m_RefreshMode = ReflectionProbeRefreshMode.OnAwake;
-        [SerializeField]
         Texture m_CustomTexture;
         [SerializeField]
         Texture m_BakedTexture;
@@ -89,7 +87,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public Texture customTexture { get { return m_CustomTexture; } set { m_CustomTexture = value; } }
         public Texture bakedTexture { get { return m_BakedTexture; } set { m_BakedTexture = value; }}
         public RenderTexture realtimeTexture { get { return m_RealtimeTexture; } internal set { m_RealtimeTexture = value; } }
-        public ReflectionProbeRefreshMode refreshMode { get { return m_RefreshMode; } }
         public FrameSettings frameSettings { get { return m_FrameSettings; } }
         public float captureNearPlane { get { return m_CaptureNearPlane; } }
         public float captureFarPlane { get { return m_CaptureFarPlane; } }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
@@ -24,8 +24,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [SerializeField]
         Vector3 m_CaptureLocalPosition;
         [SerializeField]
-        ReflectionProbeMode m_Mode = ReflectionProbeMode.Baked;
-        [SerializeField]
         ReflectionProbeRefreshMode m_RefreshMode = ReflectionProbeRefreshMode.OnAwake;
         [SerializeField]
         Texture m_CustomTexture;
@@ -61,7 +59,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                switch (m_Mode)
+                switch (mode)
                 {
                     default:
                     case ReflectionProbeMode.Baked:
@@ -75,7 +73,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
         public Bounds bounds { get { return m_InfluenceVolume.GetBoundsAt(transform); } }
         public Vector3 captureLocalPosition { get { return m_CaptureLocalPosition; } set { m_CaptureLocalPosition = value; } }
-        public ReflectionProbeMode mode { get { return m_Mode; } }
         public Matrix4x4 influenceToWorld
         {
             get

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/ProbeWrapper.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/ProbeWrapper.cs
@@ -118,8 +118,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                return additional.proxyVolumeComponent != null
-                    ? ConvertShape(additional.proxyVolumeComponent.proxyVolume.shapeType)
+                return additional.proxyVolume != null
+                    ? ConvertShape(additional.proxyVolume.proxyVolume.shapeType)
                     : influenceShapeType;
             }
         }
@@ -127,8 +127,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                return additional.proxyVolumeComponent != null
-                    ? additional.proxyVolumeComponent.proxyVolume.extents
+                return additional.proxyVolume != null
+                    ? additional.proxyVolume.proxyVolume.extents
                     : influenceExtents;
             }
         }
@@ -137,8 +137,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                return additional.proxyVolumeComponent != null
-                    ? additional.proxyVolumeComponent.proxyVolume.infiniteProjection
+                return additional.proxyVolume != null
+                    ? additional.proxyVolume.proxyVolume.infiniteProjection
                     : probe.boxProjection == 0;
             }
         }
@@ -147,8 +147,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             get
             {
-                return additional.proxyVolumeComponent != null
-                    ? additional.proxyVolumeComponent.transform.localToWorldMatrix
+                return additional.proxyVolume != null
+                    ? additional.proxyVolume.transform.localToWorldMatrix
                     : influenceToWorld;
             }
         }


### PR DESCRIPTION
- Renaming HDAdditionalReflectionData to HDReflectionProbe

- Make a common ancestor HDProbe to HDReflectionProbe and PlanarReflectionProbe

- Move ProxyVolume, common additional parameters (artistic section) and probe type and refresh to HDProbe ensuring data migration

Note: InfluenceVolume will be merged in a separate PR as it require more work and touch the editor and serialisation part.
