### PR TITLE
Update Decal contribution of shader per material API

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Fabric/FabricData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Fabric/FabricData.hlsl
@@ -6,6 +6,30 @@
 #include "HDRP/Material/BuiltinUtilities.hlsl"
 #include "HDRP/Material/Decal/DecalUtilities.hlsl"
 
+void ApplyDecalToSurfaceData(SurfaceData surfaceData, DecalSurfaceData decalSurfaceData)
+{
+    // using alpha compositing https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch23.html
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE)
+    {
+        surfaceData.baseColor.xyz = surfaceData.baseColor.xyz * decalSurfaceData.baseColor.w + decalSurfaceData.baseColor.xyz;
+    }
+
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_NORMAL)
+    {
+        surfaceData.normalWS.xyz = normalize(surfaceData.normalWS.xyz * decalSurfaceData.normalWS.w + decalSurfaceData.normalWS.xyz);
+    }
+
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK)
+    {
+#ifdef DECALS_4RT // only smoothness in 3RT mode
+        // Don't apply any metallic modification
+        surfaceData.ambientOcclusion = surfaceData.ambientOcclusion * decalSurfaceData.MAOSBlend.y + decalSurfaceData.mask.y;
+#endif
+
+        surfaceData.perceptualSmoothness = surfaceData.perceptualSmoothness * decalSurfaceData.mask.w + decalSurfaceData.mask.z;
+    }
+}
+
 void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
 {
     ApplyDoubleSidedFlipOrMirror(input); // Apply double sided flip on the vertex normal
@@ -171,7 +195,11 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #endif
 
 #if HAVE_DECALS
-    AddDecalContribution(posInput, surfaceData, alpha);
+    if (_EnableDecals)
+    {
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+    }
 #endif
 
 #if defined(DEBUG_DISPLAY)

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Fabric/FabricData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Fabric/FabricData.hlsl
@@ -6,7 +6,7 @@
 #include "HDRP/Material/BuiltinUtilities.hlsl"
 #include "HDRP/Material/Decal/DecalUtilities.hlsl"
 
-void ApplyDecalToSurfaceData(SurfaceData surfaceData, DecalSurfaceData decalSurfaceData)
+void ApplyDecalToSurfaceData(DecalSurfaceData decalSurfaceData, inout SurfaceData surfaceData)
 {
     // using alpha compositing https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch23.html
     if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE)
@@ -198,7 +198,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     if (_EnableDecals)
     {
         DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
     }
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/LayeredLit/LayeredLitData.hlsl
@@ -763,7 +763,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     if (_EnableDecals)
     {
         DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
     }
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/LayeredLit/LayeredLitData.hlsl
@@ -760,7 +760,11 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #endif
 
 #if HAVE_DECALS
-    AddDecalContribution(posInput, surfaceData, alpha);
+    if (_EnableDecals)
+    {
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+    }
 #endif
 
 #if defined(DEBUG_DISPLAY)

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitData.hlsl
@@ -4,6 +4,7 @@
 #include "CoreRP/ShaderLibrary/Sampling/SampleUVMapping.hlsl"
 #include "HDRP/Material/MaterialUtilities.hlsl"
 #include "HDRP/Material/Decal/DecalUtilities.hlsl"
+#include "HDRP/Material/Lit/LitDecalData.hlsl"
 
 //#include "HDRP/Material/SphericalCapPivot/SPTDistribution.hlsl"
 //#define SPECULAR_OCCLUSION_USE_SPTD
@@ -213,7 +214,11 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
 
 #if HAVE_DECALS
-    AddDecalContribution(posInput, surfaceData, alpha);
+    if (_EnableDecals)
+    {
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+    }
 #endif
 
 #if defined(DEBUG_DISPLAY)

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitData.hlsl
@@ -217,7 +217,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     if (_EnableDecals)
     {
         DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
     }
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl
@@ -1,0 +1,28 @@
+void ApplyDecalToSurfaceData(SurfaceData surfaceData, DecalSurfaceData decalSurfaceData)
+{
+    // using alpha compositing https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch23.html
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE)
+    {
+        surfaceData.baseColor.xyz = surfaceData.baseColor.xyz * decalSurfaceData.baseColor.w + decalSurfaceData.baseColor.xyz;
+    }
+
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_NORMAL)
+    {
+        surfaceData.normalWS.xyz = normalize(surfaceData.normalWS.xyz * decalSurfaceData.normalWS.w + decalSurfaceData.normalWS.xyz);
+    }
+
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK)
+    {
+#ifdef DECALS_4RT // only smoothness in 3RT mode
+#ifdef _MATERIAL_FEATURE_SPECULAR_COLOR
+        float3 decalSpecularColor = ComputeFresnel0((decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE) ? decalSurfaceData.baseColor : float3(1.0, 1.0, 1.0), decalSurfaceData.mask.x, DEFAULT_SPECULAR_VALUE);
+        surfaceData.specularColor = surfaceData.specularColor * decalSurfaceData.MAOSBlend.x + decalSpecularColor;
+#else
+        surfaceData.metallic = surfaceData.metallic * decalSurfaceData.MAOSBlend.x + decalSurfaceData.mask.x;
+#endif
+        surfaceData.ambientOcclusion = surfaceData.ambientOcclusion * decalSurfaceData.MAOSBlend.y + decalSurfaceData.mask.y;
+#endif
+
+        surfaceData.perceptualSmoothness = surfaceData.perceptualSmoothness * decalSurfaceData.mask.w + decalSurfaceData.mask.z;
+    }
+}

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl
@@ -15,7 +15,7 @@ void ApplyDecalToSurfaceData(DecalSurfaceData decalSurfaceData, inout SurfaceDat
     {
 #ifdef DECALS_4RT // only smoothness in 3RT mode
 #ifdef _MATERIAL_FEATURE_SPECULAR_COLOR
-        float3 decalSpecularColor = ComputeFresnel0((decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE) ? decalSurfaceData.baseColor : float3(1.0, 1.0, 1.0), decalSurfaceData.mask.x, DEFAULT_SPECULAR_VALUE);
+        float3 decalSpecularColor = ComputeFresnel0((decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE) ? decalSurfaceData.baseColor.xyz : float3(1.0, 1.0, 1.0), decalSurfaceData.mask.x, DEFAULT_SPECULAR_VALUE);
         surfaceData.specularColor = surfaceData.specularColor * decalSurfaceData.MAOSBlend.x + decalSpecularColor;
 #else
         surfaceData.metallic = surfaceData.metallic * decalSurfaceData.MAOSBlend.x + decalSurfaceData.mask.x;

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl
@@ -1,4 +1,4 @@
-void ApplyDecalToSurfaceData(SurfaceData surfaceData, DecalSurfaceData decalSurfaceData)
+void ApplyDecalToSurfaceData(DecalSurfaceData decalSurfaceData, inout SurfaceData surfaceData)
 {
     // using alpha compositing https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch23.html
     if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE)

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl.meta
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/Lit/LitDecalData.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b9794cfc79c5e594fb8141e28e478a52
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/StackLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/StackLitData.hlsl
@@ -6,7 +6,7 @@
 #include "HDRP/Material/MaterialUtilities.hlsl"
 #include "HDRP/Material/Decal/DecalUtilities.hlsl"
 
-void ApplyDecalToSurfaceData(SurfaceData surfaceData, DecalSurfaceData decalSurfaceData)
+void ApplyDecalToSurfaceData(DecalSurfaceData decalSurfaceData, inout SurfaceData surfaceData)
 {
     // using alpha compositing https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch23.html
     if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE)
@@ -395,7 +395,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     if (_EnableDecals)
     {
         DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
     }
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/StackLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/StackLit/StackLitData.hlsl
@@ -6,6 +6,31 @@
 #include "HDRP/Material/MaterialUtilities.hlsl"
 #include "HDRP/Material/Decal/DecalUtilities.hlsl"
 
+void ApplyDecalToSurfaceData(SurfaceData surfaceData, DecalSurfaceData decalSurfaceData)
+{
+    // using alpha compositing https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch23.html
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_DIFFUSE)
+    {
+        surfaceData.baseColor.xyz = surfaceData.baseColor.xyz * decalSurfaceData.baseColor.w + decalSurfaceData.baseColor.xyz;
+    }
+
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_NORMAL)
+    {
+        surfaceData.normalWS.xyz = normalize(surfaceData.normalWS.xyz * decalSurfaceData.normalWS.w + decalSurfaceData.normalWS.xyz);
+    }
+
+    if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK)
+    {
+#ifdef DECALS_4RT // only smoothness in 3RT mode
+        surfaceData.metallic = surfaceData.metallic * decalSurfaceData.MAOSBlend.x + decalSurfaceData.mask.x;
+        surfaceData.ambientOcclusion = surfaceData.ambientOcclusion * decalSurfaceData.MAOSBlend.y + decalSurfaceData.mask.y;
+#endif
+        surfaceData.perceptualSmoothnessA = surfaceData.perceptualSmoothnessA * decalSurfaceData.mask.w + decalSurfaceData.mask.z;
+        surfaceData.perceptualSmoothnessB = surfaceData.perceptualSmoothnessB * decalSurfaceData.mask.w + decalSurfaceData.mask.z;
+        surfaceData.coatPerceptualSmoothness = surfaceData.coatPerceptualSmoothness * decalSurfaceData.mask.w + decalSurfaceData.mask.z;
+    }
+}
+
 //-----------------------------------------------------------------------------
 // Texture Mapping
 //-----------------------------------------------------------------------------
