### PR TITLE
Do a late update to avoid crash for InfluenceVolume in Probe

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/Volumes/InfluenceVolume.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/Volumes/InfluenceVolume.cs
@@ -78,6 +78,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
         }
 
+        /// <summary>Return if an influence volume have been correctly initialize with a probe.</summary>
+        public bool IsInit() { return probe != null; }
+
         /// <summary>Offset of this influence volume to the component handling him.</summary>
         public Vector3 offset { get { return m_Offset; } set { m_Offset = value; } }
 


### PR DESCRIPTION
Awake is not call in the Editor (or there is an order of call problem?). 
This cause influence volume to be null and cause exceptions.

I replaced it by a late init when trying to get influence volume, but I don't like it either.
@RSlysz can you fix this? What we should do it to always allocate and influence volume, then init it when we can with the right probe. 