### PR TITLE
Add SamplerState support for CodeFunctionNode

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -118,3 +118,5 @@ You can now see the generated code for any specific node. To do so, right-click 
 - Texture 2D Array and Texture 3D nodes can no longer be used in the vertex shader.
 - Shader graphs using alpha clip now generate correct depth and shadow passes.
 - `Normal Create` node has been renamed to `Normal From Texture`.
+- `SamplerState` now functions correctly in nodes using `CodeFunctionNode` API.
+- The `CodeFunctionNode` now supports `Sampler2D` slot type, which automatically creates a matching sampler state.

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -118,5 +118,5 @@ You can now see the generated code for any specific node. To do so, right-click 
 - Texture 2D Array and Texture 3D nodes can no longer be used in the vertex shader.
 - Shader graphs using alpha clip now generate correct depth and shadow passes.
 - `Normal Create` node has been renamed to `Normal From Texture`.
-- `SamplerState` now functions correctly in nodes using `CodeFunctionNode` API.
+- `SamplerState` now functions correctly in nodes that use the `CodeFunctionNode` API.
 - The `CodeFunctionNode` now supports `Sampler2D` slot type, which automatically creates a matching sampler state.

--- a/com.unity.shadergraph/Editor/Data/Graphs/SamplerStateMaterialSlot.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SamplerStateMaterialSlot.cs
@@ -23,8 +23,26 @@ namespace UnityEditor.ShaderGraph
 
         public override SlotValueType valueType { get { return SlotValueType.SamplerState; } }
         public override ConcreteSlotValueType concreteValueType { get { return ConcreteSlotValueType.SamplerState; } }
+        
+        public override string GetDefaultValue(GenerationMode generationMode)
+        {
+            var matOwner = owner as AbstractMaterialNode;
+            if (matOwner == null)
+                throw new Exception(string.Format("Slot {0} either has no owner, or the owner is not a {1}", this, typeof(AbstractMaterialNode)));
+
+            return matOwner.GetVariableNameForSlot(id);
+        }
+
         public override void AddDefaultProperty(PropertyCollector properties, GenerationMode generationMode)
         {
+            var matOwner = owner as AbstractMaterialNode;
+            if (matOwner == null)
+                throw new Exception(string.Format("Slot {0} either has no owner, or the owner is not a {1}", this, typeof(AbstractMaterialNode)));
+
+            var prop = new SamplerStateShaderProperty();
+            prop.overrideReferenceName = matOwner.GetVariableNameForSlot(id);
+            prop.generatePropertyBlock = false;
+            properties.AddShaderProperty(prop);
         }
 
         public override void CopyValuesFrom(MaterialSlot foundSlot)

--- a/com.unity.shadergraph/Editor/Data/Nodes/CodeFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/CodeFunctionNode.cs
@@ -237,6 +237,8 @@ namespace UnityEditor.ShaderGraph
 
         public sealed override void UpdateNodeAfterDeserialization()
         {
+            m_Samplers.Clear();
+
             var method = GetFunctionToConvert();
 
             if (method == null)


### PR DESCRIPTION
Fixes Fogbugz issue: https://fogbugz.unity3d.com/f/cases/1051396/

### Purpose

Adds ability to use `SamplerState` type in custom nodes using `CodeFunctionNode` API by creating a default property. Also adds a new struct type `Sampler2D` for `SlotAttribute`. This defines both a texture and matching sampler argument when generating the function and its call.

### Changes
- Add `GetDefaultValue` to `SamplerStateMaterialSlot`
- Fill in `AddDefaultProperty` in `SamplerStateMaterialSlot`
- Add `Sampler2D` type struct to `CodeFunctionNode` (maps to `SlotValueType.Texture2D`)
- Add `List<int> m_Samplers` to `CodeFunctionNode` to track slot Ids of textures that require samplers
- Add code to add arguments for matching samplers in `GenerateNodeFunction` and `GenerateNodeCode`

### Risks
- Editing shader properties is always risky. Check all Sampler State implementations.
- Sampler names must follow strict `sampler_TextureName` format. This _should_ be covered.

### Reference
This is the version of `Sample Texture 2D` node I created to test this implementation. It _should_ handle switching between default and slot defined samplers.

```
using System.Linq;
using UnityEngine;
using UnityEditor.Graphing;
using System.Reflection;

namespace UnityEditor.ShaderGraph
{
    [Title("MyCustomNode")]
    public class MyCustomNode : CodeFunctionNode
    {
        public MyCustomNode()
        {
            name = "MyCustomNode";
        }

        protected override MethodInfo GetFunctionToConvert()
        {        
            bool isSeparateSampler = false;
            
            var samplerSlot = FindInputSlot<MaterialSlot>(1);
            if(samplerSlot != null && owner != null)
            {
                if(owner.GetEdges(samplerSlot.slotReference).Any())
                    isSeparateSampler = true;
            }

            if(isSeparateSampler)
                return GetType().GetMethod("Unity_SampleTextureSampler", BindingFlags.Static | BindingFlags.NonPublic);
            else
                return GetType().GetMethod("Unity_SampleTextureDefault", BindingFlags.Static | BindingFlags.NonPublic);
        }

        static string Unity_SampleTextureSampler(
            [Slot(0, Binding.None)] Sampler2D Texture,
            [Slot(1, Binding.None)] SamplerState Sampler,
			[Slot(2, Binding.MeshUV0)] Vector2 UV,
            [Slot(3, Binding.None)] out Vector4 Out)
        {
            Out = Vector4.zero;

            return
                @"
{
    Out = SAMPLE_TEXTURE2D(Texture, Sampler, UV);
}
";
        }

        static string Unity_SampleTextureDefault(
            [Slot(0, Binding.None)] Sampler2D Texture,
            [Slot(1, Binding.None)] SamplerState Sampler,
			[Slot(2, Binding.MeshUV0)] Vector2 UV,
            [Slot(3, Binding.None)] out Vector4 Out)
        {
            Out = Vector4.zero;

            return
                @"
{
    Out = SAMPLE_TEXTURE2D(Texture, sampler_Texture, UV);
}
";
        }
    }
}
```