### PR TITLE
Hdrp/fix namespaces

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/AssetProcessors/NormalMapAverageLengthTexturePostprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/AssetProcessors/NormalMapAverageLengthTexturePostprocessor.cs
@@ -1,121 +1,123 @@
 using System;
-using UnityEditor;
 using UnityEngine;
 using System.IO;
 
-public class NormalMapAverageLengthTexturePostprocessor : AssetPostprocessor
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
-    // This class will process a normal map and add the value of average normal length to the blue or alpha channel
-    // The texture is save as BC7.
-    // Tangent space normal map: BC7 RGB (normal xy - average normal length)
-    // Object space normal map: BC7 RGBA (normal xyz - average normal length)
-    static string s_Suffix = "_NA";
-    //static string s_SuffixOS = "_OSNA"; // Suffix for object space case - TODO
-
-    void OnPreprocessTexture()
+    public class NormalMapAverageLengthTexturePostprocessor : AssetPostprocessor
     {
-        // Any texture with _NA suffix will store average normal lenght in alpha
-        if (Path.GetFileNameWithoutExtension(assetPath).EndsWith(s_Suffix, StringComparison.InvariantCultureIgnoreCase))
+        // This class will process a normal map and add the value of average normal length to the blue or alpha channel
+        // The texture is save as BC7.
+        // Tangent space normal map: BC7 RGB (normal xy - average normal length)
+        // Object space normal map: BC7 RGBA (normal xyz - average normal length)
+        static string s_Suffix = "_NA";
+        //static string s_SuffixOS = "_OSNA"; // Suffix for object space case - TODO
+
+        void OnPreprocessTexture()
         {
-            // Make sure we don't convert as a normal map.
-            TextureImporter textureImporter = (TextureImporter)assetImporter;
-            textureImporter.convertToNormalmap = false;
-            textureImporter.alphaSource = TextureImporterAlphaSource.None;
-            textureImporter.mipmapEnabled = true;
-            textureImporter.textureCompression = TextureImporterCompression.CompressedHQ; // This is BC7 for Mac/PC
+            // Any texture with _NA suffix will store average normal lenght in alpha
+            if (Path.GetFileNameWithoutExtension(assetPath).EndsWith(s_Suffix, StringComparison.InvariantCultureIgnoreCase))
+            {
+                // Make sure we don't convert as a normal map.
+                TextureImporter textureImporter = (TextureImporter)assetImporter;
+                textureImporter.convertToNormalmap = false;
+                textureImporter.alphaSource = TextureImporterAlphaSource.None;
+                textureImporter.mipmapEnabled = true;
+                textureImporter.textureCompression = TextureImporterCompression.CompressedHQ; // This is BC7 for Mac/PC
 
 #pragma warning disable 618 // remove obsolete warning for this one
-            textureImporter.linearTexture = true; // Says deprecated but won't work without it.
+                textureImporter.linearTexture = true; // Says deprecated but won't work without it.
 #pragma warning restore 618
-            textureImporter.sRGBTexture = false;  // But we're setting the new property just in case it changes later...
-        }
-    }
-
-    private static Color GetColor(Color[] source, int x, int y, int width, int height)
-    {
-        x = (x + width) % width;
-        y = (y + height) % height;
-
-        int index = y * width + x;
-        var c = source[index];
-
-        return c;
-    }
-
-    private static Vector3 GetNormal(Color[] source, int x, int y, int width, int height)
-    {
-        Vector3 n = (Vector4)GetColor(source, x, y, width, height);
-        n = 2.0f * n - Vector3.one;
-        n.Normalize();
-
-        return n;
-    }
-
-    private static Vector3 GetAverageNormal(Color[] source, int x, int y, int width, int height, int texelFootprint)
-    {
-        Vector3 averageNormal = new Vector3(0, 0, 0);
-
-        // Calculate the average color over the texel footprint.
-        for (int i = 0; i < texelFootprint; ++i)
-        {
-            for (int j = 0; j < texelFootprint; ++j)
-            {
-                averageNormal += GetNormal(source, x + i, y + j, width, height);
+                textureImporter.sRGBTexture = false;  // But we're setting the new property just in case it changes later...
             }
         }
 
-        averageNormal /= (texelFootprint * texelFootprint);
-
-        return averageNormal;
-    }
-
-    void OnPostprocessTexture(Texture2D texture)
-    {
-        if (Path.GetFileNameWithoutExtension(assetPath).EndsWith(s_Suffix, StringComparison.InvariantCultureIgnoreCase))
+        private static Color GetColor(Color[] source, int x, int y, int width, int height)
         {
-            // Based on The Order : 1886 SIGGRAPH course notes implementation. Sample all normal map
-            // texels from the base mip level that are within the footprint of the current mipmap texel.
-            Color[] source = texture.GetPixels(0);
-            for (int m = 1; m < texture.mipmapCount; m++)
+            x = (x + width) % width;
+            y = (y + height) % height;
+
+            int index = y * width + x;
+            var c = source[index];
+
+            return c;
+        }
+
+        private static Vector3 GetNormal(Color[] source, int x, int y, int width, int height)
+        {
+            Vector3 n = (Vector4)GetColor(source, x, y, width, height);
+            n = 2.0f * n - Vector3.one;
+            n.Normalize();
+
+            return n;
+        }
+
+        private static Vector3 GetAverageNormal(Color[] source, int x, int y, int width, int height, int texelFootprint)
+        {
+            Vector3 averageNormal = new Vector3(0, 0, 0);
+
+            // Calculate the average color over the texel footprint.
+            for (int i = 0; i < texelFootprint; ++i)
             {
-                Color[] c = texture.GetPixels(m);
-
-                int mipWidth = Math.Max(1, texture.width >> m);
-                int mipHeight = Math.Max(1, texture.height >> m);
-
-                for (int x = 0; x < mipWidth; ++x)
+                for (int j = 0; j < texelFootprint; ++j)
                 {
-                    for (int y = 0; y < mipHeight; ++y)
+                    averageNormal += GetNormal(source, x + i, y + j, width, height);
+                }
+            }
+
+            averageNormal /= (texelFootprint * texelFootprint);
+
+            return averageNormal;
+        }
+
+        void OnPostprocessTexture(Texture2D texture)
+        {
+            if (Path.GetFileNameWithoutExtension(assetPath).EndsWith(s_Suffix, StringComparison.InvariantCultureIgnoreCase))
+            {
+                // Based on The Order : 1886 SIGGRAPH course notes implementation. Sample all normal map
+                // texels from the base mip level that are within the footprint of the current mipmap texel.
+                Color[] source = texture.GetPixels(0);
+                for (int m = 1; m < texture.mipmapCount; m++)
+                {
+                    Color[] c = texture.GetPixels(m);
+
+                    int mipWidth = Math.Max(1, texture.width >> m);
+                    int mipHeight = Math.Max(1, texture.height >> m);
+
+                    for (int x = 0; x < mipWidth; ++x)
                     {
-                        int texelFootprint = 1 << m;
-                        Vector3 averageNormal = GetAverageNormal(source, x * texelFootprint, y * texelFootprint,
-                                texture.width, texture.height, texelFootprint);
+                        for (int y = 0; y < mipHeight; ++y)
+                        {
+                            int texelFootprint = 1 << m;
+                            Vector3 averageNormal = GetAverageNormal(source, x * texelFootprint, y * texelFootprint,
+                                    texture.width, texture.height, texelFootprint);
 
-                        // Store the normal length for the average normal.
-                        int outputPosition = y * mipWidth + x;
+                            // Store the normal length for the average normal.
+                            int outputPosition = y * mipWidth + x;
 
-                        // Clamp to avoid any issue (TODO: Check this)
-                        // Write into the blue channel
-                        float averageNormalLength = Math.Max(0.0f, Math.Min(1.0f, averageNormal.magnitude));
+                            // Clamp to avoid any issue (TODO: Check this)
+                            // Write into the blue channel
+                            float averageNormalLength = Math.Max(0.0f, Math.Min(1.0f, averageNormal.magnitude));
 
-                        c[outputPosition].b = averageNormalLength;
-                        c[outputPosition].a = 1.0f;
+                            c[outputPosition].b = averageNormalLength;
+                            c[outputPosition].a = 1.0f;
+                        }
                     }
+
+                    texture.SetPixels(c, m);
                 }
 
-                texture.SetPixels(c, m);
-            }
-
-            // Now overwrite the first mip average normal channel - order is important as above we read the mip0
-            // For mip 0, set the normal length to 1.
-            {
-                Color[] c = texture.GetPixels(0);
-                for (int i = 0; i < c.Length; i++)
+                // Now overwrite the first mip average normal channel - order is important as above we read the mip0
+                // For mip 0, set the normal length to 1.
                 {
-                    c[i].b = 1.0f;
-                    c[i].a = 1.0f;
+                    Color[] c = texture.GetPixels(0);
+                    for (int i = 0; i < c.Length; i++)
+                    {
+                        c[i].b = 1.0f;
+                        c[i].a = 1.0f;
+                    }
+                    texture.SetPixels(c, 0);
                 }
-                texture.SetPixels(c, 0);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/BuildProcessors/HDRPPreprocessBuild.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/BuildProcessors/HDRPPreprocessBuild.cs
@@ -1,39 +1,40 @@
-using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
-using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-class HDRPPreprocessBuild : IPreprocessBuildWithReport
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
-    public int callbackOrder { get { return 0; } }
-
-    public void OnPreprocessBuild(BuildReport report)
+    class HDRPPreprocessBuild : IPreprocessBuildWithReport
     {
-        // Don't execute the preprocess if we are not HDRenderPipeline
-        HDRenderPipeline hdrp = RenderPipelineManager.currentPipeline as HDRenderPipeline;
-        if (hdrp == null)
-            return;
+        public int callbackOrder { get { return 0; } }
 
-        // Note: If you add new platform in this function, think about adding support in IsSupportedPlatform() function in HDRenderPipeline.cs
-
-        // If platform is supported all good
-        if (report.summary.platform == BuildTarget.StandaloneWindows ||
-            report.summary.platform == BuildTarget.StandaloneWindows64 ||
-            report.summary.platform == BuildTarget.StandaloneLinux64 ||
-            report.summary.platform == BuildTarget.StandaloneLinuxUniversal ||
-            report.summary.platform == BuildTarget.StandaloneOSX ||
-            report.summary.platform == BuildTarget.XboxOne ||
-            report.summary.platform == BuildTarget.PS4 ||
-            report.summary.platform == BuildTarget.Switch)
+        public void OnPreprocessBuild(BuildReport report)
         {
-            return;
+            // Don't execute the preprocess if we are not HDRenderPipeline
+            HDRenderPipeline hdrp = RenderPipelineManager.currentPipeline as HDRenderPipeline;
+            if (hdrp == null)
+                return;
+
+            // Note: If you add new platform in this function, think about adding support in IsSupportedPlatform() function in HDRenderPipeline.cs
+
+            // If platform is supported all good
+            if (report.summary.platform == BuildTarget.StandaloneWindows ||
+                report.summary.platform == BuildTarget.StandaloneWindows64 ||
+                report.summary.platform == BuildTarget.StandaloneLinux64 ||
+                report.summary.platform == BuildTarget.StandaloneLinuxUniversal ||
+                report.summary.platform == BuildTarget.StandaloneOSX ||
+                report.summary.platform == BuildTarget.XboxOne ||
+                report.summary.platform == BuildTarget.PS4 ||
+                report.summary.platform == BuildTarget.Switch)
+            {
+                return;
+            }
+
+            string msg = "The platform " + report.summary.platform.ToString() + " is not supported with Hight Definition Render Pipeline";
+
+            // Throw an exception to stop the build
+            throw new BuildFailedException(msg);
         }
-
-        string msg = "The platform " + report.summary.platform.ToString() + " is not supported with Hight Definition Render Pipeline";
-
-        // Throw an exception to stop the build
-        throw new BuildFailedException(msg);
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/BuildProcessors/HDRPreprocessShaders.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/BuildProcessors/HDRPreprocessShaders.cs
@@ -1,9 +1,7 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEditor.Build;
 using UnityEditor.Rendering;
 using UnityEngine;
-using UnityEngine.Rendering;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDAdditionalCameraEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDAdditionalCameraEditor.cs
@@ -1,7 +1,6 @@
-using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     [CanEditMultipleObjects]
     [CustomEditor(typeof(HDAdditionalCameraData))]

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDCameraEditor.Handlers.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDCameraEditor.Handlers.cs
@@ -6,7 +6,7 @@ using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEngine.Rendering.PostProcessing;
 using Object = UnityEngine.Object;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDCameraEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDCameraEditor.cs
@@ -1,11 +1,9 @@
-using System;
 using UnityEngine;
 using UnityEngine.Assertions;
-using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEngine.Rendering.PostProcessing;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     [CustomEditorForRenderPipeline(typeof(Camera), typeof(HDRenderPipelineAsset))]
     [CanEditMultipleObjects]

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDCameraUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/HDCameraUI.cs
@@ -7,7 +7,7 @@ using UnityEngine.Events;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEngine.Rendering;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<HDCameraUI, SerializedHDCamera>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/SerializedHDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Camera/SerializedHDCamera.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class SerializedHDCamera
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDCubemapInspector.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDCubemapInspector.cs
@@ -1,178 +1,180 @@
 using UnityEngine;
-using UnityEditor;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-[CustomEditorForRenderPipeline(typeof(Cubemap), typeof(HDRenderPipelineAsset))]
-class HDCubemapInspector : Editor
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
-    private enum NavMode
+    [CustomEditorForRenderPipeline(typeof(Cubemap), typeof(HDRenderPipelineAsset))]
+    class HDCubemapInspector : Editor
     {
-        None = 0,
-        Zooming = 1,
-        Rotating = 2
-    }
-
-    static GUIContent s_MipMapLow, s_MipMapHigh, s_ExposureLow;
-    static GUIStyle s_PreLabel;
-    static Mesh s_SphereMesh;
-
-    static Mesh sphereMesh
-    {
-        get { return s_SphereMesh ?? (s_SphereMesh = Resources.GetBuiltinResource(typeof(Mesh), "New-Sphere.fbx") as Mesh); }
-    }
-
-    Material m_ReflectiveMaterial;
-    PreviewRenderUtility m_PreviewUtility;
-    float m_CameraPhi = 0.75f;
-    float m_CameraTheta = 0.5f;
-    float m_CameraDistance = 2.0f;
-    NavMode m_NavMode = NavMode.None;
-    Vector2 m_PreviousMousePosition = Vector2.zero;
-
-    public float previewExposure = 0f;
-    public float mipLevelPreview = 0f;
-
-    void Awake()
-    {
-        m_ReflectiveMaterial = new Material(Shader.Find("Debug/ReflectionProbePreview"))
+        private enum NavMode
         {
-            hideFlags = HideFlags.HideAndDontSave
-        };
-    }
-
-    void OnEnable()
-    {
-        if (m_PreviewUtility == null)
-            InitPreview();
-
-        m_ReflectiveMaterial.SetTexture("_Cubemap", target as Texture);
-    }
-
-    void OnDisable()
-    {
-        if (m_PreviewUtility != null)
-            m_PreviewUtility.Cleanup();
-    }
-
-    public override bool HasPreviewGUI()
-    {
-        return true;
-    }
-
-    public override void OnPreviewGUI(Rect r, GUIStyle background)
-    {
-        if (m_ReflectiveMaterial != null)
-        {
-            m_ReflectiveMaterial.SetFloat("_Exposure", previewExposure);
-            m_ReflectiveMaterial.SetFloat("_MipLevel", mipLevelPreview);
+            None = 0,
+            Zooming = 1,
+            Rotating = 2
         }
 
-        if (m_PreviewUtility == null)
-            InitPreview();
+        static GUIContent s_MipMapLow, s_MipMapHigh, s_ExposureLow;
+        static GUIStyle s_PreLabel;
+        static Mesh s_SphereMesh;
 
-        UpdateCamera();
-
-        m_PreviewUtility.BeginPreview(r, GUIStyle.none);
-        m_PreviewUtility.DrawMesh(sphereMesh, Matrix4x4.identity, m_ReflectiveMaterial, 0);
-        m_PreviewUtility.camera.Render();
-        m_PreviewUtility.EndAndDrawPreview(r);
-
-        if (Event.current.type != EventType.Repaint)
+        static Mesh sphereMesh
         {
-            if (HandleMouse(r))
-                Repaint();
+            get { return s_SphereMesh ?? (s_SphereMesh = Resources.GetBuiltinResource(typeof(Mesh), "New-Sphere.fbx") as Mesh); }
         }
-    }
 
-    public override void OnPreviewSettings()
-    {
-        if (s_MipMapLow == null)
-            InitIcons();
+        Material m_ReflectiveMaterial;
+        PreviewRenderUtility m_PreviewUtility;
+        float m_CameraPhi = 0.75f;
+        float m_CameraTheta = 0.5f;
+        float m_CameraDistance = 2.0f;
+        NavMode m_NavMode = NavMode.None;
+        Vector2 m_PreviousMousePosition = Vector2.zero;
 
-        var mipmapCount = 0;
-        var cubemap = target as Cubemap;
-        var rt = target as RenderTexture;
-        if (cubemap != null)
-            mipmapCount = cubemap.mipmapCount;
-        if (rt != null)
-            mipmapCount = rt.useMipMap
-                ? (int)(Mathf.Log(Mathf.Max(rt.width, rt.height)) / Mathf.Log(2))
-                : 1;
+        public float previewExposure = 0f;
+        public float mipLevelPreview = 0f;
 
-        GUI.enabled = true;
-
-        GUILayout.Box(s_ExposureLow, s_PreLabel, GUILayout.MaxWidth(20));
-        GUI.changed = false;
-        previewExposure = GUILayout.HorizontalSlider(previewExposure, -10f, 10f, GUILayout.MaxWidth(80));
-        GUILayout.Space(5);
-        GUILayout.Box(s_MipMapHigh, s_PreLabel, GUILayout.MaxWidth(20));
-        GUI.changed = false;
-        mipLevelPreview = GUILayout.HorizontalSlider(mipLevelPreview, 0, mipmapCount, GUILayout.MaxWidth(80));
-        GUILayout.Box(s_MipMapLow, s_PreLabel, GUILayout.MaxWidth(20));
-    }
-
-    void InitPreview()
-    {
-        if (m_PreviewUtility != null)
-            m_PreviewUtility.Cleanup();
-        m_PreviewUtility = new PreviewRenderUtility(false, true);
-        m_PreviewUtility.cameraFieldOfView = 50.0f;
-        m_PreviewUtility.camera.nearClipPlane = 0.01f;
-        m_PreviewUtility.camera.farClipPlane = 20.0f;
-        m_PreviewUtility.camera.transform.position = new Vector3(0, 0, 2);
-        m_PreviewUtility.camera.transform.LookAt(Vector3.zero);
-    }
-
-    bool HandleMouse(Rect Viewport)
-    {
-        var result = false;
-
-        if (Event.current.type == EventType.MouseDown)
+        void Awake()
         {
-            if (Event.current.button == 0)
-                m_NavMode = NavMode.Rotating;
-            else if (Event.current.button == 1)
-                m_NavMode = NavMode.Zooming;
+            m_ReflectiveMaterial = new Material(Shader.Find("Debug/ReflectionProbePreview"))
+            {
+                hideFlags = HideFlags.HideAndDontSave
+            };
+        }
+
+        void OnEnable()
+        {
+            if (m_PreviewUtility == null)
+                InitPreview();
+
+            m_ReflectiveMaterial.SetTexture("_Cubemap", target as Texture);
+        }
+
+        void OnDisable()
+        {
+            if (m_PreviewUtility != null)
+                m_PreviewUtility.Cleanup();
+        }
+
+        public override bool HasPreviewGUI()
+        {
+            return true;
+        }
+
+        public override void OnPreviewGUI(Rect r, GUIStyle background)
+        {
+            if (m_ReflectiveMaterial != null)
+            {
+                m_ReflectiveMaterial.SetFloat("_Exposure", previewExposure);
+                m_ReflectiveMaterial.SetFloat("_MipLevel", mipLevelPreview);
+            }
+
+            if (m_PreviewUtility == null)
+                InitPreview();
+
+            UpdateCamera();
+
+            m_PreviewUtility.BeginPreview(r, GUIStyle.none);
+            m_PreviewUtility.DrawMesh(sphereMesh, Matrix4x4.identity, m_ReflectiveMaterial, 0);
+            m_PreviewUtility.camera.Render();
+            m_PreviewUtility.EndAndDrawPreview(r);
+
+            if (Event.current.type != EventType.Repaint)
+            {
+                if (HandleMouse(r))
+                    Repaint();
+            }
+        }
+
+        public override void OnPreviewSettings()
+        {
+            if (s_MipMapLow == null)
+                InitIcons();
+
+            var mipmapCount = 0;
+            var cubemap = target as Cubemap;
+            var rt = target as RenderTexture;
+            if (cubemap != null)
+                mipmapCount = cubemap.mipmapCount;
+            if (rt != null)
+                mipmapCount = rt.useMipMap
+                    ? (int)(Mathf.Log(Mathf.Max(rt.width, rt.height)) / Mathf.Log(2))
+                    : 1;
+
+            GUI.enabled = true;
+
+            GUILayout.Box(s_ExposureLow, s_PreLabel, GUILayout.MaxWidth(20));
+            GUI.changed = false;
+            previewExposure = GUILayout.HorizontalSlider(previewExposure, -10f, 10f, GUILayout.MaxWidth(80));
+            GUILayout.Space(5);
+            GUILayout.Box(s_MipMapHigh, s_PreLabel, GUILayout.MaxWidth(20));
+            GUI.changed = false;
+            mipLevelPreview = GUILayout.HorizontalSlider(mipLevelPreview, 0, mipmapCount, GUILayout.MaxWidth(80));
+            GUILayout.Box(s_MipMapLow, s_PreLabel, GUILayout.MaxWidth(20));
+        }
+
+        void InitPreview()
+        {
+            if (m_PreviewUtility != null)
+                m_PreviewUtility.Cleanup();
+            m_PreviewUtility = new PreviewRenderUtility(false, true);
+            m_PreviewUtility.cameraFieldOfView = 50.0f;
+            m_PreviewUtility.camera.nearClipPlane = 0.01f;
+            m_PreviewUtility.camera.farClipPlane = 20.0f;
+            m_PreviewUtility.camera.transform.position = new Vector3(0, 0, 2);
+            m_PreviewUtility.camera.transform.LookAt(Vector3.zero);
+        }
+
+        bool HandleMouse(Rect Viewport)
+        {
+            var result = false;
+
+            if (Event.current.type == EventType.MouseDown)
+            {
+                if (Event.current.button == 0)
+                    m_NavMode = NavMode.Rotating;
+                else if (Event.current.button == 1)
+                    m_NavMode = NavMode.Zooming;
+
+                m_PreviousMousePosition = Event.current.mousePosition;
+                result = true;
+            }
+
+            if (Event.current.type == EventType.MouseUp || Event.current.rawType == EventType.MouseUp)
+                m_NavMode = NavMode.None;
+
+            if (m_NavMode != NavMode.None)
+            {
+                var mouseDelta = Event.current.mousePosition - m_PreviousMousePosition;
+                switch (m_NavMode)
+                {
+                    case NavMode.Rotating:
+                        m_CameraTheta = (m_CameraTheta - mouseDelta.x * 0.003f) % (Mathf.PI * 2);
+                        m_CameraPhi = Mathf.Clamp(m_CameraPhi - mouseDelta.y * 0.003f, 0.2f, Mathf.PI - 0.2f);
+                        break;
+                    case NavMode.Zooming:
+                        m_CameraDistance = Mathf.Clamp(mouseDelta.y * 0.01f + m_CameraDistance, 1, 10);
+                        break;
+                }
+                result = true;
+            }
 
             m_PreviousMousePosition = Event.current.mousePosition;
-            result = true;
+            return result;
         }
 
-        if (Event.current.type == EventType.MouseUp || Event.current.rawType == EventType.MouseUp)
-            m_NavMode = NavMode.None;
-
-        if (m_NavMode != NavMode.None)
+        void UpdateCamera()
         {
-            var mouseDelta = Event.current.mousePosition - m_PreviousMousePosition;
-            switch (m_NavMode)
-            {
-                case NavMode.Rotating:
-                    m_CameraTheta = (m_CameraTheta - mouseDelta.x * 0.003f) % (Mathf.PI * 2);
-                    m_CameraPhi = Mathf.Clamp(m_CameraPhi - mouseDelta.y * 0.003f, 0.2f, Mathf.PI - 0.2f);
-                    break;
-                case NavMode.Zooming:
-                    m_CameraDistance = Mathf.Clamp(mouseDelta.y * 0.01f + m_CameraDistance, 1, 10);
-                    break;
-            }
-            result = true;
+            var pos = new Vector3(Mathf.Sin(m_CameraPhi) * Mathf.Cos(m_CameraTheta), Mathf.Cos(m_CameraPhi), Mathf.Sin(m_CameraPhi) * Mathf.Sin(m_CameraTheta)) * m_CameraDistance;
+            m_PreviewUtility.camera.transform.position = pos;
+            m_PreviewUtility.camera.transform.LookAt(Vector3.zero);
         }
 
-        m_PreviousMousePosition = Event.current.mousePosition;
-        return result;
-    }
-
-    void UpdateCamera()
-    {
-        var pos = new Vector3(Mathf.Sin(m_CameraPhi) * Mathf.Cos(m_CameraTheta), Mathf.Cos(m_CameraPhi), Mathf.Sin(m_CameraPhi) * Mathf.Sin(m_CameraTheta)) * m_CameraDistance;
-        m_PreviewUtility.camera.transform.position = pos;
-        m_PreviewUtility.camera.transform.LookAt(Vector3.zero);
-    }
-
-    static void InitIcons()
-    {
-        s_MipMapLow = EditorGUIUtility.IconContent("PreTextureMipMapLow");
-        s_MipMapHigh = EditorGUIUtility.IconContent("PreTextureMipMapHigh");
-        s_ExposureLow = EditorGUIUtility.IconContent("SceneViewLighting");
-        s_PreLabel = "preLabel";
+        static void InitIcons()
+        {
+            s_MipMapLow = EditorGUIUtility.IconContent("PreTextureMipMapLow");
+            s_MipMapHigh = EditorGUIUtility.IconContent("PreTextureMipMapHigh");
+            s_ExposureLow = EditorGUIUtility.IconContent("SceneViewLighting");
+            s_PreLabel = "preLabel";
+        }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     partial class HDReflectionProbeEditor
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Handles.cs
@@ -1,11 +1,10 @@
-using System;
 using UnityEditor.IMGUI.Controls;
 using UnityEditorInternal;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     partial class HDReflectionProbeEditor
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Preview.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Preview.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     partial class HDReflectionProbeEditor
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.ProbeUtility.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.ProbeUtility.cs
@@ -1,8 +1,4 @@
-using UnityEngine;
-using UnityEngine.Experimental.Rendering;
-using Object = UnityEngine.Object;
-
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     partial class HDReflectionProbeEditor
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Skin.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     partial class HDReflectionProbeEditor
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.cs
@@ -6,7 +6,7 @@ using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEngine.Rendering;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     [CustomEditorForRenderPipeline(typeof(ReflectionProbe), typeof(HDRenderPipelineAsset))]
     [CanEditMultipleObjects]

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditorUtility.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditorUtility.cs
@@ -1,13 +1,7 @@
-using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
-using UnityEngine.SceneManagement;
-using Object = UnityEngine.Object;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public static class HDReflectionProbeEditorUtility
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeUI.Drawers.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Reflection;
-using UnityEditor.Experimental.Rendering.HDPipeline;
 using UnityEditorInternal;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEngine.Rendering;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using CED = CoreEditorDrawer<HDReflectionProbeUI, SerializedHDReflectionProbe>;
     using _ = CoreEditorUtils;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeUI.cs
@@ -7,7 +7,7 @@ using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEngine.Rendering;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public partial class HDReflectionProbeUI : BaseUI<SerializedHDReflectionProbe>
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/ScreenSpaceRefractionEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/ScreenSpaceRefractionEditor.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/SerializedHDReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/SerializedHDReflectionProbe.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class SerializedHDReflectionProbe
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/BaseUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/BaseUI.cs
@@ -1,7 +1,7 @@
 using UnityEditor.AnimatedValues;
 using UnityEngine.Events;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class BaseUI<TType>
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Events;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<HDRenderPipelineUI, SerializedHDRenderPipelineAsset>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/FrameSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/FrameSettingsUI.cs
@@ -1,7 +1,7 @@
 using UnityEditor.AnimatedValues;
 using UnityEngine.Events;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<FrameSettingsUI, SerializedFrameSettings>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/GlobalDecalSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/GlobalDecalSettingsUI.cs
@@ -1,6 +1,4 @@
-using UnityEngine;
-
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<GlobalDecalSettingsUI, SerializedGlobalDecalSettings>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/GlobalLightLoopSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/GlobalLightLoopSettingsUI.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<GlobalLightLoopSettingsUI, SerializedGlobalLightLoopSettings>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/LightLoopSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/LightLoopSettingsUI.cs
@@ -1,7 +1,7 @@
 using UnityEditor.AnimatedValues;
 using UnityEngine;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<LightLoopSettingsUI, SerializedLightLoopSettings>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/RenderPipelineSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/RenderPipelineSettingsUI.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Events;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<RenderPipelineSettingsUI, SerializedRenderPipelineSettings>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedFrameSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedFrameSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class SerializedFrameSettings
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedGlobalDecalSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedGlobalDecalSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class SerializedGlobalDecalSettings
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedGlobalLightLoopSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedGlobalLightLoopSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class SerializedGlobalLightLoopSettings
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class SerializedHDRenderPipelineAsset
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedLightLoopSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedLightLoopSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class SerializedLightLoopSettings
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedRenderPipelineSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedRenderPipelineSettings.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class SerializedRenderPipelineSettings
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedShadowInitParameters.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/SerializedShadowInitParameters.cs
@@ -1,6 +1,6 @@
 using UnityEngine.Experimental.Rendering;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class SerializedShadowInitParameters
     {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/ShadowInitParametersUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/RenderPipeline/Settings/ShadowInitParametersUI.cs
@@ -1,9 +1,6 @@
-using UnityEditor.AnimatedValues;
-using UnityEngine.Events;
-using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEngine;
 
-namespace UnityEditor.Experimental.Rendering
+namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
     using CED = CoreEditorDrawer<ShadowInitParametersUI, SerializedShadowInitParameters>;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Shadows/HDShadowSettingsEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Shadows/HDShadowSettingsEditor.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using UnityEngine;
 using UnityEditor;
 using UnityEditor.Experimental.Rendering;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Sky/HDRISky/HDRISkyEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Sky/HDRISky/HDRISkyEditor.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-using UnityEditor;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/SphericalHarmonics.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/SphericalHarmonics.cs
@@ -1,159 +1,161 @@
-using System;
-using UnityEngine;
 using UnityEngine.Rendering;
 
-public struct ZonalHarmonicsL2
+
+namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
-    public float[] coeffs; // Must have the size of 3
-
-    public static ZonalHarmonicsL2 GetHenyeyGreensteinPhaseFunction(float anisotropy)
+    public struct ZonalHarmonicsL2
     {
-        float g = anisotropy;
+        public float[] coeffs; // Must have the size of 3
 
-        var zh    = new ZonalHarmonicsL2();
-        zh.coeffs = new float[3];
-
-        zh.coeffs[0] = 0.5f * Mathf.Sqrt(1.0f / Mathf.PI);
-        zh.coeffs[1] = 0.5f * Mathf.Sqrt(3.0f / Mathf.PI) * g;
-        zh.coeffs[2] = 0.5f * Mathf.Sqrt(5.0f / Mathf.PI) * g * g;
-
-        return zh;
-    }
-
-    public static ZonalHarmonicsL2 GetCornetteShanksPhaseFunction(float anisotropy)
-    {
-        float g = anisotropy;
-
-        var zh    = new ZonalHarmonicsL2();
-        zh.coeffs = new float[3];
-
-        zh.coeffs[0] = 0.282095f;
-        zh.coeffs[1] = 0.293162f * g * (4.0f + (g * g)) / (2.0f + (g * g));
-        zh.coeffs[2] = (0.126157f + 1.44179f * (g * g) + 0.324403f * (g * g) * (g * g)) / (2.0f + (g * g));
-
-        return zh;
-    }
-}
-
-public class SphericalHarmonicMath
-{
-    // Ref: "Stupid Spherical Harmonics Tricks", p. 6.
-    public static SphericalHarmonicsL2 Convolve(SphericalHarmonicsL2 sh, ZonalHarmonicsL2 zh)
-    {
-        for (int l = 0; l <= 2; l++)
+        public static ZonalHarmonicsL2 GetHenyeyGreensteinPhaseFunction(float anisotropy)
         {
-            float n = Mathf.Sqrt((4.0f * Mathf.PI) / (2 * l + 1));
-            float k = zh.coeffs[l];
-            float p = n * k;
+            float g = anisotropy;
 
-            for (int m = -l; m <= l; m++)
+            var zh = new ZonalHarmonicsL2();
+            zh.coeffs = new float[3];
+
+            zh.coeffs[0] = 0.5f * Mathf.Sqrt(1.0f / Mathf.PI);
+            zh.coeffs[1] = 0.5f * Mathf.Sqrt(3.0f / Mathf.PI) * g;
+            zh.coeffs[2] = 0.5f * Mathf.Sqrt(5.0f / Mathf.PI) * g * g;
+
+            return zh;
+        }
+
+        public static ZonalHarmonicsL2 GetCornetteShanksPhaseFunction(float anisotropy)
+        {
+            float g = anisotropy;
+
+            var zh = new ZonalHarmonicsL2();
+            zh.coeffs = new float[3];
+
+            zh.coeffs[0] = 0.282095f;
+            zh.coeffs[1] = 0.293162f * g * (4.0f + (g * g)) / (2.0f + (g * g));
+            zh.coeffs[2] = (0.126157f + 1.44179f * (g * g) + 0.324403f * (g * g) * (g * g)) / (2.0f + (g * g));
+
+            return zh;
+        }
+    }
+
+    public class SphericalHarmonicMath
+    {
+        // Ref: "Stupid Spherical Harmonics Tricks", p. 6.
+        public static SphericalHarmonicsL2 Convolve(SphericalHarmonicsL2 sh, ZonalHarmonicsL2 zh)
+        {
+            for (int l = 0; l <= 2; l++)
             {
-                int i = l * (l + 1) + m;
+                float n = Mathf.Sqrt((4.0f * Mathf.PI) / (2 * l + 1));
+                float k = zh.coeffs[l];
+                float p = n * k;
 
-                for (int c = 0; c < 3; c++)
+                for (int m = -l; m <= l; m++)
                 {
-                    sh[c, i] *= p;
+                    int i = l * (l + 1) + m;
+
+                    for (int c = 0; c < 3; c++)
+                    {
+                        sh[c, i] *= p;
+                    }
                 }
             }
+
+            return sh;
         }
 
-        return sh;
-    }
+        // Undoes coefficient rescaling due to the convolution with the clamped cosine kernel
+        // to obtain the canonical values of SH.
+        public static SphericalHarmonicsL2 UndoCosineRescaling(SphericalHarmonicsL2 sh)
+        {
+            const float c0 = 0.28209479177387814347f; // 1/2  * sqrt(1/Pi)
+            const float c1 = 0.32573500793527994772f; // 1/3  * sqrt(3/Pi)
+            const float c2 = 0.27313710764801976764f; // 1/8  * sqrt(15/Pi)
+            const float c3 = 0.07884789131313000151f; // 1/16 * sqrt(5/Pi)
+            const float c4 = 0.13656855382400988382f; // 1/16 * sqrt(15/Pi)
 
-    // Undoes coefficient rescaling due to the convolution with the clamped cosine kernel
-    // to obtain the canonical values of SH.
-    public static SphericalHarmonicsL2 UndoCosineRescaling(SphericalHarmonicsL2 sh)
-    {
-        const float c0 = 0.28209479177387814347f; // 1/2  * sqrt(1/Pi)
-        const float c1 = 0.32573500793527994772f; // 1/3  * sqrt(3/Pi)
-        const float c2 = 0.27313710764801976764f; // 1/8  * sqrt(15/Pi)
-        const float c3 = 0.07884789131313000151f; // 1/16 * sqrt(5/Pi)
-        const float c4 = 0.13656855382400988382f; // 1/16 * sqrt(15/Pi)
+            // Compute the inverse of SphericalHarmonicsL2::kNormalizationConstants.
+            // See SetSHEMapConstants() in "Stupid Spherical Harmonics Tricks".
+            float[] invNormConsts = { 1 / c0, -1 / c1, 1 / c1, -1 / c1, 1 / c2, -1 / c2, 1 / c3, -1 / c2, 1 / c4 };
 
-        // Compute the inverse of SphericalHarmonicsL2::kNormalizationConstants.
+            for (int c = 0; c < 3; c++)
+            {
+                for (int i = 0; i < 9; i++)
+                {
+                    sh[c, i] *= invNormConsts[i];
+                }
+            }
+
+            return sh;
+        }
+
+        // Premultiplies the SH with the polynomial coefficients of SH basis functions,
+        // which avoids using any constants during SH evaluation.
+        // The resulting evaluation takes the form:
+        // (c_0 - c_6) + c_1 y + c_2 z + c_3 x + c_4 x y + c_5 y z + c_6 (3 z^2) + c_7 x z + c_8 (x^2 - y^2)
+        public static SphericalHarmonicsL2 PremultiplyCoefficients(SphericalHarmonicsL2 sh)
+        {
+            const float k0 = 0.28209479177387814347f; // {0, 0} : 1/2 * sqrt(1/Pi)
+            const float k1 = 0.48860251190291992159f; // {1, 0} : 1/2 * sqrt(3/Pi)
+            const float k2 = 1.09254843059207907054f; // {2,-2} : 1/2 * sqrt(15/Pi)
+            const float k3 = 0.31539156525252000603f; // {2, 0} : 1/4 * sqrt(5/Pi)
+            const float k4 = 0.54627421529603953527f; // {2, 2} : 1/4 * sqrt(15/Pi)
+
+            float[] ks = { k0, -k1, k1, -k1, k2, -k2, k3, -k2, k4 };
+
+            for (int c = 0; c < 3; c++)
+            {
+                for (int i = 0; i < 9; i++)
+                {
+                    sh[c, i] *= ks[i];
+                }
+            }
+
+            return sh;
+        }
+
+        public static SphericalHarmonicsL2 RescaleCoefficients(SphericalHarmonicsL2 sh, float scalar)
+        {
+            for (int c = 0; c < 3; c++)
+            {
+                for (int i = 0; i < 9; i++)
+                {
+                    sh[c, i] *= scalar;
+                }
+            }
+
+            return sh;
+        }
+
+        // Packs coefficients so that we can use Peter-Pike Sloan's shader code.
+        // Does not perform premultiplication with coefficients of SH basis functions.
         // See SetSHEMapConstants() in "Stupid Spherical Harmonics Tricks".
-        float[] invNormConsts = { 1 / c0, -1 / c1, 1 / c1, -1 / c1, 1 / c2, -1 / c2, 1 / c3, -1 / c2, 1 / c4 };
-
-        for (int c = 0; c < 3; c++)
+        public static Vector4[] PackCoefficients(SphericalHarmonicsL2 sh)
         {
-            for (int i = 0; i < 9; i++)
+            Vector4[] coeffs = new Vector4[7];
+
+            // Constant + linear
+            for (int c = 0; c < 3; c++)
             {
-                sh[c, i] *= invNormConsts[i];
+                coeffs[c].x = sh[c, 3];
+                coeffs[c].y = sh[c, 1];
+                coeffs[c].z = sh[c, 2];
+                coeffs[c].w = sh[c, 0] - sh[c, 6];
             }
-        }
 
-        return sh;
-    }
-
-    // Premultiplies the SH with the polynomial coefficients of SH basis functions,
-    // which avoids using any constants during SH evaluation.
-    // The resulting evaluation takes the form:
-    // (c_0 - c_6) + c_1 y + c_2 z + c_3 x + c_4 x y + c_5 y z + c_6 (3 z^2) + c_7 x z + c_8 (x^2 - y^2)
-    public static SphericalHarmonicsL2 PremultiplyCoefficients(SphericalHarmonicsL2 sh)
-    {
-        const float k0 = 0.28209479177387814347f; // {0, 0} : 1/2 * sqrt(1/Pi)
-        const float k1 = 0.48860251190291992159f; // {1, 0} : 1/2 * sqrt(3/Pi)
-        const float k2 = 1.09254843059207907054f; // {2,-2} : 1/2 * sqrt(15/Pi)
-        const float k3 = 0.31539156525252000603f; // {2, 0} : 1/4 * sqrt(5/Pi)
-        const float k4 = 0.54627421529603953527f; // {2, 2} : 1/4 * sqrt(15/Pi)
-
-        float[] ks = { k0, -k1, k1, -k1, k2, -k2, k3, -k2, k4 };
-
-        for (int c = 0; c < 3; c++)
-        {
-            for (int i = 0; i < 9; i++)
+            // Quadratic (4/5)
+            for (int c = 0; c < 3; c++)
             {
-                sh[c, i] *= ks[i];
+                coeffs[3 + c].x = sh[c, 4];
+                coeffs[3 + c].y = sh[c, 5];
+                coeffs[3 + c].z = sh[c, 6] * 3.0f;
+                coeffs[3 + c].w = sh[c, 7];
             }
+
+            // Quadratic (5)
+            coeffs[6].x = sh[0, 8];
+            coeffs[6].y = sh[1, 8];
+            coeffs[6].z = sh[2, 8];
+            coeffs[6].w = 1.0f;
+
+            return coeffs;
         }
-
-        return sh;
-    }
-
-    public static SphericalHarmonicsL2 RescaleCoefficients(SphericalHarmonicsL2 sh, float scalar)
-    {
-        for (int c = 0; c < 3; c++)
-        {
-            for (int i = 0; i < 9; i++)
-            {
-                sh[c, i] *= scalar;
-            }
-        }
-
-        return sh;
-    }
-
-    // Packs coefficients so that we can use Peter-Pike Sloan's shader code.
-    // Does not perform premultiplication with coefficients of SH basis functions.
-    // See SetSHEMapConstants() in "Stupid Spherical Harmonics Tricks".
-    public static Vector4[] PackCoefficients(SphericalHarmonicsL2 sh)
-    {
-        Vector4[] coeffs = new Vector4[7];
-
-        // Constant + linear
-        for (int c = 0; c < 3; c++)
-        {
-            coeffs[c].x = sh[c, 3];
-            coeffs[c].y = sh[c, 1];
-            coeffs[c].z = sh[c, 2];
-            coeffs[c].w = sh[c, 0] - sh[c, 6];
-        }
-
-        // Quadratic (4/5)
-        for (int c = 0; c < 3; c++)
-        {
-            coeffs[3 + c].x = sh[c, 4];
-            coeffs[3 + c].y = sh[c, 5];
-            coeffs[3 + c].z = sh[c, 6] * 3.0f;
-            coeffs[3 + c].w = sh[c, 7];
-        }
-
-        // Quadratic (5)
-        coeffs[6].x = sh[0, 8];
-        coeffs[6].y = sh[1, 8];
-        coeffs[6].z = sh[2, 8];
-        coeffs[6].w = 1.0f;
-
-        return coeffs;
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/SceneViewDrawMode.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/SceneViewDrawMode.cs
@@ -1,43 +1,45 @@
 #if UNITY_EDITOR
 using System.Collections;
 using UnityEditor;
-using UnityEditor.Experimental.Rendering;
 
-public class SceneViewDrawMode
+namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
-    static private bool RejectDrawMode(SceneView.CameraMode cameraMode)
+    public class SceneViewDrawMode
     {
-        if (cameraMode.drawMode == DrawCameraMode.TexturedWire ||
-            cameraMode.drawMode == DrawCameraMode.ShadowCascades ||
-            cameraMode.drawMode == DrawCameraMode.RenderPaths ||
-            cameraMode.drawMode == DrawCameraMode.AlphaChannel ||
-            cameraMode.drawMode == DrawCameraMode.Overdraw ||
-            cameraMode.drawMode == DrawCameraMode.Mipmaps ||
-            cameraMode.drawMode == DrawCameraMode.DeferredDiffuse ||
-            cameraMode.drawMode == DrawCameraMode.DeferredSpecular ||
-            cameraMode.drawMode == DrawCameraMode.DeferredSmoothness ||
-            cameraMode.drawMode == DrawCameraMode.DeferredNormal ||
-            cameraMode.drawMode == DrawCameraMode.ValidateAlbedo ||
-            cameraMode.drawMode == DrawCameraMode.ValidateMetalSpecular ||
-            cameraMode.drawMode == DrawCameraMode.LightOverlap
-            )
-            return false;
+        static private bool RejectDrawMode(SceneView.CameraMode cameraMode)
+        {
+            if (cameraMode.drawMode == DrawCameraMode.TexturedWire ||
+                cameraMode.drawMode == DrawCameraMode.ShadowCascades ||
+                cameraMode.drawMode == DrawCameraMode.RenderPaths ||
+                cameraMode.drawMode == DrawCameraMode.AlphaChannel ||
+                cameraMode.drawMode == DrawCameraMode.Overdraw ||
+                cameraMode.drawMode == DrawCameraMode.Mipmaps ||
+                cameraMode.drawMode == DrawCameraMode.DeferredDiffuse ||
+                cameraMode.drawMode == DrawCameraMode.DeferredSpecular ||
+                cameraMode.drawMode == DrawCameraMode.DeferredSmoothness ||
+                cameraMode.drawMode == DrawCameraMode.DeferredNormal ||
+                cameraMode.drawMode == DrawCameraMode.ValidateAlbedo ||
+                cameraMode.drawMode == DrawCameraMode.ValidateMetalSpecular ||
+                cameraMode.drawMode == DrawCameraMode.LightOverlap
+                )
+                return false;
 
-        return true;
-    }
+            return true;
+        }
 
-    static public void SetupDrawMode()
-    {
-        ArrayList sceneViewArray = SceneView.sceneViews;
-        foreach (SceneView sceneView in sceneViewArray)
-            sceneView.onValidateCameraMode += RejectDrawMode;
-    }
+        static public void SetupDrawMode()
+        {
+            ArrayList sceneViewArray = SceneView.sceneViews;
+            foreach (SceneView sceneView in sceneViewArray)
+                sceneView.onValidateCameraMode += RejectDrawMode;
+        }
 
-    static public void ResetDrawMode()
-    {
-        ArrayList sceneViewArray = SceneView.sceneViews;
-        foreach (SceneView sceneView in sceneViewArray)
-            sceneView.onValidateCameraMode -= RejectDrawMode;
+        static public void ResetDrawMode()
+        {
+            ArrayList sceneViewArray = SceneView.sceneViews;
+            foreach (SceneView sceneView in sceneViewArray)
+                sceneView.onValidateCameraMode -= RejectDrawMode;
+        }
     }
 }
 #endif

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/Texture2DAtlas.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/Texture2DAtlas.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine.Rendering;
-using UnityEngine.Experimental.Rendering.HDPipeline;
 
 
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
 
-namespace UnityEngine.Experimental.Rendering
+namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
     public class AtlasAllocator
     {


### PR DESCRIPTION
Fix namespaces issue:
- Editor wrong namespace:
-- HDAdditionalCameraDataEditor.cs
-- HDCameraEditor.cs
-- HDCameraEditor.Handle.cs
-- HDCameraUI.cs
-- SerializedHDCamera.cs
-- HDReflectionProbeEditor.cs
-- HDReflectionProbeEditor.Gizmos.cs
-- HDReflectionProbeEditor.Handles.cs
-- HDReflectionProbeEditor.Preview.cs
-- HDReflectionProbeEditor.ProbeUtility.cs
-- HDReflectionProbeEditor.Skin.cs
-- HDReflectionProbeEditorUtility.cs
-- HDReflectionProbeUI.cs
-- HDReflectionProbeUI.Drawers.cs
-- SerializedHDReflectionProbe.cs
-- FrameSettingsUI.cs
-- GlobalDecalSettingsUI.cs
-- GlobalLightLoopSettingsUI.cs
-- LightLoopSettingsUI.cs
-- RenderPipelineSettingsUI.cs
-- SerializedFrameSettings.cs
-- SerializedGlobalDecalSettings.cs
-- SerializedGlobalLightLoopSettings.cs
-- SerializedHDRenderPipelineAsset.cs
-- SerializedLightLoopSettings.cs
-- SerializedRenderPipelineSettings.cs
-- SerializedShadowInitParameters.cs
-- ShadowInitParametersUI.cs
-- BaseUI.cs
-- HDRenderPipelineUI.cs
 
- editor with no namespace (may appear as full file change only due to new namespace bracket):
-- NormalMapAverageLengthTexturePostprocessor.cs
-- HDRPProcessBuild.cs
-- HDCubemapInspector.cs

- runtime with wrong namespace:
-- Texture2DAtlas.cs

- runtime with no namespace (may appear as full file change only due to new namespace bracket):
-- SphericalHarmonics.cs
-- SceneViewDrawMode.cs