### PR TITLE
fix LayeredLit layer 2 do not showing up and small display issues in materials

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitUI.cs
@@ -208,7 +208,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 SetExpendedAreas((uint)LayerExpendable.ShowLayer3, true);
             }
-            if (layerNumber == 3)
+            if (layerNumber >= 3)
             {
                 SetExpendedAreas((uint)LayerExpendable.ShowLayer2, true);
             }
@@ -388,7 +388,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
             else if (!useMainLayerInfluence.hasMixedValue && useMainLayerInfluence.floatValue != 0.0f)
             {
-                using (var header = new HeaderScope(s_Styles.layerLabels[layerIndex] + " " + styles.layeringOptionText.text, (uint)LayerExpendable.MainInput, this, colorDot: s_Styles.layerColors[layerIndex]))
+                using (var header = new HeaderScope(s_Styles.layerLabels[layerIndex].text + " " + styles.layeringOptionText.text, (uint)LayerExpendable.MainInput, this, colorDot: s_Styles.layerColors[layerIndex]))
                 {
                     if (header.expended)
                         m_MaterialEditor.TexturePropertySingleLine(styles.layerInfluenceMapMaskText, layerInfluenceMaskMap);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
@@ -249,9 +249,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected override void BaseMaterialPropertiesGUI()
         {
             base.BaseMaterialPropertiesGUI();
-
-            EditorGUI.indentLevel++;
-
+            
             // This follow double sided option
             if (doubleSidedEnable != null && doubleSidedEnable.floatValue > 0.0f)
             {
@@ -327,8 +325,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     EditorGUI.indentLevel--;
                 }
             }
-
-            EditorGUI.indentLevel--;
         }
 
         protected virtual void MaterialTesselationPropertiesGUI()

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
@@ -288,9 +288,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
 
-            if (enableMotionVectorForVertexAnimation != null)
-                m_MaterialEditor.ShaderProperty(enableMotionVectorForVertexAnimation, StylesBaseUnlit.enableMotionVectorForVertexAnimationText);
-
             if (displacementMode != null)
             {
                 EditorGUI.BeginChangeCheck();
@@ -393,24 +390,27 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         protected override void VertexAnimationPropertiesGUI()
         {
-            if (windEnable == null)
-                return;
-            
             using (var header = new HeaderScope(StylesBaseLit.vertexAnimation, (uint)Expendable.VertexAnimation, this))
             {
                 if (header.expended)
                 {
-                    m_MaterialEditor.ShaderProperty(windEnable, StylesBaseLit.windText);
-                    if (!windEnable.hasMixedValue && windEnable.floatValue > 0.0f)
+                    if (windEnable != null)
                     {
-                        EditorGUI.indentLevel++;
-                        m_MaterialEditor.ShaderProperty(windInitialBend, StylesBaseLit.windInitialBendText);
-                        m_MaterialEditor.ShaderProperty(windStiffness, StylesBaseLit.windStiffnessText);
-                        m_MaterialEditor.ShaderProperty(windDrag, StylesBaseLit.windDragText);
-                        m_MaterialEditor.ShaderProperty(windShiverDrag, StylesBaseLit.windShiverDragText);
-                        m_MaterialEditor.ShaderProperty(windShiverDirectionality, StylesBaseLit.windShiverDirectionalityText);
-                        EditorGUI.indentLevel--;
+                        m_MaterialEditor.ShaderProperty(windEnable, StylesBaseLit.windText);
+                        if (!windEnable.hasMixedValue && windEnable.floatValue > 0.0f)
+                        {
+                            EditorGUI.indentLevel++;
+                            m_MaterialEditor.ShaderProperty(windInitialBend, StylesBaseLit.windInitialBendText);
+                            m_MaterialEditor.ShaderProperty(windStiffness, StylesBaseLit.windStiffnessText);
+                            m_MaterialEditor.ShaderProperty(windDrag, StylesBaseLit.windDragText);
+                            m_MaterialEditor.ShaderProperty(windShiverDrag, StylesBaseLit.windShiverDragText);
+                            m_MaterialEditor.ShaderProperty(windShiverDirectionality, StylesBaseLit.windShiverDirectionalityText);
+                            EditorGUI.indentLevel--;
+                        }
                     }
+
+                    if (enableMotionVectorForVertexAnimation != null)
+                        m_MaterialEditor.ShaderProperty(enableMotionVectorForVertexAnimation, StylesBaseUnlit.enableMotionVectorForVertexAnimationText);
                 }
             }
         }


### PR DESCRIPTION
### Purpose of this PR
Fix layer 2 do not show up if directly modifying a layered material layer count parameter (without using slider)
Fix Layerying option name for Main Layer
See https://unity.slack.com/archives/C6Y79CZM0/p1537528286000100

Also fix indentation in Surface options
And move "Enable MotionVector for Vertex Animation" in the adequate area

---
### Release Notes
Fix LayerLit material inspector issue where layer 2 not appears every time

---
### Testing status
**Katana Tests**: 

**Manual Tests**: tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None (few lines)

**Halo Effect**: None (only layered lit material inspector affected)

---
### Comments to reviewers
