### PR TITLE
MSAA Auto Resolve Bug Fix

### DIFF
--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
@@ -251,11 +251,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             cameraData.isOffscreenRender = camera.targetTexture != null && !cameraData.isSceneViewCamera;
             cameraData.isStereoEnabled = IsStereoEnabled(camera);
 
-            // TODO: There's currently an issue in engine side that breaks MSAA with texture2DArray.
-            // for now we force msaa disabled when using texture2DArray. This fixes VR multiple and single pass instanced modes.
-            if (cameraData.isStereoEnabled && XRGraphicsConfig.eyeTextureDesc.dimension == TextureDimension.Tex2DArray)
-                cameraData.msaaSamples = 1;
-
             cameraData.isHdrEnabled = camera.allowHDR && settings.supportsHDR;
 
             cameraData.postProcessLayer = camera.GetComponent<PostProcessLayer>();

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/CreateLightweightRenderTexturesPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/CreateLightweightRenderTexturesPass.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 depthDescriptor.colorFormat = RenderTextureFormat.Depth;
                 depthDescriptor.depthBufferBits = k_DepthStencilBufferBits;
                 depthDescriptor.msaaSamples = (int)samples;
-                depthDescriptor.bindMS = (int)samples > 1;
+                depthDescriptor.bindMS = (int)samples > 1 && !SystemInfo.supportsMultisampleAutoResolve;
                 cmd.GetTemporaryRT(depthAttachmentHandle.id, depthDescriptor, FilterMode.Point);
             }
 


### PR DESCRIPTION
### Purpose of this PR
This PR fixes an msaa issue that occurs on devices which support auto resolve.  Without this fix, those devices will render black.

---
### Release Notes
MSAA will function correctly on devices that support auto resolve.

---
### Testing status
** Katana Tests
All tests passed
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lwrp%2Fmsaa%2Fauto-resolve-fix&unity_branch=trunk&automation-tools_branch=add-platform-filter

**Manual Tests**: What did you do?
I tested on a Samsung S8  and S9 as well as on a Pixel 2.

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low

**Halo Effect**: None, Low, Medium, High?
Low