### PR TITLE
xr/multi view/shadow fix - (DO NOT MERGE INTO TRUNK)

### DIFF
--- a/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/LightweightPipeline.cs
@@ -251,11 +251,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             cameraData.isOffscreenRender = camera.targetTexture != null && !cameraData.isSceneViewCamera;
             cameraData.isStereoEnabled = IsStereoEnabled(camera);
 
-            // TODO: There's currently an issue in engine side that breaks MSAA with texture2DArray.
-            // for now we force msaa disabled when using texture2DArray. This fixes VR multiple and single pass instanced modes.
-            if (cameraData.isStereoEnabled && XRGraphicsConfig.eyeTextureDesc.dimension == TextureDimension.Tex2DArray)
-                cameraData.msaaSamples = 1;
-
             cameraData.isHdrEnabled = camera.allowHDR && settings.supportsHDR;
 
             cameraData.postProcessLayer = camera.GetComponent<PostProcessLayer>();

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/CreateLightweightRenderTexturesPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/CreateLightweightRenderTexturesPass.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 depthDescriptor.colorFormat = RenderTextureFormat.Depth;
                 depthDescriptor.depthBufferBits = k_DepthStencilBufferBits;
                 depthDescriptor.msaaSamples = (int)samples;
-                depthDescriptor.bindMS = (int)samples > 1;
+                depthDescriptor.bindMS = (int)samples > 1 && !SystemInfo.supportsMultisampleAutoResolve;
                 cmd.GetTemporaryRT(depthAttachmentHandle.id, depthDescriptor, FilterMode.Point);
             }
 

--- a/com.unity.render-pipelines.lightweight/LWRP/Passes/DepthOnlyPass.cs
+++ b/com.unity.render-pipelines.lightweight/LWRP/Passes/DepthOnlyPass.cs
@@ -1,4 +1,4 @@
-using UnityEngine.Rendering;
+﻿using UnityEngine.Rendering;
 
 namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 {
@@ -44,7 +44,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
             if ((int)samples > 1)
             {
-                baseDescriptor.bindMS = (int)samples > 1;
+                baseDescriptor.bindMS = (int)samples > 1 && !SystemInfo.supportsMultisampleAutoResolve;
                 baseDescriptor.msaaSamples = (int)samples;
             }
 

--- a/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/LightweightPassLit.hlsl
+++ b/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/LightweightPassLit.hlsl
@@ -79,7 +79,6 @@ LightweightVertexOutput LitPassVertex(LightweightVertexInput v)
     LightweightVertexOutput o = (LightweightVertexOutput)0;
 
     UNITY_SETUP_INSTANCE_ID(v);
-    UNITY_TRANSFER_INSTANCE_ID(v, o);
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
     o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
@@ -129,7 +128,7 @@ LightweightVertexOutput LitPassVertex(LightweightVertexInput v)
 // Used in Standard (Physically Based) shader
 half4 LitPassFragment(LightweightVertexOutput IN) : SV_Target
 {
-    UNITY_SETUP_INSTANCE_ID(IN);
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(IN);
 
     SurfaceData surfaceData;
     InitializeStandardLitSurfaceData(IN.uv, surfaceData);

--- a/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/LightweightPassLitSimple.hlsl
+++ b/com.unity.render-pipelines.lightweight/LWRP/ShaderLibrary/LightweightPassLitSimple.hlsl
@@ -1,4 +1,4 @@
-#ifndef LIGHTWEIGHT_PASS_LIT_INCLUDED
+﻿#ifndef LIGHTWEIGHT_PASS_LIT_INCLUDED
 #define LIGHTWEIGHT_PASS_LIT_INCLUDED
 
 #include "LWRP/ShaderLibrary/Lighting.hlsl"
@@ -73,7 +73,6 @@ LightweightVertexOutput LitPassVertexSimple(LightweightVertexInput v)
     LightweightVertexOutput o = (LightweightVertexOutput)0;
 
     UNITY_SETUP_INSTANCE_ID(v);
-    UNITY_TRANSFER_INSTANCE_ID(v, o);
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
     o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
@@ -120,7 +119,7 @@ LightweightVertexOutput LitPassVertexSimple(LightweightVertexInput v)
 // Used for StandardSimpleLighting shader
 half4 LitPassFragmentSimple(LightweightVertexOutput IN) : SV_Target
 {
-    UNITY_SETUP_INSTANCE_ID(IN);
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(IN);
 
     float2 uv = IN.uv;
     half4 diffuseAlpha = SampleAlbedoAlpha(uv, TEXTURE2D_PARAM(_MainTex, sampler_MainTex));


### PR DESCRIPTION
### Purpose of this PR
Currently shadows do not render correctly in the right eye when using multi-view.  This PR fixes that issue.

---
### Release Notes
Shadows will now render correctly in both eyes when using multi-view.

---
### Testing status
Running katana tests...

**Manual Tests**: What did you do?
I tested on a samsung s9 with gearvr + multiview and I tested on a pixel 2 with daydream + multi-view.
I also verified that single-pass double wide works correctly.

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low

**Halo Effect**: None, Low, Medium, High?
Low