### PR TITLE
Hdrp/check caches size in hdrp asset

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/GlobalLightLoopSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/GlobalLightLoopSettingsUI.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Experimental.Rendering.HDPipeline;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
@@ -7,6 +9,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
     class GlobalLightLoopSettingsUI : BaseUI<SerializedGlobalLightLoopSettings>
     {
+        const string cacheErrorFormat = "This configuration will lead to more than 2 GB reserved for this cache at runtime! ({0} requested) Only {1} element will be reserved instead.";
+        const string cacheInfoFormat = "Reserving {0} in memory at runtime.";
+
         static GlobalLightLoopSettingsUI()
         {
             Inspector = CED.Group(
@@ -29,14 +34,71 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
         }
 
+        static string HumanizeWeight(long weightInByte)
+        {
+            if (weightInByte < 500)
+            {
+                return weightInByte + " B";
+            }
+            else if (weightInByte < 500000L)
+            {
+                float res = weightInByte / 1000f;
+                return res.ToString("n2") + " KB";
+            }
+            else if (weightInByte < 500000000L)
+            {
+                float res = weightInByte / 1000000f;
+                return res.ToString("n2") + " MB";
+            }
+            else
+            {
+                float res = weightInByte / 1000000000f;
+                return res.ToString("n2") + " GB";
+            }
+        }
+
         static void Drawer_SectionCookies(GlobalLightLoopSettingsUI s, SerializedGlobalLightLoopSettings d, Editor o)
         {
             EditorGUILayout.LabelField(_.GetContent("Cookies"), EditorStyles.boldLabel);
             ++EditorGUI.indentLevel;
             EditorGUILayout.PropertyField(d.cookieSize, _.GetContent("Cookie Size"));
+            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(d.cookieTexArraySize, _.GetContent("Texture Array Size"));
+            if(EditorGUI.EndChangeCheck())
+            {
+                d.cookieTexArraySize.intValue = Mathf.Clamp(d.cookieTexArraySize.intValue, 1, TextureCache.k_MaxSupported);
+            }
+            long currentCache = TextureCache2D.GetApproxCacheSizeInByte(d.cookieTexArraySize.intValue, d.cookieSize.intValue);
+            if (currentCache > LightLoop.k_MaxCacheSize)
+            {
+                int reserved = TextureCache2D.GetMaxCacheSizeForWeightInByte(LightLoop.k_MaxCacheSize, d.cookieSize.intValue);
+                string message = string.Format(cacheErrorFormat, HumanizeWeight(currentCache), reserved);
+                EditorGUILayout.HelpBox(message, MessageType.Error);
+            }
+            else
+            {
+                string message = string.Format(cacheInfoFormat, HumanizeWeight(currentCache));
+                EditorGUILayout.HelpBox(message, MessageType.Info);
+            }
             EditorGUILayout.PropertyField(d.pointCookieSize, _.GetContent("Point Cookie Size"));
+            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(d.cubeCookieTexArraySize, _.GetContent("Cubemap Array Size"));
+            if (EditorGUI.EndChangeCheck())
+            {
+                d.cubeCookieTexArraySize.intValue = Mathf.Clamp(d.cubeCookieTexArraySize.intValue, 1, TextureCache.k_MaxSupported);
+            }
+            currentCache = TextureCacheCubemap.GetApproxCacheSizeInByte(d.cubeCookieTexArraySize.intValue, d.pointCookieSize.intValue);
+            if (currentCache > LightLoop.k_MaxCacheSize)
+            {
+                int reserved = TextureCacheCubemap.GetMaxCacheSizeForWeightInByte(LightLoop.k_MaxCacheSize, d.pointCookieSize.intValue);
+                string message = string.Format(cacheErrorFormat, HumanizeWeight(currentCache), reserved);
+                EditorGUILayout.HelpBox(message, MessageType.Error);
+            }
+            else
+            {
+                string message = string.Format(cacheInfoFormat, HumanizeWeight(currentCache));
+                EditorGUILayout.HelpBox(message, MessageType.Info);
+            }
             --EditorGUI.indentLevel;
         }
 
@@ -46,13 +108,47 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             ++EditorGUI.indentLevel;
             EditorGUILayout.PropertyField(d.reflectionCacheCompressed, _.GetContent("Compress Reflection Probe Cache"));
             EditorGUILayout.PropertyField(d.reflectionCubemapSize, _.GetContent("Reflection Cubemap Size"));
+            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(d.reflectionProbeCacheSize, _.GetContent("Probe Cache Size"));
+            if (EditorGUI.EndChangeCheck())
+            {
+                d.reflectionProbeCacheSize.intValue = Mathf.Clamp(d.reflectionProbeCacheSize.intValue, 1, TextureCache.k_MaxSupported);
+            }
+            long currentCache = ReflectionProbeCache.GetApproxCacheSizeInByte(d.reflectionProbeCacheSize.intValue, d.reflectionCubemapSize.intValue);
+            if (currentCache > LightLoop.k_MaxCacheSize)
+            {
+                int reserved = ReflectionProbeCache.GetMaxCacheSizeForWeightInByte(LightLoop.k_MaxCacheSize, d.reflectionCubemapSize.intValue);
+                string message = string.Format(cacheErrorFormat, HumanizeWeight(currentCache), reserved);
+                EditorGUILayout.HelpBox(message, MessageType.Error);
+            }
+            else
+            {
+                string message = string.Format(cacheInfoFormat, HumanizeWeight(currentCache));
+                EditorGUILayout.HelpBox(message, MessageType.Info);
+            }
 
             EditorGUILayout.Space();
 
             EditorGUILayout.PropertyField(d.planarReflectionCacheCompressed, _.GetContent("Compress Planar Reflection Probe Cache"));
             EditorGUILayout.PropertyField(d.planarReflectionCubemapSize, _.GetContent("Planar Reflection Texture Size"));
+            EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(d.planarReflectionProbeCacheSize, _.GetContent("Planar Probe Cache Size"));
+            if (EditorGUI.EndChangeCheck())
+            {
+                d.planarReflectionProbeCacheSize.intValue = Mathf.Clamp(d.planarReflectionProbeCacheSize.intValue, 1, TextureCache.k_MaxSupported);
+            }
+            currentCache = PlanarReflectionProbeCache.GetApproxCacheSizeInByte(d.planarReflectionProbeCacheSize.intValue, d.planarReflectionCubemapSize.intValue);
+            if (currentCache > LightLoop.k_MaxCacheSize)
+            {
+                int reserved = PlanarReflectionProbeCache.GetMaxCacheSizeForWeightInByte(LightLoop.k_MaxCacheSize, d.planarReflectionCubemapSize.intValue);
+                string message = string.Format(cacheErrorFormat, HumanizeWeight(currentCache), reserved);
+                EditorGUILayout.HelpBox(message, MessageType.Error);
+            }
+            else
+            {
+                string message = string.Format(cacheInfoFormat, HumanizeWeight(currentCache));
+                EditorGUILayout.HelpBox(message, MessageType.Info);
+            }
             --EditorGUI.indentLevel;
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Textures/TextureCache.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Textures/TextureCache.cs
@@ -71,10 +71,23 @@ namespace UnityEngine.Experimental.Rendering
         {
             CoreUtils.Destroy(m_Cache);
         }
+        
+        internal static long GetApproxCacheSizeInByte(int nbElement, int resolution)
+        {
+            return (long)((long)nbElement * resolution * resolution * k_FP16SizeInByte * k_NbChannel * k_MipmapFactorApprox);
+        }
+
+        internal static int GetMaxCacheSizeForWeightInByte(int weight, int resolution)
+        {
+            int theoricalResult = Mathf.FloorToInt(weight / ((long)resolution * resolution * k_FP16SizeInByte * k_NbChannel * k_MipmapFactorApprox));
+            return Mathf.Clamp(theoricalResult, 1, k_MaxSupported);
+        }
     }
 
     public class TextureCacheCubemap : TextureCache
     {
+        const int k_NbFace = 6;
+
         private CubemapArray m_Cache;
 
         // the member variables below are only in use when TextureCache.supportsCubemapArrayTextures is false
@@ -204,11 +217,28 @@ namespace UnityEngine.Experimental.Rendering
             for (int m = 0; m < m_NumPanoMipLevels; m++)
                 cmd.CopyTexture(m_StagingRTs[m], 0, 0, m_CacheNoCubeArray, sliceIndex, m);
         }
+
+
+        internal static long GetApproxCacheSizeInByte(int nbElement, int resolution)
+        {
+            return (long)((long)nbElement * resolution * resolution * k_NbFace * k_FP16SizeInByte * k_NbChannel * k_MipmapFactorApprox);
+        }
+
+        internal static int GetMaxCacheSizeForWeightInByte(long weight, int resolution)
+        {
+            int theoricalResult = Mathf.FloorToInt(weight / ((long)resolution * resolution * k_NbFace * k_FP16SizeInByte * k_NbChannel * k_MipmapFactorApprox));
+            return Mathf.Clamp(theoricalResult, 1, k_MaxSupported);
+        }
     }
 
 
     public abstract class TextureCache
     {
+        protected const int k_FP16SizeInByte = 2;
+        protected const int k_NbChannel = 4;
+        protected const float k_MipmapFactorApprox = 1.33f;
+        internal const int k_MaxSupported = 250; //vary along hardware and cube/2D but 250 should be always safe 
+
         protected int m_NumMipLevels;
         protected string m_CacheName;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/PlanarReflectionProbeCache.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/PlanarReflectionProbeCache.cs
@@ -206,5 +206,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             return m_TextureCache.GetTexCache();
         }
