### PR TITLE
Hdrp/improve are animater materials enabled

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
@@ -468,7 +468,7 @@ namespace UnityEngine.Experimental.Rendering
             Debug.LogError(msg);
 
 #if UNITY_EDITOR
-            foreach (UnityEditor.SceneView sv in Resources.FindObjectsOfTypeAll(typeof(UnityEditor.SceneView)))
+            foreach (UnityEditor.SceneView sv in UnityEditor.SceneView.sceneViews)
                 sv.ShowNotification(new GUIContent(msg));
 #endif
         }
@@ -572,7 +572,7 @@ namespace UnityEngine.Experimental.Rendering
                 fogEnable = false;
 
                 // Determine whether the "Animated Materials" checkbox is checked for the current view.
-                foreach (UnityEditor.SceneView sv in Resources.FindObjectsOfTypeAll(typeof(UnityEditor.SceneView)))
+                foreach (UnityEditor.SceneView sv in UnityEditor.SceneView.sceneViews)
                 {
                     if (sv.camera == camera && sv.sceneViewState.showFog)
                     {

--- a/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
@@ -505,7 +505,7 @@ namespace UnityEngine.Experimental.Rendering
                 animateMaterials = false;
 
                 // Determine whether the "Animated Materials" checkbox is checked for the current view.
-                foreach (UnityEditor.SceneView sv in Resources.FindObjectsOfTypeAll(typeof(UnityEditor.SceneView)))
+                foreach (UnityEditor.SceneView sv in UnityEditor.SceneView.sceneViews)
                 {
                     if (sv.camera == camera && sv.sceneViewState.showMaterialUpdate)
                     {

--- a/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
@@ -519,7 +519,7 @@ namespace UnityEngine.Experimental.Rendering
                 animateMaterials = false;
 
                 // Determine whether the "Animated Materials" checkbox is checked for the current view.
-                foreach (UnityEditor.MaterialEditor med in Resources.FindObjectsOfTypeAll(typeof(UnityEditor.MaterialEditor)))
+                foreach (UnityEditor.MaterialEditor med in materialEditors)
                 {
                     // Warning: currently, there's no way to determine whether a given camera corresponds to this MaterialEditor.
                     // Therefore, if at least one of the visible MaterialEditors is in Play Mode, all of them will play.
@@ -549,6 +549,15 @@ namespace UnityEngine.Experimental.Rendering
         #endif
 
             return animateMaterials;
+        }
+        
+        static System.Reflection.FieldInfo s_MaterialEditorsField = typeof(UnityEditor.MaterialEditor).GetField("s_MaterialEditors", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        static List<UnityEditor.MaterialEditor> materialEditors
+        {
+            get
+            {
+                return (List<UnityEditor.MaterialEditor>)s_MaterialEditorsField.GetValue(null);
+            }
         }
 
         public static bool IsSceneViewFogEnabled(Camera camera)


### PR DESCRIPTION
### Purpose of this PR
Drastically increase performence of CoreUtils.AreAnimatedMaterialsEnabled
(from about 1.3ms to 0.002ms)

---
### Release Notes
Increase performence of CoreUtils.AreAnimatedMaterialsEnabled methode.

---
### Testing status
**Katana Tests**:  https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2114/files

**Manual Tests**: tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low
(few lines of code)

**Halo Effect**: Medium
(affect material preview and scene view)

---
### Comments to reviewers
