### PR TITLE
Implement smoothness fade for SSR

### DIFF
--- a/com.unity.render-pipelines.core/CoreRP/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/CoreRP/ShaderLibrary/Common.hlsl
@@ -437,11 +437,11 @@ real3 Orthonormalize(real3 tangent, real3 normal)
     return normalize(tangent - dot(tangent, normal) * normal);
 }
 
-// saturate((t - a) / (b - a)).
-real Remap01(real a, real b, real t)
-{
-    return saturate(t * rcp(b - a) - a * rcp(b - a));
-}
+// [start, end] -> [0, 1] : (x - start) / (end - start)
+TEMPLATE_3_REAL(Remap01, x, rcpLength, startTimesRcpLength, return saturate(x * rcpLength - startTimesRcpLength))
+
+// [start, end] -> [1, 0] : (end - x) / (end - start)
+TEMPLATE_3_REAL(Remap10, x, rcpLength, endTimesRcpLength, return saturate(endTimesRcpLength - x * rcpLength))
 
 // smoothstep that assumes that 'x' lies within the [0, 1] interval.
 real Smoothstep01(real x)
@@ -456,7 +456,8 @@ real Smootherstep01(real x)
 
 real Smootherstep(real a, real b, real t)
 {
-    real x = Remap01(a, b, t);
+    real r = rcp(b - a);
+    real x = Remap01(t, r, a * r);
     return Smootherstep01(x);
 }
 

--- a/com.unity.render-pipelines.core/CoreRP/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/CoreRP/ShaderLibrary/Common.hlsl
@@ -437,10 +437,10 @@ real3 Orthonormalize(real3 tangent, real3 normal)
     return normalize(tangent - dot(tangent, normal) * normal);
 }
 
-// [start, end] -> [0, 1] : (x - start) / (end - start)
+// [start, end] -> [0, 1] : (x - start) / (end - start) = x * rcpLength - (start * rcpLength)
 TEMPLATE_3_REAL(Remap01, x, rcpLength, startTimesRcpLength, return saturate(x * rcpLength - startTimesRcpLength))
 
-// [start, end] -> [1, 0] : (end - x) / (end - start)
+// [start, end] -> [1, 0] : (end - x) / (end - start) = (end * rcpLength) - x * rcpLength
 TEMPLATE_3_REAL(Remap10, x, rcpLength, endTimesRcpLength, return saturate(endTimesRcpLength - x * rcpLength))
 
 // smoothstep that assumes that 'x' lies within the [0, 1] interval.

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add an option to invert the fade parameter on a Density Volume
 - Added a Fabric shader (experimental) handling cotton and silk
 - Added support for MSAA in forward only for opaque only
