### PR TITLE
Stereo ProceduralSky/Atmospherics + Stereo MSAA Color Resolve fix

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -771,7 +771,7 @@ PositionInputs GetPositionInput_Stereo(float2 positionSS, float2 invScreenSize, 
 #endif
     posInput.positionNDC *= invScreenSize;
 
-#if UNITY_SINGLE_PASS_STEREO
+#if defined(UNITY_SINGLE_PASS_STEREO)
     posInput.positionNDC.x = posInput.positionNDC.x - eye;
 #endif
 

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improve Decal Gizmo
 - Implement Screen Space Reflections (SSR) (alpha version, highly experimental)
 - Add an option to invert the fade parameter on a Density Volume
+- Add stereo support to ShaderPassForward.hlsl. Forward rendering now seems passable in limited test scenes with camera-relative rendering disabled.
+- Added stereo support in MSAA color resolve shader
+- Added stereo support in skybox and atmospherics shaders. There is currently a slight discrepancy in horizon position between these two. 
 - Added a Fabric shader (experimental) handling cotton and silk
 - Added support for MSAA in forward only for opaque only
 - Implement smoothness fade for SSR
@@ -48,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated decal gizmo
 - Optimization: The objects that are rendered in the Motion Vector Pass are not rendered in the prepass anymore
 - Removed setting shader inclue path via old API, use package shader include paths
+- Modified deferred compute and vert/frag shaders for first steps towards stereo support
 
 ## [3.3.0-preview]
 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/RenderPipelineSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/RenderPipelineSettingsUI.cs
@@ -79,7 +79,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUILayout.PropertyField(d.increaseResolutionOfVolumetrics, _.GetContent("Increase resolution of volumetrics|Increase the resolution of volumetric lighting buffers. Warning: high performance cost, do not enable on consoles."));
             EditorGUILayout.PropertyField(d.supportLightLayers, _.GetContent("Support LightLayers|Enable light layers. In deferred this imply an extra render target in memory and extra cost."));
             EditorGUILayout.PropertyField(d.supportOnlyForward, _.GetContent("Support Only Forward|Remove all the memory and shader variant of GBuffer. The renderer can be switch to deferred anymore."));
-
             // Engine
             EditorGUILayout.PropertyField(d.supportDecals, _.GetContent("Support Decals|Enable memory and variant for decals buffer and cluster decals"));
 
@@ -101,6 +100,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUILayout.PropertyField(d.supportMotionVectors, _.GetContent("Support Motion Vectors|Motion vector are use for Motion Blur, TAA, temporal re-projection of various effect like SSR."));
             EditorGUILayout.PropertyField(d.supportRuntimeDebugDisplay, _.GetContent("Support runtime debug display|Remove all debug display shader variant only in the player. Allow faster build."));
             EditorGUILayout.PropertyField(d.supportDitheringCrossFade, _.GetContent("Support dithering cross fade|Remove all dithering cross fade shader variant only in the player. Allow faster build."));
+
+            // XR 
+            EditorGUILayout.PropertyField(d.xrConfig);
 
             --EditorGUI.indentLevel;
         }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
@@ -9,7 +9,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedProperty renderPipelineResources;
         public SerializedProperty diffusionProfileSettings;
         public SerializedProperty allowShaderVariantStripping;
-
         public SerializedRenderPipelineSettings renderPipelineSettings;
         public SerializedFrameSettings defaultFrameSettings;
 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedRenderPipelineSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedRenderPipelineSettings.cs
@@ -26,7 +26,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedProperty supportMotionVectors;
         public SerializedProperty supportRuntimeDebugDisplay;
         public SerializedProperty supportDitheringCrossFade;
-
         public SerializedGlobalLightLoopSettings lightLoopSettings;
         public SerializedShadowInitParameters shadowInitParams;
         public SerializedGlobalDecalSettings decalSettings;
@@ -53,7 +52,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             supportMotionVectors            = root.Find((RenderPipelineSettings s) => s.supportMotionVectors);
             supportRuntimeDebugDisplay      = root.Find((RenderPipelineSettings s) => s.supportRuntimeDebugDisplay);
             supportDitheringCrossFade       = root.Find((RenderPipelineSettings s) => s.supportDitheringCrossFade);
-
+            
             lightLoopSettings = new SerializedGlobalLightLoopSettings(root.Find((RenderPipelineSettings s) => s.lightLoopSettings));
             shadowInitParams  = new SerializedShadowInitParameters(root.Find((RenderPipelineSettings s) => s.shadowInitParams));
             decalSettings     = new SerializedGlobalDecalSettings(root.Find((RenderPipelineSettings s) => s.decalSettings));

