### PR TITLE
Backport PR: Move debug windows #1703 to 2018.2

### DIFF
--- a/com.unity.render-pipelines.core/CoreRP/Editor/Debugging/DebugWindow.cs
+++ b/com.unity.render-pipelines.core/CoreRP/Editor/Debugging/DebugWindow.cs
@@ -99,7 +99,7 @@ namespace UnityEditor.Experimental.Rendering
             s_TypeMapDirty = false;
         }
 
-        [MenuItem("Window/General/Render Pipeline Debug", priority = 112)] // 112 is hardcoded number given by the UxTeam to fit correctly in the Windows menu
+        [MenuItem("Window/Analysis/Render Pipeline Debug", priority = 112)] // 112 is hardcoded number given by the UxTeam to fit correctly in the Windows menu
         static void Init()
         {
             var window = GetWindow<DebugWindow>();

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Move Render Pipeline Debug "Windows from Windows->General-> Render Pipeline debug windows" to "Windows from Windows->Analysis-> Render Pipeline debug windows
+
+### Fixed
+- Fixed the light range affecting the transform scale when changed.
+
 ## [2.0.6-preview]
 
 ### Fixed
@@ -12,7 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue when manipulating a lot of decals, it was displaying a lot of errors in the inspector
 - Fixed an issue with PreIntegratedFGD texture being sometimes destroyed and not regenerated causing rendering to break
 - PostProcess input buffers are not copied anymore on PC if the viewport size matches the final render target size
-- Fixed the light range affecting the transform scale when changed.
 
 ## [2.0.5-preview]
 


### PR DESCRIPTION
Katana is green