### PR TITLE
4-channel UV support in HDRP ShaderGraphs

### DIFF
--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRPass.template
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDPBRPass.template
@@ -244,7 +244,7 @@ $include("SharedCode.template.hlsl")
 
         // Builtin Data
         // For back lighting we use the oposite vertex normal 
-        InitBuiltinData(surfaceDescription.Alpha, surfaceData.normalWS, -fragInputs.worldToTangent[2], fragInputs.positionRWS, fragInputs.texCoord1, fragInputs.texCoord2, builtinData);
+        InitBuiltinData(surfaceDescription.Alpha, surfaceData.normalWS, -fragInputs.worldToTangent[2], fragInputs.positionRWS, fragInputs.texCoord1.xy, fragInputs.texCoord2.xy, builtinData);
 
 $SurfaceDescription.Emission:     builtinData.emissiveColor =             surfaceDescription.Emission;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -15,10 +15,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             [Semantic("POSITION")]              Vector3 positionOS;
             [Semantic("NORMAL")][Optional]      Vector3 normalOS;
             [Semantic("TANGENT")][Optional]     Vector4 tangentOS;       // Stores bi-tangent sign in w
-            [Semantic("TEXCOORD0")][Optional]   Vector2 uv0;
-            [Semantic("TEXCOORD1")][Optional]   Vector2 uv1;
-            [Semantic("TEXCOORD2")][Optional]   Vector2 uv2;
-            [Semantic("TEXCOORD3")][Optional]   Vector2 uv3;
+            [Semantic("TEXCOORD0")][Optional]   Vector4 uv0;
+            [Semantic("TEXCOORD1")][Optional]   Vector4 uv1;
+            [Semantic("TEXCOORD2")][Optional]   Vector4 uv2;
+            [Semantic("TEXCOORD3")][Optional]   Vector4 uv3;
             [Semantic("COLOR")][Optional]       Vector4 color;
         };
 
@@ -29,10 +29,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             [Optional]                          Vector3 positionRWS;
             [Optional]                          Vector3 normalWS;
             [Optional]                          Vector4 tangentWS;      // w contain mirror sign
-            [Optional]                          Vector2 texCoord0;
-            [Optional]                          Vector2 texCoord1;
-            [Optional]                          Vector2 texCoord2;
-            [Optional]                          Vector2 texCoord3;
+            [Optional]                          Vector4 texCoord0;
+            [Optional]                          Vector4 texCoord1;
+            [Optional]                          Vector4 texCoord2;
+            [Optional]                          Vector4 texCoord3;
             [Optional]                          Vector4 color;
             [Optional][Semantic("FRONT_FACE_SEMANTIC")][OverrideType("FRONT_FACE_TYPE")][PreprocessorIf("SHADER_STAGE_FRAGMENT")]
             bool cullFace;
@@ -68,10 +68,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             Vector3 positionRWS;
             Vector3 normalWS;
             [Optional]      Vector4 tangentWS;
-            [Optional]      Vector2 texCoord0;
-            [Optional]      Vector2 texCoord1;
-            [Optional]      Vector2 texCoord2;
-            [Optional]      Vector2 texCoord3;
+            [Optional]      Vector4 texCoord0;
+            [Optional]      Vector4 texCoord1;
+            [Optional]      Vector4 texCoord2;
+            [Optional]      Vector4 texCoord3;
             [Optional]      Vector4 color;
 
             public static Dependency[] tessellationDependencies = new Dependency[]

--- a/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/SharedCode.template.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/Editor/ShaderGraph/SharedCode.template.hlsl
@@ -50,10 +50,10 @@
         $SurfaceDescriptionInputs.ViewSpacePosition:         output.ViewSpacePosition =           TransformWorldToView(input.positionRWS);
         $SurfaceDescriptionInputs.TangentSpacePosition:      output.TangentSpacePosition =        float3(0.0f, 0.0f, 0.0f);
         $SurfaceDescriptionInputs.ScreenPosition:            output.ScreenPosition =              ComputeScreenPos(TransformWorldToHClip(input.positionRWS), _ProjectionParams.x);
