### PR TITLE
Remove _NORMAL_BLEND_SRC_B keyword in decal

### DIFF
--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_All_ColorTint.mat
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_All_ColorTint.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Decal_All_ColorTint
   m_Shader: {fileID: 4800000, guid: 1d64af84bdc970c4fae0c1e06dd95b73, type: 3}
   m_ShaderKeywords: _ALBEDOCONTRIBUTION _COLORMAP _MASKMAP _NORMALMAP
@@ -14,7 +15,13 @@ Material:
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
-  disabledShaderPasses: []
+  disabledShaderPasses:
+  - DBufferMesh_M
+  - DBufferMesh_AO
+  - DBufferMesh_MAO
+  - DBufferMesh_MAOS
+  - DBufferMesh_MS
+  - DBufferMesh_AOS
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -133,6 +140,7 @@ Material:
     - _DoubleSidedEnable: 0
     - _DoubleSidedNormalMode: 1
     - _Drag: 1
+    - _DrawOrder: 0
     - _DstBlend: 0
     - _EmissiveColorMode: 1
     - _EnableBlendModePreserveSpecularLighting: 1
@@ -156,7 +164,7 @@ Material:
     - _InvTilingScale: 1
     - _LinkDetailsWithBase: 1
     - _MaskBlendMode: 4
-    - _MaskBlendSrc: 1
+    - _MaskBlendSrc: 0
     - _MaskmapAO: 0
     - _MaskmapMetal: 0
     - _MaskmapSmoothness: 1

--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_BlendMask.mat
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_BlendMask.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Decal_BlendMask
   m_Shader: {fileID: 4800000, guid: 1d64af84bdc970c4fae0c1e06dd95b73, type: 3}
   m_ShaderKeywords: _ALBEDOCONTRIBUTION _COLORMAP _MASKMAP _NORMALMAP
@@ -14,7 +15,13 @@ Material:
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
-  disabledShaderPasses: []
+  disabledShaderPasses:
+  - DBufferMesh_M
+  - DBufferMesh_AO
+  - DBufferMesh_MAO
+  - DBufferMesh_MAOS
+  - DBufferMesh_MS
+  - DBufferMesh_AOS
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -133,6 +140,7 @@ Material:
     - _DoubleSidedEnable: 0
     - _DoubleSidedNormalMode: 1
     - _Drag: 1
+    - _DrawOrder: 0
     - _DstBlend: 0
     - _EmissiveColorMode: 1
     - _EnableBlendModePreserveSpecularLighting: 1
@@ -156,7 +164,7 @@ Material:
     - _InvTilingScale: 1
     - _LinkDetailsWithBase: 1
     - _MaskBlendMode: 4
-    - _MaskBlendSrc: 1
+    - _MaskBlendSrc: 0
     - _MaskmapAO: 0
     - _MaskmapMetal: 0
     - _MaskmapSmoothness: 1

--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_BlendMask_Factor05.mat
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_BlendMask_Factor05.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Decal_BlendMask_Factor05
   m_Shader: {fileID: 4800000, guid: 1d64af84bdc970c4fae0c1e06dd95b73, type: 3}
   m_ShaderKeywords: _ALBEDOCONTRIBUTION _COLORMAP _MASKMAP _NORMALMAP
@@ -14,7 +15,13 @@ Material:
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
-  disabledShaderPasses: []
+  disabledShaderPasses:
+  - DBufferMesh_M
+  - DBufferMesh_AO
+  - DBufferMesh_MAO
+  - DBufferMesh_MAOS
+  - DBufferMesh_MS
+  - DBufferMesh_AOS
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -133,6 +140,7 @@ Material:
     - _DoubleSidedEnable: 0
     - _DoubleSidedNormalMode: 1
     - _Drag: 1
+    - _DrawOrder: 0
     - _DstBlend: 0
     - _EmissiveColorMode: 1
     - _EnableBlendModePreserveSpecularLighting: 1
@@ -156,7 +164,7 @@ Material:
     - _InvTilingScale: 1
     - _LinkDetailsWithBase: 1
     - _MaskBlendMode: 4
-    - _MaskBlendSrc: 1
+    - _MaskBlendSrc: 0
     - _MaskmapAO: 0
     - _MaskmapMetal: 0
     - _MaskmapSmoothness: 1

--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_BlendMask_NoAlbedo.mat
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/9x_Other/9001_Decals/Decal_BlendMask_NoAlbedo.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Decal_BlendMask_NoAlbedo
   m_Shader: {fileID: 4800000, guid: 1d64af84bdc970c4fae0c1e06dd95b73, type: 3}
   m_ShaderKeywords: _COLORMAP _MASKMAP _NORMALMAP
@@ -14,7 +15,13 @@ Material:
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
-  disabledShaderPasses: []
+  disabledShaderPasses:
+  - DBufferMesh_M
+  - DBufferMesh_AO
+  - DBufferMesh_MAO
+  - DBufferMesh_MAOS
+  - DBufferMesh_MS
+  - DBufferMesh_AOS
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -133,6 +140,7 @@ Material:
     - _DoubleSidedEnable: 0
     - _DoubleSidedNormalMode: 1
     - _Drag: 1
