### PR TITLE
Lw/api review v6

### DIFF
--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/lightweightPBRForwardPass.template
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/lightweightPBRForwardPass.template
@@ -159,7 +159,7 @@ ${PixelShaderSurfaceRemap}
 			Alpha);
 
 		// Computes fog factor per-vertex
-    	ApplyFog(color.rgb, IN.fogFactorAndVertexLight.x);
+    	color.rgb = MixFog(color.rgb, IN.fogFactorAndVertexLight.x);
 
 #if _AlphaClip
 		clip(Alpha - AlphaClipThreshold);

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/lightweightPBRForwardPass.template
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/lightweightPBRForwardPass.template
@@ -126,7 +126,7 @@ ${PixelShaderSurfaceRemap}
 		inputData.positionWS = WorldSpacePosition;
 
 #ifdef _NORMALMAP
-	    inputData.normalWS = TangentToWorldNormal(Normal, WorldSpaceTangent, WorldSpaceBiTangent, WorldSpaceNormal);
+	    inputData.normalWS = normalize(TransformTangentToWorld(Normal, half3x3(WorldSpaceTangent, WorldSpaceBiTangent, WorldSpaceNormal)));
 #else
     #if !SHADER_HINT_NICE_QUALITY
         inputData.normalWS = WorldSpaceNormal;

--- a/com.unity.render-pipelines.lightweight/Runtime/Data/LightweightRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/Data/LightweightRenderPipelineAsset.cs
@@ -62,9 +62,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
     public class LightweightRenderPipelineAsset : RenderPipelineAsset, ISerializationCallbackReceiver
     {
-        static readonly string s_SearchPathProject = "Assets";
-        static readonly string s_SearchPathPackage = "Packages/com.unity.render-pipelines.lightweight";
-
         Shader m_DefaultShader;
 
         // Default values set when a new LightweightRenderPipeline asset is created
@@ -117,6 +114,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 #if UNITY_EDITOR
         [NonSerialized]
         LightweightRenderPipelineEditorResources m_EditorResourcesAsset;
+
+        static readonly string s_SearchPathProject = "Assets";
+        static readonly string s_SearchPathPackage = "Packages/com.unity.render-pipelines.lightweight";
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1812")]
         internal class CreateLightweightPipelineAsset : EndNameEditAction

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -162,7 +162,7 @@ half3 MixFogColor(real3 fragColor, real3 fogColor, real fogFactor)
     // fogFactor = density*z compute at vertex
     fogFactor = saturate(exp2(-fogFactor*fogFactor));
 #endif
-    color = lerp(fogColor, fragColor, fogFactor);
+    fragColor = lerp(fogColor, fragColor, fogFactor);
 #endif
 
     return fragColor;

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -78,21 +78,6 @@ VertexNormalInputs GetVertexNormalInputs(float3 normalOS, float4 tangentOS)
     #define UNITY_Z_0_FAR_FROM_CLIPSPACE(coord) (coord)
 #endif
 
-// TODO: Really need a better define for iOS Metal than the framebuffer fetch one, that's also enabled on android and webgl (???)
-#if defined(SHADER_API_VULKAN) || (defined(SHADER_API_METAL) && defined(UNITY_FRAMEBUFFER_FETCH_AVAILABLE))
-    // Renderpass inputs: Vulkan/Metal subpass input
-#define UNITY_DECLARE_FRAMEBUFFER_INPUT_FLOAT(idx) cbuffer hlslcc_SubpassInput_f_##idx { float4 hlslcc_fbinput_##idx; }
-#define UNITY_DECLARE_FRAMEBUFFER_INPUT_HALF(idx) cbuffer hlslcc_SubpassInput_h_##idx { half4 hlslcc_fbinput_##idx; }
-
-#define UNITY_READ_FRAMEBUFFER_INPUT(idx, v2fname) hlslcc_fbinput_##idx
-#else
-    // Renderpass inputs: General fallback path
-#define UNITY_DECLARE_FRAMEBUFFER_INPUT_FLOAT(idx) TEXTURE2D_FLOAT(_UnityFBInput##idx); float4 _UnityFBInput##idx##_TexelSize
-#define UNITY_DECLARE_FRAMEBUFFER_INPUT_HALF(idx) TEXTURE2D_HALF(_UnityFBInput##idx); float4 _UnityFBInput##idx##_TexelSize
-
-#define UNITY_READ_FRAMEBUFFER_INPUT(idx, v2fvertexname) _UnityFBInput##idx.Load(uint3(v2fvertexname.xy, 0))
-#endif
-
 float3 GetCameraPositionWS()
 {
     return _WorldSpaceCameraPos;

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -124,26 +124,6 @@ real3 NormalizeNormalPerPixel(real3 normal)
 #endif
 }
 
-real3 FragmentViewDirWS(real3 viewDir)
-{
-#if !SHADER_HINT_NICE_QUALITY
-    // View direction is already normalized in vertex. Small acceptable error to save ALU.
-    return viewDir;
-#else
-    return SafeNormalize(viewDir);
-#endif
-}
-
-real3 VertexViewDirWS(real3 viewDir)
-{
-#if !SHADER_HINT_NICE_QUALITY
-    // Normalize in vertex and avoid renormalizing it in frag to save ALU.
-    return SafeNormalize(viewDir);
-#else
-    return viewDir;
-#endif
-}
-
 // TODO: A similar function should be already available in SRP lib on master. Use that instead
 float4 ComputeScreenPos(float4 positionCS)
 {

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -27,7 +27,7 @@ struct VertexPositionInputs
 struct VertexNormalInputs
 {
     real3 tangentWS;
-    real3 binormalWS;
+    real3 bitangentWS;
     real3 normalWS;
 };
 
@@ -44,7 +44,7 @@ VertexNormalInputs GetVertexNormalInputs(float3 normalOS)
 {
     VertexNormalInputs tbn;
     tbn.tangentWS = real3(1.0, 0.0, 0.0);
-    tbn.binormalWS = real3(0.0, 1.0, 0.0);
+    tbn.bitangentWS = real3(0.0, 1.0, 0.0);
     tbn.normalWS = TransformObjectToWorldNormal(normalOS);
     return tbn;
 }
@@ -57,7 +57,7 @@ VertexNormalInputs GetVertexNormalInputs(float3 normalOS, float4 tangentOS)
     real sign = tangentOS.w * GetOddNegativeScale();
     tbn.normalWS = TransformObjectToWorldNormal(normalOS);
     tbn.tangentWS = TransformObjectToWorldDir(tangentOS.xyz);
-    tbn.binormalWS = cross(tbn.normalWS, tbn.tangentWS) * sign;
+    tbn.bitangentWS = cross(tbn.normalWS, tbn.tangentWS) * sign;
     return tbn;
 }
 

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -191,7 +191,7 @@ real ComputeFogFactor(float z)
 #endif
 }
 
