### PR TITLE
Lw/bugfix/1059142

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The UI for Lightweight asset has been updated with new categories. A more clean structure and foldouts has been added to keep things organized.
 
 ### Fixed
+- Shadow casters are now properly culled per cascade. (case 1059142)
 - Scriptable passes no longer have missing material references. Now they access cached materials in the renderer.(case 1061353)
 - When you change a Shadow Cascade option in the Pipeline Asset, this no longer warns you that you've exceeded the array size for the _WorldToShadow property.
 

--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightShadowUtils.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightShadowUtils.cs
@@ -53,8 +53,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         }
 
         public static void RenderShadowSlice(CommandBuffer cmd, ref ScriptableRenderContext context,
-            ref ShadowSliceData shadowSliceData,
-            Matrix4x4 proj, Matrix4x4 view, DrawShadowsSettings settings)
+            ref ShadowSliceData shadowSliceData, ref DrawShadowsSettings settings,
+            Matrix4x4 proj, Matrix4x4 view)
         {
             cmd.SetViewport(new Rect(shadowSliceData.offsetX, shadowSliceData.offsetY, shadowSliceData.resolution, shadowSliceData.resolution));
             cmd.EnableScissorRect(new Rect(shadowSliceData.offsetX + 4, shadowSliceData.offsetY + 4, shadowSliceData.resolution - 8, shadowSliceData.resolution - 8));

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/DirectionalShadowsPass.cs
@@ -142,9 +142,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                     success = LightweightShadowUtils.ExtractDirectionalLightMatrix(ref cullResults, ref shadowData, shadowLightIndex, cascadeIndex, shadowResolution, shadowNearPlane, out m_CascadeSplitDistances[cascadeIndex], out m_CascadeSlices[cascadeIndex], out view, out proj);
                     if (success)
                     {
+                        settings.splitData.cullingSphere = m_CascadeSplitDistances[cascadeIndex];
                         LightweightShadowUtils.SetupShadowCasterConstants(cmd, ref shadowLight, proj, shadowResolution);
-                        LightweightShadowUtils.RenderShadowSlice(cmd, ref context, ref m_CascadeSlices[cascadeIndex], proj,
-                            view, settings);
+                        LightweightShadowUtils.RenderShadowSlice(cmd, ref context, ref m_CascadeSlices[cascadeIndex], ref settings, proj, view);
                     }
                 }
 

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/LocalShadowsPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/LocalShadowsPass.cs
@@ -174,7 +174,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
                         var settings = new DrawShadowsSettings(cullResults, shadowLightIndex);
                         LightweightShadowUtils.SetupShadowCasterConstants(cmd, ref shadowLight, proj, sliceResolution);
-                        LightweightShadowUtils.RenderShadowSlice(cmd, ref context, ref m_LocalLightSlices[i], proj, view, settings);
+                        LightweightShadowUtils.RenderShadowSlice(cmd, ref context, ref m_LocalLightSlices[i], ref settings, proj, view);
                     }
                 }
 


### PR DESCRIPTION
 Fixed [Shadow Cascades doubles tris of scene](https://issuetracker.unity3d.com/issues/lwrp-shadow-cascades-double-tris-of-scene-1)

 - Hook up to DrawShadowSettings.splitData.cullingSphere was missing. 
 - Updated RenderShadowSlice method signature