### PR TITLE
Fix Prefab for debug menu (was broken after CoreRP move)

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/CoreRP/Debugging/Prefabs/Resources/DebugUI Canvas.prefab
+++ b/com.unity.render-pipelines.high-definition/HDRP/CoreRP/Debugging/Prefabs/Resources/DebugUI Canvas.prefab
@@ -113,33 +113,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   panelPrefab: {fileID: 224481716535368988, guid: daa46a58178a6ad41ae1ddc2dc7f856d, type: 2}
   prefabs:
-  - type: UnityEngine.Experimental.Rendering.DebugUI+Value, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+Value, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224720214277421396, guid: dc0f88987826e6e48b1fe9c7c2b53a53, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+BoolField, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+BoolField, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224131888606727344, guid: ce347ad101f41ee4ab5c3fbc0ea447db, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+IntField, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+IntField, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224720214277421396, guid: ae00bb75e0cd5b04b8fe7fb4ab662629, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+UIntField, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+UIntField, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224720214277421396, guid: f22bcc84a5f4a1944b075a2c4ac71493, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+FloatField, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+FloatField, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224720214277421396, guid: 7d4fd3415ea7dd64bbcfe13fb48a730b, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+EnumField, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+EnumField, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224224135738715566, guid: 988db55689193434fb0b3b89538f978f, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+Button, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+Button, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224438017010656346, guid: f6ce33b91f6ffe54cadacbf4bb112440, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+Foldout, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+Foldout, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224053494956566916, guid: 1c87ab2ce8b8b304d98fbe9a734b1f74, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+ColorField, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+ColorField, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224636372931965878, guid: 77c185820dd1a464eac89cae3abccddf, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+Vector2Field, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+Vector2Field, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224169904409585018, guid: 326f7c58aed965d41bf7805a782d1e44, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+Vector3Field, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+Vector3Field, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224119945032119512, guid: 94afea5f242d72547979595ba963f335, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+Vector4Field, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+Vector4Field, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224325631027038092, guid: d47f009476100f545971a81ede14c750, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+VBox, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+VBox, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224489511352681190, guid: ca3e294656861a64b8aeeb9f916da0a9, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+HBox, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+HBox, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224719784157228276, guid: f7f5e36797cf0c1408561665c67b179b, type: 2}
-  - type: UnityEngine.Experimental.Rendering.DebugUI+Container, Unity.RenderPipelines.Core.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - type: UnityEngine.Experimental.Rendering.DebugUI+Container, Unity.RenderPipelines.HighDefinition.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     prefab: {fileID: 224284813447651300, guid: 38a07789c9e87004dad98c2909f58369, type: 2}


### PR DESCRIPTION
### Purpose of this PR

Fix Prefab for debug menu (was broken after CoreRP move)

Katana is green: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Fstaging&automation-tools_branch=add-platform-filter&unity_branch=trunk#