### PR TITLE
Physical camera fixes

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Core/CameraEditorUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/CameraEditorUtils.cs
@@ -7,7 +7,6 @@ namespace UnityEditor.Experimental.Rendering
     {
         public delegate Camera GetPreviewCamera(Camera sourceCamera, Vector2 previewSize);
 
-        static readonly Color k_ColorThemeCameraGizmo = new Color(233f / 255f, 233f / 255f, 233f / 255f, 128f / 255f);
         const float k_PreviewNormalizedSize = 0.2f;
 
         internal static Material s_GUITextureBlit2SRGBMaterial;
@@ -24,63 +23,6 @@ namespace UnityEditor.Experimental.Rendering
                 s_GUITextureBlit2SRGBMaterial.SetFloat("_ManualTex2SRGB", QualitySettings.activeColorSpace == ColorSpace.Linear ? 1.0f : 0.0f);
                 return s_GUITextureBlit2SRGBMaterial;
             }
-        }
-
-        public static void HandleFrustrum(Camera c)
-        {
-            Color orgHandlesColor = Handles.color;
-            Color slidersColor = k_ColorThemeCameraGizmo;
-            slidersColor.a *= 2f;
-            Handles.color = slidersColor;
-
-            // get the corners of the far clip plane in world space
-            var far = new Vector3[4];
-            float frustumAspect;
-            if (!GetFrustum(c, null, far, out frustumAspect))
-                return;
-            var leftBottomFar = far[0];
-            var leftTopFar = far[1];
-            var rightTopFar = far[2];
-            var rightBottomFar = far[3];
-
-            // manage our own gui changed state, so we can use it for individual slider changes
-            var guiChanged = GUI.changed;
-
-            // FOV handles
-            var farMid = Vector3.Lerp(leftBottomFar, rightTopFar, 0.5f);
-
-            // Top and bottom handles
-            float halfHeight = -1.0f;
-            var changedPosition = MidPointPositionSlider(leftTopFar, rightTopFar, c.transform.up);
-            if (!GUI.changed)
-                changedPosition = MidPointPositionSlider(leftBottomFar, rightBottomFar, -c.transform.up);
-            if (GUI.changed)
-                halfHeight = (changedPosition - farMid).magnitude;
-
-            // Left and right handles
-            GUI.changed = false;
-            changedPosition = MidPointPositionSlider(rightBottomFar, rightTopFar, c.transform.right);
-            if (!GUI.changed)
-                changedPosition = MidPointPositionSlider(leftBottomFar, leftTopFar, -c.transform.right);
-            if (GUI.changed)
-                halfHeight = (changedPosition - farMid).magnitude / frustumAspect;
-
-            // Update camera settings if changed
-            if (halfHeight >= 0.0f)
-            {
-                Undo.RecordObject(c, "Adjust Camera");
-                if (c.orthographic)
-                    c.orthographicSize = halfHeight;
-                else
-                {
-                    Vector3 pos = farMid + c.transform.up * halfHeight;
-                    c.fieldOfView = Vector3.Angle(c.transform.forward, (pos - c.transform.position)) * 2f;
-                }
-                guiChanged = true;
-            }
-
-            GUI.changed = guiChanged;
-            Handles.color = orgHandlesColor;
         }
 
         public static void DrawCameraSceneViewOverlay(Object target, SceneView sceneView, GetPreviewCamera previewCameraGetter)
@@ -151,83 +93,6 @@ namespace UnityEditor.Experimental.Rendering
             if (normalizedViewPortRect.y >= 1f || normalizedViewPortRect.yMax <= 0f)
                 return false;
             return true;
