### PR TITLE
Allow materials to not receive SSR

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
@@ -517,7 +517,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             // Use negation so we don't create keyword by default
             CoreUtils.SetKeyword(material, "_DISABLE_DECALS", material.HasProperty(kSupportDecals) && material.GetFloat(kSupportDecals) == 0.0);
-
+            CoreUtils.SetKeyword(material, "_DISABLE_SSR", material.HasProperty(kReceiveSSR) && material.GetFloat(kReceiveSSR) == 0.0);
             CoreUtils.SetKeyword(material, "_ENABLE_GEOMETRIC_SPECULAR_AA", material.HasProperty(kEnableGeometricSpecularAA) && material.GetFloat(kEnableGeometricSpecularAA) == 1.0);
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
@@ -62,6 +62,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static GUIContent enableGeometricSpecularAAText = new GUIContent("Enable geometric specular AA", "This reduce specular aliasing on highly dense mesh (Particularly useful when they don't use normal map)");
             public static GUIContent specularAAScreenSpaceVarianceText = new GUIContent("Screen space variance", "Allow to control the strength of the specular AA reduction. Higher mean more blurry result and less aliasing");
             public static GUIContent specularAAThresholdText = new GUIContent("Threshold", "Allow to limit the effect of specular AA reduction. 0 mean don't apply reduction, higher value mean allow higher reduction");
+
+            // SSR
+            public static GUIContent receivesSSRText = new GUIContent("Receives SSR", "Allow to specify if the material can receive SSR or not");
+
         }
 
         public enum DoubleSidedNormalMode
@@ -179,6 +183,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected MaterialProperty specularAAThreshold = null;
         protected const string kSpecularAAThreshold = "_SpecularAAThreshold";
 
+        // SSR
+        protected MaterialProperty receivesSSR = null;
+        protected const string kReceiveSSR = "_ReceivesSSR";
+
+
         protected override void FindBaseMaterialProperties(MaterialProperty[] props)
         {
             base.FindBaseMaterialProperties(props);
@@ -226,6 +235,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             enableGeometricSpecularAA = FindProperty(kEnableGeometricSpecularAA, props, false);
             specularAAScreenSpaceVariance = FindProperty(kSpecularAAScreenSpaceVariance, props, false);
             specularAAThreshold = FindProperty(kSpecularAAThreshold, props, false);
+
+            // SSR
+            receivesSSR = FindProperty(kReceiveSSR, props, false);
         }
 
         void TessellationModePopup()
@@ -286,6 +298,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     m_MaterialEditor.ShaderProperty(specularAAThreshold, StylesBaseLit.specularAAThresholdText);
                     EditorGUI.indentLevel--;
                 }
+            }
+
+            if(receivesSSR != null)
+            {
+                m_MaterialEditor.ShaderProperty(receivesSSR, StylesBaseLit.receivesSSRText);
             }
 
             if (displacementMode != null)
@@ -445,13 +462,21 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             // Set the reference value for the stencil test.
             int stencilRef = (int)StencilLightingUsage.RegularLighting;
+            int stencilWriteMask = (int)HDRenderPipeline.StencilBitMask.LightingMask;
             if (material.HasProperty(kMaterialID) && (int)material.GetFloat(kMaterialID) == (int)BaseLitGUI.MaterialId.LitSSS)
             {
                 stencilRef = (int)StencilLightingUsage.SplitLighting;
             }
+
+            if(material.HasProperty(kReceiveSSR) && material.GetInt(kReceiveSSR) == 0)
+            {
+                stencilWriteMask |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
+                stencilRef |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
+            }
+
             // As we tag both during velocity pass and Gbuffer pass we need a separate state and we need to use the write mask
             material.SetInt(kStencilRef, stencilRef);
-            material.SetInt(kStencilWriteMask, (int)HDRenderPipeline.StencilBitMask.LightingMask);
+            material.SetInt(kStencilWriteMask, stencilWriteMask);
             material.SetInt(kStencilRefMV, (int)HDRenderPipeline.StencilBitMask.ObjectVelocity);
             material.SetInt(kStencilWriteMaskMV, (int)HDRenderPipeline.StencilBitMask.ObjectVelocity);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