+- Implement smoothness fade for SSR
 
 ### Fixed
 - Fixed an issue where sometimes the deferred shadow texture would not be valid, causing wrong rendering.

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDScreenSpaceReflectionEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDScreenSpaceReflectionEditor.cs
@@ -9,21 +9,28 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
     public class HDScreenSpaceReflectionEditor : ScreenSpaceLightingEditor
     {
         SerializedDataParameter m_MinSmoothness;
+        SerializedDataParameter m_SmoothnessFadeStart;
 
         public override void OnEnable()
         {
             base.OnEnable();
 
             var o = new PropertyFetcher<ScreenSpaceReflection>(serializedObject);
-            m_MinSmoothness = Unpack(o.Find(x => x.minSmoothness));
+            m_MinSmoothness       = Unpack(o.Find(x => x.minSmoothness));
+            m_SmoothnessFadeStart = Unpack(o.Find(x => x.smoothnessFadeStart));
         }
 
         public override void OnInspectorGUI()
         {
-            OnCommonInspectorGUI();
+            PropertyField(m_ScreenWeightDistance, CoreEditorUtils.GetContent("Screen Edge Fade Distance"));
+            PropertyField(m_RayMaxIterations,     CoreEditorUtils.GetContent("Max Number of Ray Steps|Affects both correctness and performance."));
+            PropertyField(m_DepthBufferThickness, CoreEditorUtils.GetContent("Object Thickness"));
+            PropertyField(m_MinSmoothness,        CoreEditorUtils.GetContent("Min Smoothness|Smoothness value at which SSR is activated and the smoothness-controlled fade out stops."));
+            PropertyField(m_SmoothnessFadeStart,  CoreEditorUtils.GetContent("Smoothness Fade Start|Smoothness value at which the smoothness-controlled fade out starts. The fade is in the range [Min Smoothness, Smoothness Fade Start], e.g. [0.8, 0.9]."));
 
-            OnHiZInspectorGUI();
-            PropertyField(m_MinSmoothness, CoreEditorUtils.GetContent("Min Smoothness|Minimal value of smoothness at which SSR is activated."));
+            m_RayMaxIterations.value.intValue       = Mathf.Max(0, m_RayMaxIterations.value.intValue);
+            m_DepthBufferThickness.value.floatValue = Mathf.Clamp(m_DepthBufferThickness.value.floatValue, 0.001f, 1.0f);
+            m_SmoothnessFadeStart.value.floatValue  = Mathf.Max(m_MinSmoothness.value.floatValue, m_SmoothnessFadeStart.value.floatValue);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/ScreenSpaceLighting/ScreenSpaceLighting.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/ScreenSpaceLighting/ScreenSpaceLighting.cs
@@ -45,7 +45,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public IntParameter                 rayMinLevel = new IntParameter(2);
         public IntParameter                 rayMaxLevel = new IntParameter(6);
         public IntParameter                 rayMaxIterations = new IntParameter(32);
-        public FloatParameter               depthBufferThickness = new FloatParameter(1f);
+        public ClampedFloatParameter        depthBufferThickness = new ClampedFloatParameter(0.01f, 0, 1);
         public ClampedFloatParameter        screenWeightDistance = new ClampedFloatParameter(0.1f, 0, 1);
         public ClampedFloatParameter        rayMaxScreenDistance = new ClampedFloatParameter(0.3f, 0, 1);
         public ClampedFloatParameter        rayBlendScreenDistance = new ClampedFloatParameter(0.1f, 0, 1);

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/ScreenSpaceLighting/ScreenSpaceReflection.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/ScreenSpaceLighting/ScreenSpaceReflection.cs
@@ -35,6 +35,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
         public ClampedFloatParameter minSmoothness = new ClampedFloatParameter(0.9f, 0.0f, 1.0f);
+        public ClampedFloatParameter smoothnessFadeStart = new ClampedFloatParameter(0.1f, 0.0f, 1.0f);
 
         protected override void FetchIDs(
             out int rayLevelID,

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Volumetrics/DensityVolume.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Volumetrics/DensityVolume.cs
@@ -76,15 +76,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             data.textureScroll  = volumeScrollingAmount;
             data.textureTiling  = textureTiling;
 
-            // Note that we do not clamp here. Infinities work in the expected way in the shader.
-            // This also allows us to avoid artifacts caused by numerical issues.
-            data.rcpPosFade.x = 1.0f / positiveFade.x;
-            data.rcpPosFade.y = 1.0f / positiveFade.y;
-            data.rcpPosFade.z = 1.0f / positiveFade.z;
+            // Clamp to avoid NaNs.
+            data.rcpPosFade.x = Mathf.Min(1.0f / positiveFade.x, float.MaxValue);
+            data.rcpPosFade.y = Mathf.Min(1.0f / positiveFade.y, float.MaxValue);
+            data.rcpPosFade.z = Mathf.Min(1.0f / positiveFade.z, float.MaxValue);
 
-            data.rcpNegFade.y = 1.0f / negativeFade.y;
-            data.rcpNegFade.x = 1.0f / negativeFade.x;
-            data.rcpNegFade.z = 1.0f / negativeFade.z;
+            data.rcpNegFade.y = Mathf.Min(1.0f / negativeFade.y, float.MaxValue);
+            data.rcpNegFade.x = Mathf.Min(1.0f / negativeFade.x, float.MaxValue);
+            data.rcpNegFade.z = Mathf.Min(1.0f / negativeFade.z, float.MaxValue);
 
             data.invertFade = invertFade ? 1 : 0;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Volumetrics/VolumeVoxelization.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Volumetrics/VolumeVoxelization.compute
@@ -69,10 +69,9 @@ float ComputeFadeFactor(float3 coordNDC, float3 rcpPosFade, float3 rcpNegFade, b
     // We have to account for handedness.
     coordNDC.z = 1 - coordNDC.z;
 
-    float3 posT = saturate(1 + rcpPosFade * (coordNDC - 1));
-    float3 negT = saturate(1 - rcpNegFade * coordNDC);
-    float  fade = saturate(lerp(1, 0, posT.x) * lerp(1, 0, posT.y) * lerp(1, 0, posT.z) *
-                           lerp(1, 0, negT.x) * lerp(1, 0, negT.y) * lerp(1, 0, negT.z));
+    float3 posT = Remap10(coordNDC, rcpPosFade, rcpPosFade);
+    float3 negT = Remap01(coordNDC, rcpNegFade, 0);
+    float  fade = posT.x * posT.y * posT.z * negT.x * negT.y * negT.z;
 
     return invertFade ? (1 - fade) : fade;
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/Volumetrics/VolumetricLighting.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/Volumetrics/VolumetricLighting.cs
@@ -30,8 +30,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             data.textureIndex  = -1;
             data.textureTiling = Vector3.one;
             data.textureScroll = Vector3.zero;
-            data.rcpPosFade    = new Vector3(float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity);
-            data.rcpNegFade    = new Vector3(float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity);
+            data.rcpPosFade    = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            data.rcpNegFade    = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
             data.invertFade    = 0;
             data.pad1          = 0;
             data.pad2          = 0;

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
@@ -388,7 +388,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             RTHandles.Release(m_DebugColorPickerBuffer);
             RTHandles.Release(m_DebugFullScreenTempBuffer);
-            
+
             RTHandles.Release(m_CameraColorMSAABuffer);
             RTHandles.Release(m_MultiAmbientOcclusionBuffer);
             RTHandles.Release(m_CameraSssDiffuseLightingMSAABuffer);
@@ -675,7 +675,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
         void CopyDepthBufferIfNeeded(CommandBuffer cmd)
-        {           
+        {
             if (!m_IsDepthBufferCopyValid)
             {
                 using (new ProfilingSample(cmd, "Copy depth buffer", CustomSamplerId.CopyDepthBuffer.GetSampler()))
@@ -1125,7 +1125,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                 m_ScreenSpaceShadowsBuffer.rt.Create();
 
                             m_LightLoop.RenderScreenSpaceShadows(hdCamera, m_ScreenSpaceShadowsBuffer, hdCamera.frameSettings.enableMSAA ? m_SharedRTManager.GetDepthValuesTexture() : m_SharedRTManager.GetDepthTexture(), cmd);
-                            
+
                             PushFullScreenDebugTexture(hdCamera, cmd, m_ScreenSpaceShadowsBuffer, FullScreenDebugMode.ScreenSpaceShadows);
                         }
 
@@ -1908,15 +1908,24 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     depthPyramidMipLevelOffsetsY[i] = info.mipLevelOffsets[Math.Max(0, j - 1)].y;
                 }
 
-                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrIterLimit,                    volumeSettings.rayMaxIterations);
-                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrThicknessScale,               thicknessScale);
-                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrThicknessBias,                thicknessBias);
-                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrMaxRoughness,                 1 - volumeSettings.minSmoothness);
-                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrDepthPyramidMaxMip,           info.mipLevelCount);
-                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRcpFade,                      rcpFadeDistance);
-                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrOneMinusRcpFade,              1 - rcpFadeDistance);
-                cmd.SetComputeIntParams( cs, HDShaderIDs._SsrDepthPyramidMipLevelOffsetsX, depthPyramidMipLevelOffsetsX);
-                cmd.SetComputeIntParams( cs, HDShaderIDs._SsrDepthPyramidMipLevelOffsetsY, depthPyramidMipLevelOffsetsY);
+                float roughnessFadeStart             = 1 - volumeSettings.smoothnessFadeStart;
+                float roughnessFadeEnd               = 1 - volumeSettings.minSmoothness;
+                float roughnessFadeLength            = roughnessFadeEnd - roughnessFadeStart;
+                float roughnessFadeEndTimesRcpLength = (roughnessFadeLength != 0) ? (roughnessFadeEnd * (1.0f / roughnessFadeLength)) : 1;
+                float roughnessFadeRcpLength         = (roughnessFadeLength != 0) ? (1.0f / roughnessFadeLength) : 0;
+
+
+                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrIterLimit,                      volumeSettings.rayMaxIterations);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrThicknessScale,                 thicknessScale);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrThicknessBias,                  thicknessBias);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRoughnessFadeEnd,               roughnessFadeEnd);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRoughnessFadeRcpLength,         roughnessFadeRcpLength);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRoughnessFadeEndTimesRcpLength, roughnessFadeEndTimesRcpLength);
+                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrDepthPyramidMaxMip,             info.mipLevelCount);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRcpFade,                        rcpFadeDistance);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrOneMinusRcpFade,                1 - rcpFadeDistance);
+                cmd.SetComputeIntParams( cs, HDShaderIDs._SsrDepthPyramidMipLevelOffsetsX,   depthPyramidMipLevelOffsetsX);
+                cmd.SetComputeIntParams( cs, HDShaderIDs._SsrDepthPyramidMipLevelOffsetsY,   depthPyramidMipLevelOffsetsY);
 
                 // cmd.SetComputeTextureParam(cs, kernel, "_SsrDebugTexture",    m_SsrDebugTexture);
                 cmd.SetComputeTextureParam(cs, kernel, HDShaderIDs._SsrHitPointTexture, m_SsrHitPointTexture);

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDRenderPipeline.cs
@@ -1893,7 +1893,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 float thicknessScale = 1.0f / (1.0f + thickness);
                 float thicknessBias  = -n / (f - n) * (thickness * thicknessScale);
 
