### PR TITLE
Avoid recomputing FGD tables every frame

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.cs
@@ -181,6 +181,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_preIntegratedFGD_Ward = null;
             m_preIntegratedFGDMaterial_Ward = null;
             m_preIntegratedFGDMaterial_CookTorrance = null;
+            m_precomputedFGDTablesAreInit = false;
 
             // LTC data
             CoreUtils.Destroy(m_LtcData);

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.cs
@@ -117,6 +117,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         RenderTexture   m_preIntegratedFGD_Ward = null;
         RenderTexture   m_preIntegratedFGD_CookTorrance = null;
 
+        private bool m_precomputedFGDTablesAreInit = false;
+
         public static readonly int _PreIntegratedFGD_Ward = Shader.PropertyToID("_PreIntegratedFGD_Ward");
         public static readonly int _PreIntegratedFGD_CookTorrance = Shader.PropertyToID("_PreIntegratedFGD_CookTorrance");
         public static readonly int _AxFLtcData = Shader.PropertyToID("_AxFLtcData");
@@ -186,7 +188,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public override void RenderInit(CommandBuffer cmd)
         {
-            if (m_preIntegratedFGDMaterial_Ward == null || m_preIntegratedFGDMaterial_CookTorrance == null)
+            if (m_precomputedFGDTablesAreInit || m_preIntegratedFGDMaterial_Ward == null || m_preIntegratedFGDMaterial_CookTorrance == null)
             {
                 return;
             }
@@ -196,6 +198,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 CoreUtils.DrawFullScreen(cmd, m_preIntegratedFGDMaterial_Ward, new RenderTargetIdentifier(m_preIntegratedFGD_Ward));
                 CoreUtils.DrawFullScreen(cmd, m_preIntegratedFGDMaterial_CookTorrance, new RenderTargetIdentifier(m_preIntegratedFGD_CookTorrance));
             }
+
+            m_precomputedFGDTablesAreInit = true;
         }
 
         public override void Bind()


### PR DESCRIPTION
### Purpose of this PR
Check if FGD tables for AxF have been already init, if so don't recompute them again. 
---
### Release Notes
Avoid preintegration of AxF's FGD tables every frame. 

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=AxF-fix-preintegrated-FGD-every-frame&automation-tools_branch=add-platform-filter&unity_branch=trunk [Still running]


---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: Low