-        }
-
-        public static float GetGameViewAspectRatio()
-        {
-            Vector2 gameViewSize = Handles.GetMainGameViewSize();
-            if (gameViewSize.x < 0f)
-            {
-                // Fallback to Scene View of not a valid game view size
-                gameViewSize.x = Screen.width;
-                gameViewSize.y = Screen.height;
-            }
-
-            return gameViewSize.x / gameViewSize.y;
-        }
-
-        public static float GetFrustumAspectRatio(Camera camera)
-        {
-            var normalizedViewPortRect = camera.rect;
-            if (normalizedViewPortRect.width <= 0f || normalizedViewPortRect.height <= 0f)
-                return -1f;
-
-            var viewportAspect = normalizedViewPortRect.width / normalizedViewPortRect.height;
-            return GetGameViewAspectRatio() * viewportAspect;
-        }
-
-        // Returns near- and far-corners in this order: leftBottom, leftTop, rightTop, rightBottom
-        // Assumes input arrays are of length 4 (if allocated)
-        public static bool GetFrustum(Camera camera, Vector3[] near, Vector3[] far, out float frustumAspect)
-        {
-            frustumAspect = GetFrustumAspectRatio(camera);
-            if (frustumAspect < 0)
-                return false;
-
-            if (far != null)
-            {
-                far[0] = new Vector3(0, 0, camera.farClipPlane); // leftBottomFar
-                far[1] = new Vector3(0, 1, camera.farClipPlane); // leftTopFar
-                far[2] = new Vector3(1, 1, camera.farClipPlane); // rightTopFar
-                far[3] = new Vector3(1, 0, camera.farClipPlane); // rightBottomFar
-                for (int i = 0; i < 4; ++i)
-                    far[i] = camera.ViewportToWorldPoint(far[i]);
-            }
-
-            if (near != null)
-            {
-                near[0] = new Vector3(0, 0, camera.nearClipPlane); // leftBottomNear
-                near[1] = new Vector3(0, 1, camera.nearClipPlane); // leftTopNear
-                near[2] = new Vector3(1, 1, camera.nearClipPlane); // rightTopNear
-                near[3] = new Vector3(1, 0, camera.nearClipPlane); // rightBottomNear
-                for (int i = 0; i < 4; ++i)
-                    near[i] = camera.ViewportToWorldPoint(near[i]);
-            }
-            return true;
-        }
-
-        public static Vector3 PerspectiveClipToWorld(Matrix4x4 clipToWorld, Vector3 viewPositionWS, Vector3 positionCS)
-        {
-            var tempCS = new Vector3(positionCS.x, positionCS.y, 0.95f);
-            var result = clipToWorld.MultiplyPoint(tempCS);
-            var r = result - viewPositionWS;
-            return r.normalized * positionCS.z + viewPositionWS;
-        }
-
-        public static void GetFrustrumPlaneAt(Matrix4x4 clipToWorld, Vector3 viewPosition, float distance, Vector3[] points)
-        {
-            points[0] = new Vector3(-1, -1, distance); // leftBottomFar
-            points[1] = new Vector3(-1, 1, distance); // leftTopFar
-            points[2] = new Vector3(1, 1, distance); // rightTopFar
-            points[3] = new Vector3(1, -1, distance); // rightBottomFar
-            for (var i = 0; i < 4; ++i)
-                points[i] = PerspectiveClipToWorld(clipToWorld, viewPosition, points[i]);
-        }
-
-        static Vector3 MidPointPositionSlider(Vector3 position1, Vector3 position2, Vector3 direction)
-        {
-            Vector3 midPoint = Vector3.Lerp(position1, position2, 0.5f);
-            return Handles.Slider(midPoint, direction, HandleUtility.GetHandleSize(midPoint) * 0.03f, Handles.DotHandleCap, 0f);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraEditor.Handlers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraEditor.Handlers.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             SceneViewOverlay_Window(_.GetContent("Camera Preview"), OnOverlayGUI, -100, target);
 
-            CameraEditorUtils.HandleFrustrum(c);
+            UnityEditor.CameraEditorUtils.HandleFrustum(c, c.GetInstanceID());
         }
 
         void OnOverlayGUI(Object target, SceneView sceneView)

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraUI.Drawers.cs
@@ -104,33 +104,19 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static void Drawer_FieldCullingMask(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.cullingMask, cullingMaskContent);
+            EditorGUILayout.PropertyField(p.baseCameraSettings.cullingMask, cullingMaskContent);
         }
 
         static void Drawer_Projection(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            CameraProjection projection = p.orthographic.boolValue ? CameraProjection.Orthographic : CameraProjection.Perspective;
-            EditorGUI.BeginChangeCheck();
-            EditorGUI.showMixedValue = p.orthographic.hasMultipleDifferentValues;
-            projection = (CameraProjection)EditorGUILayout.EnumPopup(projectionContent, projection);
-            EditorGUI.showMixedValue = false;
-            if (EditorGUI.EndChangeCheck())
-                p.orthographic.boolValue = (projection == CameraProjection.Orthographic);
-
-            if (!p.orthographic.hasMultipleDifferentValues)
-            {
-                if (projection == CameraProjection.Orthographic)
-                    EditorGUILayout.PropertyField(p.orthographicSize, sizeContent);
-                else
-                    EditorGUILayout.Slider(p.fieldOfView, 1f, 179f, fieldOfViewContent);
-            }
+            p.baseCameraSettings.DrawProjection();
         }
 
         static void Drawer_FieldClippingPlanes(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
             CoreEditorUtils.DrawMultipleFields(
                 clippingPlaneMultiFieldTitle,
-                new[] { p.nearClippingPlane, p.farClippingPlane },
+                new[] { p.baseCameraSettings.nearClippingPlane, p.baseCameraSettings.farClippingPlane },
                 new[] { nearPlaneContent, farPlaneContent });
         }
 
