### PR TITLE
Begin/End profiler section mismatch

### DIFF
--- a/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
@@ -232,13 +232,14 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 setupToUse.Setup(renderer, ref renderingData);
                 renderer.Execute(context, ref renderingData);
 
-                context.ExecuteCommandBuffer(cmd);
-                CommandBufferPool.Release(cmd);
-                context.Submit();
 #if UNITY_EDITOR
                 Handles.DrawGizmos(camera);
 #endif
             }
+            
+            context.ExecuteCommandBuffer(cmd);
+            CommandBufferPool.Release(cmd);
+            context.Submit();
         }
 
         static void SetSupportedRenderingFeatures()


### PR DESCRIPTION
CommandBuffer is executed before profiling section is closed.

### Purpose of this PR
Profiler throws errors due to profiling section not correctly being closed.
