### PR TITLE
Hdrp/fix/reflectionprobe gizmo scale independent

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 return;
 
             var reflectionData = reflectionProbe.GetComponent<HDAdditionalReflectionData>();
-            var mat = reflectionProbe.transform.localToWorldMatrix;
+            var mat = Matrix4x4.TRS(reflectionProbe.transform.position, reflectionProbe.transform.rotation, Vector3.one);
 
             switch (EditMode.editMode)
             {
@@ -48,7 +48,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             var reflectionData = reflectionProbe.GetComponent<HDAdditionalReflectionData>();
             Gizmos_CapturePoint(reflectionProbe, reflectionData, e);
-            var mat = reflectionProbe.transform.localToWorldMatrix;
+            var mat = Matrix4x4.TRS(reflectionProbe.transform.position, reflectionProbe.transform.rotation, Vector3.one); 
             InfluenceVolumeUI.DrawGizmos(e.m_UIState.influenceVolume, reflectionData.influenceVolume, mat, InfluenceVolumeUI.HandleType.None, InfluenceVolumeUI.HandleType.Base);
 
             if (!e.sceneViewEditing)

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Handles.cs
@@ -28,7 +28,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (!s.sceneViewEditing)
                 return;
 
-            var mat = p.target.transform.localToWorldMatrix;
+            var mat = Matrix4x4.TRS(p.target.transform.position, p.target.transform.rotation, Vector3.one);
 
             EditorGUI.BeginChangeCheck();
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.cs
@@ -88,6 +88,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
 
             InitializeAllTargetProbes();
+
+            HDAdditionalReflectionData probe = (HDAdditionalReflectionData)m_AdditionalDataSerializedObject.targetObject;
+            probe.influenceVolume.Init(probe);
         }
 
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeEditor.cs
@@ -55,6 +55,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
                 s_StateMap[m_TypedTargets[i]] = m_UIHandleState[i];
             }
+            
+            PlanarReflectionProbe probe = (PlanarReflectionProbe)target;
+            probe.influenceVolume.Init(probe);
         }
 
         void OnDisable()

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Handles.cs
@@ -16,7 +16,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         public static void DrawHandles(PlanarReflectionProbeUI s, PlanarReflectionProbe d, Editor o)
         {
-            var mat = d.transform.localToWorldMatrix;
+            var mat = Matrix4x4.TRS(d.transform.position, d.transform.rotation, Vector3.one);
 
             switch (EditMode.editMode)
             {
@@ -103,7 +103,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (!PlanarReflectionProbeEditor.TryGetUIStateFor(d, out s))
                 return;
 
-            var mat = d.transform.localToWorldMatrix;
+            var mat = Matrix4x4.TRS(d.transform.position, d.transform.rotation, Vector3.one);
 
             switch (EditMode.editMode)
             {

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/Volume/ProxyVolumeUI.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/Volume/ProxyVolumeUI.cs
@@ -101,7 +101,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             s.sphereProjectionHandle.radius = proxyVolume.sphereRadius;
 
             var mat = Handles.matrix;
-            Handles.matrix = transform.localToWorldMatrix;
+            Handles.matrix = Matrix4x4.TRS(transform.position, transform.rotation, Vector3.one); 
             Handles.color = k_GizmoThemeColorProjection;
             EditorGUI.BeginChangeCheck();
             s.sphereProjectionHandle.DrawHandle();
@@ -122,7 +122,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             s.boxProjectionHandle.size = proxyVolume.boxSize;
 
             var mat = Handles.matrix;
-            Handles.matrix = transform.localToWorldMatrix;
+            Handles.matrix = Matrix4x4.TRS(transform.position, transform.rotation, Vector3.one);
 
             Handles.color = k_GizmoThemeColorProjection;
             EditorGUI.BeginChangeCheck();
@@ -155,7 +155,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         static void Gizmos_EditNone_Sphere(Transform t, ProxyVolume d, ProxyVolumeUI s, Object o)
         {
             var mat = Gizmos.matrix;
-            Gizmos.matrix = t.localToWorldMatrix;
+            Gizmos.matrix = Matrix4x4.TRS(t.position, t.rotation, Vector3.one);
 
             Gizmos.color = k_GizmoThemeColorProjection;
             Gizmos.DrawWireSphere(Vector3.zero, d.sphereRadius);
@@ -166,7 +166,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         static void Gizmos_EditNone_Box(Transform t, ProxyVolume d, ProxyVolumeUI s, Object o)
         {
             var mat = Gizmos.matrix;
-            Gizmos.matrix = t.localToWorldMatrix;
+            Gizmos.matrix = Matrix4x4.TRS(t.position, t.rotation, Vector3.one);
 
             Gizmos.color = k_GizmoThemeColorProjection;
             Gizmos.DrawWireCube(Vector3.zero, d.boxSize);

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/PlanarReflectionProbe.cs
@@ -105,7 +105,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             get
             {
                 return proxyVolume != null
-                    ? proxyVolume.transform.localToWorldMatrix
+                    ? Matrix4x4.TRS(proxyVolume.transform.position, proxyVolume.transform.rotation, Vector3.one)
                     : influenceToWorld;
             }
         }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/ProbeWrapper.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Reflection/ProbeWrapper.cs
@@ -166,7 +166,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             get
             {
                 return additional.proxyVolume != null
-                    ? additional.proxyVolume.transform.localToWorldMatrix
+                    ? Matrix4x4.TRS(additional.proxyVolume.transform.position, additional.proxyVolume.transform.rotation, Vector3.one)
                     : influenceToWorld;
             }
         }


### PR DESCRIPTION
- Fix crash when selecting a reflection probe after a code update in the editor and trying to modify the influence volume size
- Make InfluenceVolume non scale dependant as in legacy