### PR TITLE
 Fix SSS bug with 0 scattering distance

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DiffusionProfileSettingsEditor.Styles.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DiffusionProfileSettingsEditor.Styles.cs
@@ -32,11 +32,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public readonly GUIContent   profileThicknessRemap  = new GUIContent("Thickness Remap (mm)", "Remaps the thickness parameter from [0, 1] to the desired range (in millimeters).");
             public readonly GUIContent   profileWorldScale      = new GUIContent("World Scale", "Size of the world unit in meters.");
             public readonly GUIContent   profileIor             = new GUIContent("Index of Refraction", "Index of refraction. 1.4 for skin. Between 1.3-1.5 for most other material.");
-            // Jimenez SSS Model
-            public readonly GUIContent   profileScatterDistance1 = new GUIContent("Scattering Distance #1", "The radius (in centimeters) of the 1st Gaussian filter, one per color channel. Alpha is ignored. The blur is energy-preserving, so a wide filter results in a large area with small contributions of individual samples. Smaller values increase the sharpness.");
-            public readonly GUIContent   profileScatterDistance2 = new GUIContent("Scattering Distance #2", "The radius (in centimeters) of the 2nd Gaussian filter, one per color channel. Alpha is ignored. The blur is energy-preserving, so a wide filter results in a large area with small contributions of individual samples. Smaller values increase the sharpness.");
-            public readonly GUIContent   profileLerpWeight       = new GUIContent("Filter Interpolation", "Controls linear interpolation between the two Gaussian filters.");
-            // End Jimenez SSS Model
             public readonly GUIStyle     centeredMiniBoldLabel     = new GUIStyle(GUI.skin.label);
 
             public readonly GUIContent SubsurfaceScatteringLabel = new GUIContent("Subsurface Scattering only");

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DiffusionProfileSettingsEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DiffusionProfileSettingsEditor.cs
@@ -182,9 +182,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         void RenderPreview(Profile profile)
         {
+            // Premultiply S by ((-1.0 / 3.0) * LOG2_E) on the CPU.
+            const float log2e = 1.44269504088896340736f;
+            const float k     = (-1.0f / 3.0f) * log2e;
+
             var obj = profile.objReference;
             float r = obj.maxRadius;
-            var S = obj.shapeParam;
+            var S = obj.shapeParam * k;
             var T = (Vector4)profile.transmissionTint.colorValue;
             var R = profile.thicknessRemap.vector2Value;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DiffusionProfileSettingsEditor.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DiffusionProfileSettingsEditor.cs
@@ -182,13 +182,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         void RenderPreview(Profile profile)
         {
-            // Premultiply S by ((-1.0 / 3.0) * LOG2_E) on the CPU.
-            const float log2e = 1.44269504088896340736f;
-            const float k     = (-1.0f / 3.0f) * log2e;
-
             var obj = profile.objReference;
             float r = obj.maxRadius;
-            var S = obj.shapeParam * k;
+            var S = obj.shapeParam;
             var T = (Vector4)profile.transmissionTint.colorValue;
             var R = profile.thicknessRemap.vector2Value;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawDiffusionProfile.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawDiffusionProfile.shader
@@ -26,20 +26,12 @@ Shader "Hidden/HDRenderPipeline/DrawDiffusionProfile"
             #include "CoreRP/ShaderLibrary/Common.hlsl"
             #define USE_LEGACY_UNITY_MATRIX_VARIABLES
             #include "HDRP/ShaderVariables.hlsl"
-        #ifdef SSS_MODEL_BASIC
-            #include "HDRP/Material/DiffusionProfile/DiffusionProfileSettings.cs.hlsl"
-        #endif
 
             //-------------------------------------------------------------------------------------
             // Inputs & outputs
             //-------------------------------------------------------------------------------------
 
-        #ifdef SSS_MODEL_DISNEY
             float4 _ShapeParam; float _MaxRadius; // See 'DiffusionProfile'
-        #else
-            float4 _StdDev1, _StdDev2;
-            float _LerpWeight, _MaxRadius; // See 'SubsurfaceScatteringParameters'
-        #endif
 
             //-------------------------------------------------------------------------------------
             // Implementation
@@ -67,7 +59,6 @@ Shader "Hidden/HDRenderPipeline/DrawDiffusionProfile"
 
             float4 Frag(Varyings input) : SV_Target
             {
-            #ifdef SSS_MODEL_DISNEY
                 float  r = (2 * length(input.texcoord - 0.5)) * _MaxRadius;
                 float3 S = _ShapeParam.rgb;
                 float3 M = S * (exp(-r * S) + exp(-r * S * (1.0 / 3.0))) / (8 * PI * r);
@@ -76,22 +67,6 @@ Shader "Hidden/HDRenderPipeline/DrawDiffusionProfile"
                 // N.b.: we multiply by the surface albedo of the actual geometry during shading.
                 // Apply gamma for visualization only. Do not apply gamma to the color.
                 return float4(sqrt(M) * A, 1);
-            #else
-                float  r    = (2 * length(input.texcoord - 0.5)) * _MaxRadius * SSS_BASIC_DISTANCE_SCALE;
-                float3 var1 = _StdDev1.rgb * _StdDev1.rgb;
-                float3 var2 = _StdDev2.rgb * _StdDev2.rgb;
-
-                // Evaluate the linear combination of two 2D Gaussians instead of
-                // product of the linear combination of two normalized 1D Gaussians
-                // since we do not want to bother artists with the lack of radial symmetry.
-
-                float3 magnitude = lerp(exp(-r * r / (2 * var1)) / (TWO_PI * var1),
-                                        exp(-r * r / (2 * var2)) / (TWO_PI * var2), _LerpWeight);
-
-                // N.b.: we multiply by the surface albedo of the actual geometry during shading.
-                // Apply gamma for visualization only.
-                return float4(sqrt(magnitude), 1);
-            #endif
             }
             ENDHLSL
         }

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawDiffusionProfile.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawDiffusionProfile.shader
@@ -59,6 +59,7 @@ Shader "Hidden/HDRenderPipeline/DrawDiffusionProfile"
 
             float4 Frag(Varyings input) : SV_Target
             {
+                // Profile display does not use premultiplied S.
                 float  r = (2 * length(input.texcoord - 0.5)) * _MaxRadius;
                 float3 S = _ShapeParam.rgb;
                 float3 M = S * (exp(-r * S) + exp(-r * S * (1.0 / 3.0))) / (8 * PI * r);

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawTransmittanceGraph.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawTransmittanceGraph.shader
@@ -61,17 +61,7 @@ Shader "Hidden/HDRenderPipeline/DrawTransmittanceGraph"
             float4 Frag(Varyings input) : SV_Target
             {
                 float  d = (_ThicknessRemap.x + input.texcoord.x * (_ThicknessRemap.y - _ThicknessRemap.x));
-                float3 T;
-
-#if SHADEROPTIONS_USE_DISNEY_SSS
-                    T = ComputeTransmittanceDisney(_ShapeParam.rgb, float3(0.25, 0.25, 0.25), d);
-#else
-                    T = ComputeTransmittanceJimenez(_HalfRcpVarianceAndWeight1.rgb,
-                                                    _HalfRcpVarianceAndWeight1.a,
-                                                    _HalfRcpVarianceAndWeight2.rgb,
-                                                    _HalfRcpVarianceAndWeight2.a,
-                                                    float3(0.25, 0.25, 0.25), d);
-#endif
+                float3 T = ComputeTransmittanceDisney(_ShapeParam.rgb, float3(0.25, 0.25, 0.25), d);
 
                 // Apply gamma for visualization only. Do not apply gamma to the color.
                 return float4(sqrt(T) * _TransmissionTint.rgb, 1);

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawTransmittanceGraph.shader
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/Material/DiffusionProfile/DrawTransmittanceGraph.shader
@@ -60,8 +60,9 @@ Shader "Hidden/HDRenderPipeline/DrawTransmittanceGraph"
 
             float4 Frag(Varyings input) : SV_Target
             {
+                // Profile display does not use premultiplied S.
                 float  d = (_ThicknessRemap.x + input.texcoord.x * (_ThicknessRemap.y - _ThicknessRemap.x));
-                float3 T = ComputeTransmittanceDisney(_ShapeParam.rgb, float3(0.25, 0.25, 0.25), d);
+                float3 T = ComputeTransmittanceDisney(_ShapeParam.rgb * ((-1.0 / 3.0) * LOG2_E), float3(0.25, 0.25, 0.25), d);
 
                 // Apply gamma for visualization only. Do not apply gamma to the color.
                 return float4(sqrt(T) * _TransmissionTint.rgb, 1);

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/LightEvaluation.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/LightEvaluation.hlsl
@@ -317,9 +317,8 @@ float3 PreEvaluatePunctualLightTransmission(LightLoopContext lightLoopContext, P
 #if 0
             float3 expOneThird = exp(((-1.0 / 3.0) * thicknessDelta) * S);
 #else
-            // Help the compiler.
-            float  k = (-1.0 / 3.0) * LOG2_E;
-            float3 p = (k * thicknessDelta) * S;
+            // Help the compiler. S is premultiplied by ((-1.0 / 3.0) * LOG2_E) on the CPU.
+            float3 p = thicknessDelta * S;
             float3 expOneThird = exp2(p);
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Lighting/LightEvaluation.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Lighting/LightEvaluation.hlsl
@@ -308,7 +308,6 @@ float3 PreEvaluatePunctualLightTransmission(LightLoopContext lightLoopContext, P
             float thicknessInMeters = thicknessInUnits * _WorldScales[bsdfData.diffusionProfile].x;
             float thicknessInMillimeters = thicknessInMeters * MILLIMETERS_PER_METER;
 
-#if SHADEROPTIONS_USE_DISNEY_SSS
             // We need to make sure it's not less than the baked thickness to minimize light leaking.
             float thicknessDelta = max(0, thicknessInMillimeters - bsdfData.thickness);
 
@@ -325,19 +324,6 @@ float3 PreEvaluatePunctualLightTransmission(LightLoopContext lightLoopContext, P
 #endif
 
             transmittance *= expOneThird;
-
-#else // SHADEROPTIONS_USE_DISNEY_SSS
-
-            // We need to make sure it's not less than the baked thickness to minimize light leaking.
-            thicknessInMillimeters = max(thicknessInMillimeters, bsdfData.thickness);
-
-            transmittance = ComputeTransmittanceJimenez(_HalfRcpVariancesAndWeights[bsdfData.diffusionProfile][0].rgb,
-                                                        _HalfRcpVariancesAndWeights[bsdfData.diffusionProfile][0].a,
-                                                        _HalfRcpVariancesAndWeights[bsdfData.diffusionProfile][1].rgb,
-                                                        _HalfRcpVariancesAndWeights[bsdfData.diffusionProfile][1].a,
-                                                        _TransmissionTintsAndFresnel0[bsdfData.diffusionProfile].rgb,
-                                                        thicknessInMillimeters);
-#endif // SHADEROPTIONS_USE_DISNEY_SSS
 
             // Note: we do not modify the distance to the light, or the light angle for the back face.
             // This is a performance-saving optimization which makes sense as long as the thickness is small.

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfile.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfile.hlsl
@@ -2,6 +2,21 @@
 // SSS/Transmittance helper
 // ----------------------------------------------------------------------------
 
+// Computes the value of the integrand in polar coordinates: f(r, s) = r * R(r, s).
+// f(r, s) = (Exp[-r * s] + Exp[-r * s / 3]) * (s / (8 * Pi))
+// We can drop the constant (s / (8 * Pi)) due to the subsequent weight renormalization.
+float3 DisneyProfilePolar(float r, float3 S)
+{
+#if 0
+    float3 expOneThird = exp((-1.0 / 3.0) * r * S);
+#else
+    // Help the compiler. S is premultiplied by ((-1.0 / 3.0) * LOG2_E) on the CPU.
+    float3 p = r * S;
+    float3 expOneThird = exp2(p);
+#endif
+    return expOneThird + expOneThird * expOneThird * expOneThird;
+}
+
 // Computes the fraction of light passing through the object.
 // Evaluate Int{0, inf}{2 * Pi * r * R(sqrt(r^2 + d^2))}, where R is the diffusion profile.
 // Note: 'volumeAlbedo' should be premultiplied by 0.25.

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfile.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfile.hlsl
@@ -24,21 +24,3 @@ float3 ComputeTransmittanceDisney(float3 S, float3 volumeAlbedo, float thickness
     // Premultiply & optimize: T = (1/4 * A) * (e^(-t * S) + 3 * e^(-1/3 * t * S))
     return volumeAlbedo * (expOneThird * expOneThird * expOneThird + 3 * expOneThird);
 }
-
-// Evaluates transmittance for a linear combination of two normalized 2D Gaussians.
-// Ref: Real-Time Realistic Skin Translucency (2010), equation 9 (modified).
-// Note: 'volumeAlbedo' should be premultiplied by 0.25, correspondingly 'lerpWeight' by 4,
-// and 'halfRcpVariance1' should be prescaled by (0.1 * DiffusionProfileConstants.SSS_BASIC_DISTANCE_SCALE)^2.
-float3 ComputeTransmittanceJimenez(float3 halfRcpVariance1, float lerpWeight1,
-                                   float3 halfRcpVariance2, float lerpWeight2,
-                                   float3 volumeAlbedo, float thickness)
-{
-    // Thickness and SSS mask are decoupled for artists.
-    // In theory, we should modify the thickness by the inverse of the mask scale of the profile.
-    // thickness /= subsurfaceMask;
-
-    float t2 = thickness * thickness;
-
-    // T = A * lerp(exp(-t2 * halfRcpVariance1), exp(-t2 * halfRcpVariance2), lerpWeight2)
-    return volumeAlbedo * (exp(-t2 * halfRcpVariance1) * lerpWeight1 + exp(-t2 * halfRcpVariance2) * lerpWeight2);
-}

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfile.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfile.hlsl
@@ -15,9 +15,8 @@ float3 ComputeTransmittanceDisney(float3 S, float3 volumeAlbedo, float thickness
 #if 0
     float3 expOneThird = exp(((-1.0 / 3.0) * thickness) * S);
 #else
-    // Help the compiler.
-    float  k = (-1.0 / 3.0) * LOG2_E;
-    float3 p = (k * thickness) * S;
+    // Help the compiler. S is premultiplied by ((-1.0 / 3.0) * LOG2_E) on the CPU.
+    float3 p = thickness * S;
     float3 expOneThird = exp2(p);
 #endif
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfileSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfileSettings.cs
@@ -276,7 +276,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             thicknessRemaps[i]   = new Vector4(profiles[p].thicknessRemap.x, profiles[p].thicknessRemap.y - profiles[p].thicknessRemap.x, 0f, 0f);
             worldScales[i]       = new Vector4(profiles[p].worldScale, 1.0f / profiles[p].worldScale, 0f, 0f);
-            shapeParams[i]       = profiles[p].shapeParam;
+
+            // Premultiply S by ((-1.0 / 3.0) * LOG2_E) on the CPU.
+            const float log2e = 1.44269504088896340736f;
+            const float k     = (-1.0f / 3.0f) * log2e;
+
+            shapeParams[i]       = profiles[p].shapeParam * k;
             shapeParams[i].w     = profiles[p].maxRadius;
             // Convert ior to fresnel0
             float fresnel0 = (profiles[p].ior - 1.0f) / (profiles[p].ior + 1.0f);

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfileSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfileSettings.cs
@@ -78,12 +78,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (filterKernelFarField == null || filterKernelFarField.Length != DiffusionProfileConstants.SSS_N_SAMPLES_FAR_FIELD)
                 filterKernelFarField = new Vector2[DiffusionProfileConstants.SSS_N_SAMPLES_FAR_FIELD];
 
-            // Clamp to avoid artifacts.
-            shapeParam = new Vector3(
-                    1f / Mathf.Max(0.001f, scatteringDistance.r),
-                    1f / Mathf.Max(0.001f, scatteringDistance.g),
-                    1f / Mathf.Max(0.001f, scatteringDistance.b)
-                    );
+            // Note: if the scattering distance is 0, exp2(-inf) will produce 0, as desired.
+            shapeParam = new Vector3(1.0f / scatteringDistance.r,
+                                     1.0f / scatteringDistance.g,
+                                     1.0f / scatteringDistance.b);
 
             // We importance sample the color channel with the widest scattering distance.
             float s = Mathf.Min(shapeParam.x, shapeParam.y, shapeParam.z);

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfileSettings.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/DiffusionProfile/DiffusionProfileSettings.cs
@@ -273,16 +273,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             texturingModeFlags |= (uint)profiles[p].texturingMode    << i;
             transmissionFlags  |= (uint)profiles[p].transmissionMode << i;
-
-            thicknessRemaps[i]   = new Vector4(profiles[p].thicknessRemap.x, profiles[p].thicknessRemap.y - profiles[p].thicknessRemap.x, 0f, 0f);
-            worldScales[i]       = new Vector4(profiles[p].worldScale, 1.0f / profiles[p].worldScale, 0f, 0f);
+            thicknessRemaps[i]  = new Vector4(profiles[p].thicknessRemap.x, profiles[p].thicknessRemap.y - profiles[p].thicknessRemap.x, 0f, 0f);
+            worldScales[i]      = new Vector4(profiles[p].worldScale, 1.0f / profiles[p].worldScale, 0f, 0f);
 
             // Premultiply S by ((-1.0 / 3.0) * LOG2_E) on the CPU.
             const float log2e = 1.44269504088896340736f;
             const float k     = (-1.0f / 3.0f) * log2e;
 
-            shapeParams[i]       = profiles[p].shapeParam * k;
-            shapeParams[i].w     = profiles[p].maxRadius;
+            shapeParams[i]   = profiles[p].shapeParam * k;
+            shapeParams[i].w = profiles[p].maxRadius;
             // Convert ior to fresnel0
             float fresnel0 = (profiles[p].ior - 1.0f) / (profiles[p].ior + 1.0f);
             fresnel0 *= fresnel0; // square

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.compute
@@ -453,6 +453,12 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
     float  centerRcpPdf = _FilterKernels[profileID][0][iP];
     float3 centerWeight = DisneyProfilePolar(centerRadius, shapeParam) * centerRcpPdf;
 
+    // If the shape parameter is 0, the weight is be 0.
+    // This is desirable for all but the central sample.
+    // We make sure that if the shape parameter is 0, the weight is non-zero.
+    // Weight normalization will ensure that the result is correct.
+    centerWeight = max(centerWeight, FLT_EPS);
+
     // Accumulate filtered irradiance and bilateral weights (for renormalization).
     float3 totalIrradiance = centerWeight * centerIrradiance;
     float3 totalWeight     = centerWeight;

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.compute
@@ -124,21 +124,6 @@ float4 LoadSample(int2 pixelCoord, int2 cacheOffset)
     }
 }
 
-// Computes the value of the integrand in polar coordinates: f(r, s) = r * R(r, s).
-// f(r, s) = (Exp[-r * s] + Exp[-r * s / 3]) * (s / (8 * Pi))
-// We can drop the constant (s / (8 * Pi)) due to the subsequent weight renormalization.
-float3 DisneyProfilePolar(float r, float3 S)
-{
-#if 0
-    float3 expOneThird = exp((-1.0 / 3.0) * r * S);
-#else
-    // Help the compiler. S is premultiplied by ((-1.0 / 3.0) * LOG2_E) on the CPU.
-    float3 p = r * S;
-    float3 expOneThird = exp2(p);
-#endif
-    return expOneThird + expOneThird * expOneThird * expOneThird;
-}
-
 // Computes f(r, s)/p(r, s), s.t. r = sqrt(xy^2 + z^2).
 // Rescaling of the PDF is handled by 'totalWeight'.
 float3 ComputeBilateralWeight(float xy2, float z, float mmPerUnit, float3 S, float rcpPdf)

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.compute
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScattering.compute
@@ -132,9 +132,8 @@ float3 DisneyProfilePolar(float r, float3 S)
 #if 0
     float3 expOneThird = exp((-1.0 / 3.0) * r * S);
 #else
-    // Help the compiler.
-    float  k = (-1.0 / 3.0) * LOG2_E;
-    float3 p = (k * S) * r;
+    // Help the compiler. S is premultiplied by ((-1.0 / 3.0) * LOG2_E) on the CPU.
+    float3 p = r * S;
     float3 expOneThird = exp2(p);
 #endif
     return expOneThird + expOneThird * expOneThird * expOneThird;

--- a/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
@@ -23,7 +23,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         RTHandleSystem.RTHandle m_HTile;
         // End Disney SSS Model
 
-        // Jimenez need an extra buffer and Disney need one for some platform
+        // Need an extra buffer on some platforms
         RTHandleSystem.RTHandle m_CameraFilteringBuffer;
 
         // This is use to be able to read stencil value in compute shader
@@ -39,7 +39,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             m_MSAASupport = settings.supportMSAA;
 
-            // TODO: For MSAA, at least initially, we can only support Jimenez, because we can't create MSAA + UAV render targets.
             if (settings.supportOnlyForward)
             {
                 // In case of full forward we must allocate the render target for forward SSS (or reuse one already existing)
@@ -196,13 +195,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     uint texturingModeFlags = sssParameters.texturingModeFlags;
                     cmd.SetComputeFloatParam(m_SubsurfaceScatteringCS, HDShaderIDs._TexturingModeFlags, *(float*)&texturingModeFlags);
                 }
-        
+
                 cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._WorldScales,        sssParameters.worldScales);
                 cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._FilterKernels,      sssParameters.filterKernels);
                 cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._ShapeParams,        sssParameters.shapeParams);
 
                 int sssKernel = hdCamera.frameSettings.enableMSAA ? m_SubsurfaceScatteringKernelMSAA : m_SubsurfaceScatteringKernel;
-             
+
                 cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._DepthTexture,       depthTextureRT);
                 cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._SSSHTile,           m_HTile);
                 cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._IrradianceSource,   diffuseBufferRT);