-void ApplyFogColor(inout real3 color, real3 fogColor, real fogFactor)
+half3 MixFogColor(real3 fragColor, real3 fogColor, real fogFactor)
 {
 #if defined(FOG_LINEAR) || defined(FOG_EXP) || defined(FOG_EXP2)
 #if defined(FOG_EXP)
@@ -203,13 +203,15 @@ void ApplyFogColor(inout real3 color, real3 fogColor, real fogFactor)
     // fogFactor = density*z compute at vertex
     fogFactor = saturate(exp2(-fogFactor*fogFactor));
 #endif
-    color = lerp(fogColor, color, fogFactor);
+    color = lerp(fogColor, fragColor, fogFactor);
 #endif
+
+    return fragColor;
 }
 
-void ApplyFog(inout real3 color, real fogFactor)
+half3 MixFog(real3 fragColor, real fogFactor)
 {
-    ApplyFogColor(color, unity_FogColor.rgb, fogFactor);
+    return MixFogColor(fragColor, unity_FogColor.rgb, fogFactor);
 }
 
 // Stereo-related bits

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -3,7 +3,7 @@
 
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl"
-#include "Input.hlsl"
+#include "Packages/com.unity.render-pipelines.lightweight/ShaderLibrary/Input.hlsl"
 
 #if !defined(SHADER_HINT_NICE_QUALITY)
 #ifdef SHADER_API_MOBILE

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -24,7 +24,7 @@ struct VertexPositionInputs
     float4 positionCS; // Homogeneous clip space position
 };
 
-struct VertexTBN
+struct VertexNormalInputs
 {
     real3 tangentWS;
     real3 binormalWS;
@@ -40,18 +40,18 @@ VertexPositionInputs GetVertexPositionInputs(float3 positionOS)
     return input;
 }
 
-VertexTBN GetVertexTBN(float3 normalOS)
+VertexNormalInputs GetVertexNormalInputs(float3 normalOS)
 {
-    VertexTBN tbn;
+    VertexNormalInputs tbn;
     tbn.tangentWS = real3(1.0, 0.0, 0.0);
     tbn.binormalWS = real3(0.0, 1.0, 0.0);
     tbn.normalWS = TransformObjectToWorldNormal(normalOS);
     return tbn;
 }
 
-VertexTBN GetVertexTBN(float3 normalOS, float4 tangentOS)
+VertexNormalInputs GetVertexNormalInputs(float3 normalOS, float4 tangentOS)
 {
-    VertexTBN tbn;
+    VertexNormalInputs tbn;
 
     // mikkts space compliant. only normalize when extracting normal at frag.
     real sign = tangentOS.w * GetOddNegativeScale();

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -144,12 +144,6 @@ real3 VertexViewDirWS(real3 viewDir)
 #endif
 }
 
-real3 TangentToWorldNormal(real3 normalTangent, real3 tangent, real3 binormal, real3 normal)
-{
-    real3x3 tangentToWorld = real3x3(tangent, binormal, normal);
-    return FragmentNormalWS(mul(normalTangent, tangentToWorld));
-}
-
 // TODO: A similar function should be already available in SRP lib on master. Use that instead
 float4 ComputeScreenPos(float4 positionCS)
 {

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -114,7 +114,7 @@ real3 UnpackNormalScale(real4 packedNormal, real bumpScale)
 #endif
 }
 
