### PR TITLE
Fixing a hang in the metal shader compilation

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/ShaderPassDepthOnly.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/ShaderPassDepthOnly.hlsl
@@ -31,9 +31,7 @@ void Frag(  PackedVaryingsToPS packedInput
             , out float1 depthColor : SV_Target1
                 #endif
             #else
-                #ifdef SCENESELECTIONPASS
             , out float4 outColor : SV_Target0
-                #endif
             #endif
 
             #ifdef _DEPTHOFFSET_ON
@@ -70,5 +68,7 @@ void Frag(  PackedVaryingsToPS packedInput
 #elif defined(SCENESELECTIONPASS)
     // We use depth prepass for scene selection in the editor, this code allow to output the outline correctly
     outColor = float4(_ObjectId, _PassValue, 1.0, 1.0);
+#else
+    outColor = float4(0.0, 0.0, 0.0, 0.0);
 #endif
 }


### PR DESCRIPTION
Metal does not support empty fragment shaders

katana is green: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=metal_hang&automation-tools_branch=add-platform-filter&unity_branch=trunk