### PR TITLE
Tests/framework/fixes

### DIFF
--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
@@ -1,18 +1,22 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.TestTools.Graphics;
 using UnityEngine.SceneManagement;
 using UnityEngine.Events;
+using System.IO;
 
 public class HDRP_GraphicTestRunner
 {
-    [UnityTest, Category("HDRP Graphic Tests")]
-    [PrebuildSetup("SetupGraphicsTestCases")]
-    [UseGraphicsTestCases]
-    public IEnumerator Run(GraphicsTestCase testCase)
+    //[UnityTest, Category("HDRP Graphic Tests")]
+    //[PrebuildSetup("SetupGraphicsTestCases")]
+    [UseGraphicsTestCases(true)]
+    public IEnumerator Run(string scenePath)
     {
+        GraphicsTestCase testCase = UseGraphicsTestCasesAttribute.GetCaseFromScenePath(scenePath);
+
         SceneManager.LoadScene(testCase.ScenePath);
 
         // Arbitrary wait for 5 frames for the scene to load, and other stuff to happen (like Realtime GI to appear ...)

--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
@@ -7,11 +7,12 @@ using UnityEngine.TestTools.Graphics;
 using UnityEngine.SceneManagement;
 using UnityEngine.Events;
 using System.IO;
+using TestParameters = UnityEngine.TestTools.Graphics.TestParameters;
 
 public class HDRP_GraphicTestRunner
 {
     [PrebuildSetup("SetupGraphicsTestCases")]
-    [UseGraphicsTestCases(true)]
+    [UseGraphicsTestCases( TestParameters.ScenePath )]
     public IEnumerator Run(string scenePath)
     {
         GraphicsTestCase testCase = UseGraphicsTestCasesAttribute.GetCaseFromScenePath(scenePath);

--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
@@ -7,16 +7,13 @@ using UnityEngine.TestTools.Graphics;
 using UnityEngine.SceneManagement;
 using UnityEngine.Events;
 using System.IO;
-using TestParameters = UnityEngine.TestTools.Graphics.TestParameters;
 
 public class HDRP_GraphicTestRunner
 {
     [PrebuildSetup("SetupGraphicsTestCases")]
-    [UseGraphicsTestCases( TestParameters.ScenePath )]
-    public IEnumerator Run(string scenePath)
+    [UseGraphicsTestCases]
+    public IEnumerator Run(GraphicsTestCase testCase)
     {
-        GraphicsTestCase testCase = UseGraphicsTestCasesAttribute.GetCaseFromScenePath(scenePath);
-
         SceneManager.LoadScene(testCase.ScenePath);
 
         // Arbitrary wait for 5 frames for the scene to load, and other stuff to happen (like Realtime GI to appear ...)

--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
@@ -10,8 +10,7 @@ using System.IO;
 
 public class HDRP_GraphicTestRunner
 {
-    //[UnityTest, Category("HDRP Graphic Tests")]
-    //[PrebuildSetup("SetupGraphicsTestCases")]
+    [PrebuildSetup("SetupGraphicsTestCases")]
     [UseGraphicsTestCases(true)]
     public IEnumerator Run(string scenePath)
     {

--- a/com.unity.testframework.graphics/Editor/TestResultWindow.cs
+++ b/com.unity.testframework.graphics/Editor/TestResultWindow.cs
@@ -261,12 +261,14 @@ namespace UnityEngine.Experimental.Rendering
             if(templateImage == null || resultImage == null)
                 return;
 
-            EditorUtility.CopySerialized( resultImage, templateImage );
+
+            AssetDatabase.CopyAsset(AssetDatabase.GetAssetPath(resultImage), AssetDatabase.GetAssetPath(templateImage));
             AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
 
             DeleteResults();
         }
-        
+
         public const string ActualImagesRoot = "Assets/ActualImages";
 
         public bool GetImages( GraphicsTestCase _testCase = null )

--- a/com.unity.testframework.graphics/Runtime/EditorGraphicsTestCaseProvider.cs
+++ b/com.unity.testframework.graphics/Runtime/EditorGraphicsTestCaseProvider.cs
@@ -42,6 +42,24 @@ namespace UnityEditor.TestTools.Graphics
             }
         }
 
+        public GraphicsTestCase GetTestCaseFromPath(string scenePath)
+        {
+            GraphicsTestCase output = null;
+
+            var allImages = CollectReferenceImagePathsFor(string.IsNullOrEmpty(m_ReferenceImagePath) ? ReferenceImagesRoot : m_ReferenceImagePath, QualitySettings.activeColorSpace, Application.platform,
+                SystemInfo.graphicsDeviceType);
+
+            Texture2D referenceImage = null;
+
+            string imagePath;
+            if (allImages.TryGetValue(Path.GetFileNameWithoutExtension(scenePath), out imagePath))
+                referenceImage = AssetDatabase.LoadAssetAtPath<Texture2D>(imagePath);
+
+            output = new GraphicsTestCase(scenePath, referenceImage);
+
+            return output;
+        }
+
         public const string ReferenceImagesRoot = "Assets/ReferenceImages";
 
         public static Dictionary<string, string> CollectReferenceImagePathsFor(string referenceImageRoot, ColorSpace colorSpace, RuntimePlatform runtimePlatform,

--- a/com.unity.testframework.graphics/Runtime/IGraphicsTestCaseProvider.cs
+++ b/com.unity.testframework.graphics/Runtime/IGraphicsTestCaseProvider.cs
@@ -15,6 +15,12 @@ namespace UnityEngine.TestTools.Graphics
         /// </summary>
         /// <returns></returns>
         IEnumerable<GraphicsTestCase> GetTestCases();
-        
+
+        /// <summary>
+        /// Retrieve a single test case from scene path.
+        /// </summary>
+        /// <returns></returns>
+        GraphicsTestCase GetTestCaseFromPath(string scenePath);
+
     }
 }

--- a/com.unity.testframework.graphics/Runtime/ImageAssert.cs
+++ b/com.unity.testframework.graphics/Runtime/ImageAssert.cs
@@ -231,7 +231,7 @@ namespace UnityEngine.TestTools.Graphics
 
 #if UNITY_EDITOR
         // Hack do disable writing to the XML Log of TestRunner (to avoid editor hanging when tests are run locally)
-        static string s_DontWriteToLogPath = "ProjectSettings/DontWriteToLog";
+        static string s_DontWriteToLogPath = "Library/DontWriteToLog";
 
         static bool sDontWriteToLog
         {

--- a/com.unity.testframework.graphics/Runtime/ImageAssert.cs
+++ b/com.unity.testframework.graphics/Runtime/ImageAssert.cs
@@ -71,8 +71,11 @@ namespace UnityEngine.TestTools.Graphics
             if (actual == null)
                 throw new ArgumentNullException("actual");
 
+#if UNITY_EDITOR
             var imagesWritten = new HashSet<string>();
             var dirName = Path.Combine("Assets/ActualImages", string.Format("{0}/{1}/{2}", UseGraphicsTestCasesAttribute.ColorSpace, UseGraphicsTestCasesAttribute.Platform, UseGraphicsTestCasesAttribute.GraphicsDevice));
+            Directory.CreateDirectory(dirName);
+#endif
 
             try
             {

--- a/com.unity.testframework.graphics/Runtime/RuntimeGraphicsTestCaseProvider.cs
+++ b/com.unity.testframework.graphics/Runtime/RuntimeGraphicsTestCaseProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace UnityEngine.TestTools.Graphics
 {
@@ -27,6 +28,30 @@ namespace UnityEngine.TestTools.Graphics
             }
         }
 
+        public GraphicsTestCase GetTestCaseFromPath(string scenePath)
+        {
+            if (string.IsNullOrEmpty(scenePath))
+                return null;
 
+            GraphicsTestCase output = null;
+
+            AssetBundle referenceImagesBundle = null;
+
+            var referenceImagesBundlePath = string.Format("{0}/referenceimages-{1}-{2}-{3}", Application.streamingAssetsPath, UseGraphicsTestCasesAttribute.ColorSpace, UseGraphicsTestCasesAttribute.Platform, UseGraphicsTestCasesAttribute.GraphicsDevice);
+            if (File.Exists(referenceImagesBundlePath))
+                referenceImagesBundle = AssetBundle.LoadFromFile(referenceImagesBundlePath);
+
+            var imagePath = Path.GetFileNameWithoutExtension(scenePath);
+
+            Texture2D referenceImage = null;
+
+            // The bundle might not exist if there are no reference images for this configuration yet
+            if (referenceImagesBundle != null)
+                referenceImage = referenceImagesBundle.LoadAsset<Texture2D>(imagePath);
+
+            output = new GraphicsTestCase( scenePath, referenceImage );
+
+            return output;
+        }
     }
 }

--- a/com.unity.testframework.graphics/Runtime/UseGraphicsTestCasesAttribute.cs
+++ b/com.unity.testframework.graphics/Runtime/UseGraphicsTestCasesAttribute.cs
@@ -83,7 +83,7 @@ namespace UnityEngine.TestTools.Graphics
             {
                 foreach (var testCase in provider.GetTestCases())
                 {
-                    TestCaseParameters parms = new TestCaseParameters( new object[]{ m_OutputAsString? testCase.ScenePath : (object) testCase } )
+                    TestCaseParameters parms = new TestCaseParameters( new object[]{ (m_TestParameters==TestParameters.ScenePath)? testCase.ScenePath : (object) testCase } )
                     {
                         ExpectedResult = new object(),
                         HasExpectedResult = true,

--- a/com.unity.testframework.graphics/Runtime/UseGraphicsTestCasesAttribute.cs
+++ b/com.unity.testframework.graphics/Runtime/UseGraphicsTestCasesAttribute.cs
@@ -8,6 +8,8 @@ using Attribute = System.Attribute;
 
 namespace UnityEngine.TestTools.Graphics
 {
+    public enum TestParameters { GraphicTestCase = 0, ScenePath = 1 }
+
     /// <summary>
     /// Marks a test which takes <c>GraphicsTestCase</c> instances as wanting to have them generated automatically by
     /// the scene/reference-image management feature in the framework.
@@ -18,17 +20,17 @@ namespace UnityEngine.TestTools.Graphics
 
         NUnitTestCaseBuilder _builder = new NUnitTestCaseBuilder();
 
-        bool m_OutputAsString = false;
+        TestParameters m_TestParameters = TestParameters.GraphicTestCase;
 
-        public UseGraphicsTestCasesAttribute(bool outputAsString = false)
+        public UseGraphicsTestCasesAttribute(TestParameters testParameters = TestParameters.GraphicTestCase)
         {
-            m_OutputAsString = outputAsString;
+            m_TestParameters = testParameters;
         }
 
-        public UseGraphicsTestCasesAttribute(string referenceImagePath , bool outputAsString = false)
+        public UseGraphicsTestCasesAttribute(string referenceImagePath , TestParameters testParameters = TestParameters.GraphicTestCase)
         {
             m_ReferenceImagePath = referenceImagePath;
-            m_OutputAsString = outputAsString;
+            m_TestParameters = testParameters;
         }
 
         /// <summary>
@@ -109,11 +111,6 @@ namespace UnityEngine.TestTools.Graphics
 
             Console.WriteLine("Generated {0} graphics test cases.", results.Count);
             return results;
-        }
-
-        public static IEnumerable<GraphicsTestCase> GraphicsTestCaseList()
-        {
-            return new UnityEditor.TestTools.Graphics.EditorGraphicsTestCaseProvider(null).GetTestCases();
         }
 
         public static GraphicsTestCase GetCaseFromScenePath(string scenePath, string referenceImagePath = null )

--- a/com.unity.testframework.graphics/Runtime/UseGraphicsTestCasesAttribute.cs
+++ b/com.unity.testframework.graphics/Runtime/UseGraphicsTestCasesAttribute.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Builders;
@@ -8,8 +9,6 @@ using Attribute = System.Attribute;
 
 namespace UnityEngine.TestTools.Graphics
 {
-    public enum TestParameters { GraphicTestCase = 0, ScenePath = 1 }
-
     /// <summary>
     /// Marks a test which takes <c>GraphicsTestCase</c> instances as wanting to have them generated automatically by
     /// the scene/reference-image management feature in the framework.
@@ -20,17 +19,11 @@ namespace UnityEngine.TestTools.Graphics
 
         NUnitTestCaseBuilder _builder = new NUnitTestCaseBuilder();
 
-        TestParameters m_TestParameters = TestParameters.GraphicTestCase;
+        public UseGraphicsTestCasesAttribute(){}
 
-        public UseGraphicsTestCasesAttribute(TestParameters testParameters = TestParameters.GraphicTestCase)
-        {
-            m_TestParameters = testParameters;
-        }
-
-        public UseGraphicsTestCasesAttribute(string referenceImagePath , TestParameters testParameters = TestParameters.GraphicTestCase)
+        public UseGraphicsTestCasesAttribute(string referenceImagePath)
         {
             m_ReferenceImagePath = referenceImagePath;
-            m_TestParameters = testParameters;
         }
 
         /// <summary>
@@ -83,13 +76,13 @@ namespace UnityEngine.TestTools.Graphics
             {
                 foreach (var testCase in provider.GetTestCases())
                 {
-                    TestCaseParameters parms = new TestCaseParameters( new object[]{ (m_TestParameters==TestParameters.ScenePath)? testCase.ScenePath : (object) testCase } )
-                    {
-                        ExpectedResult = new object(),
-                        HasExpectedResult = true,
-                    };
+                    TestCaseData data = new TestCaseData( new object[]{ testCase } );
 
-                    TestMethod test = this._builder.BuildTestMethod(method, suite, parms);
+                    data.SetName(System.IO.Path.GetFileNameWithoutExtension(testCase.ScenePath));
+                    data.ExpectedResult = new Object();
+                    data.HasExpectedResult = true;
+
+                    TestMethod test = this._builder.BuildTestMethod(method, suite, data);
                     if (test.parms != null)
                         test.parms.HasExpectedResult = false;
 


### PR DESCRIPTION
Fix the "replace template" function of the test result window.
Option to disable XML logging (prevent the freeze of test runner if an image comparison failed).