-        $SurfaceDescriptionInputs.uv0:                       output.uv0 =                         float4(input.texCoord0, 0.0f, 0.0f);
-        $SurfaceDescriptionInputs.uv1:                       output.uv1 =                         float4(input.texCoord1, 0.0f, 0.0f);
-        $SurfaceDescriptionInputs.uv2:                       output.uv2 =                         float4(input.texCoord2, 0.0f, 0.0f);
-        $SurfaceDescriptionInputs.uv3:                       output.uv3 =                         float4(input.texCoord3, 0.0f, 0.0f);
+        $SurfaceDescriptionInputs.uv0:                       output.uv0 =                         input.texCoord0;
+        $SurfaceDescriptionInputs.uv1:                       output.uv1 =                         input.texCoord1;
+        $SurfaceDescriptionInputs.uv2:                       output.uv2 =                         input.texCoord2;
+        $SurfaceDescriptionInputs.uv3:                       output.uv3 =                         input.texCoord3;
         $SurfaceDescriptionInputs.VertexColor:               output.VertexColor =                 input.color;
         $SurfaceDescriptionInputs.FaceSign:                  output.FaceSign =                    input.isFrontFace;
 

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/FragInputs.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/FragInputs.hlsl
@@ -12,10 +12,10 @@ struct FragInputs
     // Note: SV_POSITION is the result of the clip space position provide to the vertex shaders that is transform by the viewport
     float4 positionSS; // In case depth offset is use, positionRWS.w is equal to depth offset
     float3 positionRWS; // Relative camera space position
-    float2 texCoord0;
-    float2 texCoord1;
-    float2 texCoord2;
-    float2 texCoord3;
+    float4 texCoord0;
+    float4 texCoord1;
+    float4 texCoord2;
+    float4 texCoord3;
     float4 color; // vertex color
 
     // TODO: confirm with Morten following statement
@@ -35,16 +35,16 @@ void GetVaryingsDataDebug(uint paramId, FragInputs input, inout float3 result, i
     switch (paramId)
     {
     case DEBUGVIEWVARYING_TEXCOORD0:
-        result = float3(input.texCoord0, 0.0);
+        result = input.texCoord0.xyz;
         break;
     case DEBUGVIEWVARYING_TEXCOORD1:
-        result = float3(input.texCoord1, 0.0);
+        result = input.texCoord1.xyz;
         break;
     case DEBUGVIEWVARYING_TEXCOORD2:
-        result = float3(input.texCoord2, 0.0);
+        result = input.texCoord2.xyz;
         break;
     case DEBUGVIEWVARYING_TEXCOORD3:
-        result = float3(input.texCoord3, 0.0);
+        result = input.texCoord3.xyz;
         break;
     case DEBUGVIEWVARYING_VERTEX_TANGENT_WS:
         result = input.worldToTangent[0].xyz * 0.5 + 0.5;

--- a/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/VaryingMesh.hlsl
+++ b/com.unity.render-pipelines.high-definition/HDRP/ShaderPass/VaryingMesh.hlsl
@@ -168,16 +168,16 @@ FragInputs UnpackVaryingsMeshToFragInputs(PackedVaryingsMeshToPS input)
 #endif // VARYINGS_NEED_TANGENT_TO_WORLD
 
 #ifdef VARYINGS_NEED_TEXCOORD0
-    output.texCoord0 = input.interpolators3.xy;
+    output.texCoord0.xy = input.interpolators3.xy;
 #endif
 #ifdef VARYINGS_NEED_TEXCOORD1
-    output.texCoord1 = input.interpolators3.zw;
+    output.texCoord1.xy = input.interpolators3.zw;
 #endif
 #ifdef VARYINGS_NEED_TEXCOORD2
-    output.texCoord2 = input.interpolators4.xy;
+    output.texCoord2.xy = input.interpolators4.xy;
 #endif
 #ifdef VARYINGS_NEED_TEXCOORD3
-    output.texCoord3 = input.interpolators4.zw;
+    output.texCoord3.xy = input.interpolators4.zw;
 #endif
 #ifdef VARYINGS_NEED_COLOR
     output.color = input.interpolators5;

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -59,4 +59,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Normal Create` node has been renamed to `Normal From Texture`.
 - The preview of nodes now updates correctly.
 - Your system locale can no longer cause incorrect commands due to full stops being converted to commas.
-- HDRP ShaderGraphs now support 4 channel UVs
+- In the High Definition Render Pipeline, Shader Graph now supports 4-channel UVs.

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -59,3 +59,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Normal Create` node has been renamed to `Normal From Texture`.
 - The preview of nodes now updates correctly.
 - Your system locale can no longer cause incorrect commands due to full stops being converted to commas.
+- HDRP ShaderGraphs now support 4 channel UVs


### PR DESCRIPTION
(Doesn't change non-shadergraph interpolators)

### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Speedtree needs four channel UV support for their tree animation node.
We need speedtree shaderes in SRP, so shadergraph is an easy way to get it.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.
This modifies FragInputs texcoords to be float4, but the .shader interpolators are still two channel.
Shadergraph builds it's own interpolators, and makes them float4 (though a future work item is to make 4-channel UV's something that is requested rather than the default..)

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
Load up my test project with four channel UV1, rebuild template project.

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low: worst case is shader compilation failures we would have to fix.

**Halo Effect**: None, Low, Medium, High?
Medium at the shader level: modifies HDRP FragInputs definition of texcoords
Low outside of shaders

---
### Comments to reviewers
Notes for the reviewers you have assigned.