-real3 FragmentNormalWS(real3 normal)
+real3 NormalizeNormalPerPixel(real3 normal)
 {
 #if !SHADER_HINT_NICE_QUALITY
     // World normal is already normalized in vertex. Small acceptable error to save ALU.

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Lighting.hlsl
@@ -36,15 +36,6 @@
 //                          Light Helpers                                    //
 ///////////////////////////////////////////////////////////////////////////////
 
-// Abstraction over Light input constants
-struct LightInput
-{
-    float4  position;
-    half3   color;
-    half4   distanceAndSpotAttenuation;
-    half4   spotDirection;
-};
-
 // Abstraction over Light shading data.
 struct Light
 {
@@ -111,18 +102,6 @@ half AngleAttenuation(half3 spotDirection, half3 lightDirection, half2 spotAtten
     half SdotL = dot(spotDirection, lightDirection);
     half atten = saturate(SdotL * spotAttenuation.x + spotAttenuation.y);
     return atten * atten;
-}
-
-half4 GetLightDirectionAndAttenuation(LightInput lightInput, float3 positionWS)
-{
-    half4 directionAndAttenuation;
-    float3 posToLightVec = lightInput.position.xyz - positionWS * lightInput.position.w;
-    float distanceSqr = max(dot(posToLightVec, posToLightVec), FLT_MIN);
-
-    directionAndAttenuation.xyz = half3(posToLightVec * rsqrt(distanceSqr));
-    directionAndAttenuation.w = DistanceAttenuation(distanceSqr, lightInput.distanceAndSpotAttenuation.xy);
-    directionAndAttenuation.w *= AngleAttenuation(lightInput.spotDirection.xyz, directionAndAttenuation.xyz, lightInput.distanceAndSpotAttenuation.zw);
-    return directionAndAttenuation;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Lighting.hlsl
@@ -4,8 +4,8 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/EntityLighting.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
-#include "Core.hlsl"
-#include "Shadows.hlsl"
+#include "Packages/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl"
+#include "Packages/com.unity.render-pipelines.lightweight/ShaderLibrary/Shadows.hlsl"
 
 // If lightmap is not defined than we evaluate GI (ambient + probes) from SH
 // We might do it fully or partially in vertex to save shader ALU

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
@@ -250,10 +250,11 @@ void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData o
     output.positionWS = input.posWS.xyz;
 
 #if _NORMALMAP
-    output.normalWS = TangentToWorldNormal(normalTS, input.tangent, input.binormal, input.normal);
+    output.normalWS = TransformTangentToWorld(normalTS, half3x3(input.tangent, input.binormal, input.normal));
 #else
-    output.normalWS = FragmentNormalWS(input.normal);
+    output.normalWS = input.normal;
 #endif
+    output.normalWS = FragmentNormalWS(output.normalWS);
 
     output.viewDirectionWS = FragmentViewDirWS(input.viewDirShininess.xyz);
     output.shadowCoord = float4(0, 0, 0, 0);

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
@@ -247,6 +247,11 @@ half3 AlphaModulate(half3 albedo, half alpha)
 
 void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData output)
 {
+    half3 viewDirWS = input.viewDirShininess.xyz;
+#if SHADER_HINT_NICE_QUALITY
+    viewDirWS = SafeNormalize(viewDirWS);
+#endif
+
     output.positionWS = input.posWS.xyz;
 
 #if _NORMALMAP
@@ -256,7 +261,7 @@ void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData o
 #endif
     output.normalWS = NormalizeNormalPerPixel(output.normalWS);
 
-    output.viewDirectionWS = FragmentViewDirWS(input.viewDirShininess.xyz);
+    output.viewDirectionWS = viewDirWS;
     output.shadowCoord = float4(0, 0, 0, 0);
     output.fogCoord = (half)input.posWS.w;
     output.vertexLighting = half3(0.0h, 0.0h, 0.0h);

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
@@ -254,7 +254,7 @@ void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData o
 #else
     output.normalWS = input.normal;
 #endif
-    output.normalWS = FragmentNormalWS(output.normalWS);
+    output.normalWS = NormalizeNormalPerPixel(output.normalWS);
 
     output.viewDirectionWS = FragmentViewDirWS(input.viewDirShininess.xyz);
     output.shadowCoord = float4(0, 0, 0, 0);

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Particles.hlsl
@@ -147,7 +147,7 @@ struct VaryingsParticle
     float2 texcoord                 : TEXCOORD0;
 #ifdef _NORMALMAP
     half3 tangent                   : TEXCOORD1;
-    half3 binormal                  : TEXCOORD2;
+    half3 bitangent                  : TEXCOORD2;
     half3 normal                    : TEXCOORD3;
 #else
     half3 normal                    : TEXCOORD1;
@@ -250,7 +250,7 @@ void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData o
     output.positionWS = input.posWS.xyz;
 
 #if _NORMALMAP
-    output.normalWS = TransformTangentToWorld(normalTS, half3x3(input.tangent, input.binormal, input.normal));
+    output.normalWS = TransformTangentToWorld(normalTS, half3x3(input.tangent, input.bitangent, input.normal));
 #else
     output.normalWS = input.normal;
 #endif

--- a/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
@@ -25,7 +25,7 @@ struct Varyings
 #ifdef _NORMALMAP
     half4 normalWS                  : TEXCOORD3;    // xyz: normal, w: viewDir.x
     half4 tangentWS                 : TEXCOORD4;    // xyz: tangent, w: viewDir.y
-    half4 binormalWS                : TEXCOORD5;    // xyz: binormal, w: viewDir.z
+    half4 bitangentWS                : TEXCOORD5;    // xyz: bitangent, w: viewDir.z
 #else
     half3 normalWS                  : TEXCOORD3;
     half3 viewDirWS                 : TEXCOORD4;
@@ -51,9 +51,9 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
 #endif
 
 #ifdef _NORMALMAP
-    half3 viewDirWS = half3(input.normalWS.w, input.tangentWS.w, input.binormalWS.w);
+    half3 viewDirWS = half3(input.normalWS.w, input.tangentWS.w, input.bitangentWS.w);
     inputData.normalWS = TransformTangentToWorld(normalTS,
-        half3x3(input.tangentWS.xyz, input.binormalWS.xyz, input.normalWS.xyz));
+        half3x3(input.tangentWS.xyz, input.bitangentWS.xyz, input.normalWS.xyz));
 #else
     half3 viewDirWS = input.viewDirWS;
     inputData.normalWS = input.normalWS;
@@ -96,7 +96,7 @@ Varyings LitPassVertex(Attributes input)
 #ifdef _NORMALMAP
     output.normalWS = half4(normalInput.normalWS, viewDir.x);
     output.tangentWS = half4(normalInput.tangentWS, viewDir.y);
-    output.binormalWS = half4(normalInput.binormalWS, viewDir.z);
+    output.bitangentWS = half4(normalInput.bitangentWS, viewDir.z);
 #else
     output.normalWS = normalInput.normalWS;
     output.viewDirWS = viewDir;

--- a/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
@@ -130,7 +130,7 @@ half4 LitPassFragment(Varyings input) : SV_Target
 
     half4 color = LightweightFragmentPBR(inputData, surfaceData.albedo, surfaceData.metallic, surfaceData.specular, surfaceData.smoothness, surfaceData.occlusion, surfaceData.emission, surfaceData.alpha);
 
-    ApplyFog(color.rgb, inputData.fogCoord);
+    color.rgb = MixFog(color.rgb, inputData.fogCoord);
     return color;
 }
 

--- a/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
@@ -59,7 +59,7 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     inputData.normalWS = input.normalWS;
 #endif
 
-    inputData.normalWS = FragmentNormalWS(inputData.normalWS);
+    inputData.normalWS = NormalizeNormalPerPixel(inputData.normalWS);
 
     inputData.viewDirectionWS = FragmentViewDirWS(viewDirWS);
 #if defined(_MAIN_LIGHT_SHADOWS) && !defined(_RECEIVE_SHADOWS_OFF)

--- a/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
@@ -83,19 +83,19 @@ Varyings LitPassVertex(Attributes input)
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
     VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
-    VertexTBN vertexTBN = GetVertexTBN(input.normalOS, input.tangentOS);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
     half3 viewDir = VertexViewDirWS(GetCameraPositionWS() - vertexInput.positionWS);
-    half3 vertexLight = VertexLighting(vertexInput.positionWS, vertexTBN.normalWS);
+    half3 vertexLight = VertexLighting(vertexInput.positionWS, normalInput.normalWS);
     half fogFactor = ComputeFogFactor(vertexInput.positionCS.z);
 
     output.uv = TRANSFORM_TEX(input.texcoord, _MainTex);
 
 #ifdef _NORMALMAP
-    output.normalWS = half4(vertexTBN.normalWS, viewDir.x);
-    output.tangentWS = half4(vertexTBN.tangentWS, viewDir.y);
-    output.binormalWS = half4(vertexTBN.binormalWS, viewDir.z);
+    output.normalWS = half4(normalInput.normalWS, viewDir.x);
+    output.tangentWS = half4(normalInput.tangentWS, viewDir.y);
+    output.binormalWS = half4(normalInput.binormalWS, viewDir.z);
 #else
-    output.normalWS = vertexTBN.normalWS;
+    output.normalWS = normalInput.normalWS;
     output.viewDirWS = viewDir;
 #endif
     

--- a/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/LitForwardPass.hlsl
@@ -52,11 +52,14 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
 
 #ifdef _NORMALMAP
     half3 viewDirWS = half3(input.normalWS.w, input.tangentWS.w, input.binormalWS.w);
-    inputData.normalWS = TangentToWorldNormal(normalTS, input.tangentWS.xyz, input.binormalWS.xyz, input.normalWS.xyz);
+    inputData.normalWS = TransformTangentToWorld(normalTS,
+        half3x3(input.tangentWS.xyz, input.binormalWS.xyz, input.normalWS.xyz));
 #else
     half3 viewDirWS = input.viewDirWS;
-    inputData.normalWS = FragmentNormalWS(input.normalWS);
+    inputData.normalWS = input.normalWS;
 #endif
+
+    inputData.normalWS = FragmentNormalWS(inputData.normalWS);
 
     inputData.viewDirectionWS = FragmentViewDirWS(viewDirWS);
 #if defined(_MAIN_LIGHT_SHADOWS) && !defined(_RECEIVE_SHADOWS_OFF)

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
@@ -115,7 +115,7 @@ Shader "Lightweight Render Pipeline/Particles/Lit"
 
                 half4 color = LightweightFragmentPBR(inputData, surfaceData.albedo,
                     surfaceData.metallic, half3(0, 0, 0), surfaceData.smoothness, surfaceData.occlusion, surfaceData.emission, surfaceData.alpha);
-                ApplyFog(color.rgb, inputData.fogCoord);
+                color.rgb = MixFog(color.rgb, inputData.fogCoord);
                 return color;
             }
 

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
@@ -83,7 +83,10 @@ Shader "Lightweight Render Pipeline/Particles/Lit"
                     , input.tangent
 #endif
                 );