@@ -185,7 +185,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         // SSR
         protected MaterialProperty receivesSSR = null;
-        protected const string kReceiveSSR = "_ReceivesSSR";
+        protected const string kReceivesSSR = "_ReceivesSSR";
 
 
         protected override void FindBaseMaterialProperties(MaterialProperty[] props)
@@ -237,7 +237,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             specularAAThreshold = FindProperty(kSpecularAAThreshold, props, false);
 
             // SSR
-            receivesSSR = FindProperty(kReceiveSSR, props, false);
+            receivesSSR = FindProperty(kReceivesSSR, props, false);
         }
 
         void TessellationModePopup()
@@ -468,7 +468,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 stencilRef = (int)StencilLightingUsage.SplitLighting;
             }
 
-            if(material.HasProperty(kReceiveSSR) && material.GetInt(kReceiveSSR) == 0)
+            if(material.HasProperty(kReceivesSSR) && material.GetInt(kReceivesSSR) == 0)
             {
                 stencilWriteMask |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
                 stencilRef |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
@@ -517,7 +517,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             // Use negation so we don't create keyword by default
             CoreUtils.SetKeyword(material, "_DISABLE_DECALS", material.HasProperty(kSupportDecals) && material.GetFloat(kSupportDecals) == 0.0);
-            CoreUtils.SetKeyword(material, "_DISABLE_SSR", material.HasProperty(kReceiveSSR) && material.GetFloat(kReceiveSSR) == 0.0);
+            CoreUtils.SetKeyword(material, "_DISABLE_SSR", material.HasProperty(kReceivesSSR) && material.GetFloat(kReceivesSSR) == 0.0);
             CoreUtils.SetKeyword(material, "_ENABLE_GEOMETRIC_SPECULAR_AA", material.HasProperty(kEnableGeometricSpecularAA) && material.GetFloat(kEnableGeometricSpecularAA) == 1.0);
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -218,11 +218,13 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 
         // Apply SSR.
     #ifndef _SURFACE_TYPE_TRANSPARENT
+    #ifndef _DISABLE_SSR
         {
             IndirectLighting indirect = EvaluateBSDF_ScreenSpaceReflection(posInput, preLightData, bsdfData,
                                                                            reflectionHierarchyWeight);
             AccumulateIndirectLighting(indirect, aggregateLighting);
         }
+    #endif
     #endif
 
         EnvLightData envLightData;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -217,14 +217,12 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         //  3. Sky Reflection / Refraction
 
         // Apply SSR.
-    #ifndef _SURFACE_TYPE_TRANSPARENT
-    #ifndef _DISABLE_SSR
+    #if !defined(_SURFACE_TYPE_TRANSPARENT) && !defined(_DISABLE_SSR)
         {
             IndirectLighting indirect = EvaluateBSDF_ScreenSpaceReflection(posInput, preLightData, bsdfData,
                                                                            reflectionHierarchyWeight);
             AccumulateIndirectLighting(indirect, aggregateLighting);
         }
-    #endif
     #endif
 
         EnvLightData envLightData;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/materialflags.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/materialflags.compute
@@ -54,8 +54,7 @@ void MATERIALFLAGSGEN(uint threadID : SV_GroupIndex, uint3 u3GroupID : SV_GroupI
         int idx = i * NR_THREADS + threadID;
         uint2 uCrd = min( uint2(viTilLL.x + (idx & 0xf), viTilLL.y + (idx >> 4)), uint2(iWidth - 1, iHeight - 1));
 
-        // TODO_FCC: Change this comment.  
-        // StencilTexture here contain the result of testing if we are not equal to stencil usage NoLighting. i.e (stencil value != NoLighting). The 1.0 mean true.
+        // StencilTexture here contain the result of testing if we are not equal to stencil usage NoLighting. i.e (stencil value != NoLighting). A value > 0 means true.
         // This test if we are the sky/background or a forward opaque (which tag the stencil as NoLighting)
         uint stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, uCrd).r);
         if (stencilVal > 0)

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/materialflags.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/materialflags.compute
@@ -54,9 +54,11 @@ void MATERIALFLAGSGEN(uint threadID : SV_GroupIndex, uint3 u3GroupID : SV_GroupI
         int idx = i * NR_THREADS + threadID;
         uint2 uCrd = min( uint2(viTilLL.x + (idx & 0xf), viTilLL.y + (idx >> 4)), uint2(iWidth - 1, iHeight - 1));
 
+        // TODO_FCC: Change this comment.  
         // StencilTexture here contain the result of testing if we are not equal to stencil usage NoLighting. i.e (stencil value != NoLighting). The 1.0 mean true.
         // This test if we are the sky/background or a forward opaque (which tag the stencil as NoLighting)
-        if (LOAD_TEXTURE2D(_StencilTexture, uCrd).r == 1.0)
+        uint stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, uCrd).r);
+        if (stencilVal > 0)
         {
             PositionInputs posInput = GetPositionInput(uCrd, invScreenSize);
             materialFeatureFlags |= MATERIAL_FEATURE_FLAGS_FROM_GBUFFER(posInput.positionSS);

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
@@ -81,11 +81,10 @@ void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 {
     // If we are in forward only, the exclusion happens at a later stage. This is detected with _SsrStencilExclusionValue < 0
     // TODO: It would be good to find a way to skip some work here even in forward.
-    bool doesntReceiveSSR = false;
     UNITY_BRANCH if (_SsrStencilExclusionValue > 0)
     {
-        uint   stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
-        doesntReceiveSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
+        uint stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
+        bool doesntReceiveSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
 
         if (doesntReceiveSSR)
         {

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
@@ -39,6 +39,7 @@
 #ifdef SSR_TRACE
     // TEXTURE2D(        _NormalBufferTexture); // Declared in NormalBuffer.hlsl.
     // TEXTURE2D(        _DepthPyramidTexture);  // Declared in ShaderVariablesScreenSpaceLighting.hlsl
+    TEXTURE2D(           _StencilTexture);
     RW_TEXTURE2D(float2, _SsrHitPointTexture);
 #else
     // TEXTURE2D(        _NormalBufferTexture); // Declared in NormalBuffer.hlsl.
@@ -59,6 +60,7 @@ CBUFFER_START(UnityScreenSpaceReflections)
     float _SsrRoughnessFadeEndTimesRcpLength;
     float _SsrEdgeFadeRcpLength;
     int   _SsrDepthPyramidMaxMip;
+    int   _SsrStencilExclusionValue;
 CBUFFER_END
 
 //--------------------------------------------------------------------------------------------------
@@ -77,13 +79,21 @@ void WriteDebugInfo(uint2 positionSS, float4 value)
 [numthreads(8, 8, 1)]
 void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 {
+
+    uint   stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
+    bool   skipSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
+
+    if (skipSSR)
+    {
+        WriteDebugInfo(positionSS, -1);
+        return;
+    }
+
     float2 positionNDC = positionSS * _ScreenSize.zw + (0.5 * _ScreenSize.zw); // Should we precompute the half-texel bias? We seem to use it a lot.
     float  deviceDepth = LOAD_TEXTURE2D(_DepthPyramidTexture, positionSS).r;
     float3 positionWS  = ComputeWorldSpacePosition(positionNDC, deviceDepth, UNITY_MATRIX_I_VP); // Jittered
     float3 V           = GetWorldSpaceNormalizeViewDir(positionWS);
 
-    // TODO: mark stencil during the G-Buffer pass with pixels which should receive SSR .
-    // Reading the stencil is faster than reading the depth and the G-Buffer.
     bool killRay = deviceDepth == UNITY_RAW_FAR_CLIP_VALUE;
 
     // Load normal and roughness.

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
@@ -63,6 +63,7 @@ CBUFFER_START(UnityScreenSpaceReflections)
     int   _SsrStencilExclusionValue;
 CBUFFER_END
 
+
 //--------------------------------------------------------------------------------------------------
 // Implementation
 //--------------------------------------------------------------------------------------------------
@@ -79,11 +80,16 @@ void WriteDebugInfo(uint2 positionSS, float4 value)
 [numthreads(8, 8, 1)]
 void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 {
+    // If we are in forward only, the exclusion happens at a later stage.
+    // TODO: It would be good to find a way to skip some work here even in forward.
+    bool doesntReceiveSSR = false;
+    UNITY_BRANCH if (_SsrStencilExclusionValue > 0)
+    {
+        uint   stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
+        doesntReceiveSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
+    }
 
-    uint   stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
-    bool   skipSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
-
-    if (skipSSR)
+    if (doesntReceiveSSR)
     {
         WriteDebugInfo(positionSS, -1);
         return;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
@@ -63,7 +63,6 @@ CBUFFER_START(UnityScreenSpaceReflections)
     int   _SsrStencilExclusionValue;
 CBUFFER_END
 
-
 //--------------------------------------------------------------------------------------------------
 // Implementation
 //--------------------------------------------------------------------------------------------------
@@ -80,19 +79,19 @@ void WriteDebugInfo(uint2 positionSS, float4 value)
 [numthreads(8, 8, 1)]
 void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 {
-    // If we are in forward only, the exclusion happens at a later stage.
+    // If we are in forward only, the exclusion happens at a later stage. This is detected with _SsrStencilExclusionValue < 0
     // TODO: It would be good to find a way to skip some work here even in forward.
     bool doesntReceiveSSR = false;
     UNITY_BRANCH if (_SsrStencilExclusionValue > 0)
     {
         uint   stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
         doesntReceiveSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
-    }
 
-    if (doesntReceiveSSR)
-    {
-        WriteDebugInfo(positionSS, -1);
-        return;
+        if (doesntReceiveSSR)
+        {
+            WriteDebugInfo(positionSS, -1);
+            return;
+        }
     }
 
     float2 positionNDC = positionSS * _ScreenSize.zw + (0.5 * _ScreenSize.zw); // Should we precompute the half-texel bias? We seem to use it a lot.

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -424,6 +424,7 @@ Shader "HDRenderPipeline/LayeredLit"
     #pragma shader_feature _ _LAYEREDLIT_3_LAYERS _LAYEREDLIT_4_LAYERS
 
     #pragma shader_feature _DISABLE_DECALS
+    #pragma shader_feature _DISABLE_SSR
     #pragma shader_feature _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -346,6 +346,7 @@ Shader "HDRenderPipeline/LayeredLit"
         _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
+        [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
 
         // this will let collapsable element of material be persistant
         //this will also replace in a more concise way:

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -362,6 +362,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
+        [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
 
         // this will let collapsable element of material be persistant
         [HideInInspector] _EditorExpendedAreas("_EditorExpendedAreas", Float) = 0

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -435,6 +435,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
     #pragma shader_feature _ _LAYEREDLIT_3_LAYERS _LAYEREDLIT_4_LAYERS
 
     #pragma shader_feature _DISABLE_DECALS
+    #pragma shader_feature _DISABLE_SSR
     #pragma shader_feature _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -203,6 +203,7 @@ Shader "HDRenderPipeline/Lit"
         _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
+        [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
 
         // this will let collapsable element of material be persistant
         [HideInInspector] _EditorExpendedAreas("_EditorExpendedAreas", Float) = 0

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -250,6 +250,7 @@ Shader "HDRenderPipeline/Lit"
     #pragma shader_feature _TRANSMITTANCECOLORMAP
 
     #pragma shader_feature _DISABLE_DECALS
+    #pragma shader_feature _DISABLE_SSR
     #pragma shader_feature _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -262,6 +262,7 @@ Shader "HDRenderPipeline/LitTessellation"
     #pragma shader_feature _TRANSMITTANCECOLORMAP
 
     #pragma shader_feature _DISABLE_DECALS
+    #pragma shader_feature _DISABLE_SSR
     #pragma shader_feature _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -214,6 +214,7 @@ Shader "HDRenderPipeline/LitTessellation"
         _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
+        [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
 
         // this will let collapsable element of material be persistant
         [HideInInspector] _EditorExpendedAreas("_EditorExpendedAreas", Float) = 0

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SharedRTManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SharedRTManager.cs
@@ -61,7 +61,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_CameraDepthBufferMipChain = RTHandles.Alloc(ComputeDepthBufferMipChainSize, colorFormat: RenderTextureFormat.RFloat, filterMode: FilterMode.Point, sRGB: false, enableRandomWrite: true, name: "CameraDepthBufferMipChain");
 
             // Technically we won't need this buffer in some cases, but nothing that we can determine at init time.
-            m_CameraStencilBufferCopy = RTHandles.Alloc(Vector2.one, depthBufferBits: DepthBits.None, colorFormat: RenderTextureFormat.R8, sRGB: false, filterMode: FilterMode.Point, name: "CameraStencilCopy"); // DXGI_FORMAT_R8_UINT is not supported by Unity
+            m_CameraStencilBufferCopy = RTHandles.Alloc(Vector2.one, depthBufferBits: DepthBits.None, colorFormat: RenderTextureFormat.R8, sRGB: false, filterMode: FilterMode.Point, enableRandomWrite: true, name: "CameraStencilCopy"); // DXGI_FORMAT_R8_UINT is not supported by Unity
 
             if (m_VelocitySupport)
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
@@ -39,6 +39,7 @@ Shader "HDRenderPipeline/TerrainLit"
         _Color("Color", Color) = (1,1,1,1)
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
+        [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
 
         // this will let collapsable element of material be persistant
         [HideInInspector] _EditorExpendedAreas("_EditorExpendedAreas", Float) = 0

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Basemap.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Basemap.shader
@@ -29,6 +29,7 @@ Shader "Hidden/HDRenderPipeline/TerrainLit_Basemap"
         _Color("Color", Color) = (1,1,1,1)
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
+        [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
 
         // TEMP: See comment later for motion vector pass
         [HideInInspector] _EnableMotionVectorForVertexAnimation("EnableMotionVectorForVertexAnimation", Float) = 0.0

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDCustomSamplerId.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDCustomSamplerId.cs
@@ -51,6 +51,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         HDRenderPipelineRender,
         CullResultsCull,
         CopyDepth,
+        UpdateStencilCopyForSSRExclusion,
 
         // Profile sampler for tile pass
         TPPrepareLightsForGPU,

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1136,7 +1136,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         // TODO: Move this code inside LightLoop
                         if (m_LightLoop.GetFeatureVariantsEnabled())
                         {
-
                             // For material classification we use compute shader and so can't read into the stencil, so prepare it.
                             using (new ProfilingSample(cmd, "Clear and copy stencil texture", CustomSamplerId.ClearAndCopyStencilTexture.GetSampler()))
                             {
@@ -1167,7 +1166,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                     cmd.ClearRandomWriteTargets();
                                 }
                             }
-
                         }
 
                         // Needs the depth pyramid and motion vectors, as well as the render of the previous frame.

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1156,9 +1156,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                 CoreUtils.DrawFullScreen(cmd, m_CopyStencilForNoLighting, null, 3);
                                 cmd.ClearRandomWriteTargets();
                             }
-                        }
 
-                        {
                             using (new ProfilingSample(cmd, "Update stencil copy for SSR Exclusion", CustomSamplerId.UpdateStencilCopyForSSRExclusion.GetSampler()))
                             {
                                 HDUtils.SetRenderTarget(cmd, hdCamera, m_SharedRTManager.GetDepthStencilBuffer()); // No need for color buffer here
@@ -1167,6 +1165,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                 CoreUtils.DrawFullScreen(cmd, m_UpdateStencilForSSRExclusion, null, 4);
                                 cmd.ClearRandomWriteTargets();
                             }
+
+                        }
+
+                        {
 
                         }
 
@@ -2006,7 +2008,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrRoughnessFadeEndTimesRcpLength, roughnessFadeEndTimesRcpLength);
                 cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrDepthPyramidMaxMip,             info.mipLevelCount);
                 cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrEdgeFadeRcpLength,              edgeFadeRcpLength);
-                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrStencilExclusionValue,          (int)StencilBitMask.DoesntReceiveSSR);
+                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrStencilExclusionValue,          hdCamera.frameSettings.enableForwardRenderingOnly ? -1 : (int)StencilBitMask.DoesntReceiveSSR);
 
                 // cmd.SetComputeTextureParam(cs, kernel, "_SsrDebugTexture",    m_SsrDebugTexture);
                 cmd.SetComputeTextureParam(cs, kernel, HDShaderIDs._SsrHitPointTexture, m_SsrHitPointTexture);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1147,6 +1147,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                 m_CopyStencil.SetInt(HDShaderIDs._StencilRef, (int)StencilLightingUsage.NoLighting);
                                 m_CopyStencil.SetInt(HDShaderIDs._StencilMask, (int)StencilBitMask.LightingMask);
 
+                                // Use ShaderPassID 3 => "Pass 3 - Initialize Stencil UAV copy with 1 if value different from stencilRef to output"
                                 CoreUtils.DrawFullScreen(cmd, m_CopyStencil, null, 3);
                                 cmd.ClearRandomWriteTargets();
                             }
@@ -1161,7 +1162,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                     m_CopyStencil.SetInt(HDShaderIDs._StencilRef, (int)StencilBitMask.DoesntReceiveSSR);
                                     m_CopyStencil.SetInt(HDShaderIDs._StencilMask, (int)StencilBitMask.DoesntReceiveSSR);
 
-                                    // Pass 4 perform an OR between the already present content of the copy and the stencil ref, if stencil test passes. 
+                                    // Pass 4 performs an OR between the already present content of the copy and the stencil ref, if stencil test passes. 
                                     CoreUtils.DrawFullScreen(cmd, m_CopyStencil, null, 4);
                                     cmd.ClearRandomWriteTargets();
                                 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -331,6 +331,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _SsrLightingTextureRW              = Shader.PropertyToID("_SsrLightingTextureRW");
         public static readonly int _SsrHitPointTexture                = Shader.PropertyToID("_SsrHitPointTexture");
         public static readonly int _SsrDepthPyramidMipOffsets         = Shader.PropertyToID("_SsrDepthPyramidMipLevelOffsets");
+        public static readonly int _SsrStencilExclusionValue          = Shader.PropertyToID("_SsrStencilExclusionValue");
+
 
 
         public static readonly int _VelocityTexture = Shader.PropertyToID("_VelocityTexture");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
@@ -27,7 +27,7 @@ MonoBehaviour:
     enableLightLayers: 1
     diffuseGlobalDimmer: 1
     specularGlobalDimmer: 1
-    enableForwardRenderingOnly: 1
+    enableForwardRenderingOnly: 0
     enableDepthPrepassWithDeferredRendering: 0
     enableTransparentPrepass: 1
     enableMotionVectors: 1

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
@@ -29,7 +29,7 @@ MonoBehaviour:
     enableLightLayers: 1
     diffuseGlobalDimmer: 1
     specularGlobalDimmer: 1
-    enableForwardRenderingOnly: 0
+    enableForwardRenderingOnly: 1
     enableDepthPrepassWithDeferredRendering: 0
     enableTransparentPrepass: 1
     enableMotionVectors: 1

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
@@ -13,7 +13,8 @@ MonoBehaviour:
   m_Name: HDRenderPipelineAsset
   m_EditorClassIdentifier: 
   m_Version: 1
-  m_RenderPipelineResources: {fileID: 11400000, guid: 3ce144cff5783da45aa5d4fdc2da14b7, type: 2}
+  m_RenderPipelineResources: {fileID: 11400000, guid: 3ce144cff5783da45aa5d4fdc2da14b7,
+    type: 2}
   m_FrameSettings:
     enableShadow: 1
     enableContactShadows: 1
@@ -24,6 +25,7 @@ MonoBehaviour:
     enableTransmission: 1
     enableAtmosphericScattering: 1
     enableVolumetrics: 1
+    enableReprojectionForVolumetrics: 1
     enableLightLayers: 1
     diffuseGlobalDimmer: 1
     specularGlobalDimmer: 1
@@ -57,7 +59,7 @@ MonoBehaviour:
       isFptlEnabled: 1
   renderPipelineSettings:
     supportShadowMask: 0
-    supportSSR: 0
+    supportSSR: 1
     supportSSAO: 1
     supportSubsurfaceScattering: 1
     increaseSssSampleCount: 0
@@ -70,7 +72,7 @@ MonoBehaviour:
     msaaSampleCount: 1
     supportMotionVectors: 1
     supportRuntimeDebugDisplay: 1
-    supportDitheringCrossFade: 1
+    supportDitheringCrossFade: 0
     xrConfig:
       renderScale: 1
       viewportScale: 1
@@ -91,18 +93,12 @@ MonoBehaviour:
       skyLightingOverrideLayerMask:
         serializedVersion: 2
         m_Bits: 256
-    shadowInitParams:
-      shadowAtlasWidth: 4096
-      shadowAtlasHeight: 4096
-      shadowMap16Bit: 0
-      maxPointLightShadows: 6
-      maxSpotLightShadows: 12
-      maxDirectionalLightShadows: 1
     hdShadowInitParams:
       shadowAtlasWidth: 4096
       shadowAtlasHeight: 4096
       maxShadowRequests: 128
       shadowMapsDepthBits: 32
+      useDynamicViewportRescale: 1
       punctualShadowQuality: 2
       directionalShadowQuality: 2
     decalSettings:
@@ -111,4 +107,5 @@ MonoBehaviour:
       atlasHeight: 4096
       perChannelMask: 0
   allowShaderVariantStripping: 1
-  diffusionProfileSettings: {fileID: 11400000, guid: 404820c4cf36ad944862fa59c56064f0, type: 2}
+  diffusionProfileSettings: {fileID: 11400000, guid: 404820c4cf36ad944862fa59c56064f0,
+    type: 2}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineAsset.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: HDRenderPipelineAsset
   m_EditorClassIdentifier: 
   m_Version: 1
-  m_RenderPipelineResources: {fileID: 11400000, guid: 3ce144cff5783da45aa5d4fdc2da14b7,
-    type: 2}
+  m_RenderPipelineResources: {fileID: 11400000, guid: 3ce144cff5783da45aa5d4fdc2da14b7, type: 2}
   m_FrameSettings:
     enableShadow: 1
     enableContactShadows: 1
@@ -25,7 +24,6 @@ MonoBehaviour:
     enableTransmission: 1
     enableAtmosphericScattering: 1
     enableVolumetrics: 1
-    enableReprojectionForVolumetrics: 1
     enableLightLayers: 1
     diffuseGlobalDimmer: 1
     specularGlobalDimmer: 1
@@ -59,7 +57,7 @@ MonoBehaviour:
       isFptlEnabled: 1
   renderPipelineSettings:
     supportShadowMask: 0
-    supportSSR: 1
+    supportSSR: 0
     supportSSAO: 1
     supportSubsurfaceScattering: 1
     increaseSssSampleCount: 0
@@ -72,7 +70,7 @@ MonoBehaviour:
     msaaSampleCount: 1
     supportMotionVectors: 1
     supportRuntimeDebugDisplay: 1
-    supportDitheringCrossFade: 0
+    supportDitheringCrossFade: 1
     xrConfig:
       renderScale: 1
       viewportScale: 1
@@ -93,12 +91,18 @@ MonoBehaviour:
       skyLightingOverrideLayerMask:
         serializedVersion: 2
         m_Bits: 256
+    shadowInitParams:
+      shadowAtlasWidth: 4096
+      shadowAtlasHeight: 4096
+      shadowMap16Bit: 0
+      maxPointLightShadows: 6
+      maxSpotLightShadows: 12
+      maxDirectionalLightShadows: 1
     hdShadowInitParams:
       shadowAtlasWidth: 4096
       shadowAtlasHeight: 4096
       maxShadowRequests: 128
       shadowMapsDepthBits: 32
-      useDynamicViewportRescale: 1
       punctualShadowQuality: 2
       directionalShadowQuality: 2
     decalSettings:
@@ -107,5 +111,4 @@ MonoBehaviour:
       atlasHeight: 4096
       perChannelMask: 0
   allowShaderVariantStripping: 1
-  diffusionProfileSettings: {fileID: 11400000, guid: 404820c4cf36ad944862fa59c56064f0,
-    type: 2}
+  diffusionProfileSettings: {fileID: 11400000, guid: 404820c4cf36ad944862fa59c56064f0, type: 2}

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/CopyStencilBuffer.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/CopyStencilBuffer.shader
@@ -18,6 +18,7 @@ Shader "Hidden/HDRenderPipeline/CopyStencilBuffer"
 
     int _StencilRef;
     RW_TEXTURE2D(float, _HTile); // DXGI_FORMAT_R8_UINT is not supported by Unity
+    RW_TEXTURE2D(float, _StencilBufferCopy); // DXGI_FORMAT_R8_UINT is not supported by Unity
 
     struct Attributes
     {
@@ -138,6 +139,72 @@ Shader "Hidden/HDRenderPipeline/CopyStencilBuffer"
             }
 
             ENDHLSL
+        }
+
+        Pass
+        {
+            // Note, when supporting D3D 11.3+, this can be a one off copy pass.
+            // This is essentially the equivalent of Pass 1
+            Name "Pass 3 - Initialize Stencil UAV copy with 1 if value different from stencilRef to output"  
+
+            Stencil
+            {
+                ReadMask[_StencilMask]
+                Ref[_StencilRef]
+                Comp NotEqual
+                Pass Keep
+            }
+
+            Cull   Off
+            ZTest  Always
+            ZWrite Off
+            Blend  Off
+
+            HLSLPROGRAM
+            #pragma fragment Frag
+
+                // Force the stencil test before the UAV write.
+                [earlydepthstencil]
+                float4 Frag(Varyings input) : SV_Target // use SV_StencilRef in D3D 11.3+
+                {
+                    _StencilBufferCopy[(uint2)input.positionCS.xy] = PackByte(1);
+                    return float4(0.0, 0.0, 0.0, 0.0);
+                }
+
+                ENDHLSL
+        }
+
+        Pass
+        {
+            Name "Pass 4 - Update Stencil UAV copy with Stencil Ref"  
+
+            Stencil
+            {
+                ReadMask[_StencilMask]
+                Ref[_StencilRef]
+                Comp Equal
+                Pass Keep
+            }
+
+            Cull   Off
+            ZTest  Always
+            ZWrite Off
+            Blend  Off
+
+            HLSLPROGRAM
+            #pragma fragment Frag
+
+                // Force the stencil test before the UAV write.
+                [earlydepthstencil]
+                float4 Frag(Varyings input) : SV_Target // use SV_StencilRef in D3D 11.3+
+                {
+                    uint2 dstPixCoord = (uint2)input.positionCS.xy;
+                    uint oldStencilVal = UnpackByte(_StencilBufferCopy[dstPixCoord]);
+                    _StencilBufferCopy[dstPixCoord] = PackByte(oldStencilVal | _StencilRef);
+                    return float4(0.0, 0.0, 0.0, 0.0);
+                }
+
+                ENDHLSL
         }
     }
     Fallback Off

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/CopyStencilBuffer.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/CopyStencilBuffer.shader
@@ -144,7 +144,7 @@ Shader "Hidden/HDRenderPipeline/CopyStencilBuffer"
         Pass
         {
             // Note, when supporting D3D 11.3+, this can be a one off copy pass.
-            // This is essentially the equivalent of Pass 1
+            // This is essentially the equivalent of Pass 1, but writing to a UAV instead.
             Name "Pass 3 - Initialize Stencil UAV copy with 1 if value different from stencilRef to output"  
 
             Stencil


### PR DESCRIPTION
### Purpose of this PR
This adds a checkbox on a per-material basis that allow the user to exclude specific materials from receiving SSR (if unchecked). This could be useful in case of instabilities. 

![onoff](https://user-images.githubusercontent.com/43168857/46339769-f7edf900-c633-11e8-9cea-e562e501776e.png)


This is achieved by modifying the stencil copy generation, the stencil copy has now also an UAV and, after a first clear+mark pixel that receive light pass, the content is OR'd to receive a SSR-specific bit flag.
The whole stencil handling would be faster if we could create an SRV to read directly the stencil or if we could guarantee access to SV_StencilRef in shader. In absence of those two, this was the fastest way I could think of. 

---
### Release Notes
Select on a per-material basis whether SSR should be received or not. 

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=allow-materials-to-not-receive-ssr&automation-tools_branch=add-platform-filter&unity_branch=trunk [Running]

**Manual Tests**: Tested both in forward only and deferred in editor and in game mode, both on PC and Xbox. 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**:  Low
