### PR TITLE
Add support for Vector4 texcoords to FragInputs and ShaderGraph.

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a new HD Lit Master node that implements Lit shader support for Shader Graph
 - Added Micro shadowing support (hack)
 - Added an event on HDAdditionalCameraData for custom rendering
+- HDRP Shader Graph shaders now support 4-channel UVs.
 
 ### Fixed
 - Fixed an issue where sometimes the deferred shadow texture would not be valid, causing wrong rendering.

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -15,10 +15,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             [Semantic("POSITION")]                  Vector3 positionOS;
             [Semantic("NORMAL")][Optional]          Vector3 normalOS;
             [Semantic("TANGENT")][Optional]         Vector4 tangentOS;       // Stores bi-tangent sign in w
-            [Semantic("TEXCOORD0")][Optional]       Vector2 uv0;
-            [Semantic("TEXCOORD1")][Optional]       Vector2 uv1;
-            [Semantic("TEXCOORD2")][Optional]       Vector2 uv2;
-            [Semantic("TEXCOORD3")][Optional]       Vector2 uv3;
+            [Semantic("TEXCOORD0")][Optional]       Vector4 uv0;
+            [Semantic("TEXCOORD1")][Optional]       Vector4 uv1;
+            [Semantic("TEXCOORD2")][Optional]       Vector4 uv2;
+            [Semantic("TEXCOORD3")][Optional]       Vector4 uv3;
             [Semantic("COLOR")][Optional]           Vector4 color;
             [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("INSTANCING_ON")] uint instanceID;
         };
@@ -30,10 +30,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             [Optional]                                                              Vector3 positionRWS;
             [Optional]                                                              Vector3 normalWS;
             [Optional]                                                              Vector4 tangentWS;      // w contain mirror sign
-            [Optional]                                                              Vector2 texCoord0;
-            [Optional]                                                              Vector2 texCoord1;
-            [Optional]                                                              Vector2 texCoord2;
-            [Optional]                                                              Vector2 texCoord3;
+            [Optional]                                                              Vector4 texCoord0;
+            [Optional]                                                              Vector4 texCoord1;
+            [Optional]                                                              Vector4 texCoord2;
+            [Optional]                                                              Vector4 texCoord3;
             [Optional]                                                              Vector4 color;
             [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("INSTANCING_ON")]     uint instanceID;
             [Optional][Semantic("FRONT_FACE_SEMANTIC")][OverrideType("FRONT_FACE_TYPE")][PreprocessorIf("SHADER_STAGE_FRAGMENT")] bool cullFace;
@@ -71,10 +71,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             Vector3 positionRWS;
             Vector3 normalWS;
             [Optional]      Vector4 tangentWS;
-            [Optional]      Vector2 texCoord0;
-            [Optional]      Vector2 texCoord1;
-            [Optional]      Vector2 texCoord2;
-            [Optional]      Vector2 texCoord3;
+            [Optional]      Vector4 texCoord0;
+            [Optional]      Vector4 texCoord1;
+            [Optional]      Vector4 texCoord2;
+            [Optional]      Vector4 texCoord3;
             [Optional]      Vector4 color;
             [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("INSTANCING_ON")] uint instanceID;
 

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/SharedCode.template.hlsl
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/SharedCode.template.hlsl
@@ -50,10 +50,10 @@
         $SurfaceDescriptionInputs.ViewSpacePosition:         output.ViewSpacePosition =           TransformWorldToView(input.positionRWS);
         $SurfaceDescriptionInputs.TangentSpacePosition:      output.TangentSpacePosition =        float3(0.0f, 0.0f, 0.0f);
         $SurfaceDescriptionInputs.ScreenPosition:            output.ScreenPosition =              ComputeScreenPos(TransformWorldToHClip(input.positionRWS), _ProjectionParams.x);
