### PR TITLE
Streamline data propagation through XR matrices and vectors

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -42,6 +42,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         Matrix4x4[] invViewStereo;
         Matrix4x4[] invProjStereo;
         Matrix4x4[] invViewProjStereo;
+        Vector4[] worldSpaceCameraPosStereo;
 
         // Non oblique projection matrix (RHS)
         public Matrix4x4 nonObliqueProjMatrix
@@ -185,6 +186,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             invProjStereo = new Matrix4x4[2];
             invViewProjStereo = new Matrix4x4[2];
 
+            worldSpaceCameraPosStereo = new Vector4[2];
+
             postprocessRenderContext = new PostProcessRenderContext();
 
             m_AdditionalCameraData = null; // Init in Update
@@ -273,7 +276,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_ActualHeight = xrDesc.height;
 
             }
-            ConfigureStereoMatrices();
 
             if (ShaderConfig.s_CameraRelativeRendering != 0)
             {
@@ -308,15 +310,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             projMatrix = gpuProj;
             nonJitteredProjMatrix = gpuNonJitteredProj;
             cameraPos = pos;
-
-            if (!m_frameSettings.enableStereo)
-            {
-                // TODO VR: Current solution for compute shaders grabs matrices from
-                // stereo matrices even when not rendering stereo in order to reduce shader variants.
-                // After native fix for compute shader keywords is completed, qualify this with stereoEnabled.
-                viewMatrixStereo[0] = viewMatrix;
-                projMatrixStereo[0] = projMatrix;
-            }
+            
+            ConfigureStereoMatrices();
 
             if (ShaderConfig.s_CameraRelativeRendering != 0)
             {
@@ -484,34 +479,65 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void ConfigureStereoMatrices()
         {
-            for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
+            if (frameSettings.enableStereo)
             {
-                viewMatrixStereo[eyeIndex] = camera.GetStereoViewMatrix((Camera.StereoscopicEye)eyeIndex);
-
-                projMatrixStereo[eyeIndex] = camera.GetStereoProjectionMatrix((Camera.StereoscopicEye)eyeIndex);
-                projMatrixStereo[eyeIndex] = GL.GetGPUProjectionMatrix(projMatrixStereo[eyeIndex], true);
-            }
-
-            if (ShaderConfig.s_CameraRelativeRendering != 0)
-            {
-                var leftTranslation = viewMatrixStereo[0].GetColumn(3);
-                var rightTranslation = viewMatrixStereo[1].GetColumn(3);
-                var centerTranslation = (leftTranslation + rightTranslation) / 2;
-                var centerOffset = -centerTranslation;
-                centerOffset.w = 0;
-
-                // TODO: Grabbing the CenterEye transform would be preferable, but XRNode.CenterEye
-                // doesn't always seem to be valid.
-
                 for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
                 {
-                    var translation = viewMatrixStereo[eyeIndex].GetColumn(3);
-                    translation += centerOffset;
-                    viewMatrixStereo[eyeIndex].SetColumn(3, translation);
+                    viewMatrixStereo[eyeIndex] = camera.GetStereoViewMatrix((Camera.StereoscopicEye)eyeIndex);
+                    invViewStereo[eyeIndex] = viewMatrixStereo[eyeIndex].inverse;
+
+                    worldSpaceCameraPosStereo[eyeIndex] = viewMatrixStereo[eyeIndex].GetColumn(3);
+
+                    projMatrixStereo[eyeIndex] = camera.GetStereoProjectionMatrix((Camera.StereoscopicEye)eyeIndex);
+                    projMatrixStereo[eyeIndex] = GL.GetGPUProjectionMatrix(projMatrixStereo[eyeIndex], true);
+                    invProjStereo[eyeIndex] = projMatrixStereo[eyeIndex].inverse;
+
+                    viewProjStereo[eyeIndex] = GetViewProjMatrixStereo(eyeIndex);
+                    invViewProjStereo[eyeIndex] = viewProjStereo[eyeIndex].inverse;
                 }
 
-                centerEyeTranslationOffset = centerOffset;
+                if (ShaderConfig.s_CameraRelativeRendering != 0)
+                {
+                    var leftTranslation = viewMatrixStereo[0].GetColumn(3);
+                    var rightTranslation = viewMatrixStereo[1].GetColumn(3);
+                    var centerTranslation = (leftTranslation + rightTranslation) / 2;
+                    var centerOffset = -centerTranslation;
+                    centerOffset.w = 0;
+
+                    // TODO: Grabbing the CenterEye transform would be preferable, but XRNode.CenterEye
+                    // doesn't always seem to be valid.
+
+                    for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
+                    {
+                        var translation = viewMatrixStereo[eyeIndex].GetColumn(3);
+                        translation += centerOffset;
+                        viewMatrixStereo[eyeIndex].SetColumn(3, translation);
+                        worldSpaceCameraPosStereo[eyeIndex] = viewMatrixStereo[eyeIndex].GetColumn(3);
+                    }
+
+                    centerEyeTranslationOffset = centerOffset;
+
+                }
+
             }
+            else
+            {
+                // TODO VR: Current solution for compute shaders grabs matrices from
+                // stereo matrices even when not rendering stereo in order to reduce shader variants.
+                // After native fix for compute shader keywords is completed, qualify this with stereoEnabled.
+                viewMatrixStereo[0] = viewMatrix;
+                invViewStereo[0] = viewMatrix.inverse;
+
+                projMatrixStereo[0] = projMatrix;
+                invProjStereo[0] = projMatrix.inverse;
+
+                viewProjStereo[0] = viewProjMatrix;
+                invViewProjStereo[0] = viewProjMatrix.inverse;
+
+                worldSpaceCameraPosStereo[0] = worldSpaceCameraPos;
+            }
+
+
 
             // TODO: Fetch the single cull matrix stuff
         }
@@ -640,20 +666,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void SetupGlobalStereoParams(CommandBuffer cmd)
         {
-            Vector4[] worldSpaceCameraPos = new Vector4[2];
-            for (uint eyeIndex = 0; eyeIndex < 2; eyeIndex++)
-            {
-                var proj = projMatrixStereo[eyeIndex];
-                invProjStereo[eyeIndex] = proj.inverse;
-
-                var view = viewMatrixStereo[eyeIndex];
-                invViewStereo[eyeIndex] = view.inverse;
-
-                viewProjStereo[eyeIndex] = proj * view;
-                invViewProjStereo[eyeIndex] = viewProjStereo[eyeIndex].inverse;
-
-                worldSpaceCameraPos[eyeIndex] = view.GetColumn(3);
-            }
 
             // corresponds to UnityPerPassStereo
             // TODO: Migrate the other stereo matrices to HDRP-managed UnityPerPassStereo?
@@ -664,7 +676,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetGlobalMatrixArray(HDShaderIDs._InvProjMatrixStereo, invProjStereo);
             cmd.SetGlobalMatrixArray(HDShaderIDs._InvViewProjMatrixStereo, invViewProjStereo);
             cmd.SetGlobalMatrixArray(HDShaderIDs._PrevViewProjMatrixStereo, prevViewProjMatrixStereo);
-            cmd.SetGlobalVectorArray(HDShaderIDs._WorldSpaceCameraPosStereo, worldSpaceCameraPos);
+            cmd.SetGlobalVectorArray(HDShaderIDs._WorldSpaceCameraPosStereo, worldSpaceCameraPosStereo);
             cmd.SetGlobalVector(HDShaderIDs._TextureWidthScaling, textureWidthScaling);
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -250,7 +250,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _InvProjMatrixStereo = Shader.PropertyToID("_InvProjMatrixStereo");
         public static readonly int _InvViewProjMatrixStereo = Shader.PropertyToID("_InvViewProjMatrixStereo");
         public static readonly int _PrevViewProjMatrixStereo = Shader.PropertyToID("_PrevViewProjMatrixStereo");
-        public static readonly int _WorldSpaceCameraPosStereo = Shader.PropertyToID("__WorldSpaceCameraPosStereo");
+        public static readonly int _WorldSpaceCameraPosStereo = Shader.PropertyToID("_WorldSpaceCameraPosStereo");
         public static readonly int _TextureWidthScaling = Shader.PropertyToID("_TextureWidthScaling"); // (2.0, 0.5) for SinglePassDoubleWide (stereo) and (1.0, 1.0) otherwise
         public static readonly int _ComputeEyeIndex = Shader.PropertyToID("_ComputeEyeIndex");
 


### PR DESCRIPTION
### Purpose of this PR
Small stylistic patch to @FrancescoC-unity's PR https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2071

---
### Release Notes
Moved ConfigureStereoMatrices() call lower in HDCamera to grab updated non-stereo viewMatrices when XR is disabled. 
---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=xr-matrices-fix&unity_branch=trunk&automation-tools_branch=add-platform-filter

**Manual Tests**: What did you do?
Ran in template test scene and visually confirmed no regression. 

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