-
+                half3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
+#if !SHADER_HINT_NICE_QUALITY
+                viewDirWS = SafeNormalize(viewDirWS);
+#endif
 
                 output.normal = normalInput.normalWS;
 #ifdef _NORMAL_MAP
@@ -94,8 +97,7 @@ Shader "Lightweight Render Pipeline/Particles/Lit"
                 output.posWS.xyz = vertexInput.positionWS;
                 output.posWS.w = ComputeFogFactor(vertexInput.positionCS.z);
                 output.clipPos = vertexInput.positionCS;
-                output.viewDirShininess.xyz = VertexViewDirWS(GetCameraPositionWS() - vertexInput.positionWS);
-                output.viewDirShininess.w = 0.0;
+                output.viewDirShininess = half4(viewDirWS, 0.0);
                 output.color = input.color;
 
                 // TODO: Instancing

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
@@ -88,7 +88,7 @@ Shader "Lightweight Render Pipeline/Particles/Lit"
                 output.normal = normalInput.normalWS;
 #ifdef _NORMAL_MAP
                 output.tangent = normalInput.tangentWS;
-                output.binormal = normalInput.binormalWS;
+                output.bitangent = normalInput.bitangentWS;
 #endif
 
                 output.posWS.xyz = vertexInput.positionWS;

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesLit.shader
@@ -78,17 +78,17 @@ Shader "Lightweight Render Pipeline/Particles/Lit"
             {
                 VaryingsParticle output;
                 VertexPositionInputs vertexInput = GetVertexPositionInputs(input.vertex.xyz);
-                VertexTBN vertexTBN = GetVertexTBN(input.normal
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normal
 #if defined(_NORMALMAP)
                     , input.tangent
 #endif
                 );
 
 
-                output.normal = vertexTBN.normalWS;
+                output.normal = normalInput.normalWS;
 #ifdef _NORMAL_MAP
-                output.tangent = vertexTBN.tangentWS;
-                output.binormal = vertexTBN.binormalWS;
+                output.tangent = normalInput.tangentWS;
+                output.binormal = normalInput.binormalWS;
 #endif
 
                 output.posWS.xyz = vertexInput.positionWS;

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
@@ -100,7 +100,7 @@ Shader "Lightweight Render Pipeline/Particles/Simple Lit"
                 output.normal = normalInput.normalWS;
 #ifdef _NORMALMAP
                 output.tangent = normalInput.tangentWS;
-                output.binormal = normalInput.binormalWS;
+                output.bitangent = normalInput.bitangentWS;
 #endif
 
                 output.posWS.xyz = vertexInput.positionWS.xyz;

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
@@ -132,7 +132,7 @@ Shader "Lightweight Render Pipeline/Particles/Simple Lit"
 
                 half4 color = LightweightFragmentBlinnPhong(inputData, diffuse, specularGloss, shininess, emission, alpha);
 
-                ApplyFog(color.rgb, inputData.fogCoord);
+                color.rgb = MixFog(color.rgb, inputData.fogCoord);
                 return color;
             }
 

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
@@ -96,6 +96,10 @@ Shader "Lightweight Render Pipeline/Particles/Simple Lit"
                     , input.tangent
 #endif
                 );