--- a/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/Default Diffusion Profile Settings.asset
+++ b/com.unity.render-pipelines.high-definition/HDRP/RenderPipelineResources/Default Diffusion Profile Settings.asset
@@ -3,9 +3,8 @@
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -14,13 +13,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   profiles:
   - name: Skin
-    scatteringDistance: {r: 2.298572, g: 4.075472, b: 1.7109292, a: 1}
-    transmissionTint: {r: 0.8962264, g: 0.6271773, b: 0.5538003, a: 1}
+    scatteringDistance: {r: 0.7568628, g: 0.32156864, b: 0.20000002, a: 1}
+    transmissionTint: {r: 0.7568628, g: 0.32156864, b: 0.20000002, a: 1}
     texturingMode: 0
     transmissionMode: 0
-    thicknessRemap: {x: 0.62111986, y: 7.263967}
-    worldScale: 0.4
+    thicknessRemap: {x: 0, y: 8.152544}
+    worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3019608, g: 0.20000002, b: 0.20000002, a: 0}
+    scatterDistance2: {r: 0.6, g: 0.20000002, b: 0.20000002, a: 0}
+    lerpWeight: 0.5
   - name: Foliage
     scatteringDistance: {r: 0.7568628, g: 0.7019608, b: 0.24313727, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -29,6 +31,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 0.2873168}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 0.5
   - name: Profile 2
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -37,6 +42,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 3
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -45,6 +53,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 4
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -53,6 +64,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 5
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -61,6 +75,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 6
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -69,6 +86,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 8
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -77,6 +97,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 9
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -85,6 +108,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 10
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -93,6 +119,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 11
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -101,6 +130,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 12
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -109,6 +141,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 13
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -117,6 +152,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 14
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -125,6 +163,9 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1
   - name: Profile 15
     scatteringDistance: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     transmissionTint: {r: 1, g: 1, b: 1, a: 1}