@@ -158,12 +144,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static void Drawer_FieldNormalizedViewPort(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.normalizedViewPortRect, viewportContent);
+            EditorGUILayout.PropertyField(p.baseCameraSettings.normalizedViewPortRect, viewportContent);
         }
 
         static void Drawer_FieldDepth(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.depth, depthContent);
+            EditorGUILayout.PropertyField(p.baseCameraSettings.depth, depthContent);
         }
 
         static void Drawer_FieldClear(HDCameraUI s, SerializedHDCamera p, Editor owner)
@@ -181,13 +167,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static void Drawer_FieldRenderTarget(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.targetTexture);
+            EditorGUILayout.PropertyField(p.baseCameraSettings.targetTexture);
 
             // show warning if we have deferred but manual MSAA set
             // only do this if the m_TargetTexture has the same values across all target cameras
-            if (!p.targetTexture.hasMultipleDifferentValues)
+            if (!p.baseCameraSettings.targetTexture.hasMultipleDifferentValues)
             {
-                var targetTexture = p.targetTexture.objectReferenceValue as RenderTexture;
+                var targetTexture = p.baseCameraSettings.targetTexture.objectReferenceValue as RenderTexture;
                 if (targetTexture
                     && targetTexture.antiAliasing > 1
                     && p.frameSettings.litShaderMode.enumValueIndex == (int)LitShaderMode.Deferred)
@@ -199,7 +185,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static void Drawer_FieldOcclusionCulling(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.occlusionCulling, occlusionCullingContent);
+            EditorGUILayout.PropertyField(p.baseCameraSettings.occlusionCulling, occlusionCullingContent);
         }
 
         static void Drawer_CameraWarnings(HDCameraUI s, SerializedHDCamera p, Editor owner)
@@ -214,8 +200,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static void Drawer_FieldVR(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.PropertyField(p.stereoSeparation, stereoSeparationContent);
-            EditorGUILayout.PropertyField(p.stereoConvergence, stereoConvergenceContent);
+            EditorGUILayout.PropertyField(p.baseCameraSettings.stereoSeparation, stereoSeparationContent);
+            EditorGUILayout.PropertyField(p.baseCameraSettings.stereoConvergence, stereoConvergenceContent);
         }
 
 #if ENABLE_MULTIPLE_DISPLAYS
@@ -223,9 +209,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             if (ModuleManager_ShouldShowMultiDisplayOption())
             {
-                var prevDisplay = p.targetDisplay.intValue;
-                EditorGUILayout.IntPopup(p.targetDisplay, DisplayUtility_GetDisplayNames(), DisplayUtility_GetDisplayIndices(), targetDisplayContent);
-                if (prevDisplay != p.targetDisplay.intValue)
+                var prevDisplay = p.baseCameraSettings.targetDisplay.intValue;
+                EditorGUILayout.IntPopup(p.baseCameraSettings.targetDisplay, DisplayUtility_GetDisplayNames(), DisplayUtility_GetDisplayIndices(), targetDisplayContent);
+                if (prevDisplay != p.baseCameraSettings.targetDisplay.intValue)
                     UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
             }
         }
