### PR TITLE
Fix extension case sensitivity

### DIFF
--- a/TestProjects/ShaderGraph/Assets/Testing/Editor/IntegrationTests/ShaderGenerationTest.cs
+++ b/TestProjects/ShaderGraph/Assets/Testing/Editor/IntegrationTests/ShaderGenerationTest.cs
@@ -35,13 +35,14 @@ namespace UnityEditor.ShaderGraph.IntegrationTests
             {
                 get
                 {
-                    var filePaths = Directory.GetFiles(s_Path, "*.ShaderGraph", SearchOption.AllDirectories).Select(x => new FileInfo(x));
+                    var filePaths = Directory.GetFiles(s_Path, string.Format("*.{0}", ShaderGraphImporter.Extension), SearchOption.AllDirectories).Select(x => new FileInfo(x));
 
                     foreach (var p in filePaths)
                     {
+                        var extension = Path.GetExtension(p.FullName);
                         yield return new TestInfo
                         {
-                            name = p.FullName.Replace(s_Path + Path.DirectorySeparatorChar, "").Replace(Path.DirectorySeparatorChar, '/').Replace(".ShaderGraph", ""),
+                            name = p.FullName.Replace(s_Path + Path.DirectorySeparatorChar, "").Replace(Path.DirectorySeparatorChar, '/').Replace(extension, ""),
                             info = p,
                             threshold = 0.05f
                         };

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -75,3 +75,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - SpaceMaterialSlot now reads correct slot.
 - Slider node control now functions correctly.
 - Shader Graphs no longer display an error message intended for Sub Graphs when you delete properties.
+- The Shader Graph and Sub Shader Graph file extensions are no longer case-sensitive.

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -211,7 +211,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         public void ToSubGraph()
         {
-            var path = EditorUtility.SaveFilePanelInProject("Save subgraph", "New SubGraph", "ShaderSubGraph", "");
+            var path = EditorUtility.SaveFilePanelInProject("Save subgraph", "New SubGraph", ShaderSubGraphImporter.Extension, "");
             path = path.Replace(Application.dataPath, "Assets");
             if (path.Length == 0)
                 return;
@@ -482,13 +482,18 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                 var path = AssetDatabase.GetAssetPath(asset);
                 var extension = Path.GetExtension(path);
+                if (extension == null)
+                    return;
+                // Path.GetExtension returns the extension prefixed with ".", so we remove it. We force lower case such that
+                // the comparison will be case-insensitive.
+                extension = extension.Substring(1).ToLowerInvariant();
                 Type graphType;
                 switch (extension)
                 {
-                    case ".ShaderGraph":
+                    case ShaderGraphImporter.Extension:
                         graphType = typeof(MaterialGraph);
                         break;
-                    case ".ShaderSubGraph":
+                    case ShaderSubGraphImporter.Extension:
                         graphType = typeof(SubGraph);
                         break;
                     default:

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.ShaderGraph
         {
             foreach (var path in paths)
             {
-                if (!path.EndsWith(ShaderGraphImporter.ShaderGraphExtension, StringComparison.InvariantCultureIgnoreCase))
+                if (!path.EndsWith(ShaderGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase))
                     continue;
 
                 var mainObj = AssetDatabase.LoadMainAssetAtPath(path);
@@ -53,7 +53,7 @@ namespace UnityEditor.ShaderGraph
 
             RegisterShaders(importedAssets);
 
-            bool anyShaders = movedAssets.Any(val => val.EndsWith(ShaderGraphImporter.ShaderGraphExtension, StringComparison.InvariantCultureIgnoreCase));
+            bool anyShaders = movedAssets.Any(val => val.EndsWith(ShaderGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
             anyShaders |= movedAssets.Any(val => val.EndsWith("shadersubgraph", StringComparison.InvariantCultureIgnoreCase));
             if (anyShaders)
                 UpdateAfterAssetChange(movedAssets);

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -1,20 +1,17 @@
-using UnityEditor.ShaderGraph;
 using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
-using UnityEditor.ShaderGraph.Drawing;
 
 namespace UnityEditor.ShaderGraph
 {
-    [ScriptedImporter(18, ShaderGraphExtension)]
+    [ScriptedImporter(18, Extension)]
     public class ShaderGraphImporter : ScriptedImporter
     {
-        public const string ShaderGraphExtension = "shadergraph";
+        public const string Extension = "shadergraph";
 
         const string k_ErrorShader = @"
 Shader ""Hidden/GraphErrorShader2""

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporterEditor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporterEditor.cs
@@ -1,5 +1,5 @@
+using System;
 using System.IO;
-using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEditor.ShaderGraph.Drawing;
@@ -25,7 +25,12 @@ namespace UnityEditor.ShaderGraph
         {
             var guid = AssetDatabase.AssetPathToGUID(path);
             var extension = Path.GetExtension(path);
-            if (extension != ".ShaderGraph" && extension != ".LayeredShaderGraph" && extension != ".ShaderSubGraph" && extension != ".ShaderRemapGraph")
+            if (extension == null)
+                return false;
+            // Path.GetExtension returns the extension prefixed with ".", so we remove it. We force lower case such that
+            // the comparison will be case-insensitive.
+            extension = extension.Substring(1).ToLowerInvariant();
+            if (extension != ShaderGraphImporter.Extension && extension != ShaderSubGraphImporter.Extension)
                 return false;
 
             var foundWindow = false;

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -6,9 +6,11 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-[ScriptedImporter(2, "ShaderSubGraph")]
+[ScriptedImporter(2, Extension)]
 public class ShaderSubGraphImporter : ScriptedImporter
 {
+    public const string Extension = "shadersubgraph";
+
     public override void OnImportAsset(AssetImportContext ctx)
     {
         var textGraph = File.ReadAllText(ctx.assetPath, Encoding.UTF8);


### PR DESCRIPTION
### Purpose of this PR
Shader Graphs that were not matching exactly ".ShaderGraph" with that casing would fail to open in the Shader Graph Editor. Note that this also changes the extension for newly created Shader Graph files from ".ShaderGraph" to ".shadergraph".  Existing files won't have their extension changed.

---
### Release Notes
The Shader Graph and Sub Shader Graph file extensions are no longer case-sensitive.

---
### Testing status
**Katana Tests**: Running [here](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Ffix-importer-editor-extension-check&automation-tools_branch=add-platform-filter&unity_branch=trunk).

**Manual Tests**: Opened Shader Graph files using ".ShaderGraph", ".shadergraph", ".ShaderSubGraph", and ".shadersubgraph" extensions.

**Automated Tests**: Nothing new.

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low

**Halo Effect**: None, Low, Medium, High? None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
