### PR TITLE
Add missing area light handle

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Core/Lighting/CoreLightEditorUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/Lighting/CoreLightEditorUtilities.cs
@@ -220,23 +220,37 @@ namespace UnityEditor.Experimental.Rendering
 
             return new Vector3(outerAngle, innerAngle, range);
         }
-
-        public static void DrawArealightGizmo(Light arealight)
+        
+        public static void DrawAreaLightWireframe(Vector2 rectangleSize)
         {
-            var RectangleSize = new Vector3(arealight.areaSize.x, arealight.areaSize.y, 0);
-            // Remove scale for light, not take into account
-            var localToWorldMatrix = Matrix4x4.TRS(arealight.transform.position, arealight.transform.rotation, Vector3.one);
-            Gizmos.matrix = localToWorldMatrix;
-            Gizmos.DrawWireCube(Vector3.zero, RectangleSize);
-            Gizmos.matrix = Matrix4x4.identity;
-            Gizmos.DrawWireSphere(arealight.transform.position, arealight.range);
+            Handles.DrawWireCube(Vector3.zero, rectangleSize);
         }
 
-        [Obsolete("Should use the legacy gizmo draw")]
-        public static void DrawPointlightGizmo(Light pointlight, bool selected)
+        public static Vector2 DrawAreaLightHandle(Vector2 rectangleSize, bool withYAxis)
         {
-            if (pointlight.shadows != LightShadows.None && selected) Gizmos.DrawWireSphere(pointlight.transform.position, pointlight.shadowNearPlane);
-            Gizmos.DrawWireSphere(pointlight.transform.position, pointlight.range);
+            float halfWidth = rectangleSize.x * 0.5f;
+            float halfHeight = rectangleSize.y * 0.5f;
+
+            EditorGUI.BeginChangeCheck();
+            halfWidth = SliderLineHandle(Vector3.zero, Vector3.right, halfWidth);
+            halfWidth = SliderLineHandle(Vector3.zero, Vector3.left, halfWidth);
+            if (EditorGUI.EndChangeCheck())
+            {
+                halfWidth = Mathf.Max(0f, halfWidth);
+            }
+
+            if (withYAxis)
+            {
+                EditorGUI.BeginChangeCheck();
+                halfHeight = SliderLineHandle(Vector3.zero, Vector3.up, halfHeight);
+                halfHeight = SliderLineHandle(Vector3.zero, Vector3.down, halfHeight);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    halfHeight = Mathf.Max(0f, halfHeight);
+                }
+            }
+
+            return new Vector2(halfWidth * 2f, halfHeight * 2f);
         }
 
         // Same as Gizmo.DrawFrustum except that when aspect is below one, fov represent fovX instead of fovY
@@ -490,18 +504,6 @@ namespace UnityEditor.Experimental.Rendering
             }
 
             return new Vector4(halfWidth * 2f, halfHeight * 2f, maxRange, minRange);
-        }
-
-        [Obsolete("Should use the legacy gizmo draw")]
-        public static void DrawDirectionalLightGizmo(Light directionalLight)
-        {
-            var gizmoSize = 0.2f;
-            DrawWireDisc(directionalLight.transform.rotation, directionalLight.transform.position, directionalLight.gameObject.transform.forward, gizmoSize);
-            Gizmos.DrawLine(directionalLight.transform.position, directionalLight.transform.position + directionalLight.transform.forward);
-            Gizmos.DrawLine(directionalLight.transform.position + directionalLight.transform.up * gizmoSize, directionalLight.transform.position + directionalLight.transform.up * gizmoSize + directionalLight.transform.forward);
-            Gizmos.DrawLine(directionalLight.transform.position + directionalLight.transform.up * -gizmoSize, directionalLight.transform.position + directionalLight.transform.up * -gizmoSize + directionalLight.transform.forward);
-            Gizmos.DrawLine(directionalLight.transform.position + directionalLight.transform.right * gizmoSize, directionalLight.transform.position + directionalLight.transform.right * gizmoSize + directionalLight.transform.forward);
-            Gizmos.DrawLine(directionalLight.transform.position + directionalLight.transform.right * -gizmoSize, directionalLight.transform.position + directionalLight.transform.right * -gizmoSize + directionalLight.transform.forward);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
@@ -403,6 +403,38 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                             break;
                     }
                     break;
+                case LightTypeExtent.Rectangle:
+                case LightTypeExtent.Line:
+                    bool withYAxis = src.lightTypeExtent == LightTypeExtent.Rectangle;
+                    using (new Handles.DrawingScope(Matrix4x4.TRS(light.transform.position, light.transform.rotation, Vector3.one)))
+                    {
+                        Vector2 widthHeight = new Vector4(light.areaSize.x, withYAxis ? light.areaSize.y : 0f);
+                        float range = light.range;
+                        EditorGUI.BeginChangeCheck();
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.Greater;
+                        Handles.color = wireframeColorBehind;
+                        CoreLightEditorUtilities.DrawAreaLightWireframe(widthHeight);
+                        range = Handles.RadiusHandle(Quaternion.identity, Vector3.zero, range); //also draw handles
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.LessEqual;
+                        Handles.color = wireframeColorAbove;
+                        CoreLightEditorUtilities.DrawAreaLightWireframe(widthHeight);
+                        range = Handles.RadiusHandle(Quaternion.identity, Vector3.zero, range); //also draw handles
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.Greater;
+                        Handles.color = handleColorBehind;
+                        widthHeight = CoreLightEditorUtilities.DrawAreaLightHandle(widthHeight, withYAxis);
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.LessEqual;
+                        Handles.color = handleColorAbove;
+                        widthHeight = CoreLightEditorUtilities.DrawAreaLightHandle(widthHeight, withYAxis);
+                        if (EditorGUI.EndChangeCheck())
+                        {
+                            Undo.RecordObjects(new UnityEngine.Object[] { target, src }, withYAxis ? "Adjust Area Rectangle Light" : "Adjust Area Line Light");
+                            light.areaSize = withYAxis ? widthHeight : new Vector2(widthHeight.x, light.areaSize.y);
+                            light.range = range;
+                        }
+
+                        // Handles.color reseted at end of scope
+                    }
+                    break;
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR
Add missing gizmo on Area Lights and also add handles on them

---
### Release Notes
Gizmo one area lights are here again.
Improved area light handles to manipulate it in scene.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low
(few lines of code)

**Halo Effect**: None
(Only affect Area Light gizmo/handles)

---
### Comments to reviewers
