### PR TITLE
Fixed an issue where sometime the lookup texture used for GGX convolution was broken, causing broken rendering

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed wrong error message display when switching to unsupported target like IOS
 - Fixed an issue with ambient occlusion texture sometimes not being created properly causing broken rendering
 - Shadow near plane is no longer limited at 0.1
+- Fixed an issue where sometime the lookup texture used for GGX convolution was broken, causing broken rendering
 
 ### Changed
 - Use samplerunity_ShadowMask instead of samplerunity_samplerLightmap for shadow mask


### PR DESCRIPTION
### Purpose of this PR
Fixed an issue where sometime the lookup texture used for GGX convolution was broken, causing broken rendering

### Testing status
Manual tests +  Katana: [https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-convolution-texture&automation-tools_branch=add-platform-filter&unity_branch=2018.3%2Fstaging#]