-        $SurfaceDescriptionInputs.uv0:                       output.uv0 =                         float4(input.texCoord0, 0.0f, 0.0f);
-        $SurfaceDescriptionInputs.uv1:                       output.uv1 =                         float4(input.texCoord1, 0.0f, 0.0f);
-        $SurfaceDescriptionInputs.uv2:                       output.uv2 =                         float4(input.texCoord2, 0.0f, 0.0f);
-        $SurfaceDescriptionInputs.uv3:                       output.uv3 =                         float4(input.texCoord3, 0.0f, 0.0f);
+        $SurfaceDescriptionInputs.uv0:                       output.uv0 =                         input.texCoord0;
+        $SurfaceDescriptionInputs.uv1:                       output.uv1 =                         input.texCoord1;
+        $SurfaceDescriptionInputs.uv2:                       output.uv2 =                         input.texCoord2;
+        $SurfaceDescriptionInputs.uv3:                       output.uv3 =                         input.texCoord3;
         $SurfaceDescriptionInputs.VertexColor:               output.VertexColor =                 input.color;
         $SurfaceDescriptionInputs.FaceSign:                  output.FaceSign =                    input.isFrontFace;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxFData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxFData.hlsl
@@ -75,7 +75,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     alpha = SAMPLE_TEXTURE2D(_SVBRDF_AlphaMap, sampler_SVBRDF_AlphaMap, UV0).x;
 
     // Useless for SVBRDF
-    surfaceData.flakesUV = input.texCoord0;
+    surfaceData.flakesUV = input.texCoord0.xy;
     surfaceData.flakesMipLevel = 0.0;
 
     //-----------------------------------------------------------------------------

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl
@@ -125,7 +125,7 @@ float2 CalculateVelocity(float4 positionCS, float4 previousPositionCS)
 // 3. PostInitBuiltinData - Handle debug mode + allow the current lighting model to update the data with ModifyBakedDiffuseLighting
 
 // This method initialize BuiltinData usual values and after update of builtinData by the caller must be follow by PostInitBuiltinData