+
+        internal static long GetApproxCacheSizeInByte(int nbElement, int resolution)
+        {
+            return TextureCache2D.GetApproxCacheSizeInByte(nbElement, resolution);
+        }
+
+        internal static int GetMaxCacheSizeForWeightInByte(int weight, int resolution)
+        {
+            return TextureCache2D.GetMaxCacheSizeForWeightInByte(weight, resolution);
+        }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/ReflectionProbeCache.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/ReflectionProbeCache.cs
@@ -223,5 +223,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             return m_TextureCache.GetTexCache();
         }
+
+        internal static long GetApproxCacheSizeInByte(int nbElement, int resolution)
+        {
+            return TextureCacheCubemap.GetApproxCacheSizeInByte(nbElement, resolution);
+        }
+
+        internal static int GetMaxCacheSizeForWeightInByte(int weight, int resolution)
+        {
+            return TextureCacheCubemap.GetMaxCacheSizeForWeightInByte(weight, resolution);
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Clamp size of texture caches exceeding 2GB in HDRenderPipelineAsset

---
### Release Notes
Texture cache size is now visible in HDRenderPipelineAsset.
Texture cache exceding 2GB will be automatically resized to handle less textures instead of crashing. (FB issue https://fogbugz.unity3d.com/f/cases/1082338/)

---
### Testing status
**Katana Tests**: 

**Manual Tests**: Tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low-medium
(modify some lines of code)

**Halo Effect**: Low
(will impact max texture size that can be used)

---
### Comments to reviewers
