### PR TITLE
Fix DynamicValueMaterialSlot decimal separator

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -75,3 +75,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - SpaceMaterialSlot now reads correct slot.
 - Slider node control now functions correctly.
 - Shader Graphs no longer display an error message intended for Sub Graphs when you delete properties.
+- The dynamic value slot type now uses the correct decimal separator during HLSL generation.

--- a/com.unity.shadergraph/Editor/Data/Graphs/DynamicValueMaterialSlot.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/DynamicValueMaterialSlot.cs
@@ -82,7 +82,7 @@ namespace UnityEditor.ShaderGraph
             if (channelCount == 1)
                 return values;
             for (var i = 1; i < channelCount; i++)
-                values += ", " + value.GetRow(0)[i];
+                values += ", " + NodeUtils.FloatToShaderValue(value.GetRow(0)[i]);
             return string.Format("{0}{1}({2})", precision, channelCount, values);
         }
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -11,7 +11,7 @@ using UnityEditor.ShaderGraph.Drawing;
 
 namespace UnityEditor.ShaderGraph
 {
-    [ScriptedImporter(18, ShaderGraphExtension)]
+    [ScriptedImporter(19, ShaderGraphExtension)]
     public class ShaderGraphImporter : ScriptedImporter
     {
         public const string ShaderGraphExtension = "shadergraph";


### PR DESCRIPTION
### Purpose of this PR
Found yet another instance where we incorrectly convert a float to a string, which causes shader compile errors on certain locales. Bumping importer version because it changes shader generation for some people.

---
### Release Notes
The dynamic value slot type now uses the correct decimal separator during HLSL generation.

---
### Testing status
**Katana Tests**: Running [here](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Ffix-dynamicvaluematerialslot-decimal-separator&automation-tools_branch=add-platform-filter&unity_branch=trunk)

**Manual Tests**: Open up Unity and check that stuff still generally works. This is the same fix that we have been applying to other instances of the issue for a long time.

**Automated Tests**: Nothing new.

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