-                float rcpFadeDistance = Mathf.Min(1.0f / volumeSettings.screenWeightDistance, 65536.0f);
 
                 HDUtils.PackedMipChainInfo info = m_SharedRTManager.GetDepthBufferMipChainInfo();
 
@@ -1913,7 +1912,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 float roughnessFadeLength            = roughnessFadeEnd - roughnessFadeStart;
                 float roughnessFadeEndTimesRcpLength = (roughnessFadeLength != 0) ? (roughnessFadeEnd * (1.0f / roughnessFadeLength)) : 1;
                 float roughnessFadeRcpLength         = (roughnessFadeLength != 0) ? (1.0f / roughnessFadeLength) : 0;
-
+                float edgeFadeRcpLength              = Mathf.Min(1.0f / volumeSettings.screenWeightDistance, float.MaxValue);
 
                 cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrIterLimit,                      volumeSettings.rayMaxIterations);
                 cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrThicknessScale,                 thicknessScale);
@@ -1922,8 +1921,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRoughnessFadeRcpLength,         roughnessFadeRcpLength);
                 cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRoughnessFadeEndTimesRcpLength, roughnessFadeEndTimesRcpLength);
                 cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrDepthPyramidMaxMip,             info.mipLevelCount);
-                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRcpFade,                        rcpFadeDistance);
-                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrOneMinusRcpFade,                1 - rcpFadeDistance);
+                cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrEdgeFadeRcpLength,              edgeFadeRcpLength);
                 cmd.SetComputeIntParams( cs, HDShaderIDs._SsrDepthPyramidMipLevelOffsetsX,   depthPyramidMipLevelOffsetsX);
                 cmd.SetComputeIntParams( cs, HDShaderIDs._SsrDepthPyramidMipLevelOffsetsY,   depthPyramidMipLevelOffsetsY);
 

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDStringConstants.cs
@@ -317,18 +317,20 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _SSReflectionProjectionModel = Shader.PropertyToID("_SSReflectionProjectionModel");
         public static readonly int _SSReflectionEnabled = Shader.PropertyToID("_SSReflectionEnabled");
 