--- a/com.unity.render-pipelines.high-definition/Runtime/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Camera/HDCamera.cs
@@ -35,7 +35,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public Matrix4x4[] viewMatrixStereo;
         public Matrix4x4[] projMatrixStereo;
         public Vector4 centerEyeTranslationOffset;
-        public float textureWidthScaling; // 0.5 for SinglePassDoubleWide (stereo) and 1.0 otherwise
+        public Vector4 textureWidthScaling; // (2.0, 0.5) for SinglePassDoubleWide (stereo) and (1.0, 1.0) otherwise
 
         // Non oblique projection matrix (RHS)
         public Matrix4x4 nonObliqueProjMatrix
@@ -212,10 +212,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_ActualHeight = camera.pixelHeight;
             var screenWidth = m_ActualWidth;
             var screenHeight = m_ActualHeight;
-            textureWidthScaling = 1.0f; 
+            textureWidthScaling = new Vector4(1.0f, 1.0f, 0.0f, 0.0f); 
             if (m_frameSettings.enableStereo)
             {
-                textureWidthScaling = 0.5f; 
+                if (XRGraphicsConfig.stereoRenderingMode == UnityEditor.StereoRenderingPath.SinglePass) // VR TODO: is this also true for single-pass instanced and multi-view?
+                    textureWidthScaling = new Vector4(2.0f, 0.5f, 0.0f, 0.0f); 
                 for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
                 {
                     // For VR, TAA proj matrices don't need to be jittered
@@ -290,6 +291,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             projMatrix = gpuProj;
             nonJitteredProjMatrix = gpuNonJitteredProj;
             cameraPos = pos;
+
+            if (!m_frameSettings.enableStereo)
+            {
+                // TODO VR: Current solution for compute shaders grabs matrices from
+                // stereo matrices even when not rendering stereo in order to reduce shader variants.
+                // After native fix for compute shader keywords is completed, qualify this with stereoEnabled.
+                viewMatrixStereo[0] = viewMatrix;
+                projMatrixStereo[0] = projMatrix;
+            }
 
             if (ShaderConfig.s_CameraRelativeRendering != 0)
             {
@@ -632,7 +642,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetGlobalMatrixArray(HDShaderIDs._InvProjMatrixStereo, invProjStereo);
             cmd.SetGlobalMatrixArray(HDShaderIDs._InvViewProjMatrixStereo, invViewProjStereo);
             cmd.SetGlobalMatrixArray(HDShaderIDs._PrevViewProjMatrixStereo, prevViewProjMatrixStereo);
-            cmd.SetGlobalFloat(HDShaderIDs._TextureWidthScaling, textureWidthScaling);
+            cmd.SetGlobalVector(HDShaderIDs._TextureWidthScaling, textureWidthScaling);
         }
 
         public RTHandleSystem.RTHandle GetPreviousFrameRT(int id)

--- a/com.unity.render-pipelines.high-definition/Runtime/CoreRP/Textures/RTHandles.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/CoreRP/Textures/RTHandles.cs
@@ -101,6 +101,56 @@ namespace UnityEngine.Experimental.Rendering
                 name
                 );
         }
