### PR TITLE
Fixed re-create of DepthPyramid RT when loading renderdoc

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/MipGenerator.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/MipGenerator.cs
@@ -42,6 +42,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // TODO: Mip-mapping depth is problematic for precision at lower mips, generate a packed atlas instead
         public void RenderMinDepthPyramid(CommandBuffer cmd, RenderTexture texture, HDUtils.PackedMipChainInfo info)
         {
+            // Since this process only goes through a compute shader, internal C++ code won't recreate it automatically if detroyed.
+            if (!texture.IsCreated())
+                texture.Create();
+
             var cs     = m_DepthPyramidCS;
             int kernel = m_DepthDownsampleKernel;
 


### PR DESCRIPTION
### Purpose of this PR
Fixed re-create of DepthPyramid RT when loading renderdoc

Katana: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-depth-pyramid-create&automation-tools_branch=add-platform-filter&unity_branch=trunk#