### PR TITLE
Fix contact shadow load out of bouds in lightloop

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl
@@ -267,7 +267,10 @@ float InitContactShadow(PositionInputs posInput)
 {
     // For now we only support one contact shadow
     // Contactshadow is store in Green Channel of _DeferredShadowTexture
-    return LOAD_TEXTURE2D(_DeferredShadowTexture, posInput.positionSS).y;
+    // Note: When we ImageLoad outside of texture size, the value returned by Load is 0 (Note: On Metal maybe it clamp to value of texture which is also fine)
+    // We use this property to have a neutral value for contact shadows that doesn't consume a sampler and work also with compute shader (i.e use ImageLoad)
+    // We store inverse contact shadow so neutral is white. So either we sample inside or outside the texture it return 1 in case of neutral
+    return 1.0 - LOAD_TEXTURE2D(_DeferredShadowTexture, posInput.positionSS).y;
 }
 
 float GetContactShadow(LightLoopContext lightLoopContext, int contactShadowIndex)

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceShadow.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceShadow.compute
@@ -151,5 +151,5 @@ void DEFERRED_CONTACT_SHADOW_GENERIC(uint2 groupThreadId : SV_GroupThreadID, uin
 
     float contactShadow = ComputeContactShadow(posInput, direction);
 
-    _DeferredShadowTextureUAV[pixelCoord] = float4(1.0, contactShadow, 1.0, 1.0); // Note: RT is RG16 format
+    _DeferredShadowTextureUAV[pixelCoord] = float4(1.0, 1.0 - contactShadow, 1.0, 1.0); // Note: RT is RG16 format
 }


### PR DESCRIPTION
### Purpose of this PR
Fix contact shadows hiding the light when the contact shadow were disabled in the volume and enabled on the light

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**:  Low