-void InitBuiltinData(   float alpha, float3 normalWS, float3 backNormalWS, float3 positionRWS, float2 texCoord1, float2 texCoord2,
+void InitBuiltinData(   float alpha, float3 normalWS, float3 backNormalWS, float3 positionRWS, float4 texCoord1, float4 texCoord2,
                         out BuiltinData builtinData)
 {
     ZERO_INITIALIZE(BuiltinData, builtinData);
@@ -133,15 +133,15 @@ void InitBuiltinData(   float alpha, float3 normalWS, float3 backNormalWS, float
     builtinData.opacity = alpha;
 
     // Sample lightmap/lightprobe/volume proxy
-    builtinData.bakeDiffuseLighting = SampleBakedGI(positionRWS, normalWS, texCoord1, texCoord2);
+    builtinData.bakeDiffuseLighting = SampleBakedGI(positionRWS, normalWS, texCoord1.xy, texCoord2.xy);
     // We also sample the back lighting in case we have transmission. If not use this will be optimize out by the compiler
     // For now simply recall the function with inverted normal, the compiler should be able to optimize the lightmap case to not resample the directional lightmap
     // however it may not optimize the lightprobe case due to the proxy volume relying on dynamic if (to verify), not a problem for SH9, but a problem for proxy volume.
     // TODO: optimize more this code.    
-    builtinData.backBakeDiffuseLighting = SampleBakedGI(positionRWS, backNormalWS, texCoord1, texCoord2);
+    builtinData.backBakeDiffuseLighting = SampleBakedGI(positionRWS, backNormalWS, texCoord1.xy, texCoord2.xy);
 
 #ifdef SHADOWS_SHADOWMASK
-    float4 shadowMask = SampleShadowMask(positionRWS, texCoord1);
+    float4 shadowMask = SampleShadowMask(positionRWS, texCoord1.xy);
     builtinData.shadowMask0 = shadowMask.x;
     builtinData.shadowMask1 = shadowMask.y;
     builtinData.shadowMask2 = shadowMask.z;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalData.hlsl
@@ -23,7 +23,7 @@ void GetSurfaceData(FragInputs input, out DecalSurfaceData surfaceData)
 	float2 texCoords = texCoordDS * scale + offset;
 #elif (SHADERPASS == SHADERPASS_DBUFFER_MESH)
 	float albedoMapBlend = _DecalBlend;
-	float2 texCoords = input.texCoord0;
+	float2 texCoords = input.texCoord0.xy;
 #endif
 
 #if _COLORMAP

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Fabric/FabricData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Fabric/FabricData.hlsl
@@ -51,20 +51,20 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #endif
     
     // Generate the primary uv coordinates
-    float2 uvBase = _UVMappingMask.x * input.texCoord0 +
-                    _UVMappingMask.y * input.texCoord1 +
-                    _UVMappingMask.z * input.texCoord2 +
-                    _UVMappingMask.w * input.texCoord3;
+    float2 uvBase = _UVMappingMask.x * input.texCoord0.xy +
+                    _UVMappingMask.y * input.texCoord1.xy +
+                    _UVMappingMask.z * input.texCoord2.xy +
+                    _UVMappingMask.w * input.texCoord3.xy;
 
     // Apply tiling and offset
     uvBase = uvBase * _BaseColorMap_ST.xy + _BaseColorMap_ST.zw;
 
 
     // Generate the detail uv coordinates
-    float2 uvThread =  _UVMappingMaskThread.x * input.texCoord0 +
-                        _UVMappingMaskThread.y * input.texCoord1 +
-                        _UVMappingMaskThread.z * input.texCoord2 +
-                        _UVMappingMaskThread.w * input.texCoord3;
+    float2 uvThread =  _UVMappingMaskThread.x * input.texCoord0.xy +
+                        _UVMappingMaskThread.y * input.texCoord1.xy +
+                        _UVMappingMaskThread.z * input.texCoord2.xy +
+                        _UVMappingMaskThread.w * input.texCoord3.xy;
 
     // Apply offset and tiling
     uvThread = uvThread * _ThreadMap_ST.xy + _ThreadMap_ST.zw;
@@ -227,10 +227,10 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     builtinData.emissiveColor = _EmissiveColor.rgb * lerp(float3(1.0, 1.0, 1.0), surfaceData.baseColor.rgb, _AlbedoAffectEmissive);
 #ifdef _EMISSIVE_COLOR_MAP
     // Generate the primart uv coordinates
-    float2 uvEmissive = _UVMappingMaskEmissive.x * input.texCoord0 +
-                    _UVMappingMaskEmissive.y * input.texCoord1 +
-                    _UVMappingMaskEmissive.z * input.texCoord2 +
-                    _UVMappingMaskEmissive.w * input.texCoord3;
+    float2 uvEmissive = _UVMappingMaskEmissive.x * input.texCoord0.xy +
+                    _UVMappingMaskEmissive.y * input.texCoord1.xy +
+                    _UVMappingMaskEmissive.z * input.texCoord2.xy +
+                    _UVMappingMaskEmissive.w * input.texCoord3.xy;
     
     uvEmissive = uvEmissive * _EmissiveColorMap_ST.xy + _EmissiveColorMap_ST.zw;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
@@ -396,7 +396,7 @@ void GetLayerTexCoord(FragInputs input, inout LayerTexCoord layerTexCoord)
     GenerateLayerTexCoordBasisTB(input, layerTexCoord);
 #endif
 
-    GetLayerTexCoord(   input.texCoord0, input.texCoord1, input.texCoord2, input.texCoord3,
+    GetLayerTexCoord(   input.texCoord0.xy, input.texCoord1.xy, input.texCoord2.xy, input.texCoord3.xy,
                         input.positionRWS, input.worldToTangent[2].xyz, layerTexCoord);
 }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitBuiltinData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitBuiltinData.hlsl
@@ -27,7 +27,7 @@ void GetBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, S
     #else
     ComputeLayerTexCoord0(
     #endif
-                            input.texCoord0, input.texCoord1, input.texCoord2, input.texCoord3, _UVMappingMaskEmissive, _UVMappingMaskEmissive,
+                            input.texCoord0.xy, input.texCoord1.xy, input.texCoord2.xy, input.texCoord3.xy, _UVMappingMaskEmissive, _UVMappingMaskEmissive,
                             _EmissiveColorMap_ST.xy, _EmissiveColorMap_ST.zw, float2(0.0, 0.0), float2(0.0, 0.0), 1.0, false,
                             input.positionRWS, _TexWorldScaleEmissive,
                             mappingType, layerTexCoord);
@@ -42,7 +42,7 @@ void GetBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, S
 #endif // _EMISSIVE_COLOR_MAP
 
 #if (SHADERPASS == SHADERPASS_DISTORTION) || defined(DEBUG_DISPLAY)
-    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb;
+    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0.xy).rgb;
     distortion.rg = distortion.rg * _DistortionVectorScale.xx + _DistortionVectorBias.xx;
     builtinData.distortion = distortion.rg * _DistortionScale;
     builtinData.distortionBlur = clamp(distortion.b * _DistortionBlurScale, 0.0, 1.0) * (_DistortionBlurRemapMax - _DistortionBlurRemapMin) + _DistortionBlurRemapMin;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
@@ -63,12 +63,12 @@ void GenerateLayerTexCoordBasisTB(FragInputs input, inout LayerTexCoord layerTex
 
     // TODO: Optimize! The compiler will not be able to remove the tangent space that are not use because it can't know due to our UVMapping constant we use for both base and details
     // To solve this we should track which UVSet is use for normal mapping... Maybe not as simple as it sounds
-    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord1, layerTexCoord.vertexTangentWS1, layerTexCoord.vertexBitangentWS1);
+    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord1.xy, layerTexCoord.vertexTangentWS1, layerTexCoord.vertexBitangentWS1);
     #if defined(_REQUIRE_UV2) || defined(_REQUIRE_UV3)
-    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord2, layerTexCoord.vertexTangentWS2, layerTexCoord.vertexBitangentWS2);
+    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord2.xy, layerTexCoord.vertexTangentWS2, layerTexCoord.vertexBitangentWS2);
     #endif
     #if defined(_REQUIRE_UV3)
