### PR TITLE
Fix multi gizmo texture previews

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
@@ -47,7 +47,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 return;
 
             var reflectionData = reflectionProbe.GetComponent<HDAdditionalReflectionData>();
-            Gizmos_CapturePoint(reflectionProbe, reflectionData, e);
+            if (reflectionProbe == e.target)
+            {
+                //will draw every preview, thus no need to do it multiple times
+                Gizmos_CapturePoint(e);
+            }
             var mat = Matrix4x4.TRS(reflectionProbe.transform.position, reflectionProbe.transform.rotation, Vector3.one); 
             InfluenceVolumeUI.DrawGizmos(e.m_UIState.influenceVolume, reflectionData.influenceVolume, mat, InfluenceVolumeUI.HandleType.None, InfluenceVolumeUI.HandleType.Base);
 
@@ -77,7 +81,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
-        static void Gizmos_CapturePoint(ReflectionProbe p, HDAdditionalReflectionData a, HDReflectionProbeEditor e)
+        static void Gizmos_CapturePoint(HDReflectionProbeEditor e)
         {
             if(sphere == null)
             {
@@ -87,9 +91,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 material = new Material(Shader.Find("Debug/ReflectionProbePreview"));
             }
-            material.SetTexture("_Cubemap", e.GetTexture());
-            material.SetPass(0);
-            Graphics.DrawMeshNow(sphere, Matrix4x4.TRS(p.transform.position, Quaternion.identity, Vector3.one));
+
+            foreach (ReflectionProbe target in e.targets)
+            {
+                material.SetTexture("_Cubemap", GetTexture(e, target));
+                material.SetPass(0);
+                Graphics.DrawMeshNow(sphere, Matrix4x4.TRS(target.transform.position, Quaternion.identity, Vector3.one));
+            }
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Preview.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.Preview.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 return false;  // We only handle one preview for reflection probes
 
             // Ensure valid cube map editor (if possible)
-            Texture texture = GetTexture();
+            Texture texture = GetTexture(this, target);
             if (m_CubemapEditor != null && m_CubemapEditor.target as Texture != texture)
             {
                 DestroyImmediate(m_CubemapEditor);
@@ -22,7 +22,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (ValidPreviewSetup() && m_CubemapEditor == null)
             {
                 Editor editor = m_CubemapEditor;
-                CreateCachedEditor(GetTexture(), typeof(HDCubemapInspector), ref editor);
+                CreateCachedEditor(GetTexture(this, target), typeof(HDCubemapInspector), ref editor);
                 m_CubemapEditor = editor as HDCubemapInspector;
             }
 
@@ -55,19 +55,19 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 return;
             }
             
-            Texture tex = GetTexture();
+            Texture tex = GetTexture(this, target);
             if (tex != null && targets.Length == 1)
                 m_CubemapEditor.DrawPreview(position);
         }
 
         bool ValidPreviewSetup()
         {
-            return GetTexture() != null;
+            return GetTexture(this, target) != null;
         }
 
-        Texture GetTexture()
+        static Texture GetTexture(HDReflectionProbeEditor e, Object target)
         {
-            HDProbe additional = GetTarget(target);
+            HDProbe additional = e.GetTarget(target);
             if (additional != null && additional.mode == UnityEngine.Rendering.ReflectionProbeMode.Realtime)
             {
                 return additional.realtimeTexture;

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDReflectionProbeEditor.cs
@@ -3,6 +3,7 @@ using UnityEditorInternal;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Experimental.Rendering.HDPipeline;
+using System.Linq;
 using UnityEngine.Rendering;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline
@@ -52,7 +53,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         internal override HDProbe GetTarget(Object editorTarget)
         {
-            return (HDProbe)s_ReflectionProbeEditors[(ReflectionProbe)editorTarget].m_AdditionalDataSerializedObject.targetObject;
+            HDReflectionProbeEditor e = s_ReflectionProbeEditors[(ReflectionProbe)editorTarget];
+            return (HDProbe)e.m_AdditionalDataSerializedObject.targetObjects.First(a => ((HDAdditionalReflectionData)a).reflectionProbe == editorTarget);
         }
 
         protected override void Draw(HDProbeUI s, SerializedHDProbe serialized, Editor owner)


### PR DESCRIPTION
### Purpose of this PR
Fix gizmo preview of cubemap in HD ReflectionProbe when multi-selecting https://fogbugz.unity3d.com/f/cases/1067871/

---
### Release Notes
Fix gizmo preview of cubemap in HD ReflectionProbe when multi-selecting 

---
### Testing status
**Katana Tests**: 

**Manual Tests**: Tested locally with several probe in different mode (realtime, custom and baked)

**Automated Tests**: 

Could be tested in the testing scene of ReflectionProbe importance

---
### Overall Product Risks
**Technical Risk**: Low 
(Few modification)

**Halo Effect**: Low
(Only affect HD ReflectionProbe editor)

---
### Comments to reviewers
