### PR TITLE
Fix duplicate disabling scope creation for UI

### DIFF
--- a/com.unity.render-pipelines.core/CoreRP/Editor/SettingsDisableScope.cs
+++ b/com.unity.render-pipelines.core/CoreRP/Editor/SettingsDisableScope.cs
@@ -1,23 +1,20 @@
 using System;
-using UnityEngine;
 
 namespace UnityEditor.Experimental.Rendering
 {
-    public class SettingsDisableScope : IDisposable
+    [Obsolete("Use EditorGUI.DisabledScope instead", true)]
+    public struct SettingsDisableScope : IDisposable
     {
-        bool enable;
+        EditorGUI.DisabledScope scope;
 
         public SettingsDisableScope(bool enable)
         {
-            this.enable = enable;
-            if (!enable)
-                GUI.enabled = false;
+            scope = new EditorGUI.DisabledScope(!enable);
         }
 
         public void Dispose()
         {
-            if (!enable)
-                GUI.enabled = true;
+            scope.Dispose();
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/HDLightEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/HDLightEditor.cs
@@ -674,7 +674,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 EditorGUILayout.LabelField("Additional Settings", EditorStyles.boldLabel);
                 EditorGUI.indentLevel++;
                 var hdPipeline = RenderPipelineManager.currentPipeline as HDRenderPipeline;
-                using (new SettingsDisableScope(hdPipeline.asset.renderPipelineSettings.supportLightLayers))
+                using (new EditorGUI.DisabledScope(!hdPipeline.asset.renderPipelineSettings.supportLightLayers))
                 {
                     m_AdditionalLightData.lightLayers.intValue = Convert.ToInt32(EditorGUILayout.EnumFlagsField(s_Styles.lightLayer, (LightLayerEnum)m_AdditionalLightData.lightLayers.intValue));
                 }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
@@ -130,7 +130,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected static void Drawer_SectionCustomSettings(HDProbeUI s, SerializedHDProbe d, Editor o)
         {
             var hdPipeline = RenderPipelineManager.currentPipeline as HDRenderPipeline;
-            using (new SettingsDisableScope(hdPipeline.asset.renderPipelineSettings.supportLightLayers))
+            using (new EditorGUI.DisabledScope(!hdPipeline.asset.renderPipelineSettings.supportLightLayers))
             {
                 d.lightLayers.intValue = Convert.ToInt32(EditorGUILayout.EnumFlagsField(lightLayersContent, (LightLayerEnum)d.lightLayers.intValue));
             }


### PR DESCRIPTION
### Purpose of this PR
Remove duplicate disabling scope for UI.

---
### Release Notes

---
### Testing status
**Katana Tests**:  Windows is green . https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-duplicate-disabled-scope&automation-tools_branch=add-platform-filter&unity_branch=trunk

**Manual Tests**: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: Low
(May affect LWRP if using it, that is why it is obsolete instead of removed)

---
### Comments to reviewers