@@ -236,7 +222,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static void Drawer_FieldTargetEye(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {
-            EditorGUILayout.IntPopup(p.targetEye, k_TargetEyes, k_TargetEyeValues, targetEyeContent);
+            EditorGUILayout.IntPopup(p.baseCameraSettings.targetEye, k_TargetEyes, k_TargetEyeValues, targetEyeContent);
         }
 
         static MethodInfo k_DisplayUtility_GetDisplayIndices = Type.GetType("UnityEditor.DisplayUtility,UnityEditor")

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraUI.cs
@@ -48,7 +48,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             var renderingPath = (HDAdditionalCameraData.RenderingPath)m_SerializedHdCamera.renderingPath.intValue;
             canOverrideRenderLoopSettings = renderingPath == HDAdditionalCameraData.RenderingPath.Custom;
 
-            isSectionExpandedOrthoOptions.target = !m_SerializedHdCamera.orthographic.hasMultipleDifferentValues && m_SerializedHdCamera.orthographic.boolValue;
+            isSectionExpandedOrthoOptions.target = !m_SerializedHdCamera.baseCameraSettings.orthographic.hasMultipleDifferentValues && m_SerializedHdCamera.baseCameraSettings.orthographic.boolValue;
             isSectionAvailableXRSettings.target = PlayerSettings.virtualRealitySupported;
             // SRP settings are available only if the rendering path is not the Default one (configured by the SRP asset)
             isSectionAvailableRenderLoopSettings.target = canOverrideRenderLoopSettings;

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/SerializedHDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/SerializedHDCamera.cs
@@ -21,20 +21,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedProperty volumeLayerMask;
         public SerializedProperty volumeAnchorOverride;
         public SerializedFrameSettings frameSettings;
-        private CameraEditor.Settings m_Settings;
+        public CameraEditor.Settings baseCameraSettings { get; private set; }
 
-        public CameraEditor.Settings baseCameraSettings
-        {
-            get
-            {
-                if (m_Settings == null)
-                {
-                    m_Settings = new CameraEditor.Settings(serializedObject);
-                    m_Settings.OnEnable();
-                }
-                return m_Settings;
-            }
-        }
 
         public SerializedHDCamera(SerializedObject serializedObject)
         {
@@ -61,6 +49,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             volumeLayerMask = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.volumeLayerMask);
             volumeAnchorOverride = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.volumeAnchorOverride);
             frameSettings = new SerializedFrameSettings(serializedAdditionalDataObject.FindProperty("m_FrameSettings"));
+
+            baseCameraSettings = new CameraEditor.Settings(serializedObject);
+            baseCameraSettings.OnEnable();
         }
 
         public void Update()

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/SerializedHDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/SerializedHDCamera.cs
@@ -9,28 +9,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedObject serializedAdditionalDataObject;
 
         //public SerializedProperty backgroundColor;
-        public SerializedProperty normalizedViewPortRect;
-        public SerializedProperty fieldOfView;
-        public SerializedProperty orthographic;
-        public SerializedProperty orthographicSize;
-        public SerializedProperty depth;
-        public SerializedProperty cullingMask;
-        public SerializedProperty occlusionCulling;
-        public SerializedProperty targetTexture;
-        public SerializedProperty HDR;
-        public SerializedProperty stereoConvergence;
-        public SerializedProperty stereoSeparation;
-        public SerializedProperty nearClippingPlane;
-        public SerializedProperty farClippingPlane;
-        public SerializedProperty targetEye;
-
+        
         public SerializedProperty aperture;
         public SerializedProperty shutterSpeed;
         public SerializedProperty iso;
-
-#if ENABLE_MULTIPLE_DISPLAYS
-        public SerializedProperty targetDisplay;
-#endif
 
         public SerializedProperty clearColorMode;
         public SerializedProperty backgroundColorHDR;
@@ -39,7 +21,20 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedProperty volumeLayerMask;
         public SerializedProperty volumeAnchorOverride;
         public SerializedFrameSettings frameSettings;
+        private CameraEditor.Settings m_Settings;
 