+                half3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
+#if !SHADER_HINT_NICE_QUALITY
+                viewDirWS = SafeNormalize(viewDirWS);
+#endif
 
                 output.normal = normalInput.normalWS;
 #ifdef _NORMALMAP
@@ -106,8 +110,7 @@ Shader "Lightweight Render Pipeline/Particles/Simple Lit"
                 output.posWS.xyz = vertexInput.positionWS.xyz;
                 output.posWS.w = ComputeFogFactor(vertexInput.positionCS.z);
                 output.clipPos = vertexInput.positionCS;
-                output.viewDirShininess.xyz = VertexViewDirWS(GetCameraPositionWS() - vertexInput.positionWS);
-                output.viewDirShininess.w = _Shininess * 128.0h;
+                output.viewDirShininess = half4(viewDirWS, _Shininess * 128.0h);
                 output.color = input.color;
 
                 // TODO: Instancing

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesSimpleLit.shader
@@ -91,16 +91,16 @@ Shader "Lightweight Render Pipeline/Particles/Simple Lit"
                 VaryingsParticle output;
 
                 VertexPositionInputs vertexInput = GetVertexPositionInputs(input.vertex.xyz);
-                VertexTBN vertexTBN = GetVertexTBN(input.normal
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normal
 #if defined(_NORMALMAP)
                     , input.tangent
 #endif
                 );
 
-                output.normal = vertexTBN.normalWS;
+                output.normal = normalInput.normalWS;
 #ifdef _NORMALMAP
-                output.tangent = vertexTBN.tangentWS;
-                output.binormal = vertexTBN.binormalWS;
+                output.tangent = normalInput.tangentWS;
+                output.binormal = normalInput.binormalWS;
 #endif
 
                 output.posWS.xyz = vertexInput.positionWS.xyz;

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlit.shader
@@ -97,7 +97,7 @@ Shader "Lightweight Render Pipeline/Particles/Unlit"
 
                     half3 result = diffuse + emission;
                     half fogFactor = input.posWS.w;
-                    ApplyFogColor(result, half3(0, 0, 0), fogFactor);
+                    result = MixFogColor(result, half3(0, 0, 0), fogFactor);
                     return half4(result, alpha);
                 }
                 ENDHLSL

--- a/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
@@ -132,7 +132,7 @@ half4 LitPassFragmentSimple(Varyings input) : SV_Target
     InitializeInputData(input, normalTS, inputData);
 
     half4 color = LightweightFragmentBlinnPhong(inputData, diffuse, specularGloss, shininess, emission, alpha);
-    ApplyFog(color.rgb, inputData.fogCoord);
+    color.rgb = MixFog(color.rgb, inputData.fogCoord);
     return color;
 };
 

--- a/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
@@ -23,7 +23,7 @@ struct Varyings
 #ifdef _NORMALMAP
     half4 normal                    : TEXCOORD3;    // xyz: normal, w: viewDir.x
     half4 tangent                   : TEXCOORD4;    // xyz: tangent, w: viewDir.y
-    half4 binormal                  : TEXCOORD5;    // xyz: binormal, w: viewDir.z
+    half4 bitangent                  : TEXCOORD5;    // xyz: bitangent, w: viewDir.z
 #else
     half3  normal                   : TEXCOORD3;
     half3 viewDir                   : TEXCOORD4;
@@ -45,9 +45,9 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     inputData.positionWS = input.posWSShininess.xyz;
 
 #ifdef _NORMALMAP
-    half3 viewDir = half3(input.normal.w, input.tangent.w, input.binormal.w);
+    half3 viewDir = half3(input.normal.w, input.tangent.w, input.bitangent.w);
     inputData.normalWS = TransformTangentToWorld(normalTS,
-        half3x3(input.tangent.xyz, input.binormal.xyz, input.normal.xyz));
+        half3x3(input.tangent.xyz, input.bitangent.xyz, input.normal.xyz));
 #else
     half3 viewDir = input.viewDir;
     inputData.normalWS = input.normal;
@@ -93,7 +93,7 @@ Varyings LitPassVertexSimple(Attributes input)
 #ifdef _NORMALMAP
     output.normal = half4(normalInput.normalWS, viewDir.x);
     output.tangent = half4(normalInput.tangentWS, viewDir.y);
-    output.binormal = half4(normalInput.binormalWS, viewDir.z);
+    output.bitangent = half4(normalInput.bitangentWS, viewDir.z);
 #else
     output.normal = normalInput.normalWS;
     output.viewDir = viewDir;

