### PR TITLE
Add toggle for SRP override of XRSettings [DO NOT MERGE]

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [4.1.0-preview] - 2018-09-28
+### Added
+- Toggle for SRP override of XRSettings
+
+### 
+- XRGraphicsConfig UI is now replaced with a warning when VR is not enabled in player settings
 
 ## [4.0.0-preview] - 2018-09-28
 ### Added

--- a/com.unity.render-pipelines.core/Editor/XRGraphicsConfigDrawer.cs
+++ b/com.unity.render-pipelines.core/Editor/XRGraphicsConfigDrawer.cs
@@ -5,14 +5,17 @@ namespace UnityEngine.Experimental.Rendering
     [CustomPropertyDrawer(typeof(XRGraphicsConfig))]
     public class XRGraphicsConfigDrawer : PropertyDrawer
     {
+        public AnimBool srpOverride; 
         internal class Styles
         {
-            public static GUIContent XRSettingsLabel = new GUIContent("XR Config", "Enable XR in Player Settings. Then SetConfig can be used to set this configuration to XRSettings.");
+            public static GUIContent XRSettingsLabel = new GUIContent("XR Config", "Enable XR in Player Settings, then enable SRP Override of XRSettings. Then the below values will be set to XRSettings by SRP.");
             public static GUIContent srpOverrideLabel = new GUIContent("Override XRSettings with SRP", "Overwrite default and non-SRP-programmed XRSettings with the values chosen in this SRP asset.");
             public static GUIContent useOcclusionMeshLabel = new GUIContent("Use Occlusion Mesh", "Determines whether or not to draw the occlusion mesh (goggles-shaped overlay) when rendering");
             public static GUIContent occlusionScaleLabel = new GUIContent("Occlusion Mesh Scale", "Scales the occlusion mesh");
+            public static GUIContent warnVRDisabled = EditorGUIUtility.TrTextContent("VR is disabled in Player Settings.");
 
         }
+
         // Draw the property inside the given rect
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -22,13 +25,20 @@ namespace UnityEngine.Experimental.Rendering
 
             EditorGUILayout.LabelField(Styles.XRSettingsLabel, EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(drawSRPOverride, Styles.srpOverrideLabel);
-            EditorGUI.BeginDisabledGroup(!XRGraphicsConfig.tryEnable);
-            EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(drawUseOcclusionMesh, Styles.useOcclusionMeshLabel);
-            EditorGUILayout.PropertyField(drawOcclusionMeshScale, Styles.occlusionScaleLabel);
-            EditorGUI.indentLevel--;
-            EditorGUILayout.Space();
-            EditorGUI.EndDisabledGroup();
+            if (XRGraphicsConfig.tryEnable)
+            {
+                EditorGUI.BeginDisabledGroup(!drawSRPOverride.boolValue);
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(drawUseOcclusionMesh, Styles.useOcclusionMeshLabel);
+                EditorGUILayout.PropertyField(drawOcclusionMeshScale, Styles.occlusionScaleLabel);
+                EditorGUI.indentLevel--;
+                EditorGUILayout.Space();
+                EditorGUI.EndDisabledGroup();
+            }
+            else
+            {
+                EditorGUILayout.HelpBox(Styles.warnVRDisabled.text, MessageType.Warning);
+            }
         }
     }
 }