+        public CameraEditor.Settings baseCameraSettings
+        {
+            get
+            {
+                if (m_Settings == null)
+                {
+                    m_Settings = new CameraEditor.Settings(serializedObject);
+                    m_Settings.OnEnable();
+                }
+                return m_Settings;
+            }
+        }
 
         public SerializedHDCamera(SerializedObject serializedObject)
         {
@@ -54,27 +49,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             serializedAdditionalDataObject.ApplyModifiedProperties();
 
             //backgroundColor = serializedObject.FindProperty("m_BackGroundColor");
-            normalizedViewPortRect = serializedObject.FindProperty("m_NormalizedViewPortRect");
-            nearClippingPlane = serializedObject.FindProperty("near clip plane");
-            farClippingPlane = serializedObject.FindProperty("far clip plane");
-            fieldOfView = serializedObject.FindProperty("field of view");
-            orthographic = serializedObject.FindProperty("orthographic");
-            orthographicSize = serializedObject.FindProperty("orthographic size");
-            depth = serializedObject.FindProperty("m_Depth");
-            cullingMask = serializedObject.FindProperty("m_CullingMask");
-            occlusionCulling = serializedObject.FindProperty("m_OcclusionCulling");
-            targetTexture = serializedObject.FindProperty("m_TargetTexture");
-            HDR = serializedObject.FindProperty("m_HDR");
-
-            stereoConvergence = serializedObject.FindProperty("m_StereoConvergence");
-            stereoSeparation = serializedObject.FindProperty("m_StereoSeparation");
-
-#if ENABLE_MULTIPLE_DISPLAYS
-            targetDisplay = serializedObject.FindProperty("m_TargetDisplay");
-#endif
-
-            targetEye = serializedObject.FindProperty("m_TargetEye");
-
+           
             aperture = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.aperture);
             shutterSpeed = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.shutterSpeed);
             iso = serializedAdditionalDataObject.Find((HDAdditionalCameraData d) => d.iso);
@@ -97,7 +72,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // When HDR option is enabled, Unity render in FP16 then convert to 8bit with a stretch copy (this cause banding as it should be convert to sRGB (or other color appropriate color space)), then do a final shader with sRGB conversion
             // When LDR, unity render in 8bitSRGB, then do a final shader with sRGB conversion
             // What should be done is just in our Post process we convert to sRGB and store in a linear 10bit, but require C++ change...
-            HDR.boolValue = false;
+            baseCameraSettings.HDR.boolValue = false;
         }
 
         public void Apply()

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/GeometryUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/GeometryUtils.cs
@@ -251,7 +251,7 @@ namespace UnityEngine.Experimental.Rendering
                 return Matrix4x4.Ortho(-w, w, -h, h, camera.nearClipPlane, camera.farClipPlane);
             }
             else
-                return Matrix4x4.Perspective(camera.GetGateFittedFOV() * Mathf.Deg2Rad, camera.aspect, camera.nearClipPlane, camera.farClipPlane);
+                return Matrix4x4.Perspective(camera.GetGateFittedFOV(), camera.aspect, camera.nearClipPlane, camera.farClipPlane);
         }
     } // class GeometryUtils
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/GeometryUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/GeometryUtils.cs
@@ -251,7 +251,11 @@ namespace UnityEngine.Experimental.Rendering
                 return Matrix4x4.Ortho(-w, w, -h, h, camera.nearClipPlane, camera.farClipPlane);
             }
             else
-                return Matrix4x4.Perspective(camera.GetGateFittedFOV(), camera.aspect, camera.nearClipPlane, camera.farClipPlane);
+#if UNITY_2019_1_OR_NEWER
+                return Matrix4x4.Perspective(camera.GetGateFittedFieldOfView(), camera.aspect, camera.nearClipPlane, camera.farClipPlane);
+#else
+                return Matrix4x4.Perspective(camera.fieldOfView, camera.aspect, camera.nearClipPlane, camera.farClipPlane);
+#endif
         }
     } // class GeometryUtils
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/GeometryUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/GeometryUtils.cs
@@ -251,7 +251,7 @@ namespace UnityEngine.Experimental.Rendering
                 return Matrix4x4.Ortho(-w, w, -h, h, camera.nearClipPlane, camera.farClipPlane);
             }
             else
-                return Matrix4x4.Perspective(camera.fieldOfView, camera.aspect, camera.nearClipPlane, camera.farClipPlane);
+                return Matrix4x4.Perspective(camera.GetGateFittedFOV() * Mathf.Deg2Rad, camera.aspect, camera.nearClipPlane, camera.farClipPlane);
         }
     } // class GeometryUtils
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/ReflectionSystemInternal.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/ReflectionSystemInternal.cs
@@ -523,9 +523,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline.Internal
             nearClipPlane = probe.captureSettings.nearClipPlane;
             farClipPlane = probe.captureSettings.farClipPlane;
             aspect = 1;
