### PR TITLE
Fix for Y-flip issue with tile debug view

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Debug/DebugViewTiles.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/Debug/DebugViewTiles.shader
@@ -139,6 +139,12 @@ Shader "Hidden/HDRenderPipeline/DebugViewTiles"
 
             float4 Frag(Varyings input) : SV_Target
             {
+#if UNITY_UV_STARTS_AT_TOP
+                // Flip Y coodinate if not flipped in projection
+                if (_ProjectionParams.x > 0)
+                    input.positionCS.y = _ScreenSize.y - input.positionCS.y;
+#endif
+
                 // positionCS is SV_Position
                 float depth = LOAD_TEXTURE2D(_CameraDepthTexture, input.positionCS.xy).x;
                 PositionInputs posInput = GetPositionInput(input.positionCS.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, uint2(input.positionCS.xy) / GetTileSize());


### PR DESCRIPTION
### Purpose of this PR

Fix an issue where the tile/cluster debug view flips upside-down.

![before](https://i.imgur.com/HMuCbzel.png)

![after](https://i.imgur.com/AyEwzXlm.png)

---

### Release Notes

- Fix an issue where the tile/cluster debug view flips upside-down.

---

### Testing status

**Manual Tests**: Tested on DX11 and Metal.

---

### Comments to reviewers

It's not clear when this issue was introduced.

Not tested on platforms where `UNITY_UV_STARTS_AT_TOP` is defined as 0 (as far as I know there is no such platform under HDRP support at the moment).