+    - _DrawOrder: 0
     - _DstBlend: 0
     - _EmissiveColorMode: 1
     - _EnableBlendModePreserveSpecularLighting: 1
@@ -156,7 +164,7 @@ Material:
     - _InvTilingScale: 1
     - _LinkDetailsWithBase: 1
     - _MaskBlendMode: 4
-    - _MaskBlendSrc: 1
+    - _MaskBlendSrc: 0
     - _MaskmapAO: 0
     - _MaskmapMetal: 0
     - _MaskmapSmoothness: 1

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/Decal/DecalUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/Decal/DecalUI.cs
@@ -119,8 +119,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             CoreUtils.SetKeyword(material, "_COLORMAP", material.GetTexture(kBaseColorMap));
             CoreUtils.SetKeyword(material, "_NORMALMAP", material.GetTexture(kNormalMap));
             CoreUtils.SetKeyword(material, "_MASKMAP", material.GetTexture(kMaskMap)); 
-            CoreUtils.SetKeyword(material, "_NORMAL_BLEND_SRC_B", material.GetFloat(kNormalBlendSrc) == 1.0f);
-            CoreUtils.SetKeyword(material, "_MASK_BLEND_SRC_B", material.GetFloat(kMaskBlendSrc) == 1.0f);
 
             material.SetShaderPassEnabled(HDShaderPassNames.s_MeshDecalsMStr, false);
             material.SetShaderPassEnabled(HDShaderPassNames.s_MeshDecalsAOStr, false);

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/Decal.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/Decal.shader
@@ -35,9 +35,6 @@ Shader "HDRenderPipeline/Decal"
     #pragma shader_feature _MASKMAP
 	#pragma shader_feature _ALBEDOCONTRIBUTION
 
-	#pragma shader_feature _NORMAL_BLEND_SRC_B
-	#pragma shader_feature _MASK_BLEND_SRC_B
-
     #pragma multi_compile_instancing
     // No need to teset for DECALS_3RT we are in decal shader, so there is no OFF state
 	#pragma multi_compile _ DECALS_4RT

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/DecalData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/DecalData.hlsl
@@ -38,17 +38,15 @@ void GetSurfaceData(FragInputs input, out DecalSurfaceData surfaceData)
 	surfaceData.baseColor.w = 0;	// dont blend any albedo
 #endif
 
-	float maskMapBlend;
+    // Default to _DecalBlend, if we use _NormalBlendSrc as maskmap and there is no maskmap, it mean we have 1
+	float maskMapBlend = _DecalBlend;
+
 #if _MASKMAP
     surfaceData.mask = SAMPLE_TEXTURE2D(_MaskMap, sampler_MaskMap, texCoords);
-	maskMapBlend = surfaceData.mask.z * _DecalBlend;	// store before overwriting with smoothness
+	maskMapBlend *= surfaceData.mask.z;	// store before overwriting with smoothness
     surfaceData.mask.z = surfaceData.mask.w;
 	surfaceData.HTileMask |= DBUFFERHTILEBIT_MASK;
-#if _MASK_BLEND_SRC_B
-	surfaceData.mask.w = maskMapBlend;
-#else
-    surfaceData.mask.w = albedoMapBlend;
-#endif
+	surfaceData.mask.w = _MaskBlendSrc ? maskMapBlend : albedoMapBlend;
 #endif
 
 	// needs to be after mask, because blend source could be in the mask map blue
@@ -62,11 +60,7 @@ void GetSurfaceData(FragInputs input, out DecalSurfaceData surfaceData)
 #endif
 	surfaceData.normalWS.xyz = normalWS * 0.5f + 0.5f;
 	surfaceData.HTileMask |= DBUFFERHTILEBIT_NORMAL;
-#if _NORMAL_BLEND_SRC_B
-	surfaceData.normalWS.w = maskMapBlend;
-#else
-	surfaceData.normalWS.w = albedoMapBlend;
-#endif	
+	surfaceData.normalWS.w = _NormalBlendSrc ? maskMapBlend : albedoMapBlend;
 #endif
 	surfaceData.MAOSBlend.xy = float2(surfaceData.mask.w, surfaceData.mask.w);
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/DecalProperties.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/DecalProperties.hlsl
@@ -8,6 +8,8 @@ SAMPLER(sampler_NormalMap);
 TEXTURE2D(_MaskMap);
 SAMPLER(sampler_MaskMap);
 
+float _NormalBlendSrc;
+float _MaskBlendSrc;
 float _DecalBlend;
 float4 _BaseColor;
 float _DecalMeshDepthBias;


### PR DESCRIPTION
Test Runner green,

Remove Keyword _NORMAL_BLEND_SRC_B and _MASK_BLEND_SRC_B from Decal shader to reduce number of keyword and don't break batch
+ 
Fix an issue where the DecalSurfaceData was not correctly initalize (when there was no mask map with a source for normal map opacity setup as mask map), now it correctly take _DecalBlend.