### PR TITLE
Update motion vector pass for stacklit and fabric

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Fabric/Fabric.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Fabric/Fabric.shader
@@ -232,6 +232,36 @@ Shader "HDRenderPipeline/Fabric"
             ENDHLSL
         }
 
+        Pass
+        {
+            Name "Motion Vectors"
+            Tags{ "LightMode" = "MotionVectors" } // Caution, this need to be call like this to setup the correct parameters by C++ (legacy Unity)
+             // If velocity pass (motion vectors) is enabled we tag the stencil so it don't perform CameraMotionVelocity
+            Stencil
+            {
+                WriteMask [_StencilWriteMaskMV]
+                Ref [_StencilRefMV]
+                Comp Always
+                Pass Replace
+            }
+
+            Cull[_CullMode]
+
+            ZWrite On
+
+            HLSLPROGRAM
+            #define WRITE_NORMAL_BUFFER
+            #pragma multi_compile _ WRITE_MSAA_DEPTH
+            
+            #define SHADERPASS SHADERPASS_VELOCITY
+            #include "../../ShaderVariables.hlsl"
+            #include "../../Material/Material.hlsl"
+            #include "ShaderPass/FabricSharePass.hlsl"
+            #include "FabricData.hlsl"
+            #include "../../ShaderPass/ShaderPassVelocity.hlsl"
+            ENDHLSL
+        }
+
         // Extracts information for lightmapping, GI (emission, albedo, ...)
         // This pass it not used during regular rendering.
         Pass

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLit.shader
@@ -425,6 +425,36 @@ Shader "HDRenderPipeline/StackLit"
             ENDHLSL
         }
 
+        Pass
+        {
+            Name "Motion Vectors"
+            Tags{ "LightMode" = "MotionVectors" } // Caution, this need to be call like this to setup the correct parameters by C++ (legacy Unity)
+             // If velocity pass (motion vectors) is enabled we tag the stencil so it don't perform CameraMotionVelocity
+            Stencil
+            {
+                WriteMask [_StencilWriteMaskMV]
+                Ref [_StencilRefMV]
+                Comp Always
+                Pass Replace
+            }
+
+            Cull[_CullMode]
+
+            ZWrite On
+
+            HLSLPROGRAM
+            #define WRITE_NORMAL_BUFFER
+            #pragma multi_compile _ WRITE_MSAA_DEPTH
+            
+            #define SHADERPASS SHADERPASS_VELOCITY
+            #include "../../ShaderVariables.hlsl"
+            #include "../../Material/Material.hlsl"
+            #include "ShaderPass/StackLitSharePass.hlsl"
+            #include "StackLitData.hlsl"
+            #include "../../ShaderPass/ShaderPassVelocity.hlsl"
+            ENDHLSL
+        }
+
         // Extracts information for lightmapping, GI (emission, albedo, ...)
         // This pass it not used during regular rendering.
         Pass


### PR DESCRIPTION
Stacklit and Fabric miss a motion vector pass

Katana: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=fix-missing-motoin-vector-pass&automation-tools_branch=add-platform-filter&unity_branch=trunk#