-        public static readonly int _SsrIterLimit                    = Shader.PropertyToID("_SsrIterLimit");
-        public static readonly int _SsrThicknessScale               = Shader.PropertyToID("_SsrThicknessScale");
-        public static readonly int _SsrThicknessBias                = Shader.PropertyToID("_SsrThicknessBias");
-        public static readonly int _SsrMaxRoughness                 = Shader.PropertyToID("_SsrMaxRoughness");
-        public static readonly int _SsrDepthPyramidMaxMip           = Shader.PropertyToID("_SsrDepthPyramidMaxMip");
-        public static readonly int _SsrRcpFade                      = Shader.PropertyToID("_SsrRcpFade");
-        public static readonly int _SsrOneMinusRcpFade              = Shader.PropertyToID("_SsrOneMinusRcpFade");
-        public static readonly int _SsrDepthPyramidMipLevelOffsetsX = Shader.PropertyToID("_SsrDepthPyramidMipLevelOffsetsX");
-        public static readonly int _SsrDepthPyramidMipLevelOffsetsY = Shader.PropertyToID("_SsrDepthPyramidMipLevelOffsetsY");
-        public static readonly int _SsrLightingTexture              = Shader.PropertyToID("_SsrLightingTexture");
-        public static readonly int _SsrLightingTextureRW            = Shader.PropertyToID("_SsrLightingTextureRW");
-        public static readonly int _SsrHitPointTexture              = Shader.PropertyToID("_SsrHitPointTexture");
+        public static readonly int _SsrIterLimit                      = Shader.PropertyToID("_SsrIterLimit");
+        public static readonly int _SsrThicknessScale                 = Shader.PropertyToID("_SsrThicknessScale");
+        public static readonly int _SsrThicknessBias                  = Shader.PropertyToID("_SsrThicknessBias");
+        public static readonly int _SsrRoughnessFadeEnd               = Shader.PropertyToID("_SsrRoughnessFadeEnd");
+        public static readonly int _SsrRoughnessFadeRcpLength         = Shader.PropertyToID("_SsrRoughnessFadeRcpLength");
+        public static readonly int _SsrRoughnessFadeEndTimesRcpLength = Shader.PropertyToID("_SsrRoughnessFadeEndTimesRcpLength");
+        public static readonly int _SsrDepthPyramidMaxMip             = Shader.PropertyToID("_SsrDepthPyramidMaxMip");
+        public static readonly int _SsrRcpFade                        = Shader.PropertyToID("_SsrRcpFade");
+        public static readonly int _SsrOneMinusRcpFade                = Shader.PropertyToID("_SsrOneMinusRcpFade");
+        public static readonly int _SsrDepthPyramidMipLevelOffsetsX   = Shader.PropertyToID("_SsrDepthPyramidMipLevelOffsetsX");
+        public static readonly int _SsrDepthPyramidMipLevelOffsetsY   = Shader.PropertyToID("_SsrDepthPyramidMipLevelOffsetsY");
+        public static readonly int _SsrLightingTexture                = Shader.PropertyToID("_SsrLightingTexture");
+        public static readonly int _SsrLightingTextureRW              = Shader.PropertyToID("_SsrLightingTextureRW");
+        public static readonly int _SsrHitPointTexture                = Shader.PropertyToID("_SsrHitPointTexture");
 
         public static readonly int _VelocityTexture = Shader.PropertyToID("_VelocityTexture");
         public static readonly int _ShadowMaskTexture = Shader.PropertyToID("_ShadowMaskTexture");

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipeline/HDStringConstants.cs
@@ -324,8 +324,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _SsrRoughnessFadeRcpLength         = Shader.PropertyToID("_SsrRoughnessFadeRcpLength");
         public static readonly int _SsrRoughnessFadeEndTimesRcpLength = Shader.PropertyToID("_SsrRoughnessFadeEndTimesRcpLength");
         public static readonly int _SsrDepthPyramidMaxMip             = Shader.PropertyToID("_SsrDepthPyramidMaxMip");
