### PR TITLE
Fixed support of depth texture for RenderTexture

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Stencil test during decals normal buffer update is now properly applied
 - Decals corectly update normal buffer in forward
 - Fixed a normalization problem in reflection probe face fading causing artefacts in some cases
+- Fixed support of depth texture for RenderTexture. HDRP now correctly output depth to user depth buffer if RenderTexture request it.
 
 ## [3.3.0-preview]
 

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDCustomSamplerId.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDCustomSamplerId.cs
@@ -50,7 +50,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         ClearSsrBuffers,
         HDRenderPipelineRender,
         CullResultsCull,
-        CopyDepthForSceneView,
+        CopyDepth,
 
         // Profile sampler for tile pass
         TPPrepareLightsForGPU,

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
@@ -1230,25 +1230,24 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             renderContext.StereoEndRender(hdCamera.camera);
                     }
 
-
-#if UNITY_EDITOR
-                    // During rendering we use our own depth buffer instead of the one provided by the scene view (because we need to be able to control its life cycle)
-                    // In order for scene view gizmos/icons etc to be depth test correctly, we need to copy the content of our own depth buffer into the scene view depth buffer.
-                    // On subtlety here is that our buffer can be bigger than the camera one so we need to copy only the corresponding portion
+                    // Copy depth buffer if render texture has one as our depth buffer can be bigger than the one provided adn we use our RT handle system.
+                    // We need to copy only the corresponding portion
                     // (it's handled automatically by the copy shader because it uses a load in pixel coordinates based on the target).
-                    // This copy will also have the effect of re-binding this depth buffer correctly for subsequent editor rendering.
+                    // This copy will also have the effect of re-binding this depth buffer correctly for subsequent editor rendering (This allow to have correct Gizmo/Icons).
+                    // TODO: If at some point we get proper render target aliasing, we will be able to use the provided depth texture directly with our RT handle system
+                    bool copyDepth = hdCamera.camera.targetTexture != null ? hdCamera.camera.targetTexture.depth != 0 : false;
 
                     // NOTE: This needs to be done before the call to RenderDebug because debug overlays need to update the depth for the scene view as well.
                     // Make sure RenderDebug does not change the current Render Target
-                    if (camera.cameraType == CameraType.SceneView)
+                    if (copyDepth)
                     {
-                        using (new ProfilingSample(cmd, "Copy Depth For SceneView", CustomSamplerId.CopyDepthForSceneView.GetSampler()))
+                        using (new ProfilingSample(cmd, "Copy Depth in Target Texture", CustomSamplerId.CopyDepth.GetSampler()))
                         {
                             m_CopyDepth.SetTexture(HDShaderIDs._InputDepth, m_CameraDepthStencilBuffer);
                             cmd.Blit(null, BuiltinRenderTextureType.CameraTarget, m_CopyDepth);
                         }
                     }
-#endif
+
                     PushFullScreenDebugTexture(hdCamera, cmd, m_CameraColorBuffer, FullScreenDebugMode.ScreenSpaceTracing);
                     // Caution: RenderDebug need to take into account that we have flip the screen (so anything capture before the flip will be flipped)
                     RenderDebug(hdCamera, cmd, m_CullResults);

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
@@ -1230,7 +1230,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             renderContext.StereoEndRender(hdCamera.camera);
                     }
 
-                    // Copy depth buffer if render texture has one as our depth buffer can be bigger than the one provided adn we use our RT handle system.
+                    // Copy depth buffer if render texture has one as our depth buffer can be bigger than the one provided and we use our RT handle system.
                     // We need to copy only the corresponding portion
                     // (it's handled automatically by the copy shader because it uses a load in pixel coordinates based on the target).
                     // This copy will also have the effect of re-binding this depth buffer correctly for subsequent editor rendering (This allow to have correct Gizmo/Icons).


### PR DESCRIPTION

### Purpose of this PR

Fixed support of depth texture for RenderTexture. 
HDRP now correctly output depth to user depth buffer if RenderTexture request it.

---
### Release Notes
Updated changelog

---
### Testing status
**Katana Tests**: Green: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=Copy-depth-texture&automation-tools_branch=add-platform-filter&unity_branch=trunk#

**Manual Tests**: Tested within Editor and game view with multiple render texture using depth or not.

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: Low