-    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord3, layerTexCoord.vertexTangentWS3, layerTexCoord.vertexBitangentWS3);
+    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord3.xy, layerTexCoord.vertexTangentWS3, layerTexCoord.vertexBitangentWS3);
     #endif
 }
 #endif
@@ -155,7 +155,7 @@ void GetLayerTexCoord(FragInputs input, inout LayerTexCoord layerTexCoord)
     GenerateLayerTexCoordBasisTB(input, layerTexCoord);
 #endif
 
-    GetLayerTexCoord(   input.texCoord0, input.texCoord1, input.texCoord2, input.texCoord3,
+    GetLayerTexCoord(   input.texCoord0.xy, input.texCoord1.xy, input.texCoord2.xy, input.texCoord3.xy,
                         input.positionRWS, input.worldToTangent[2].xyz, layerTexCoord);
 }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDataMeshModification.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDataMeshModification.hlsl
@@ -142,22 +142,22 @@ void ApplyTessellationModification(VaryingsMeshToDS input, float3 normalWS, inou
 
     positionRWS += GetVertexDisplacement(positionRWS, normalWS,
     #ifdef VARYINGS_DS_NEED_TEXCOORD0
-        input.texCoord0,
+        input.texCoord0.xy,
     #else
         float2(0.0, 0.0),
     #endif
     #ifdef VARYINGS_DS_NEED_TEXCOORD1
-        input.texCoord1,
+        input.texCoord1.xy,
     #else
         float2(0.0, 0.0),
     #endif
     #ifdef VARYINGS_DS_NEED_TEXCOORD2
-        input.texCoord2,
+        input.texCoord2.xy,
     #else
         float2(0.0, 0.0),
     #endif
     #ifdef VARYINGS_DS_NEED_TEXCOORD3
-        input.texCoord3,
+        input.texCoord3.xy,
     #else
         float2(0.0, 0.0),
     #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLitData.hlsl
@@ -104,9 +104,9 @@ void InitializeMappingData(FragInputs input, out TextureUVMapping uvMapping)
     //float flipSign = dot(sigmaY, cross(vertexNormalWS, sigmaX) ) ? -1.0 : 1.0;
     float flipSign = dot(dPdy, cross(vertexNormalWS, dPdx)) < 0.0 ? -1.0 : 1.0; // gives same as the commented out line above
 
-    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord1, uvMapping.vertexTangentWS[1], uvMapping.vertexBitangentWS[1]);
-    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord2, uvMapping.vertexTangentWS[2], uvMapping.vertexBitangentWS[2]);
-    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord3, uvMapping.vertexTangentWS[3], uvMapping.vertexBitangentWS[3]);
+    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord1.xy, uvMapping.vertexTangentWS[1], uvMapping.vertexBitangentWS[1]);
+    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord2.xy, uvMapping.vertexTangentWS[2], uvMapping.vertexBitangentWS[2]);
+    SurfaceGradientGenBasisTB(vertexNormalWS, sigmaX, sigmaY, flipSign, input.texCoord3.xy, uvMapping.vertexTangentWS[3], uvMapping.vertexBitangentWS[3]);
 }
 
 float4 SampleTexture2DScaleBias(TEXTURE2D_ARGS(textureName, samplerName), float textureNameUV, float textureNameUVLocal, float4 textureNameST, TextureUVMapping uvMapping)