-        public static readonly int _SsrRcpFade                        = Shader.PropertyToID("_SsrRcpFade");
-        public static readonly int _SsrOneMinusRcpFade                = Shader.PropertyToID("_SsrOneMinusRcpFade");
+        public static readonly int _SsrEdgeFadeRcpLength              = Shader.PropertyToID("_SsrEdgeFadeRcpLength");
         public static readonly int _SsrDepthPyramidMipLevelOffsetsX   = Shader.PropertyToID("_SsrDepthPyramidMipLevelOffsetsX");
         public static readonly int _SsrDepthPyramidMipLevelOffsetsY   = Shader.PropertyToID("_SsrDepthPyramidMipLevelOffsetsY");
         public static readonly int _SsrLightingTexture                = Shader.PropertyToID("_SsrLightingTexture");

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
@@ -267,11 +267,9 @@ void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 
 float EdgeFade(float2 coordNDC, float rcpFade, float oneMinusRcpFade)
 {
-    float2 posT = Remap10(coordNDC * rcpFade + oneMinusRcpFade);
-    float2 negT = saturate(1 - coordNDC * rcpFade);
-
-    // TODO: optimize away (1 - ).
-    return Smoothstep01(1 - max(posT.x, negT.x)) * Smoothstep01(1 - max(posT.y, negT.y));
+    float2 coordCS = coordNDC * 2 - 1;
+    float2 t = Remap10(abs(coordCS), rcpFade, rcpFade);
+    return Smoothstep01(t.x) * Smoothstep01(t.y);
 }
 
 float RoughnessFade(float roughness, float fadeRcpLength, float fadeEndTimesRcpLength)

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
@@ -267,22 +267,16 @@ void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 
 float EdgeFade(float2 coordNDC, float rcpFade, float oneMinusRcpFade)
 {
-    float2 posT = saturate(coordNDC * rcpFade + oneMinusRcpFade);
+    float2 posT = Remap10(coordNDC * rcpFade + oneMinusRcpFade);
     float2 negT = saturate(1 - coordNDC * rcpFade);
 
     // TODO: optimize away (1 - ).
     return Smoothstep01(1 - max(posT.x, negT.x)) * Smoothstep01(1 - max(posT.y, negT.y));
 }
 
