### PR TITLE
Small decal fixes

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.4.0-preview]
+
+### Fixed
+- Stencil test during decals normal buffer update is now properly applied
+
 ## [3.3.0-preview]
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/DecalNormalBuffer.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Decal/DecalNormalBuffer.shader
@@ -16,9 +16,9 @@ Shader "Hidden/HDRenderPipeline/Material/Decal/DecalNormalBuffer"
         #include "../../ShaderVariables.hlsl"
         #include "Decal.hlsl"
         #include "../NormalBuffer.hlsl"
-        
+
         RW_TEXTURE2D(float4, _NormalBuffer);
-                
+
         struct Attributes
         {
             uint vertexID : SV_VertexID;
@@ -40,6 +40,8 @@ Shader "Hidden/HDRenderPipeline/Material/Decal/DecalNormalBuffer"
             return output;
         }
 
+        // Force the stencil test before the UAV write.
+        [earlydepthstencil]
         float4 FragNearest(Varyings input) : SV_Target
         {
             FETCH_DBUFFER(DBuffer, _DBufferTexture, input.texcoord * _ScreenSize.xy);
@@ -73,7 +75,7 @@ Shader "Hidden/HDRenderPipeline/Material/Decal/DecalNormalBuffer"
                 ReadMask[_DecalNormalBufferStencilReadMask]
                 Ref[_DecalNormalBufferStencilRef]
                 Comp Equal
-                Pass Zero   // doesn't really matter, but clear to 0 for debugging 
+                Pass Zero   // doesn't really matter, but clear to 0 for debugging
             }
 
             HLSLPROGRAM

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/NormalBufferManager.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/NormalBufferManager.cs
@@ -26,7 +26,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 // In case of full forward we must allocate the render target for normal buffer (or reuse one already existing)
                 // TODO: Provide a way to reuse a render target
-                m_ColorMRTs[0] = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: false, name: "NormalBuffer");
+                m_ColorMRTs[0] = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: false, enableRandomWrite: true, name: "NormalBuffer");
                 m_ExternalBuffer[0] = false;
             }
             else

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/HDRenderPipelineResources.asset
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/HDRenderPipelineResources.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b6f86e1523e69a4282e92d393be89a4, type: 3}
   m_Name: HDRenderPipelineResources
   m_EditorClassIdentifier: 
-  m_Version: 2
+  m_Version: 3
   defaultDiffuseMaterial: {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
   defaultMirrorMaterial: {fileID: 2100000, guid: 6b17274157b33bc45b6a40e7d4ff51fe, type: 2}
   defaultDecalMaterial: {fileID: 2100000, guid: 500e733574922d04ea961553b1b26a63, type: 2}
@@ -66,3 +66,4 @@ MonoBehaviour:
   shadowClearShader: {fileID: 4800000, guid: e3cab24f27741f44d8af1e94d006267c, type: 3}
   shadowBlurMoments: {fileID: 7200000, guid: fb36979473602464fa32deacb9630c08, type: 3}
   debugShadowMapShader: {fileID: 4800000, guid: ee25e539f5594f44085e0a9000c15d9b, type: 3}
+  decalNormalBuffer: {fileID: 4800000, guid: fd532bf1795188c4daaa66ea798b8b0a, type: 3}


### PR DESCRIPTION
### Purpose of this PR
- Fixed stencil test for decal normal pass (stencil test does not apply before UAV updates by default)
- Fixed normal buffer creation flag (was missing enableRandomWrite flag)