@@ -439,7 +439,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     builtinData.emissiveColor *= SAMPLE_TEXTURE2D_SCALE_BIAS(_EmissiveColorMap).rgb;
 
 #if (SHADERPASS == SHADERPASS_DISTORTION) || defined(DEBUG_DISPLAY)
-    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb;
+    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0.xy).rgb;
     distortion.rg = distortion.rg * _DistortionVectorScale.xx + _DistortionVectorBias.xx;
     builtinData.distortion = distortion.rg * _DistortionScale;
     builtinData.distortionBlur = clamp(distortion.b * _DistortionBlurScale, 0.0, 1.0) * (_DistortionBlurRemapMax - _DistortionBlurRemapMin) + _DistortionBlurRemapMin;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
@@ -21,7 +21,7 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
 {
 #ifdef ENABLE_TERRAIN_PERPIXEL_NORMAL
     {
-        float3 normalOS = SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_Control0, (input.texCoord0 + 0.5f) * _TerrainHeightmapRecipSize.xy).rgb * 2 - 1;
+        float3 normalOS = SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_Control0, (input.texCoord0.xy + 0.5f) * _TerrainHeightmapRecipSize.xy).rgb * 2 - 1;
         float3 normalWS = mul((float3x3)GetObjectToWorldMatrix(), normalOS);
         float3 tangentWS = cross(GetObjectToWorldMatrix()._13_23_33, normalWS);
         float renormFactor = 1.0 / length(normalWS);
@@ -36,7 +36,7 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
         input.worldToTangent[1] = worldToTangent[1] * renormFactor;
         input.worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
 
-        input.texCoord0 *= _TerrainHeightmapRecipSize.zw;
+        input.texCoord0.xy *= _TerrainHeightmapRecipSize.zw;
     }
 #endif
 
@@ -44,7 +44,7 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
     input.texCoord1 = input.texCoord2 = input.texCoord0;
 
     float3 normalTS;