+#if UNITY_2019_1_OR_NEWER
+            fov = (probe.captureSettings.overrides & CaptureSettingsOverrides.FieldOfview) > 0
+                ? probe.captureSettings.fieldOfView
+                : Mathf.Max(viewerCamera.GetGateFittedFieldOfView(), viewerCamera.GetGateFittedFieldOfView() * viewerCamera.aspect);
+#else
             fov = (probe.captureSettings.overrides & CaptureSettingsOverrides.FieldOfview) > 0
                 ? probe.captureSettings.fieldOfView
                 : Mathf.Max(viewerCamera.fieldOfView, viewerCamera.fieldOfView * viewerCamera.aspect);
+#endif
             clearFlags = viewerCamera.clearFlags;
             backgroundColor = viewerCamera.backgroundColor;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.cs
@@ -578,10 +578,16 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 var     frameParams = hdCamera.vBufferParams[0];
                 Vector4 resolution  = frameParams.viewportResolution;
-                float   vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
+#if UNITY_2019_1_OR_NEWER
+                float vFoV        = hdCamera.camera.GetGateFittedFieldOfView() * Mathf.Deg2Rad;
+                Vector2 lensShift = hdCamera.camera.GetGateFittedLensShift();
+#else
+                float vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
+                Vector2 lensShift = Vector2.zero;
+#endif
 
                 // Compose the matrix which allows us to compute the world space view direction.
-                Matrix4x4 transform   = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(vFoV, resolution, hdCamera.viewMatrix, false);
+                Matrix4x4 transform = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(vFoV, lensShift, resolution, hdCamera.viewMatrix, false);
 
                 Texture3D volumeAtlas = DensityVolumeManager.manager.volumeAtlas.GetAtlas();
                 Vector4 volumeAtlasDimensions = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -700,9 +706,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 var       frameParams = hdCamera.vBufferParams[0];
                 Vector4   resolution  = frameParams.viewportResolution;
-                float     vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
+#if UNITY_2019_1_OR_NEWER
+                float vFoV = hdCamera.camera.GetGateFittedFieldOfView() * Mathf.Deg2Rad;
+                Vector2 lensShift = hdCamera.camera.GetGateFittedLensShift();
+#else
+                float vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
+                Vector2 lensShift   = Vector2.zero;
+#endif
                 // Compose the matrix which allows us to compute the world space view direction.
-                Matrix4x4 transform   = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(vFoV, resolution, hdCamera.viewMatrix, false);
+                Matrix4x4 transform   = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(vFoV, lensShift, resolution, hdCamera.viewMatrix, false);
 
                 GetHexagonalClosePackedSpheres7(m_xySeq);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.cs
@@ -579,11 +579,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 var     frameParams = hdCamera.vBufferParams[0];
                 Vector4 resolution  = frameParams.viewportResolution;
 #if UNITY_2019_1_OR_NEWER
-                float vFoV        = hdCamera.camera.GetGateFittedFieldOfView() * Mathf.Deg2Rad;
-                Vector2 lensShift = hdCamera.camera.GetGateFittedLensShift();
+                var vFoV        = hdCamera.camera.GetGateFittedFieldOfView() * Mathf.Deg2Rad;
+                var lensShift = hdCamera.camera.GetGateFittedLensShift();
 #else
-                float vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
-                Vector2 lensShift = Vector2.zero;
+                var vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
+                var lensShift = Vector2.zero;
 #endif
 
                 // Compose the matrix which allows us to compute the world space view direction.
@@ -707,11 +707,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 var       frameParams = hdCamera.vBufferParams[0];
                 Vector4   resolution  = frameParams.viewportResolution;
 #if UNITY_2019_1_OR_NEWER
-                float vFoV = hdCamera.camera.GetGateFittedFieldOfView() * Mathf.Deg2Rad;
-                Vector2 lensShift = hdCamera.camera.GetGateFittedLensShift();
+                var vFoV = hdCamera.camera.GetGateFittedFieldOfView() * Mathf.Deg2Rad;
+                var lensShift = hdCamera.camera.GetGateFittedLensShift();
 #else
-                float vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
-                Vector2 lensShift   = Vector2.zero;
+                var vFoV        = hdCamera.camera.fieldOfView * Mathf.Deg2Rad;
+                var lensShift   = Vector2.zero;
 #endif
                 // Compose the matrix which allows us to compute the world space view direction.
                 Matrix4x4 transform   = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(vFoV, lensShift, resolution, hdCamera.viewMatrix, false);

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Fabric/IBLFilterCharlie.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Fabric/IBLFilterCharlie.cs
@@ -72,7 +72,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     for (int face = 0; face < 6; ++face)
                     {
                         var faceSize = new Vector4(source.width >> mip, source.height >> mip, 1.0f / (source.width >> mip), 1.0f / (source.height >> mip));
-                        var transform = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI, faceSize, worldToViewMatrices[face], true);
+                        var transform = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI, Vector2.zero, faceSize, worldToViewMatrices[face], true);
 
                         props.SetMatrix(HDShaderIDs._PixelCoordToViewDirWS, transform);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/IBLFilterGGX.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/IBLFilterGGX.cs