+        public static RTHandleSystem.RTHandle Alloc(
+            Vector2 scaleFactor,
+            bool stereoEnabled,
+            DepthBits depthBufferBits = DepthBits.None,
+            RenderTextureFormat colorFormat = RenderTextureFormat.Default,
+            FilterMode filterMode = FilterMode.Point,
+            TextureWrapMode wrapMode = TextureWrapMode.Repeat,
+            TextureDimension dimension = TextureDimension.Tex2D,
+            bool sRGB = true,
+            bool enableRandomWrite = false,
+            bool useMipMap = false,
+            bool autoGenerateMips = true,
+            int anisoLevel = 1,
+            float mipMapBias = 0,
+            bool enableMSAA = false,
+            bool bindTextureMS = false,
+            bool useDynamicScale = false,
+            RenderTextureMemoryless memoryless = RenderTextureMemoryless.None,
+            string name = ""
+            )
+        {
+            int slices = 1;
+            VRTextureUsage vrUsage = VRTextureUsage.None;
+            if (stereoEnabled)
+            {
+                slices = (XRGraphicsConfig.eyeTextureDesc.dimension == TextureDimension.Tex2DArray) ? 2 : 1; // TODO VR: double-check that this works as expected
+                vrUsage = XRGraphicsConfig.eyeTextureDesc.vrUsage;
+            }
+            return s_DefaultInstance.Alloc(
+                scaleFactor,
+                slices,
+                depthBufferBits,
+                colorFormat,
+                filterMode,
+                wrapMode,
+                dimension,
+                sRGB,
+                enableRandomWrite,
+                useMipMap,
+                autoGenerateMips,
+                anisoLevel,
+                mipMapBias,
+                enableMSAA,
+                bindTextureMS,
+                useDynamicScale,
+                vrUsage,
+                memoryless,
+                name
+                );
+        }
 
         public static RTHandleSystem.RTHandle Alloc(
             ScaleFunc scaleFunc,

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/AtmosphericScattering/OpaqueAtmosphericScattering.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/AtmosphericScattering/OpaqueAtmosphericScattering.shader
@@ -36,7 +36,7 @@ Shader "Hidden/HDRenderPipeline/OpaqueAtmosphericScattering"
 
         inline float4 AtmosphericScatteringCompute(Varyings input, float depth)
         {
-            PositionInputs posInput = GetPositionInput(input.positionCS.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V);
+            PositionInputs posInput = GetPositionInput_Stereo(input.positionCS.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, unity_StereoEyeIndex);
 
             if (depth == UNITY_RAW_FAR_CLIP_VALUE)
             {
@@ -44,7 +44,7 @@ Shader "Hidden/HDRenderPipeline/OpaqueAtmosphericScattering"
                 // So in order to have a valid position (for example for height fog) we just consider that the sky is a sphere centered on camera with a radius of 5km (arbitrarily chosen value!)
                 // And recompute the position on the sphere with the current camera direction.
                 float3 viewDirection = -GetWorldSpaceNormalizeViewDir(posInput.positionWS) * 5000.0f;
-                posInput.positionWS = GetPrimaryCameraPosition() + viewDirection;
+                posInput.positionWS = GetCurrentViewPosition() + viewDirection;
             }
 
             return EvaluateAtmosphericScattering(posInput);
@@ -58,7 +58,7 @@ Shader "Hidden/HDRenderPipeline/OpaqueAtmosphericScattering"
 
         float4 FragMSAA(Varyings input, uint sampleIndex: SV_SampleIndex) : SV_Target
         {
-            int2 msTex = int2(input.texcoord.xy * _ScreenSize.xy);
+            int2 msTex = int2(TexCoordStereoOffset(input.texcoord.xy * _ScreenSize.xy));
             float depth = _DepthTextureMS.Load(msTex, sampleIndex).x;
             return AtmosphericScatteringCompute(input, depth);
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
@@ -102,7 +102,8 @@ Shader "Hidden/HDRenderPipeline/Deferred"
 
                 // input.positionCS is SV_Position
                 float depth = LOAD_TEXTURE2D(_CameraDepthTexture, input.positionCS.xy).x;
-                PositionInputs posInput = GetPositionInput(input.positionCS.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, uint2(input.positionCS.xy) / GetTileSize());
+
+                PositionInputs posInput = GetPositionInput_Stereo(input.positionCS.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, uint2(input.positionCS.xy) / GetTileSize(), unity_StereoEyeIndex);
                 float3 V = GetWorldSpaceNormalizeViewDir(posInput.positionWS);
 
                 BSDFData bsdfData;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
@@ -60,6 +60,7 @@
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant25      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant25      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=25
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant26      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant26      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=26
 
+#define UNITY_SINGLE_PASS_STEREO 1
 
 #define LIGHTLOOP_TILE_PASS 1
 // deferred opaque always use FPTL
@@ -95,6 +96,7 @@ RWTexture2D<float4> specularLightingUAV;
 
 CBUFFER_START(UnityDeferredCompute)
     uint g_TileListOffset;
+    uint _Eye;
 CBUFFER_END
 
 #ifdef USE_INDIRECT
@@ -118,7 +120,7 @@ void SHADE_OPAQUE_ENTRY(uint2 groupThreadId : SV_GroupThreadID, uint groupId : S
 void SHADE_OPAQUE_ENTRY(uint2 dispatchThreadId : SV_DispatchThreadID, uint2 groupId : SV_GroupID)
 {
     uint2 tileCoord    = (TILE_SIZE_FPTL * groupId) / GetTileSize();
-    uint2 pixelCoord   = dispatchThreadId;
+    uint2 pixelCoord   = dispatchThreadId + uint2((_Eye * _ScreenSize.x), 0);
     uint  featureFlags = UINT_MAX;
 
 #endif
@@ -126,7 +128,7 @@ void SHADE_OPAQUE_ENTRY(uint2 dispatchThreadId : SV_DispatchThreadID, uint2 grou
     // This need to stay in sync with deferred.shader
 
     float depth = LOAD_TEXTURE2D(_CameraDepthTexture, pixelCoord.xy).x;
-    PositionInputs posInput = GetPositionInput(pixelCoord.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, tileCoord);
+    PositionInputs posInput = GetPositionInput_Stereo(pixelCoord.xy, _ScreenSize.zw, depth, _InvViewProjMatrixStereo[_Eye], _ViewMatrixStereo[_Eye], tileCoord, _Eye);
 
     // For indirect case: we can still overlap inside a tile with the sky/background, reject it
     // Can't rely on stencil as we are in compute shader

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceShadow.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceShadow.compute
@@ -6,6 +6,8 @@
 #   pragma argument( scheduler=minpressure ) // instruct the shader compiler to prefer minimizing vgpr usage
 #endif
 
+#define UNITY_SINGLE_PASS_STEREO 1
+
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
 #include "../ShaderVariables.hlsl"
 #include "../Material/NormalBuffer.hlsl"
@@ -27,6 +29,7 @@ float4  _PunctualLightPosition;
 float4  _ContactShadowParamsParameters;
 float4  _ContactShadowParamsParameters2;
 int     _SampleCount;
+uint    _Eye;
 CBUFFER_END
 
 #define _ContactShadowLength                _ContactShadowParamsParameters.x
@@ -133,6 +136,7 @@ float ComputeContactShadow(PositionInputs posInput, float3 direction)
 void DEFERRED_CONTACT_SHADOW_GENERIC(uint2 groupThreadId : SV_GroupThreadID, uint2 groupId : SV_GroupID)
 {
     uint2 pixelCoord = groupId * DEFERRED_SHADOW_TILE_SIZE + groupThreadId;
+    pixelCoord.x = pixelCoord.x + (_Eye * _ScreenSize.x);
     uint2 tileCoord = groupId;
 
 #ifdef ENABLE_MSAA
@@ -144,7 +148,7 @@ void DEFERRED_CONTACT_SHADOW_GENERIC(uint2 groupThreadId : SV_GroupThreadID, uin
     if (depth == UNITY_RAW_FAR_CLIP_VALUE)
         return;
 
-    PositionInputs posInput = GetPositionInput(pixelCoord.xy, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, tileCoord);
+    PositionInputs posInput = GetPositionInput(pixelCoord.xy - (_Eye * float2(_ScreenSize.x, 0)), _ScreenSize.zw, depth, _InvViewProjMatrixStereo[_Eye], _ViewMatrixStereo[_Eye], tileCoord);
     
     //Direction got from either the directional light direction or the difference of punctual light position and the pixel position
     float3 direction = normalize(_DirectionalLightDirection.xyz * _DirectionalLightDirection.w + (_PunctualLightPosition.xyz - posInput.positionWS) * _PunctualLightPosition.w);

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DBufferManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DBufferManager.cs
@@ -23,7 +23,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             for (int dbufferIndex = 0; dbufferIndex < m_BufferCount; ++dbufferIndex)
             {
-                m_RTs[dbufferIndex] = RTHandles.Alloc(Vector2.one, colorFormat: rtFormat[dbufferIndex], sRGB: sRGBFlags[dbufferIndex], filterMode: FilterMode.Point, name: string.Format("DBuffer{0}", dbufferIndex));
+                m_RTs[dbufferIndex] = RTHandles.Alloc(Vector2.one, colorFormat: rtFormat[dbufferIndex], sRGB: sRGBFlags[dbufferIndex], filterMode: FilterMode.Point, name: string.Format("DBuffer{0}", dbufferIndex), stereoEnabled: XRGraphicsConfig.enabled);
                 m_RTIDs[dbufferIndex] = m_RTs[dbufferIndex].nameID;
                 m_TextureShaderIDs[dbufferIndex] = HDShaderIDs._DBufferTexture[dbufferIndex];
             }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GBufferManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GBufferManager.cs
@@ -48,7 +48,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             for (int gbufferIndex = 0; gbufferIndex < m_BufferCount; ++gbufferIndex)
             {
-                m_RTs[gbufferIndex] = RTHandles.Alloc(Vector2.one, colorFormat: rtFormat[gbufferIndex], sRGB: sRGBFlags[gbufferIndex], filterMode: FilterMode.Point, name: string.Format("GBuffer{0}", gbufferIndex), enableRandomWrite: enableWrite[gbufferIndex]); 
+                m_RTs[gbufferIndex] = RTHandles.Alloc(Vector2.one, colorFormat: rtFormat[gbufferIndex], sRGB: sRGBFlags[gbufferIndex], filterMode: FilterMode.Point, name: string.Format("GBuffer{0}", gbufferIndex), enableRandomWrite: enableWrite[gbufferIndex], stereoEnabled: XRGraphicsConfig.enabled); 
                 m_RTIDs[gbufferIndex] = m_RTs[gbufferIndex].nameID;
                 m_TextureShaderIDs[gbufferIndex] = HDShaderIDs._GBufferTexture[gbufferIndex];
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SharedRTManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SharedRTManager.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_ReuseGBufferMemory = !settings.supportOnlyForward;
 
             // Create the depth/stencil buffer
-            m_CameraDepthStencilBuffer = RTHandles.Alloc(Vector2.one, depthBufferBits: DepthBits.Depth32, colorFormat: RenderTextureFormat.Depth, filterMode: FilterMode.Point, name: "CameraDepthStencil");
+            m_CameraDepthStencilBuffer = RTHandles.Alloc(Vector2.one, depthBufferBits: DepthBits.Depth32, colorFormat: RenderTextureFormat.Depth, filterMode: FilterMode.Point, name: "CameraDepthStencil", stereoEnabled: XRGraphicsConfig.enabled);
 
             // Create the mip chain buffer
             m_CameraDepthBufferMipChainInfo = new HDUtils.PackedMipChainInfo();
@@ -65,10 +65,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             if (m_VelocitySupport)
             {
-                m_VelocityRT = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: Builtin.GetVelocityBufferFormat(), sRGB: Builtin.GetVelocityBufferSRGBFlag(), name: "Velocity");
+                m_VelocityRT = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: Builtin.GetVelocityBufferFormat(), sRGB: Builtin.GetVelocityBufferSRGBFlag(), name: "Velocity", stereoEnabled: XRGraphicsConfig.enabled);
                 if (m_MSAASupported)
                 {
-                    m_VelocityMSAART = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: Builtin.GetVelocityBufferFormat(), sRGB: Builtin.GetVelocityBufferSRGBFlag(), enableMSAA: true, bindTextureMS: true, name: "VelocityMSAA");
+                    m_VelocityMSAART = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: Builtin.GetVelocityBufferFormat(), sRGB: Builtin.GetVelocityBufferSRGBFlag(), enableMSAA: true, bindTextureMS: true, name: "VelocityMSAA", stereoEnabled: XRGraphicsConfig.enabled);
                 }
             }
 
@@ -76,8 +76,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (m_MSAASupported)
             {
                 // Let's create the MSAA textures
-                m_CameraDepthStencilMSAABuffer = RTHandles.Alloc(Vector2.one, depthBufferBits: DepthBits.Depth24, colorFormat: RenderTextureFormat.Depth, filterMode: FilterMode.Point, bindTextureMS: true, enableMSAA: true, name: "CameraDepthStencilMSAA");
-                m_CameraDepthValuesBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGBFloat, sRGB: false, name: "DepthValuesBuffer");
+                m_CameraDepthStencilMSAABuffer = RTHandles.Alloc(Vector2.one, depthBufferBits: DepthBits.Depth24, colorFormat: RenderTextureFormat.Depth, filterMode: FilterMode.Point, bindTextureMS: true, enableMSAA: true, name: "CameraDepthStencilMSAA", stereoEnabled: XRGraphicsConfig.enabled);
+                m_CameraDepthValuesBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGBFloat, sRGB: false, name: "DepthValuesBuffer", stereoEnabled: XRGraphicsConfig.enabled);
 
                 // Create the required resolve materials
                 m_DepthResolveMaterial = CoreUtils.CreateEngineMaterial(resources.depthValues);
@@ -89,14 +89,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 // In case of full forward we must allocate the render target for normal buffer (or reuse one already existing)
                 // TODO: Provide a way to reuse a render target
-                m_NormalRT = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: false, enableRandomWrite: true, name: "NormalBuffer");
+                m_NormalRT = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: false, enableRandomWrite: true, name: "NormalBuffer", stereoEnabled: XRGraphicsConfig.enabled);
 
                 // Is MSAA supported?
                 if (m_MSAASupported)
                 {
                     // Allocate the two render textures we need in the MSAA case
-                    m_NormalMSAART = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: false, enableMSAA: true, bindTextureMS: true, name: "NormalBufferMSAA");
-                    m_DepthAsColorMSAART = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.RFloat, sRGB: false, bindTextureMS: true, enableMSAA: true, name: "DepthAsColorMSAA");
+                    m_NormalMSAART = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: false, enableMSAA: true, bindTextureMS: true, name: "NormalBufferMSAA", stereoEnabled: XRGraphicsConfig.enabled);
+                    m_DepthAsColorMSAART = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.RFloat, sRGB: false, bindTextureMS: true, enableMSAA: true, name: "DepthAsColorMSAA", stereoEnabled: XRGraphicsConfig.enabled);
                 }
             }
             else

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
@@ -43,12 +43,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 // In case of full forward we must allocate the render target for forward SSS (or reuse one already existing)
                 // TODO: Provide a way to reuse a render target