@@ -133,3 +174,6 @@ MonoBehaviour:
     thicknessRemap: {x: 0, y: 5}
     worldScale: 1
     ior: 1.4
+    scatterDistance1: {r: 0.3, g: 0.3, b: 0.3, a: 0}
+    scatterDistance2: {r: 0.5, g: 0.5, b: 0.5, a: 0}
+    lerpWeight: 1

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderConfig.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderConfig.cs
@@ -10,7 +10,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     public enum ShaderOptions
     {
         CameraRelativeRendering = 1, // Rendering sets the origin of the world to the position of the primary (scene view) camera
-        UseDisneySSS = 1             // Allow to chose between Burley Normalized Diffusion (Multi + Fix direction single scattering) or Jimenez diffusion approximation (Multiscattering only - More blurry) for Subsurface scattering
     };
 
     // Note: #define can't be use in include file in C# so we chose this way to configure both C# and hlsl
@@ -19,8 +18,5 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     {
         public const  int k_CameraRelativeRendering = (int)ShaderOptions.CameraRelativeRendering;
         public static int s_CameraRelativeRendering = (int)ShaderOptions.CameraRelativeRendering;
-
-        public const  int k_UseDisneySSS = (int)ShaderOptions.UseDisneySSS;
-        public static int s_UseDisneySSS = (int)ShaderOptions.UseDisneySSS;
     }
 }

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderConfig.cs.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderConfig.cs.hlsl
@@ -8,7 +8,5 @@
 // UnityEngine.Experimental.Rendering.HDPipeline.ShaderOptions:  static fields
 //
 #define SHADEROPTIONS_CAMERA_RELATIVE_RENDERING (1)
-#define SHADEROPTIONS_USE_DISNEY_SSS (1)
-
 
 #endif


### PR DESCRIPTION
This PR fix an issue with SSS profile authoring and clean the remaining Jimenez code.

FogBugz: https://fogbugz.unity3d.com/f/cases/1048802/

Katana is green:    https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=bugfix&automation-tools_branch=add-platform-filter&unity_branch=trunk

(note: the mac version is fail due to the fix for mac on master not there when katana was launched)