### PR TITLE
Send missing stereo informations to compute shaders

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -42,6 +42,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         Matrix4x4[] invViewStereo;
         Matrix4x4[] invProjStereo;
         Matrix4x4[] invViewProjStereo;
+        Vector4[] worldSpaceCameraPosStereo;
 
         // Non oblique projection matrix (RHS)
         public Matrix4x4 nonObliqueProjMatrix
@@ -185,6 +186,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             invProjStereo = new Matrix4x4[2];
             invViewProjStereo = new Matrix4x4[2];
 
+            worldSpaceCameraPosStereo = new Vector4[2];
+
             postprocessRenderContext = new PostProcessRenderContext();
 
             m_AdditionalCameraData = null; // Init in Update
@@ -273,7 +276,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_ActualHeight = xrDesc.height;
 
             }
-            ConfigureStereoMatrices();
 
             if (ShaderConfig.s_CameraRelativeRendering != 0)
             {
@@ -308,15 +310,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             projMatrix = gpuProj;
             nonJitteredProjMatrix = gpuNonJitteredProj;
             cameraPos = pos;
-
-            if (!m_frameSettings.enableStereo)
-            {
-                // TODO VR: Current solution for compute shaders grabs matrices from
-                // stereo matrices even when not rendering stereo in order to reduce shader variants.
-                // After native fix for compute shader keywords is completed, qualify this with stereoEnabled.
-                viewMatrixStereo[0] = viewMatrix;
-                projMatrixStereo[0] = projMatrix;
-            }
+            
+            ConfigureStereoMatrices();
 
             if (ShaderConfig.s_CameraRelativeRendering != 0)
             {
@@ -484,34 +479,65 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void ConfigureStereoMatrices()
         {
-            for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
+            if (frameSettings.enableStereo)
             {
-                viewMatrixStereo[eyeIndex] = camera.GetStereoViewMatrix((Camera.StereoscopicEye)eyeIndex);
-
-                projMatrixStereo[eyeIndex] = camera.GetStereoProjectionMatrix((Camera.StereoscopicEye)eyeIndex);
-                projMatrixStereo[eyeIndex] = GL.GetGPUProjectionMatrix(projMatrixStereo[eyeIndex], true);
-            }
-
-            if (ShaderConfig.s_CameraRelativeRendering != 0)
-            {
-                var leftTranslation = viewMatrixStereo[0].GetColumn(3);
-                var rightTranslation = viewMatrixStereo[1].GetColumn(3);
-                var centerTranslation = (leftTranslation + rightTranslation) / 2;
-                var centerOffset = -centerTranslation;
-                centerOffset.w = 0;
-
-                // TODO: Grabbing the CenterEye transform would be preferable, but XRNode.CenterEye
-                // doesn't always seem to be valid.
-
                 for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
                 {
-                    var translation = viewMatrixStereo[eyeIndex].GetColumn(3);
-                    translation += centerOffset;
-                    viewMatrixStereo[eyeIndex].SetColumn(3, translation);
+                    viewMatrixStereo[eyeIndex] = camera.GetStereoViewMatrix((Camera.StereoscopicEye)eyeIndex);
+                    invViewStereo[eyeIndex] = viewMatrixStereo[eyeIndex].inverse;
+
+                    worldSpaceCameraPosStereo[eyeIndex] = viewMatrixStereo[eyeIndex].GetColumn(3);
+
+                    projMatrixStereo[eyeIndex] = camera.GetStereoProjectionMatrix((Camera.StereoscopicEye)eyeIndex);
+                    projMatrixStereo[eyeIndex] = GL.GetGPUProjectionMatrix(projMatrixStereo[eyeIndex], true);
+                    invProjStereo[eyeIndex] = projMatrixStereo[eyeIndex].inverse;
+
+                    viewProjStereo[eyeIndex] = GetViewProjMatrixStereo(eyeIndex);
+                    invViewProjStereo[eyeIndex] = viewProjStereo[eyeIndex].inverse;
                 }
 
-                centerEyeTranslationOffset = centerOffset;
+                if (ShaderConfig.s_CameraRelativeRendering != 0)
+                {
+                    var leftTranslation = viewMatrixStereo[0].GetColumn(3);
+                    var rightTranslation = viewMatrixStereo[1].GetColumn(3);
+                    var centerTranslation = (leftTranslation + rightTranslation) / 2;
+                    var centerOffset = -centerTranslation;
+                    centerOffset.w = 0;
+
+                    // TODO: Grabbing the CenterEye transform would be preferable, but XRNode.CenterEye
+                    // doesn't always seem to be valid.
+
+                    for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
+                    {
+                        var translation = viewMatrixStereo[eyeIndex].GetColumn(3);
+                        translation += centerOffset;
+                        viewMatrixStereo[eyeIndex].SetColumn(3, translation);
+                        worldSpaceCameraPosStereo[eyeIndex] = viewMatrixStereo[eyeIndex].GetColumn(3);
+                    }
+
+                    centerEyeTranslationOffset = centerOffset;
+
+                }
+
             }
+            else
+            {
+                // TODO VR: Current solution for compute shaders grabs matrices from
+                // stereo matrices even when not rendering stereo in order to reduce shader variants.
+                // After native fix for compute shader keywords is completed, qualify this with stereoEnabled.
+                viewMatrixStereo[0] = viewMatrix;
+                invViewStereo[0] = viewMatrix.inverse;
+
+                projMatrixStereo[0] = projMatrix;
+                invProjStereo[0] = projMatrix.inverse;
+
+                viewProjStereo[0] = viewProjMatrix;
+                invViewProjStereo[0] = viewProjMatrix.inverse;
+
+                worldSpaceCameraPosStereo[0] = worldSpaceCameraPos;
+            }
+
+
 
             // TODO: Fetch the single cull matrix stuff
         }
@@ -640,20 +666,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void SetupGlobalStereoParams(CommandBuffer cmd)
         {
-            Vector4[] worldSpaceCameraPos = new Vector4[2];
-            for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
-            {
-                var proj = projMatrixStereo[eyeIndex];
-                invProjStereo[eyeIndex] = proj.inverse;
-
-                var view = viewMatrixStereo[eyeIndex];
-                invViewStereo[eyeIndex] = view.inverse;
-
-                viewProjStereo[eyeIndex] = proj * view;
-                invViewProjStereo[eyeIndex] = viewProjStereo[eyeIndex].inverse;
-
-                worldSpaceCameraPos[eyeIndex] = view.GetColumn(3);
-            }
 
             // corresponds to UnityPerPassStereo
             // TODO: Migrate the other stereo matrices to HDRP-managed UnityPerPassStereo?
@@ -664,7 +676,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetGlobalMatrixArray(HDShaderIDs._InvProjMatrixStereo, invProjStereo);
             cmd.SetGlobalMatrixArray(HDShaderIDs._InvViewProjMatrixStereo, invViewProjStereo);
             cmd.SetGlobalMatrixArray(HDShaderIDs._PrevViewProjMatrixStereo, prevViewProjMatrixStereo);
-            cmd.SetGlobalVectorArray(HDShaderIDs._WorldSpaceCameraPosStereo, worldSpaceCameraPos);
+            cmd.SetGlobalVectorArray(HDShaderIDs._WorldSpaceCameraPosStereo, worldSpaceCameraPosStereo);
             cmd.SetGlobalVector(HDShaderIDs._TextureWidthScaling, textureWidthScaling);
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -487,7 +487,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
             {
                 viewMatrixStereo[eyeIndex] = camera.GetStereoViewMatrix((Camera.StereoscopicEye)eyeIndex);
-                var location = camera.GetStereoViewMatrix((Camera.StereoscopicEye)eyeIndex).GetColumn(3);
 
                 projMatrixStereo[eyeIndex] = camera.GetStereoProjectionMatrix((Camera.StereoscopicEye)eyeIndex);
                 projMatrixStereo[eyeIndex] = GL.GetGPUProjectionMatrix(projMatrixStereo[eyeIndex], true);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -250,7 +250,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _InvProjMatrixStereo = Shader.PropertyToID("_InvProjMatrixStereo");
         public static readonly int _InvViewProjMatrixStereo = Shader.PropertyToID("_InvViewProjMatrixStereo");
         public static readonly int _PrevViewProjMatrixStereo = Shader.PropertyToID("_PrevViewProjMatrixStereo");
-        public static readonly int _WorldSpaceCameraPosStereo = Shader.PropertyToID("__WorldSpaceCameraPosStereo");
+        public static readonly int _WorldSpaceCameraPosStereo = Shader.PropertyToID("_WorldSpaceCameraPosStereo");
         public static readonly int _TextureWidthScaling = Shader.PropertyToID("_TextureWidthScaling"); // (2.0, 0.5) for SinglePassDoubleWide (stereo) and (1.0, 1.0) otherwise
         public static readonly int _ComputeEyeIndex = Shader.PropertyToID("_ComputeEyeIndex");
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -244,11 +244,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _TaaFrameRotation = Shader.PropertyToID("_TaaFrameRotation");
 
         public static readonly int _ViewMatrixStereo = Shader.PropertyToID("_ViewMatrixStereo");
+        public static readonly int _ProjMatrixStereo = Shader.PropertyToID("_ProjMatrixStereo");
         public static readonly int _ViewProjMatrixStereo = Shader.PropertyToID("_ViewProjMatrixStereo");
         public static readonly int _InvViewMatrixStereo = Shader.PropertyToID("_InvViewMatrixStereo");
         public static readonly int _InvProjMatrixStereo = Shader.PropertyToID("_InvProjMatrixStereo");
         public static readonly int _InvViewProjMatrixStereo = Shader.PropertyToID("_InvViewProjMatrixStereo");
         public static readonly int _PrevViewProjMatrixStereo = Shader.PropertyToID("_PrevViewProjMatrixStereo");
+        public static readonly int _WorldSpaceCameraPosStereo = Shader.PropertyToID("__WorldSpaceCameraPosStereo");
         public static readonly int _TextureWidthScaling = Shader.PropertyToID("_TextureWidthScaling"); // (2.0, 0.5) for SinglePassDoubleWide (stereo) and (1.0, 1.0) otherwise
         public static readonly int _ComputeEyeIndex = Shader.PropertyToID("_ComputeEyeIndex");
 

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -24,7 +24,7 @@
     #define unity_CameraInvProjection unity_StereoCameraInvProjection[unity_StereoEyeIndex]
     #define unity_WorldToCamera unity_StereoWorldToCamera[unity_StereoEyeIndex]
     #define unity_CameraToWorld unity_StereoCameraToWorld[unity_StereoEyeIndex]
-    #define _WorldSpaceCameraPos unity_StereoWorldSpaceCameraPos[unity_StereoEyeIndex]
+    #define _WorldSpaceCameraPos _WorldSpaceCameraPosStereo[unity_StereoEyeIndex].xyz
 #endif
 
 #define UNITY_LIGHTMODEL_AMBIENT (glstate_lightmodel_ambient * 2)
@@ -298,12 +298,13 @@ CBUFFER_END
 
 CBUFFER_START(UnityPerPassStereo)
 float4x4 _ViewMatrixStereo[2];
-// Proj not needed...yet?
+float4x4 _ProjMatrixStereo[2];
 float4x4 _ViewProjMatrixStereo[2];
 float4x4 _InvViewMatrixStereo[2];
 float4x4 _InvProjMatrixStereo[2];
 float4x4 _InvViewProjMatrixStereo[2];
 float4x4 _PrevViewProjMatrixStereo[2];
+float4   _WorldSpaceCameraPosStereo[2];
 #if SHADER_STAGE_COMPUTE
 // Currently the Unity engine doesn't automatically update stereo indices, offsets, and matrices for compute shaders.
 // Instead, we manually update _ComputeEyeIndex in SRP code. 

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariablesMatrixDefsHDCamera.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariablesMatrixDefsHDCamera.hlsl
@@ -9,7 +9,7 @@
 
 #define UNITY_MATRIX_V     _ViewMatrixStereo[unity_StereoEyeIndex]
 #define UNITY_MATRIX_I_V   _InvViewMatrixStereo[unity_StereoEyeIndex]
-#define UNITY_MATRIX_P     OptimizeProjectionMatrix(unity_StereoMatrixP[unity_StereoEyeIndex])
+#define UNITY_MATRIX_P     OptimizeProjectionMatrix(_ProjMatrixStereo[unity_StereoEyeIndex])
 #define UNITY_MATRIX_I_P   _InvProjMatrixStereo[unity_StereoEyeIndex]
 #define UNITY_MATRIX_VP    _ViewProjMatrixStereo[unity_StereoEyeIndex]
 #define UNITY_MATRIX_I_VP  _InvViewProjMatrixStereo[unity_StereoEyeIndex]


### PR DESCRIPTION

### Purpose of this PR
Currently stereo matrices where not configured when stereo was disabled and some information (world space stereo camera pos and stereo projection matrices) where missing altogether. 

This caused Screen space shadows to be broken in master. 

---
### Release Notes
Fixed Contact shadows in master. Allow access to additional stereo information in compute shaders.

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=fix-compute-shader-XR-issues-when-no-XR&automation-tools_branch=add-platform-filter&unity_branch=trunk [ Running ]

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**:  Medium - it may impact other shaders using stereo informations.