-                m_ColorMRTs[0] = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: true, name: "SSSBuffer");
+                m_ColorMRTs[0] = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, sRGB: true, name: "SSSBuffer", stereoEnabled: XRGraphicsConfig.enabled);
                 m_ReuseGBufferMemory [0] = false;
 
                 if (m_MSAASupport)
                 {
-                    m_ColorMSAAMRTs[0] = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, enableMSAA: true, bindTextureMS: true, sRGB: true, name: "SSSBufferMSAA");
+                    m_ColorMSAAMRTs[0] = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.ARGB32, enableMSAA: true, bindTextureMS: true, sRGB: true, name: "SSSBufferMSAA", stereoEnabled: XRGraphicsConfig.enabled);
                 }
             }
             else
@@ -61,7 +61,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (NeedTemporarySubsurfaceBuffer() || settings.supportMSAA)
             {
                 // Caution: must be same format as m_CameraSssDiffuseLightingBuffer
-                m_CameraFilteringBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.RGB111110Float, sRGB: false, enableRandomWrite: true, name: "SSSCameraFiltering"); // Enable UAV
+                m_CameraFilteringBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: RenderTextureFormat.RGB111110Float, sRGB: false, enableRandomWrite: true, name: "SSSCameraFiltering", stereoEnabled: XRGraphicsConfig.enabled); // Enable UAV
             }
 
             // We use 8x8 tiles in order to match the native GCN HTile as closely as possible.

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1052,11 +1052,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     // We can't currently render object velocity after depth prepass because if there is no depth prepass we can have motion vector write that should have been rejected
                     RenderCameraVelocity(m_CullResults, hdCamera, renderContext, cmd);
 
