### PR TITLE
Fix for float.tryparse 

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph;
 using UnityEngine.Experimental.Rendering;
@@ -473,7 +474,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             float constantAlpha = 0.0f;
             if (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId) ||
-                (float.TryParse(masterNode.GetSlotValue(PBRMasterNode.AlphaThresholdSlotId, GenerationMode.ForReals), out constantAlpha) && (constantAlpha > 0.0f)))
+                (float.TryParse(masterNode.GetSlotValue(PBRMasterNode.AlphaThresholdSlotId, GenerationMode.ForReals), NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out constantAlpha) && (constantAlpha > 0.0f)))
             {
                 activeFields.Add("AlphaTest");
             }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRSubShader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph;
 using UnityEngine.Experimental.Rendering;
@@ -472,9 +473,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     break;
             }
 
-            float constantAlpha = 0.0f;
             if (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId) ||
-                (float.TryParse(masterNode.GetSlotValue(PBRMasterNode.AlphaThresholdSlotId, GenerationMode.ForReals), NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out constantAlpha) && (constantAlpha > 0.0f)))
+                masterNode.GetInputSlots<Vector1MaterialSlot>().First(x => x.id == PBRMasterNode.AlphaThresholdSlotId).value > 0.0f)
             {
                 activeFields.Add("AlphaTest");
             }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph;
 using UnityEngine.Experimental.Rendering;
@@ -135,9 +136,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
 
-            float constantAlpha = 0.0f;
             if (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId) ||
-                (float.TryParse(masterNode.GetSlotValue(PBRMasterNode.AlphaThresholdSlotId, GenerationMode.ForReals), NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out constantAlpha) && (constantAlpha > 0.0f)))
+                masterNode.GetInputSlots<Vector1MaterialSlot>().First(x => x.id == PBRMasterNode.AlphaThresholdSlotId).value > 0.0f)
             {
                 activeFields.Add("AlphaTest");
             }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDUnlitSubShader.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph;
 using UnityEngine.Experimental.Rendering;
@@ -136,7 +137,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             float constantAlpha = 0.0f;
             if (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId) ||
-                (float.TryParse(masterNode.GetSlotValue(PBRMasterNode.AlphaThresholdSlotId, GenerationMode.ForReals), out constantAlpha) && (constantAlpha > 0.0f)))
+                (float.TryParse(masterNode.GetSlotValue(PBRMasterNode.AlphaThresholdSlotId, GenerationMode.ForReals), NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out constantAlpha) && (constantAlpha > 0.0f)))
             {
                 activeFields.Add("AlphaTest");
             }

--- a/com.unity.shadergraph/Editor/Drawing/Controls/DielectricSpecularControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/DielectricSpecularControl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Reflection;
 using UnityEditor.Experimental.UIElements;
 using UnityEngine;
@@ -155,7 +156,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
                         m_Node.owner.owner.RegisterCompleteObjectUndo("Change " + m_Node.name);
                     }
                     float newValue;
-                    if (!float.TryParse(evt.newData, out newValue))
+                    if (!float.TryParse(evt.newData, NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out newValue))
                         newValue = 0f;
                     var value = (DielectricSpecularNode.DielectricMaterial)m_PropertyInfo.GetValue(m_Node, null);
                     if (index == 1)

--- a/com.unity.shadergraph/Editor/Drawing/Controls/SliderControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/SliderControl.cs
@@ -4,6 +4,7 @@ using UnityEditor.Experimental.UIElements;
 using UnityEngine;
 using UnityEngine.Experimental.UIElements;
 using UnityEditor.Graphing;
+using System.Globalization;
 
 namespace UnityEditor.ShaderGraph.Drawing.Controls
 {
@@ -118,7 +119,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
                         m_Node.owner.owner.RegisterCompleteObjectUndo("Change " + m_Node.name);
                     }
                     float newValue;
-                    if (!float.TryParse(evt.newData, out newValue))
+                    if (!float.TryParse(evt.newData, NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out newValue))
                         newValue = 0f;
                     var value = (Vector3)m_PropertyInfo.GetValue(m_Node, null);
                     value[index] = newValue;

--- a/com.unity.shadergraph/Editor/Drawing/Controls/VectorControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/VectorControl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using UnityEditor.Experimental.UIElements;
@@ -93,7 +94,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
                         m_Node.owner.owner.RegisterCompleteObjectUndo("Change " + m_Node.name);
                     }
                     float newValue;
-                    if (!float.TryParse(evt.newData, out newValue))
+                    if (!float.TryParse(evt.newData, NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out newValue))
                         newValue = 0f;
                     var value = GetValue();
                     value[index] = newValue;

--- a/com.unity.shadergraph/Editor/Drawing/Views/Slots/MultiFloatSlotControlView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/Slots/MultiFloatSlotControlView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using UnityEditor.Experimental.UIElements;
 using UnityEditor.Graphing;
 using UnityEngine;
@@ -49,7 +50,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Slots
                         m_Node.owner.owner.RegisterCompleteObjectUndo("Change " + m_Node.name);
                     }
                     float newValue;
-                    if (!float.TryParse(evt.newData, out newValue))
+                    if (!float.TryParse(evt.newData, NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out newValue))
                         newValue = 0f;
                     var value = m_Get();
                     if (Math.Abs(value[index] - newValue) > 1e-9)


### PR DESCRIPTION
Added  NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, in the tryparse method.

### Purpose of this PR
Periods and commas sometimes did not evaluate properly depending on your system locale.

---
### Release Notes

---
### Testing status
Katana

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low
**Halo Effect**: None, Low, Medium, High?
Low
---
### Comments to reviewers
Notes for the reviewers you have assigned.