-// (end - x) / (end - start)
-float FastRemap01(float x, float rcpLength, float endTimesRcpLength)
-{
-    return saturate(endTimesRcpLength - x * rcpLength);
-}
-
 float RoughnessFade(float roughness, float fadeRcpLength, float fadeEndTimesRcpLength)
 {
-    float t = FastRemap01(roughness, fadeRcpLength, fadeEndTimesRcpLength);
+    float t = Remap10(roughness, fadeRcpLength, fadeEndTimesRcpLength);
     return Smoothstep01(t);
 }
 

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
@@ -52,7 +52,9 @@ CBUFFER_START(UnityScreenSpaceReflections)
     int   _SsrIterLimit;
     float _SsrThicknessScale;
     float _SsrThicknessBias;
-    float _SsrMaxRoughness;
+    float _SsrRoughnessFadeEnd;
+    float _SsrRoughnessFadeRcpLength;
+    float _SsrRoughnessFadeEndTimesRcpLength;
     int   _SsrDepthPyramidMaxMip;
     float _SsrRcpFade;
     float _SsrOneMinusRcpFade;
@@ -122,7 +124,7 @@ void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
     // if we mark stencil during the G-Buffer pass with pixels which should receive SSR,
     // and sample the color pyramid during the lighting pass.
     killRay = killRay || (dot(N, V) <= 0);
-    killRay = killRay || (roughness > _SsrMaxRoughness);
+    killRay = killRay || (roughness > _SsrRoughnessFadeEnd);
 #ifndef SSR_TRACE_TOWARDS_EYE
     killRay = killRay || rayTowardsEye;
 #endif
@@ -268,7 +270,20 @@ float EdgeFade(float2 coordNDC, float rcpFade, float oneMinusRcpFade)
     float2 posT = saturate(coordNDC * rcpFade + oneMinusRcpFade);
     float2 negT = saturate(1 - coordNDC * rcpFade);
 
+    // TODO: optimize away (1 - ).
     return Smoothstep01(1 - max(posT.x, negT.x)) * Smoothstep01(1 - max(posT.y, negT.y));