--- a/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
@@ -77,7 +77,7 @@ Varyings LitPassVertexSimple(Attributes input)
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
     VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
-    VertexTBN vertexTBN = GetVertexTBN(input.normalOS, input.tangentOS);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
     half3 viewDir = VertexViewDirWS(GetCameraPositionWS() - vertexInput.positionWS);
     half3 vertexLight = VertexLighting(vertexInput.positionWS, output.normal.xyz);
     half fogFactor = ComputeFogFactor(vertexInput.positionCS.z);
@@ -88,11 +88,11 @@ Varyings LitPassVertexSimple(Attributes input)
     output.positionCS = vertexInput.positionCS;
 
 #ifdef _NORMALMAP
-    output.normal = half4(vertexTBN.normalWS, viewDir.x);
-    output.tangent = half4(vertexTBN.tangentWS, viewDir.y);
-    output.binormal = half4(vertexTBN.binormalWS, viewDir.z);
+    output.normal = half4(normalInput.normalWS, viewDir.x);
+    output.tangent = half4(normalInput.tangentWS, viewDir.y);
+    output.binormal = half4(normalInput.binormalWS, viewDir.z);
 #else
-    output.normal = vertexTBN.normalWS;
+    output.normal = normalInput.normalWS;
     output.viewDir = viewDir;
 #endif
 

--- a/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
@@ -53,7 +53,7 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     inputData.normalWS = input.normal;
 #endif
 
-    inputData.normalWS = FragmentNormalWS(inputData.normalWS);
+    inputData.normalWS = NormalizeNormalPerPixel(inputData.normalWS);
 
     inputData.viewDirectionWS = FragmentViewDirWS(viewDir);
 #if defined(_MAIN_LIGHT_SHADOWS) && !defined(_RECEIVE_SHADOWS_OFF)

--- a/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/SimpleLitForwardPass.hlsl
@@ -46,11 +46,14 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
 
 #ifdef _NORMALMAP
     half3 viewDir = half3(input.normal.w, input.tangent.w, input.binormal.w);
-    inputData.normalWS = TangentToWorldNormal(normalTS, input.tangent.xyz, input.binormal.xyz, input.normal.xyz);
+    inputData.normalWS = TransformTangentToWorld(normalTS,
+        half3x3(input.tangent.xyz, input.binormal.xyz, input.normal.xyz));
 #else
     half3 viewDir = input.viewDir;
-    inputData.normalWS = FragmentNormalWS(input.normal);
+    inputData.normalWS = input.normal;
 #endif
+
+    inputData.normalWS = FragmentNormalWS(inputData.normalWS);
 
     inputData.viewDirectionWS = FragmentViewDirWS(viewDir);
 #if defined(_MAIN_LIGHT_SHADOWS) && !defined(_RECEIVE_SHADOWS_OFF)

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainDetailLit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainDetailLit.shader
@@ -114,7 +114,7 @@ Shader "Hidden/TerrainEngine/Details/Vertexlit"
                 half4 color = 1.0;
                 color.rgb = input.Color.rgb * tex.rgb * lighting;
     
-                ApplyFog(color.rgb, input.LightingFog.w);
+                color.rgb = MixFog(color.rgb, input.LightingFog.w);
     
                 return color;
             }

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -183,11 +183,11 @@ VertexOutput SplatmapVert(VertexInput v)
 
 #if defined(_NORMALMAP) && !defined(ENABLE_TERRAIN_PERPIXEL_NORMAL)
     float4 vertexTangent = float4(cross(float3(0, 0, 1), v.normal), 1.0);
-    VertexTBN vertexTBN = GetVertexTBN(v.normal, vertexTangent);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(v.normal, vertexTangent);
 
-    o.normal = half4(vertexTBN.normalWS, viewDir.x);
-    o.tangent = half4(vertexTBN.tangentWS, viewDir.y);
-    o.binormal = half4(vertexTBN.binormalWS, viewDir.z);
+    o.normal = half4(normalInput.normalWS, viewDir.x);
+    o.tangent = half4(normalInput.tangentWS, viewDir.y);
+    o.binormal = half4(normalInput.binormalWS, viewDir.z);
 #else
     o.normal = TransformObjectToWorldNormal(v.normal);
     o.viewDir = viewDir;

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -70,7 +70,7 @@ void InitializeInputData(VertexOutput IN, half3 normalTS, out InputData input)
     input.normalWS = IN.normal;
 #endif
 
-    input.normalWS = FragmentNormalWS(input.normalWS);
+    input.normalWS = NormalizeNormalPerPixel(input.normalWS);
 
     input.viewDirectionWS = FragmentViewDirWS(viewDir);
 #ifdef _MAIN_LIGHT_SHADOWS

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -58,17 +58,19 @@ void InitializeInputData(VertexOutput IN, half3 normalTS, out InputData input)
 
 #if defined(_NORMALMAP) && !defined(ENABLE_TERRAIN_PERPIXEL_NORMAL)
     half3 viewDir = half3(IN.normal.w, IN.tangent.w, IN.binormal.w);
-    input.normalWS = TangentToWorldNormal(normalTS, IN.tangent.xyz, IN.binormal.xyz, IN.normal.xyz);
+    input.normalWS = TransformTangentToWorld(normalTS, half3x3(IN.tangent.xyz, IN.binormal.xyz, IN.normal.xyz));
 #elif defined(ENABLE_TERRAIN_PERPIXEL_NORMAL)
     half3 viewDir = IN.viewDir;
     float2 sampleCoords = (IN.uvMainAndLM.xy / _TerrainHeightmapRecipSize.zw + 0.5f) * _TerrainHeightmapRecipSize.xy;
     half3 normalWS = TransformObjectToWorldNormal(normalize(SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_TerrainNormalmapTexture, sampleCoords).rgb * 2 - 1));
     half3 tangentWS = cross(GetObjectToWorldMatrix()._13_23_33, normalWS);