-    TerrainSplatBlend(input.texCoord0, input.worldToTangent[0], input.worldToTangent[1],
+    TerrainSplatBlend(input.texCoord0.xy, input.worldToTangent[0], input.worldToTangent[1],
         surfaceData.baseColor, normalTS, surfaceData.perceptualSmoothness, surfaceData.metallic, surfaceData.ambientOcclusion);
 
     surfaceData.tangentWS = normalize(input.worldToTangent[0].xyz); // The tangent is not normalize in worldToTangent for mikkt. Tag: SURFACE_GRADIENT
@@ -91,24 +91,24 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
     if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)
     {
         if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_CONTROL)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0, _Control0, _Control0_TexelSize, _Control0_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy, _Control0, _Control0_TexelSize, _Control0_MipInfo, surfaceData.baseColor);
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER0)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat0_ST.xy + _Splat0_ST.zw, _Splat0, _Splat0_TexelSize, _Splat0_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat0_ST.xy + _Splat0_ST.zw, _Splat0, _Splat0_TexelSize, _Splat0_MipInfo, surfaceData.baseColor);
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER1)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat1_ST.xy + _Splat1_ST.zw, _Splat1, _Splat1_TexelSize, _Splat1_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat1_ST.xy + _Splat1_ST.zw, _Splat1, _Splat1_TexelSize, _Splat1_MipInfo, surfaceData.baseColor);
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER2)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat2_ST.xy + _Splat2_ST.zw, _Splat2, _Splat2_TexelSize, _Splat2_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat2_ST.xy + _Splat2_ST.zw, _Splat2, _Splat2_TexelSize, _Splat2_MipInfo, surfaceData.baseColor);
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER3)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat3_ST.xy + _Splat3_ST.zw, _Splat3, _Splat3_TexelSize, _Splat3_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat3_ST.xy + _Splat3_ST.zw, _Splat3, _Splat3_TexelSize, _Splat3_MipInfo, surfaceData.baseColor);
     #ifdef _TERRAIN_8_LAYERS
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER4)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat4_ST.xy + _Splat4_ST.zw, _Splat4, _Splat4_TexelSize, _Splat4_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat4_ST.xy + _Splat4_ST.zw, _Splat4, _Splat4_TexelSize, _Splat4_MipInfo, surfaceData.baseColor);
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER5)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat5_ST.xy + _Splat5_ST.zw, _Splat5, _Splat5_TexelSize, _Splat5_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat5_ST.xy + _Splat5_ST.zw, _Splat5, _Splat5_TexelSize, _Splat5_MipInfo, surfaceData.baseColor);
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER6)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat6_ST.xy + _Splat6_ST.zw, _Splat6, _Splat6_TexelSize, _Splat6_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat6_ST.xy + _Splat6_ST.zw, _Splat6, _Splat6_TexelSize, _Splat6_MipInfo, surfaceData.baseColor);
         else if (_DebugMipMapModeTerrainTexture == DEBUGMIPMAPMODETERRAINTEXTURE_LAYER7)
-            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0 * _Splat7_ST.xy + _Splat7_ST.zw, _Splat7, _Splat7_TexelSize, _Splat7_MipInfo, surfaceData.baseColor);
+            surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy * _Splat7_ST.xy + _Splat7_ST.zw, _Splat7, _Splat7_TexelSize, _Splat7_MipInfo, surfaceData.baseColor);
     #endif
         surfaceData.metallic = 0;
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData_Basemap.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData_Basemap.hlsl
@@ -30,7 +30,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 {
 #ifdef ENABLE_TERRAIN_PERPIXEL_NORMAL
     {
-        float3 normalOS = SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_MainTex, (input.texCoord0 + 0.5f) * _TerrainHeightmapRecipSize.xy).rgb * 2 - 1;
+        float3 normalOS = SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_MainTex, (input.texCoord0.xy + 0.5f) * _TerrainHeightmapRecipSize.xy).rgb * 2 - 1;
         float3 normalWS = mul((float3x3)GetObjectToWorldMatrix(), normalOS);
         float3 tangentWS = cross(GetObjectToWorldMatrix()._13_23_33, normalWS);
         float renormFactor = 1.0 / length(normalWS);
@@ -45,17 +45,17 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
         input.worldToTangent[1] = worldToTangent[1] * renormFactor;
         input.worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
 
-        input.texCoord0 *= _TerrainHeightmapRecipSize.zw;
+        input.texCoord0.xy *= _TerrainHeightmapRecipSize.zw;
     }
 #endif
 
     // terrain lightmap uvs are always taken from uv0
     input.texCoord1 = input.texCoord2 = input.texCoord0;
 
