### PR TITLE
fix light gizmo when inspector locked

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
@@ -293,10 +293,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         protected override void OnSceneGUI()
         {
+            Light light = (Light)target;
+            if (!Selection.Contains(light.gameObject))
+            {
+                return;
+            }
+
             m_SerializedAdditionalLightData.Update();
 
             HDAdditionalLightData src = (HDAdditionalLightData)m_SerializedAdditionalLightData.targetObject;
-            Light light = (Light)target;
 
             Color wireframeColorAbove = light.enabled ? LightEditor.kGizmoLight : LightEditor.kGizmoDisabledLight;
             Color handleColorAbove = CoreLightEditorUtilities.GetLightHandleColor(wireframeColorAbove);


### PR DESCRIPTION
### Purpose of this PR
Fix FB https://fogbugz.unity3d.com/f/cases/1076691/

---
### Release Notes
Fix light gizmo appearing when inspector is locked but light not selected.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None
(very few lines of code)

**Halo Effect**: None
(only affect light gizmo)

---
### Comments to reviewers