-    input.normalWS = TangentToWorldNormal(normalTS, tangentWS, cross(normalWS, tangentWS), normalWS);
+    input.normalWS = TransformTangentToWorld(normalTS, half3x3(tangentWS, cross(normalWS, tangentWS), normalWS));
 #else
     half3 viewDir = IN.viewDir;
-    input.normalWS = FragmentNormalWS(IN.normal);
+    input.normalWS = IN.normal;
 #endif
+
+    input.normalWS = FragmentNormalWS(input.normalWS);
 
     input.viewDirectionWS = FragmentViewDirWS(viewDir);
 #ifdef _MAIN_LIGHT_SHADOWS

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -123,9 +123,9 @@ void SplatmapFinalColor(inout half4 color, half fogCoord)
 {
     color.rgb *= color.a;
     #ifdef TERRAIN_SPLAT_ADDPASS
-        ApplyFogColor(color.rgb, half3(0,0,0), fogCoord);
+        color.rgb = MixFogColor(color.rgb, half3(0,0,0), fogCoord);
     #else
-        ApplyFog(color.rgb, fogCoord);
+        color.rgb = MixFog(color.rgb, fogCoord);
     #endif
 }
 

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -38,7 +38,7 @@ struct VertexOutput
 #if defined(_NORMALMAP) && !defined(ENABLE_TERRAIN_PERPIXEL_NORMAL)
     half4 normal                    : TEXCOORD3;    // xyz: normal, w: viewDir.x
     half4 tangent                   : TEXCOORD4;    // xyz: tangent, w: viewDir.y
-    half4 binormal                  : TEXCOORD5;    // xyz: binormal, w: viewDir.z
+    half4 bitangent                  : TEXCOORD5;    // xyz: bitangent, w: viewDir.z
 #else
     half3 normal                    : TEXCOORD3;
     half3 viewDir                   : TEXCOORD4;
@@ -57,8 +57,8 @@ void InitializeInputData(VertexOutput IN, half3 normalTS, out InputData input)
     input.positionWS = IN.positionWS;
 
 #if defined(_NORMALMAP) && !defined(ENABLE_TERRAIN_PERPIXEL_NORMAL)
-    half3 viewDir = half3(IN.normal.w, IN.tangent.w, IN.binormal.w);
-    input.normalWS = TransformTangentToWorld(normalTS, half3x3(IN.tangent.xyz, IN.binormal.xyz, IN.normal.xyz));
+    half3 viewDir = half3(IN.normal.w, IN.tangent.w, IN.bitangent.w);
+    input.normalWS = TransformTangentToWorld(normalTS, half3x3(IN.tangent.xyz, IN.bitangent.xyz, IN.normal.xyz));
 #elif defined(ENABLE_TERRAIN_PERPIXEL_NORMAL)
     half3 viewDir = IN.viewDir;
     float2 sampleCoords = (IN.uvMainAndLM.xy / _TerrainHeightmapRecipSize.zw + 0.5f) * _TerrainHeightmapRecipSize.xy;
@@ -189,7 +189,7 @@ VertexOutput SplatmapVert(VertexInput v)
 
     o.normal = half4(normalInput.normalWS, viewDir.x);
     o.tangent = half4(normalInput.tangentWS, viewDir.y);
-    o.binormal = half4(normalInput.binormalWS, viewDir.z);
+    o.bitangent = half4(normalInput.bitangentWS, viewDir.z);
 #else
     o.normal = TransformObjectToWorldNormal(v.normal);
     o.viewDir = viewDir;

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/WavingGrassPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/WavingGrassPasses.hlsl
@@ -40,10 +40,14 @@ void InitializeInputData(GrassVertexOutput input, out InputData inputData)
 {
     inputData.positionWS = input.posWSShininess.xyz;
 
-    half3 viewDir = input.viewDir;
+    half3 viewDirWS = input.viewDir;
+#if SHADER_HINT_NICE_QUALITY
+    viewDirWS = SafeNormalize(viewDirWS);
+#endif
+
     inputData.normalWS = NormalizeNormalPerPixel(input.normal);
 
-    inputData.viewDirectionWS = FragmentViewDirWS(viewDir);
+    inputData.viewDirectionWS = viewDirWS;
 #ifdef _MAIN_LIGHT_SHADOWS
     inputData.shadowCoord = input.shadowCoord;
 #else
@@ -63,7 +67,12 @@ void InitializeVertData(GrassVertexInput input, inout GrassVertexOutput vertData
     vertData.posWSShininess.w = 32;
     vertData.clipPos = vertexInput.positionCS;
 
-    vertData.viewDir = VertexViewDirWS(GetCameraPositionWS() - vertexInput.positionWS);
+    vertData.viewDir = GetCameraPositionWS() - vertexInput.positionWS;
+
+#if !SHADER_QUALITY_NICE_HINT
+    vertData.viewDir = SafeNormalize(vertData.viewDir);
+#endif
+
     vertData.normal = TransformObjectToWorldNormal(input.normal);
 
     // We either sample GI from lightmap or SH.

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/WavingGrassPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/WavingGrassPasses.hlsl
@@ -148,7 +148,7 @@ half4 LitPassFragmentGrass(GrassVertexOutput input) : SV_Target
     InitializeInputData(input, inputData);
 
     half4 color = LightweightFragmentBlinnPhong(inputData, diffuse, specularGloss, shininess, emission, alpha);
-    ApplyFog(color.rgb, inputData.fogCoord);
+    color.rgb = MixFog(color.rgb, inputData.fogCoord);
     return color;
 };
 

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/WavingGrassPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/WavingGrassPasses.hlsl
@@ -41,7 +41,7 @@ void InitializeInputData(GrassVertexOutput input, out InputData inputData)
     inputData.positionWS = input.posWSShininess.xyz;
 
     half3 viewDir = input.viewDir;
-    inputData.normalWS = FragmentNormalWS(input.normal);
+    inputData.normalWS = NormalizeNormalPerPixel(input.normal);
 
     inputData.viewDirectionWS = FragmentViewDirWS(viewDir);
 #ifdef _MAIN_LIGHT_SHADOWS

--- a/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
@@ -70,7 +70,7 @@ Shader "Lightweight Render Pipeline/Unlit"
                 half3 normal                    : TEXCOORD2;
     #if _NORMALMAP
                 half3 tangent                   : TEXCOORD3;
-                half3 binormal                  : TEXCOORD4;
+                half3 bitangent                  : TEXCOORD4;
     #endif
 #endif
                 float4 vertex : SV_POSITION;
@@ -97,7 +97,7 @@ Shader "Lightweight Render Pipeline/Unlit"
                 output.normal = normalInput.normalWS;
 #ifdef _NORMALMAP
                 output.tangent = normalInput.tangentWS;
-                output.binormal = normalInput.binormalWS;
+                output.bitangent = normalInput.bitangentWS;
 #endif
                 OUTPUT_LIGHTMAP_UV(input.lightmapUV, unity_LightmapST, output.lightmapUV);
                 OUTPUT_SH(output.normal, output.vertexSH);
@@ -123,7 +123,7 @@ Shader "Lightweight Render Pipeline/Unlit"
 #if _SAMPLE_GI
     #if _NORMALMAP
                 half3 normalWS = TransformTangentToWorld(surfaceData.normalTS,
-                    half3x3(input.tangent, input.binormal, input.normal));
+                    half3x3(input.tangent, input.bitangent, input.normal));
     #else
                 half3 normalWS = input.normal;
     #endif