@@ -128,7 +128,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     for (int face = 0; face < 6; ++face)
                     {
                         var faceSize = new Vector4(source.width >> mip, source.height >> mip, 1.0f / (source.width >> mip), 1.0f / (source.height >> mip));
-                        var transform = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI, faceSize, worldToViewMatrices[face], true);
+                        var transform = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI,Vector2.zero, faceSize, worldToViewMatrices[face], true);
 
                         props.SetMatrix(HDShaderIDs._PixelCoordToViewDirWS, transform);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/IBLFilterGGX.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/IBLFilterGGX.cs
@@ -128,7 +128,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     for (int face = 0; face < 6; ++face)
                     {
                         var faceSize = new Vector4(source.width >> mip, source.height >> mip, 1.0f / (source.width >> mip), 1.0f / (source.height >> mip));
-                        var transform = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI,Vector2.zero, faceSize, worldToViewMatrices[face], true);
+                        var transform = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI, Vector2.zero, faceSize, worldToViewMatrices[face], true);
 
                         props.SetMatrix(HDShaderIDs._PixelCoordToViewDirWS, transform);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
@@ -91,21 +91,22 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
         }
 
-        public static Matrix4x4 ComputePixelCoordToWorldSpaceViewDirectionMatrix(float verticalFoV, Vector4 screenSize, Matrix4x4 worldToViewMatrix, bool renderToCubemap)
+        public static Matrix4x4 ComputePixelCoordToWorldSpaceViewDirectionMatrix(float verticalFoV, Vector2 lensShift, Vector4 screenSize, Matrix4x4 worldToViewMatrix, bool renderToCubemap)
         {
             // Compose the view space version first.
             // V = -(X, Y, Z), s.t. Z = 1,
             // X = (2x / resX - 1) * tan(vFoV / 2) * ar = x * [(2 / resX) * tan(vFoV / 2) * ar] + [-tan(vFoV / 2) * ar] = x * [-m00] + [-m20]
             // Y = (2y / resY - 1) * tan(vFoV / 2)      = y * [(2 / resY) * tan(vFoV / 2)]      + [-tan(vFoV / 2)]      = y * [-m11] + [-m21]
+            
             float tanHalfVertFoV = Mathf.Tan(0.5f * verticalFoV);
             float aspectRatio    = screenSize.x * screenSize.w;
 
             // Compose the matrix.
-            float m21 = tanHalfVertFoV;
-            float m20 = tanHalfVertFoV * aspectRatio;
-            float m00 = -2.0f * screenSize.z * m20;
-            float m11 = -2.0f * screenSize.w * m21;
-            float m33 = -1.0f;
+            float m21 = (1.0f - 2.0f * lensShift.y) * tanHalfVertFoV;
+            float m11 = -2.0f * screenSize.w * tanHalfVertFoV;
+
+            float m20 = (1.0f - 2.0f * lensShift.x) * tanHalfVertFoV * aspectRatio;
+            float m00 = -2.0f * screenSize.z * tanHalfVertFoV * aspectRatio;
 
             if (renderToCubemap)
             {
@@ -116,7 +117,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             var viewSpaceRasterTransform = new Matrix4x4(new Vector4(m00, 0.0f, 0.0f, 0.0f),
                     new Vector4(0.0f, m11, 0.0f, 0.0f),
-                    new Vector4(m20, m21, m33, 0.0f),
+                    new Vector4(m20, m21, -1.0f, 0.0f),
                     new Vector4(0.0f, 0.0f, 0.0f, 1.0f));
 
             // Remove the translation component.

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyRenderingContext.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyRenderingContext.cs
@@ -113,7 +113,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 var lookAt      = Matrix4x4.LookAt(Vector3.zero, CoreUtils.lookAtList[i], CoreUtils.upVectorList[i]);
                 var worldToView = lookAt * Matrix4x4.Scale(new Vector3(1.0f, 1.0f, -1.0f)); // Need to scale -1.0 on Z to match what is being done in the camera.wolrdToCameraMatrix API. ...
 
-                m_facePixelCoordToViewDirMatrices[i] = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI,Vector2.zero, m_CubemapScreenSize, worldToView, true);
+                m_facePixelCoordToViewDirMatrices[i] = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI, Vector2.zero, m_CubemapScreenSize, worldToView, true);
                 m_faceCameraInvViewProjectionMatrix[i] = HDUtils.GetViewProjectionMatrix(lookAt, cubeProj).inverse;
             }
         }