+                    StopStereoRendering(cmd, renderContext, hdCamera);
                     // Caution: We require sun light here as some skies use the sun light to render, it means that UpdateSkyEnvironment must be called after PrepareLightsForGPU.
                     // TODO: Try to arrange code so we can trigger this call earlier and use async compute here to run sky convolution during other passes (once we move convolution shader to compute).
                     UpdateSkyEnvironment(hdCamera, cmd);
 
-                    StopStereoRendering(cmd, renderContext, hdCamera);
 
                     if (m_CurrentDebugDisplaySettings.IsDebugMaterialDisplayEnabled())
                     {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -7,7 +7,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     {
         [HideInInspector]
         const int currentVersion = 1;
-
         // Currently m_Version is not used and produce a warning, remove these pragmas at the next version incrementation
 #pragma warning disable 414
         [SerializeField]

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -199,6 +199,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _DirectionalContactShadowSampleCount = Shader.PropertyToID("_SampleCount");
         public static readonly int _DirectionalLightDirection = Shader.PropertyToID("_DirectionalLightDirection");
         public static readonly int _PunctualLightPosition = Shader.PropertyToID("_PunctualLightPosition");
+        public static readonly int _Matrix_I_VP = Shader.PropertyToID("_Matrix_I_VP");
+        public static readonly int _Matrix_V = Shader.PropertyToID("_Matrix_V");
+        public static readonly int _Eye = Shader.PropertyToID("_Eye");
 
         public static readonly int _StencilMask = Shader.PropertyToID("_StencilMask");
         public static readonly int _StencilRef = Shader.PropertyToID("_StencilRef");
@@ -248,7 +251,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _InvProjMatrixStereo = Shader.PropertyToID("_InvProjMatrixStereo");
         public static readonly int _InvViewProjMatrixStereo = Shader.PropertyToID("_InvViewProjMatrixStereo");
         public static readonly int _PrevViewProjMatrixStereo = Shader.PropertyToID("_PrevViewProjMatrixStereo");
-        public static readonly int _TextureWidthScaling = Shader.PropertyToID("_TextureWidthScaling"); // 0.5 for SinglePassDoubleWide (stereo) and 1.0 otherwise
+        public static readonly int _TextureWidthScaling = Shader.PropertyToID("_TextureWidthScaling"); // (2.0, 0.5) for SinglePassDoubleWide (stereo) and (1.0, 1.0) otherwise
 
         public static readonly int _DepthTexture                   = Shader.PropertyToID("_DepthTexture");
         public static readonly int _CameraColorTexture             = Shader.PropertyToID("_CameraColorTexture");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.cs
@@ -204,7 +204,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (enableStereo)
             {
                 // Force forward if we request stereo. TODO: We should not enforce that, users should be able to chose deferred
-                enableForwardRenderingOnly = true;
+                //enableForwardRenderingOnly = true;
 
                 // TODO: The work will be implemented piecemeal to support all passes
                 //enableMotionVectors = !enableMSAA;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/CameraMotionVectors.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/CameraMotionVectors.shader
@@ -49,7 +49,7 @@ Shader "Hidden/HDRenderPipeline/CameraMotionVectors"
             velocity.y = -velocity.y;
 #endif
 
-            velocity.x = velocity.x * _TextureWidthScaling; // _TextureWidthScaling = 0.5 for SinglePassDoubleWide (stereo) and 1.0 otherwise
+            velocity.x = velocity.x * _TextureWidthScaling.y; // _TextureWidthScaling = (2.0, 0.5) for SinglePassDoubleWide (stereo) and (1.0, 1.0) otherwise
 
             // Convert velocity from Clip space (-1..1) to NDC 0..1 space
             // Note it doesn't mean we don't have negative value, we store negative or positive offset in NDC space.

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/MSAA/ColorResolve.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/MSAA/ColorResolve.shader
@@ -31,26 +31,26 @@ Shader "Hidden/HDRenderPipeline/ColorResolve"
 
         float4 Frag1X(Varyings input) : SV_Target
         {
-            int2 pixelCoords = int2(input.texcoord);
+            int2 pixelCoords = int2(TexCoordStereoOffset(input.texcoord));
             return _ColorTextureMS.Load(pixelCoords, 0);
         }
 
         float4 Frag2X(Varyings input) : SV_Target
         {
-            int2 pixelCoords = int2(input.texcoord);
+            int2 pixelCoords = int2(TexCoordStereoOffset(input.texcoord));
             return FastTonemapInvert((FastTonemap(_ColorTextureMS.Load(pixelCoords, 0)) + FastTonemap(_ColorTextureMS.Load(pixelCoords, 1))) * 0.5f);
         }
 
         float4 Frag4X(Varyings input) : SV_Target
         {
-            int2 pixelCoords = int2(input.texcoord);
+            int2 pixelCoords = int2(TexCoordStereoOffset(input.texcoord));
             return FastTonemapInvert((FastTonemap(_ColorTextureMS.Load(pixelCoords, 0)) + FastTonemap(_ColorTextureMS.Load(pixelCoords, 1))
                             + FastTonemap(_ColorTextureMS.Load(pixelCoords, 2)) + FastTonemap(_ColorTextureMS.Load(pixelCoords, 3))) * 0.25f);
         }
 
         float4 Frag8X(Varyings input) : SV_Target
         {
-            int2 pixelCoords = int2(input.texcoord);
+            int2 pixelCoords = int2(TexCoordStereoOffset(input.texcoord));
             return FastTonemapInvert((FastTonemap(_ColorTextureMS.Load(pixelCoords, 0)) + FastTonemap(_ColorTextureMS.Load(pixelCoords, 1))
                             + FastTonemap(_ColorTextureMS.Load(pixelCoords, 2)) + FastTonemap(_ColorTextureMS.Load(pixelCoords, 3))
                             + FastTonemap(_ColorTextureMS.Load(pixelCoords, 4)) + FastTonemap(_ColorTextureMS.Load(pixelCoords, 5))

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderPass/ShaderPassForward.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderPass/ShaderPassForward.hlsl
@@ -40,7 +40,7 @@ void Frag(PackedVaryingsToPS packedInput,
     FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
 
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS.xyz, uint2(input.positionSS.xy) / GetTileSize());
+    PositionInputs posInput = GetPositionInput_Stereo(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS.xyz, uint2(input.positionSS.xy) / GetTileSize(), unity_StereoEyeIndex);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderVariables.hlsl
@@ -202,7 +202,7 @@ CBUFFER_START(UnityGlobal)
     float4x4 _NonJitteredViewProjMatrix;
     float4x4 _PrevViewProjMatrix;       // non-jittered
 
-    float _TextureWidthScaling; // 0.5 for SinglePassDoubleWide (stereo) and 1.0 otherwise
+    float4 _TextureWidthScaling; // 0.5 for SinglePassDoubleWide (stereo) and 1.0 otherwise
 
     // TODO: put commonly used vars together (below), and then sort them by the frequency of use (descending).
     // Note: a matrix is 4 * 4 * 4 = 64 bytes (1x cache line), so no need to sort those.

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderVariablesFunctions.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderVariablesFunctions.hlsl
@@ -137,7 +137,7 @@ float3 GetPrimaryCameraPosition()
 // Could be e.g. the position of a primary camera or a shadow-casting light.
 float3 GetCurrentViewPosition()
 {
-#if defined(SHADERPASS) && (SHADERPASS != SHADERPASS_SHADOWS)
+#if (defined(SHADERPASS) && (SHADERPASS != SHADERPASS_SHADOWS)) && (!UNITY_SINGLE_PASS_STEREO) // Can't use camera position when rendering stereo
     return GetPrimaryCameraPosition();
 #else
     // This is a generic solution.
@@ -262,4 +262,11 @@ float4 SampleSkyTexture(float3 texCoord, float lod)
     return SAMPLE_TEXTURECUBE_LOD(_SkyTexture, s_trilinear_clamp_sampler, texCoord, lod);
 }
 
+float2 TexCoordStereoOffset(float2 texCoord)
+{
+#if defined(UNITY_SINGLE_PASS_STEREO)
+    return texCoord + float2(unity_StereoEyeIndex * _ScreenSize.x, 0.0);
+#endif
+    return texCoord;
+}
 #endif // UNITY_SHADER_VARIABLES_FUNCTIONS_INCLUDED

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/ProceduralSky/ProceduralSky.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/ProceduralSky/ProceduralSky.shader
@@ -120,9 +120,11 @@ Shader "Hidden/HDRenderPipeline/Sky/ProceduralSky"
     float4 Frag(Varyings input) : SV_Target
     {
         // Points towards the camera
-        float3 viewDirWS = normalize(mul(float3(input.positionCS.xy, 1.0), (float3x3)_PixelCoordToViewDirWS));
+        float2 pos = input.positionCS.xy - uint2(unity_StereoEyeIndex * _ScreenSize.x, 0.0);
+        PositionInputs posInput = GetPositionInput_Stereo(input.positionCS.xy, _ScreenSize.zw, UNITY_RAW_FAR_CLIP_VALUE, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, unity_StereoEyeIndex);
+        float3 viewDirWS = normalize(mul(float3(pos, 1.0), (float3x3)_PixelCoordToViewDirWS));
         // Reverse it to point into the scene
-        float3 dir = -viewDirWS;
+        float3 dir = normalize(posInput.positionWS);
 
         // Rotate direction
         float phi = DegToRad(_SkyParam.z);

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/ProceduralSky/ProceduralSky.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/ProceduralSky/ProceduralSky.shader
@@ -120,12 +120,16 @@ Shader "Hidden/HDRenderPipeline/Sky/ProceduralSky"
 
     float4 Frag(Varyings input) : SV_Target
     {
-        // Points towards the camera
+#if defined(UNITY_SINGLE_PASS_STEREO)
         float2 pos = input.positionCS.xy - uint2(unity_StereoEyeIndex * _ScreenSize.x, 0.0);
-        PositionInputs posInput = GetPositionInput_Stereo(input.positionCS.xy, _ScreenSize.zw, UNITY_RAW_FAR_CLIP_VALUE, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, unity_StereoEyeIndex);
-        float3 viewDirWS = normalize(mul(float3(pos, 1.0), (float3x3)_PixelCoordToViewDirWS));
-        // Reverse it to point into the scene
+        PositionInputs posInput = GetPositionInput_Stereo(input.positionCS.xy, _ScreenSize.zw, input.positionCS.z, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, unity_StereoEyeIndex);
         float3 dir = normalize(posInput.positionWS);
+#else
+        // Points towards the camera
+        float3 viewDirWS = normalize(mul(float3(input.positionCS.xy, 1.0), (float3x3)_PixelCoordToViewDirWS));
+        // Reverse it to point into the scene
+        float3 dir = -viewDirWS;
+#endif
 
         // Rotate direction
         float phi = DegToRad(_SkyParam.z);

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/ProceduralSky/ProceduralSky.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/ProceduralSky/ProceduralSky.shader
@@ -18,6 +18,7 @@ Shader "Hidden/HDRenderPipeline/Sky/ProceduralSky"
     #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
     #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
     #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/CommonLighting.hlsl"
+    #include "../../ShaderVariables.hlsl"
 
     float4   _SkyParam; // x exposure, y multiplier, z rotation
     float4x4 _PixelCoordToViewDirWS; // Actually just 3x3, but Unity can only set 4x4


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
- Fixed skybox rendering for single-pass stereo
- Fixed atmospherics for single-pass stereo
- Fixed MSAA color resolve shader for single-pass stereo
---
### Release Notes
- Includes changesets from the pending hdrp_xr PR: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/1907

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=stereo_msaa_skybox&unity_branch=trunk&automation-tools_branch=add-platform-filter

**Manual Tests**: What did you do?
With forward rendering on, visually confirmed correct skybox + atmospherics with single-pass stereo enabled and MSAA on and off: 
MSAA off:
![image](https://user-images.githubusercontent.com/3450690/45724622-e43e8f00-bb6b-11e8-91e4-aee1611e83a6.png)

MSAA on:
![image](https://user-images.githubusercontent.com/3450690/45724686-32ec2900-bb6c-11e8-9a41-22e7e7cfffcd.png)


**Automated Tests**: What did you setup?
No additional tests.

Any test projects to go with this to help reviewers?
HDRP template scene should demonstrate working atmospherics

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Medium: Modified view direction computation for proceduralsky shader if UNITY_SINGLE_PASS_STEREO defined. Texture coordinate modifications for color resolve, and opaque atmospheric scattering shaders. 

**Halo Effect**: None, Low, Medium, High?
Low: Changes are in common shaders but are protected by #ifdef UNITY_SINGLE_PASS_STEREO.

---
### Comments to reviewers
Might be easier to see the changes specific to this commit after merging the PR mentioned above. 