--- a/com.unity.render-pipelines.core/Editor/XRGraphicsConfigDrawer.cs
+++ b/com.unity.render-pipelines.core/Editor/XRGraphicsConfigDrawer.cs
@@ -5,7 +5,6 @@ namespace UnityEngine.Experimental.Rendering
     [CustomPropertyDrawer(typeof(XRGraphicsConfig))]
     public class XRGraphicsConfigDrawer : PropertyDrawer
     {
-        public AnimBool srpOverride; 
         internal class Styles
         {
             public static GUIContent XRSettingsLabel = new GUIContent("XR Config", "Enable XR in Player Settings, then enable SRP Override of XRSettings. Then the below values will be set to XRSettings by SRP.");
@@ -24,9 +23,9 @@ namespace UnityEngine.Experimental.Rendering
             var drawSRPOverride = property.FindPropertyRelative("useSRPOverride");
 
             EditorGUILayout.LabelField(Styles.XRSettingsLabel, EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(drawSRPOverride, Styles.srpOverrideLabel);
             if (XRGraphicsConfig.tryEnable)
             {
+                EditorGUILayout.PropertyField(drawSRPOverride, Styles.srpOverrideLabel);
                 EditorGUI.BeginDisabledGroup(!drawSRPOverride.boolValue);
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(drawUseOcclusionMesh, Styles.useOcclusionMeshLabel);

--- a/com.unity.render-pipelines.core/Editor/XRGraphicsConfigDrawer.cs
+++ b/com.unity.render-pipelines.core/Editor/XRGraphicsConfigDrawer.cs
@@ -8,6 +8,7 @@ namespace UnityEngine.Experimental.Rendering
         internal class Styles
         {
             public static GUIContent XRSettingsLabel = new GUIContent("XR Config", "Enable XR in Player Settings. Then SetConfig can be used to set this configuration to XRSettings.");
+            public static GUIContent srpOverrideLabel = new GUIContent("Override XRSettings with SRP", "Overwrite default and non-SRP-programmed XRSettings with the values chosen in this SRP asset.");
             public static GUIContent useOcclusionMeshLabel = new GUIContent("Use Occlusion Mesh", "Determines whether or not to draw the occlusion mesh (goggles-shaped overlay) when rendering");
             public static GUIContent occlusionScaleLabel = new GUIContent("Occlusion Mesh Scale", "Scales the occlusion mesh");
 
@@ -17,9 +18,11 @@ namespace UnityEngine.Experimental.Rendering
         {
             var drawUseOcclusionMesh = property.FindPropertyRelative("useOcclusionMesh");
             var drawOcclusionMeshScale = property.FindPropertyRelative("occlusionMeshScale");
+            var drawSRPOverride = property.FindPropertyRelative("useSRPOverride");
 
-            EditorGUI.BeginDisabledGroup(!XRGraphicsConfig.tryEnable);
             EditorGUILayout.LabelField(Styles.XRSettingsLabel, EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(drawSRPOverride, Styles.srpOverrideLabel);
+            EditorGUI.BeginDisabledGroup(!XRGraphicsConfig.tryEnable);
             EditorGUI.indentLevel++;
             EditorGUILayout.PropertyField(drawUseOcclusionMesh, Styles.useOcclusionMeshLabel);
             EditorGUILayout.PropertyField(drawOcclusionMeshScale, Styles.occlusionScaleLabel);

--- a/com.unity.render-pipelines.core/Runtime/Common/XRGraphicsConfig.cs
+++ b/com.unity.render-pipelines.core/Runtime/Common/XRGraphicsConfig.cs
@@ -18,18 +18,31 @@ namespace UnityEngine.Experimental.Rendering
         public float viewportScale = 1.0f;
         public bool useOcclusionMesh = true;
         public float occlusionMeshScale = 1.0f;
-
+        public bool useSRPOverride = false;
+        
         public void CopyTo(XRGraphicsConfig targetConfig)
         {
-            targetConfig.renderScale = this.renderScale;
-            targetConfig.viewportScale = this.viewportScale;
-            targetConfig.useOcclusionMesh = this.useOcclusionMesh;
-            targetConfig.occlusionMeshScale = this.occlusionMeshScale;
+            if (!useSRPOverride && enabled)
+            {
+                targetConfig.renderScale = XRSettings.eyeTextureResolutionScale;
+                targetConfig.viewportScale = XRSettings.renderViewportScale;
+                targetConfig.useOcclusionMesh = XRSettings.useOcclusionMesh;
+                targetConfig.occlusionMeshScale = XRSettings.occlusionMaskScale;
+                targetConfig.useSRPOverride = this.useSRPOverride;
+            }
+            else
+            {
+                targetConfig.renderScale = this.renderScale;
+                targetConfig.viewportScale = this.viewportScale;
+                targetConfig.useOcclusionMesh = this.useOcclusionMesh;
+                targetConfig.occlusionMeshScale = this.occlusionMeshScale;
+                targetConfig.useSRPOverride = this.useSRPOverride;
+            }
         }
 
         public void SetConfig()
-        { // If XR is enabled, sets XRSettings from our saved config
-            if (!enabled)
+        { // If XR is enabled and overridden from SRP, sets XRSettings from our saved config
+            if (!enabled || !useSRPOverride)
                 return;
 
             XRSettings.eyeTextureResolutionScale = renderScale;
@@ -39,7 +52,7 @@ namespace UnityEngine.Experimental.Rendering
         }
         public void SetViewportScale(float viewportScale)
         { // Only sets viewport- since this is probably the only thing getting updated every frame
-            if (!enabled)
+            if (!enabled || !useSRPOverride)
                 return;
 
             XRSettings.renderViewportScale = viewportScale;

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed issue where XRGraphicsConfig values set in the asset inspector GUI weren't propagating correctly (VR still disabled for now)
 - Fixed issue with tangent that was using SurfaceGradient instead of regular normal decoding
 - Fixed wrong error message display when switching to unsupported target like IOS
+- Fixed y-flip in renderpostprocess when VR is enabled in Player Settings but disabled in HDRP framesettings
 
 ### Changed
 - Use samplerunity_ShadowMask instead of samplerunity_samplerLightmap for shadow mask

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -2134,7 +2134,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 context.command = cmd;
                 context.camera = hdcamera.camera;
                 context.sourceFormat = RenderTextureFormat.ARGBHalf;
-                context.flip = (hdcamera.camera.targetTexture == null) && (!hdcamera.camera.stereoEnabled) && !needOutputToColorBuffer;
+                context.flip = (hdcamera.camera.targetTexture == null) && (!hdcamera.frameSettings.enableStereo) && !needOutputToColorBuffer;
 
                 layer.Render(context);
 


### PR DESCRIPTION
### Purpose of this PR
Before SRP, users would control XRSettings through C# monobehaviours in their projects. In order to prevent SRP from clobbering previous functionality if such a project is upgraded from legacy to SRP, a toggle was added to enable SRP override of XRSettings. This toggle is off by default, and if it is off, the XRGraphicsConfig section of the SRP asset will be disabled, and XRGraphicsConfig.SetConfig() will do nothing. This seems like the best possible compromise between smoothing the transition to SRP for projects designed on legacy, and giving SRP users intuitive control over rendering settings. 
![image](https://user-images.githubusercontent.com/3450690/46316541-51e3b580-c585-11e8-8307-0109ca2b73dc.png)

Additionally, a warning will now be displayed in place of the XRGraphicsConfig UI when VR is not enabled. 

![image](https://user-images.githubusercontent.com/3450690/46316625-8a838f00-c585-11e8-96aa-3593a87c0864.png)

Finally, a minor fix for HDRP to fix y-flip when framesettings.stereoEnabled is toggled off, but VR is still enabled in player settings. 

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=xrgc_override&unity_branch=trunk&automation-tools_branch=add-platform-filter

**Manual Tests**: What did you do?
Toggled VR enable and new SRP override enable in HDRP. 
Toggled VR enable in Player Settings with LWRP and new SRP override. 

**Automated Tests**: What did you setup?
None

Any test projects to go with this to help reviewers?
Any project will work.

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low- simple change affecting the self-contained XRGraphicsConfig class.

**Halo Effect**: None, Low, Medium, High?
None for same reasons as above

---
### Comments to reviewers
Also linking Mike Chow to this PR for approval