@@ -277,7 +277,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     m_BuiltinParameters.commandBuffer = cmd;
                     m_BuiltinParameters.sunLight = sunLight;
-                    m_BuiltinParameters.pixelCoordToViewDirMatrix = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(hdCamera.camera.GetGateFittedFOV() * Mathf.Deg2Rad, hdCamera.camera.GetGateFittedLensShift(), hdCamera.screenSize, hdCamera.viewMatrix, false);
+#if UNITY_2019_1_OR_NEWER
+                    m_BuiltinParameters.pixelCoordToViewDirMatrix = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(hdCamera.camera.GetGateFittedFieldOfView() * Mathf.Deg2Rad, hdCamera.camera.GetGateFittedLensShift(), hdCamera.screenSize, hdCamera.viewMatrix, false);
+#else
+                    m_BuiltinParameters.pixelCoordToViewDirMatrix = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(hdCamera.camera.fieldOfView * Mathf.Deg2Rad, hdCamera.camera.GetGateFittedLensShift(), hdCamera.screenSize, hdCamera.viewMatrix, false);
+#endif
                     m_BuiltinParameters.invViewProjMatrix = hdCamera.viewProjMatrix.inverse;
                     m_BuiltinParameters.screenSize = hdCamera.screenSize;
                     m_BuiltinParameters.cameraPosWS = hdCamera.camera.transform.position;

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyRenderingContext.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyRenderingContext.cs
@@ -113,7 +113,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 var lookAt      = Matrix4x4.LookAt(Vector3.zero, CoreUtils.lookAtList[i], CoreUtils.upVectorList[i]);
                 var worldToView = lookAt * Matrix4x4.Scale(new Vector3(1.0f, 1.0f, -1.0f)); // Need to scale -1.0 on Z to match what is being done in the camera.wolrdToCameraMatrix API. ...
 
-                m_facePixelCoordToViewDirMatrices[i] = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI, m_CubemapScreenSize, worldToView, true);
+                m_facePixelCoordToViewDirMatrices[i] = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(0.5f * Mathf.PI,Vector2.zero, m_CubemapScreenSize, worldToView, true);
                 m_faceCameraInvViewProjectionMatrix[i] = HDUtils.GetViewProjectionMatrix(lookAt, cubeProj).inverse;
             }
         }
@@ -277,7 +277,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     m_BuiltinParameters.commandBuffer = cmd;
                     m_BuiltinParameters.sunLight = sunLight;
-                    m_BuiltinParameters.pixelCoordToViewDirMatrix = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(hdCamera.camera.fieldOfView * Mathf.Deg2Rad, hdCamera.screenSize, hdCamera.viewMatrix, false);
+                    m_BuiltinParameters.pixelCoordToViewDirMatrix = HDUtils.ComputePixelCoordToWorldSpaceViewDirectionMatrix(hdCamera.camera.GetGateFittedFOV() * Mathf.Deg2Rad, hdCamera.camera.GetGateFittedLensShift(), hdCamera.screenSize, hdCamera.viewMatrix, false);
                     m_BuiltinParameters.invViewProjMatrix = hdCamera.viewProjMatrix.inverse;
                     m_BuiltinParameters.screenSize = hdCamera.screenSize;
                     m_BuiltinParameters.cameraPosWS = hdCamera.camera.transform.position;


### PR DESCRIPTION
### Purpose of this PR
Adds Physical Camera properties UI to the HDCamera inspector and fixes procedural sky and HDRI sky when using physical camera mode with non-zero lens shift. This PR relies on methods not available yet in released version of Unity.
---
### Release Notes
- Enabled Physical Camera mode in HDRP.

---
### Testing status
Tested manually, waiting for QA pass by joelf.
---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Medium

---
### Comments to reviewers
Do not merge, waiting for changes to land in 2018.3 first.
