### PR TITLE
 Fixed _WorldToShadow warning.

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fixed Property (_WorldToShadow) exceeds previous array size (5 vs 1) warning
+- When you change a Shadow Cascade option in the Pipeline Asset, this no longer warns you that you've exceeded the array size for the _WorldToShadow property.
 
 ## [3.1.0-preview]
 

--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Fixed Property (_WorldToShadow) exceeds previous array size (5 vs 1) warning
+
 ## [3.1.0-preview]
 
 ### Fixed

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
@@ -181,10 +181,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             float invHalfShadowAtlasWidth = 0.5f * invShadowAtlasWidth;
             float invHalfShadowAtlasHeight = 0.5f * invShadowAtlasHeight;
             cmd.SetGlobalTexture(destination.id, m_DirectionalShadowmapTexture);
-            if (shadowData.directionalLightCascadeCount > 1)
-                cmd.SetGlobalMatrixArray(DirectionalShadowConstantBuffer._WorldToShadow, m_DirectionalShadowMatrices);
-            else
-                cmd.SetGlobalMatrix(DirectionalShadowConstantBuffer._WorldToShadow, m_DirectionalShadowMatrices[0]);
+            cmd.SetGlobalMatrixArray(DirectionalShadowConstantBuffer._WorldToShadow, m_DirectionalShadowMatrices);
             cmd.SetGlobalVector(DirectionalShadowConstantBuffer._ShadowData, new Vector4(light.shadowStrength, 0.0f, 0.0f, 0.0f));
             cmd.SetGlobalVector(DirectionalShadowConstantBuffer._DirShadowSplitSpheres0, m_CascadeSplitDistances[0]);
             cmd.SetGlobalVector(DirectionalShadowConstantBuffer._DirShadowSplitSpheres1, m_CascadeSplitDistances[1]);

--- a/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/Shadows.hlsl
@@ -28,11 +28,7 @@ CBUFFER_START(_DirectionalShadowBuffer)
 // Last cascade is initialized with a no-op matrix. It always transforms
 // shadow coord to half(0, 0, NEAR_PLANE). We use this trick to avoid
 // branching since ComputeCascadeIndex can return cascade index = MAX_SHADOW_CASCADES
-#ifdef _SHADOWS_CASCADE
 float4x4    _WorldToShadow[MAX_SHADOW_CASCADES + 1];
-#else
-float4x4    _WorldToShadow;
-#endif
 float4      _DirShadowSplitSpheres0;
 float4      _DirShadowSplitSpheres1;
 float4      _DirShadowSplitSpheres2;
@@ -164,7 +160,6 @@ real SampleShadowmap(float4 shadowCoord, TEXTURE2D_SHADOW_ARGS(ShadowMap, sample
 
 half ComputeCascadeIndex(float3 positionWS)
 {
-    // TODO: profile if there's a performance improvement if we avoid indexing here
     float3 fromCenter0 = positionWS - _DirShadowSplitSpheres0.xyz;
     float3 fromCenter1 = positionWS - _DirShadowSplitSpheres1.xyz;
     float3 fromCenter2 = positionWS - _DirShadowSplitSpheres2.xyz;
@@ -183,7 +178,7 @@ float4 TransformWorldToShadowCoord(float3 positionWS)
     half cascadeIndex = ComputeCascadeIndex(positionWS);
     return mul(_WorldToShadow[cascadeIndex], float4(positionWS, 1.0));
 #else
-    return mul(_WorldToShadow, float4(positionWS, 1.0));
+    return mul(_WorldToShadow[0], float4(positionWS, 1.0));
 #endif
 }
 


### PR DESCRIPTION
 Fixed Property (_WorldToShadow) exceeds previous array size (5 vs 1) warning due caused because we cache the shader property ID. Solution was to remove the ifdef around the property. In the shader code the matrix will be turned into a vec4 array and we don't benefit from not indexing. 
 