-    surfaceData.baseColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.texCoord0).rgb;
+    surfaceData.baseColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.texCoord0.xy).rgb;
 
-    surfaceData.perceptualSmoothness = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.texCoord0).a;
-    surfaceData.ambientOcclusion = SAMPLE_TEXTURE2D(_MetallicTex, sampler_MainTex, input.texCoord0).g;
+    surfaceData.perceptualSmoothness = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.texCoord0.xy).a;
+    surfaceData.ambientOcclusion = SAMPLE_TEXTURE2D(_MetallicTex, sampler_MainTex, input.texCoord0.xy).g;
     surfaceData.metallic = SAMPLE_TEXTURE2D(_MetallicTex, sampler_MainTex, input.texCoord0).r;
     surfaceData.tangentWS = normalize(input.worldToTangent[0].xyz); // The tangent is not normalize in worldToTangent for mikkt. Tag: SURFACE_GRADIENT
     surfaceData.subsurfaceMask = 0;
@@ -104,7 +104,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #ifdef DEBUG_DISPLAY
     if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)
     {
-        surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0, _MainTex, _MainTex_TexelSize, _MainTex_MipInfo, surfaceData.baseColor);
+        surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, input.texCoord0.xy, _MainTex, _MainTex_TexelSize, _MainTex_MipInfo, surfaceData.baseColor);
         surfaceData.metallic = 0;
     }
 #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/UnlitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/UnlitData.hlsl
@@ -9,7 +9,7 @@
 
 void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
 {
-    float2 unlitColorMapUv = TRANSFORM_TEX(input.texCoord0, _UnlitColorMap);
+    float2 unlitColorMapUv = TRANSFORM_TEX(input.texCoord0.xy, _UnlitColorMap);
     surfaceData.color = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, unlitColorMapUv).rgb * _UnlitColor.rgb;
     float alpha = SAMPLE_TEXTURE2D(_UnlitColorMap, sampler_UnlitColorMap, unlitColorMapUv).a * _UnlitColor.a;
 
@@ -22,13 +22,13 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     builtinData.opacity = alpha;
 
 #ifdef _EMISSIVE_COLOR_MAP
-    builtinData.emissiveColor = SAMPLE_TEXTURE2D(_EmissiveColorMap, sampler_EmissiveColorMap, TRANSFORM_TEX(input.texCoord0, _EmissiveColorMap)).rgb * _EmissiveColor;
+    builtinData.emissiveColor = SAMPLE_TEXTURE2D(_EmissiveColorMap, sampler_EmissiveColorMap, TRANSFORM_TEX(input.texCoord0.xy, _EmissiveColorMap)).rgb * _EmissiveColor;
 #else
     builtinData.emissiveColor = _EmissiveColor;
 #endif
 
 #if (SHADERPASS == SHADERPASS_DISTORTION) || defined(DEBUG_DISPLAY)
-    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0).rgb;
+    float3 distortion = SAMPLE_TEXTURE2D(_DistortionVectorMap, sampler_DistortionVectorMap, input.texCoord0.xy).rgb;
     distortion.rg = distortion.rg * _DistortionVectorScale.xx + _DistortionVectorBias.xx;
     builtinData.distortion = distortion.rg * _DistortionScale;
     builtinData.distortionBlur = clamp(distortion.b * _DistortionBlurScale, 0.0, 1.0) * (_DistortionBlurRemapMax - _DistortionBlurRemapMin) + _DistortionBlurRemapMin;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/FragInputs.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/FragInputs.hlsl
@@ -12,10 +12,10 @@ struct FragInputs
     // Note: SV_POSITION is the result of the clip space position provide to the vertex shaders that is transform by the viewport
     float4 positionSS; // In case depth offset is use, positionRWS.w is equal to depth offset
     float3 positionRWS; // Relative camera space position
-    float2 texCoord0;
-    float2 texCoord1;
-    float2 texCoord2;
-    float2 texCoord3;
+    float4 texCoord0;
+    float4 texCoord1;
+    float4 texCoord2;
+    float4 texCoord3;
     float4 color; // vertex color
 
     // TODO: confirm with Morten following statement