@@ -367,7 +392,11 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
 
 #if HAVE_DECALS
-    AddDecalContribution(posInput, surfaceData, alpha);
+    if (_EnableDecals)
+    {
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+    }
 #endif
 
     if ((_GeometricNormalFilteringEnabled + _TextureNormalFilteringEnabled) > 0.0)

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData.hlsl
@@ -83,7 +83,7 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
     {
         float alpha = 1.0; // unused
         DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
     }
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData.hlsl
@@ -3,18 +3,19 @@
 //-------------------------------------------------------------------------------------
 
 #include "CoreRP/ShaderLibrary/Sampling/SampleUVMapping.hlsl"
-#include "../MaterialUtilities.hlsl"
+#include "HDRP/Material/MaterialUtilities.hlsl"
 
 #include "TerrainLitSplatCommon.hlsl"
 
 // We don't use emission for terrain
 #define _EmissiveColor float3(0,0,0)
 #define _AlbedoAffectEmissive 0
-#include "../Lit/LitBuiltinData.hlsl"
+#include "HDRP/Material/Lit/LitBuiltinData.hlsl"
 #undef _EmissiveColor
 #undef _AlbedoAffectEmissive
 
-#include "../Decal/DecalUtilities.hlsl"
+#include "HDRP/Material/Decal/DecalUtilities.hlsl"
+#include "HDRP/Material/Lit/LitDecalData.hlsl"
 
 void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
 {
@@ -78,8 +79,12 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
 #endif
 
 #if HAVE_DECALS
-    float alpha = 1;
-    AddDecalContribution(posInput, surfaceData, alpha);
+    if (_EnableDecals)
+    {
+        float alpha = 1.0; // unused
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+    }
 #endif
 
 #ifdef DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData_Basemap.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData_Basemap.hlsl
@@ -97,7 +97,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     {
         float alpha = 1.0; // unused
         DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
     }
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData_Basemap.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/TerrainLit/TerrainLitData_Basemap.hlsl
@@ -3,7 +3,7 @@
 //-------------------------------------------------------------------------------------
 
 #include "CoreRP/ShaderLibrary/Sampling/SampleUVMapping.hlsl"
-#include "../MaterialUtilities.hlsl"
+#include "HDRP/Material/MaterialUtilities.hlsl"
 
 #include "TerrainLitSplatCommon.hlsl"
 
@@ -19,11 +19,12 @@ float4 _MainTex_MipInfo;
 // We don't use emission for terrain
 #define _EmissiveColor float3(0,0,0)
 #define _AlbedoAffectEmissive 0
-#include "../Lit/LitBuiltinData.hlsl"
+#include "HDRP/Material/Lit/LitBuiltinData.hlsl"
 #undef _EmissiveColor
 #undef _AlbedoAffectEmissive
 
-#include "../Decal/DecalUtilities.hlsl"
+#include "HDRP/Material/Decal/DecalUtilities.hlsl"
+#include "HDRP/Material/Lit/LitDecalData.hlsl"
 
 void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
 {
@@ -92,8 +93,12 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
         surfaceData.specularOcclusion = 1.0f;
 
 #if HAVE_DECALS
-    float alpha = 1;
-    AddDecalContribution(posInput, surfaceData, alpha);
+    if (_EnableDecals)
+    {
+        float alpha = 1.0; // unused
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(surfaceData, decalSurfaceData);
+    }
 #endif
 
 #ifdef DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/ShaderPassDBuffer.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/ShaderPassDBuffer.hlsl
@@ -45,7 +45,6 @@ void Frag(  PackedVaryingsToPS packedInput,
 	// have to do explicit test since compiler behavior is not defined for RW resources and discard instructions
 	if ((all(positionDS.xyz > 0.0f) && all(1.0f - positionDS.xyz > 0.0f)))
 	{
-
 #elif (SHADERPASS == SHADERPASS_DBUFFER_MESH)
 	GetSurfaceData(input, surfaceData);
 #endif
@@ -56,5 +55,6 @@ void Frag(  PackedVaryingsToPS packedInput,
 #if (SHADERPASS == SHADERPASS_DBUFFER_PROJECTOR)
     }
 #endif
+
     ENCODE_INTO_DBUFFER(surfaceData, outDBuffer);
 }


### PR DESCRIPTION
### Purpose of this PR

This PR change the way the decal contribution is done. Now it is the material that handle the application of decal part.

The AddDecalContribution have been rename GetDecalSurfaceData. It now only fill a DecalSurfaceData which is apply on the material side.

Any shader willing to work with decal need to add the following when building its surface data:

    if (_EnableDecals)
    {
        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
    }

The ApplyDecalToSurfaceData is control by the material.

Note for Russel for shader graph: You will need to upgrade the template to deal with this way of handling decal.

Note for anis: You will need to update the AxF PR with this.

---
### Release Notes

This doesn't affect any content, no release note.

---
### Testing status
**Katana Tests**: Green

https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=update-shader-decal-API&automation-tools_branch=add-platform-filter&unity_branch=trunk#
---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