+}
+
+// (end - x) / (end - start)
+float FastRemap01(float x, float rcpLength, float endTimesRcpLength)
+{
+    return saturate(endTimesRcpLength - x * rcpLength);
+}
+
+float RoughnessFade(float roughness, float fadeRcpLength, float fadeEndTimesRcpLength)
+{
+    float t = FastRemap01(roughness, fadeRcpLength, fadeEndTimesRcpLength);
+    return Smoothstep01(t);
 }
 
 [numthreads(8, 8, 1)]
@@ -302,7 +317,8 @@ void ScreenSpaceReflectionsReprojection(uint2 positionSS : SV_DispatchThreadID)
     // TODO: filtering is quite awful. Needs to be non-Gaussian, bilateral and anisotropic.
     float  mipLevel = lerp(0, _SsrDepthPyramidMaxMip, roughness);
     float3 color    = SAMPLE_TEXTURE2D_LOD(_ColorPyramidTexture, s_trilinear_clamp_sampler, prevFrameNDC * _ScreenToTargetScale.zw, mipLevel).rgb;
-    float  opacity  = EdgeFade(prevFrameNDC, _SsrRcpFade, _SsrOneMinusRcpFade);
+    float  opacity  = EdgeFade(prevFrameNDC, _SsrRcpFade, _SsrOneMinusRcpFade)
+                    * RoughnessFade(roughness, _SsrRoughnessFadeRcpLength, _SsrRoughnessFadeEndTimesRcpLength);
 
     // Use premultiplied alpha.
     _SsrLightingTextureRW[positionSS] = float4(color, 1) * opacity;

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/ScreenSpaceReflections.compute
@@ -55,9 +55,8 @@ CBUFFER_START(UnityScreenSpaceReflections)
     float _SsrRoughnessFadeEnd;
     float _SsrRoughnessFadeRcpLength;
     float _SsrRoughnessFadeEndTimesRcpLength;
+    float _SsrEdgeFadeRcpLength;
     int   _SsrDepthPyramidMaxMip;
-    float _SsrRcpFade;
-    float _SsrOneMinusRcpFade;
     int4  _SsrDepthPyramidMipLevelOffsetsX[2]; // Up to 15 levels => 8 offsets => 2 int4s
     int4  _SsrDepthPyramidMipLevelOffsetsY[2]; // Up to 15 levels => 8 offsets => 2 int4s
 CBUFFER_END
@@ -265,10 +264,10 @@ void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 
 #else // SSR_REPROJECT
 
-float EdgeFade(float2 coordNDC, float rcpFade, float oneMinusRcpFade)
+float EdgeFade(float2 coordNDC, float fadeRcpLength)
 {
     float2 coordCS = coordNDC * 2 - 1;
-    float2 t = Remap10(abs(coordCS), rcpFade, rcpFade);
+    float2 t = Remap10(abs(coordCS), fadeRcpLength, fadeRcpLength);
     return Smoothstep01(t.x) * Smoothstep01(t.y);
 }
 
@@ -309,7 +308,7 @@ void ScreenSpaceReflectionsReprojection(uint2 positionSS : SV_DispatchThreadID)
     // TODO: filtering is quite awful. Needs to be non-Gaussian, bilateral and anisotropic.
     float  mipLevel = lerp(0, _SsrDepthPyramidMaxMip, roughness);
     float3 color    = SAMPLE_TEXTURE2D_LOD(_ColorPyramidTexture, s_trilinear_clamp_sampler, prevFrameNDC * _ScreenToTargetScale.zw, mipLevel).rgb;
-    float  opacity  = EdgeFade(prevFrameNDC, _SsrRcpFade, _SsrOneMinusRcpFade)
+    float  opacity  = EdgeFade(prevFrameNDC, _SsrEdgeFadeRcpLength)
                     * RoughnessFade(roughness, _SsrRoughnessFadeRcpLength, _SsrRoughnessFadeEndTimesRcpLength);
 
     // Use premultiplied alpha.


### PR DESCRIPTION
This PR implement a smooth fallback for SSR to a better transtion with reflection probe

Katana is green : https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?
ScriptableRenderLoop_branch=ssr_add_smoothness_fade&automation-tools_branch=add-platform-filter&unity_branch=trunk

(Note: Mac is red because it was red on master, not because of this PR)