@@ -35,16 +35,16 @@ void GetVaryingsDataDebug(uint paramId, FragInputs input, inout float3 result, i
     switch (paramId)
     {
     case DEBUGVIEWVARYING_TEXCOORD0:
-        result = float3(input.texCoord0, 0.0);
+        result = input.texCoord0.xyz;
         break;
     case DEBUGVIEWVARYING_TEXCOORD1:
-        result = float3(input.texCoord1, 0.0);
+        result = input.texCoord1.xyz;
         break;
     case DEBUGVIEWVARYING_TEXCOORD2:
-        result = float3(input.texCoord2, 0.0);
+        result = input.texCoord2.xyz;
         break;
     case DEBUGVIEWVARYING_TEXCOORD3:
-        result = float3(input.texCoord3, 0.0);
+        result = input.texCoord3.xyz;
         break;
     case DEBUGVIEWVARYING_VERTEX_TANGENT_WS:
         result = input.worldToTangent[0].xyz * 0.5 + 0.5;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/VaryingMesh.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/VaryingMesh.hlsl
@@ -168,16 +168,16 @@ FragInputs UnpackVaryingsMeshToFragInputs(PackedVaryingsMeshToPS input)
 #endif // VARYINGS_NEED_TANGENT_TO_WORLD
 
 #ifdef VARYINGS_NEED_TEXCOORD0
-    output.texCoord0 = input.interpolators3.xy;
+    output.texCoord0.xy = input.interpolators3.xy;
 #endif
 #ifdef VARYINGS_NEED_TEXCOORD1
-    output.texCoord1 = input.interpolators3.zw;
+    output.texCoord1.xy = input.interpolators3.zw;
 #endif
 #ifdef VARYINGS_NEED_TEXCOORD2
-    output.texCoord2 = input.interpolators4.xy;
+    output.texCoord2.xy = input.interpolators4.xy;
 #endif
 #ifdef VARYINGS_NEED_TEXCOORD3
-    output.texCoord3 = input.interpolators4.zw;
+    output.texCoord3.xy = input.interpolators4.zw;
 #endif
 #ifdef VARYINGS_NEED_COLOR
     output.color = input.interpolators5;

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -79,3 +79,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The Shader Graph and Sub Shader Graph file extensions are no longer case-sensitive.
 - The dynamic value slot type now uses the correct decimal separator during HLSL generation.
 - Fixed an issue where Show Generated Code could fail when external editor was not set.
+- In the High Definition Render Pipeline, Shader Graph now supports 4-channel UVs.


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Speedtree needs four channel UV support for their tree animation node.
We need speedtree shaders in SRP, so shadergraph is an easy way to get it.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

This modifies FragInputs texcoords to be float4, but the default HDRP .shader interpolators are still two channels.  ShaderGraph builds it's own interpolators, and now makes them float4 (though a future work item is to make 4-channel UV's something that is requested when necessary, rather than the default..)

All existing .shader references to FragInputs.texcoord* were converted to specify .xy to ensure identical behavior in default shaders.  With the exception of InitBuiltinData(), which I modified to take float4 texcoords and do the .xy truncation internally.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
Currently running:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Fvec4hdrp2&unity_branch=2018.3%2Fstaging&automation-tools_branch=add-platform-filter

**Manual Tests**: What did you do?
Tested in local test scenes based on HD template with 2018.3.0b3.
Made a mesh with data in all four channels of UV0, and a shadergraph to pipe that to albedo, to display the output.

**Automated Tests**: What did you setup?
None.

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low: worst case is shader compilation failures we would have to fix.

**Halo Effect**: None, Low, Medium, High?
Medium at the shader level: modifies HDRP FragInputs definition of texcoords; fixed up all references I could find, possible there are disguised references somewhere.  In most cases any missed references will automatically downcast to Vector2, and issue a compile warning at worst.
Low effect outside of shaders.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
