### PR TITLE
Add NaN & +/- infinity check to non-master node previews

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added definitions used by new HD Lit Master node.
 - Added a popup control for a string list.
 - Added conversion type (position/direction) to TransformNode.
+- In your preview for nodes that are not master nodes, pixels now display as pink if they are not finite.
 
 ### Changed
 - The settings for master nodes now live in a small window that you can toggle on and off. Here, you can change various rendering settings for your shader.

--- a/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
@@ -829,7 +829,7 @@ namespace UnityEditor.ShaderGraph
             }
             else
             {
-                pixelShaderSurfaceRemap.AppendLine("return surf.PreviewOutput;");
+                pixelShaderSurfaceRemap.AppendLine("return all(isfinite(surf.PreviewOutput)) ? surf.PreviewOutput : float4(1.0f, 0.0f, 1.0f, 1.0f);");
             }
 
             // -------------------------------------


### PR DESCRIPTION
### Purpose of this PR
Non-finite values can easily sneak up on users of Shader Graph, and cause unexpected results that are hard to debug. This PR introduces a check at the end of the preview uber shader, and outputs Unity Pink™ if the value is not finite. Non-finite values include NaN and +/- infinity.

![image](https://user-images.githubusercontent.com/123919/46078887-bb368380-c195-11e8-866c-520624f1cca5.png)

---
### Release Notes
In your preview for nodes that are not master nodes, pixels now display as pink if they are not finite.

---
### Testing status
**Katana Tests**: Running [here](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Fnode-preview-nan-detection&automation-tools_branch=add-platform-filter&unity_branch=trunk)

**Manual Tests**: Test that previews generally still work by opening some of our usual demo graphs. I also added a Power Node with a negative A input, and verified that the preview is pink, since HLSL defines `pow` with a negative base to be NaN. Likewise I typed "infinity" into a Vector 1 node, and verified that the preview was also pink in this case.

**Automated Tests**: Nothing new.

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low

**Halo Effect**: None, Low, Medium, High? None, this is only in the preview on nodes