--- a/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
@@ -128,7 +128,7 @@ Shader "Lightweight Render Pipeline/Unlit"
     #endif
                 color *= SAMPLE_GI(input.lightmapUV, input.vertexSH, normalWS);
 #endif
-                ApplyFog(color, input.uv0AndFogCoord.z);
+                color = MixFog(color, input.uv0AndFogCoord.z);
 
                 return half4(color, alpha);
             }

--- a/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
@@ -127,7 +127,7 @@ Shader "Lightweight Render Pipeline/Unlit"
     #else
                 half3 normalWS = input.normal;
     #endif
-                normalWS = FragmentNormalWS(normalWS);
+                normalWS = NormalizeNormalPerPixel(normalWS);
                 color *= SAMPLE_GI(input.lightmapUV, input.vertexSH, normalWS);
 #endif
                 color = MixFog(color, input.uv0AndFogCoord.z);

--- a/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
@@ -122,10 +122,12 @@ Shader "Lightweight Render Pipeline/Unlit"
 
 #if _SAMPLE_GI
     #if _NORMALMAP
-                half3 normalWS = TangentToWorldNormal(surfaceData.normalTS, input.tangent, input.binormal, input.normal);
+                half3 normalWS = TransformTangentToWorld(surfaceData.normalTS,
+                    half3x3(input.tangent, input.binormal, input.normal));
     #else
-                half3 normalWS = normalize(input.normal);
+                half3 normalWS = input.normal;
     #endif
+                normalWS = FragmentNormalWS(normalWS);
                 color *= SAMPLE_GI(input.lightmapUV, input.vertexSH, normalWS);
 #endif
                 color = MixFog(color, input.uv0AndFogCoord.z);

--- a/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Unlit.shader
@@ -93,11 +93,11 @@ Shader "Lightweight Render Pipeline/Unlit"
                 output.uv0AndFogCoord.z = ComputeFogFactor(vertexInput.positionCS.z);
 
 #if _SAMPLE_GI
-                VertexTBN vertexTBN = GetVertexTBN(input.normalOS, input.tangentOS);
-                output.normal = vertexTBN.normalWS;
+                VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+                output.normal = normalInput.normalWS;
 #ifdef _NORMALMAP
-                output.tangent = vertexTBN.tangentWS;
-                output.binormal = vertexTBN.binormalWS;
+                output.tangent = normalInput.tangentWS;
+                output.binormal = normalInput.binormalWS;
 #endif
                 OUTPUT_LIGHTMAP_UV(input.lightmapUV, unity_LightmapST, output.lightmapUV);
                 OUTPUT_SH(output.normal, output.vertexSH);


### PR DESCRIPTION
### Purpose of this PR
 Review LWRP shader API to have the leanest possible API and go out of preview. 

 ---
### Release Notes
## Added
 - Added `VertexNormalInputs` struct that contains data for per-pixel normal computation.
 - Added `GetVertexNormalInputs` function to return an initialized `VertexNormalInputs`.
## Changed
 - Removed `LightInput` struct and `GetLightDirectionAndAttenuation`. Use `GetAdditionalLight` function instead.
 - Removed `ApplyFog` and `ApplyFogColor` functions. Use `MixFog` and `MixFogColor` instead.
 - Removed `TangentWorldToNormal` function. Use `TransformTangentToWorld` instead.
 - Removed view direction normalization functions. View direction should always be normalized per pixel for accurate results.
 - Renamed `FragmentNormalWS` function to `NormalizeNormalPerPixel`.  

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=add-platform-filter&ScriptableRenderLoop_branch=lw%2Fapi-review-v6&unity_branch=trunk

**Manual Tests**: Done by myself.

**Automated Tests**: No additional automated tests required.

Any test projects to go with this to help reviewers? Use GraphicsTests.

---
### Overall Product Risks
**Technical Risk**: Low. 

**Halo Effect**: Medium. They are some API breaking changes.

---
### Comments to reviewers
 Renamed some functions for simplicity/better usage. Removed functions that might not make sense in the future. We want to decrease the chance of deprecating these when we are out of experimental.
