### PR TITLE
Fix orverriding of frame settings broken debug menu

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopSettings.cs
@@ -81,6 +81,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     s_Overrides[val](result, this);
                 }
             }
+
+            //propagate override to be chained
+            result.overrides = overrides | overridedFrameSettings.overrides;
             return result;
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDAdditionalCameraData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDAdditionalCameraData.cs
@@ -132,7 +132,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
                 else
                 {
-                    m_FrameSettings.CopyTo(m_FrameSettingsRuntime);
+                    m_FrameSettings.Override(defaultFrameSettings).CopyTo(m_FrameSettingsRuntime);
                 }
 
                 m_frameSettingsIsDirty = false;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -865,17 +865,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 FrameSettings srcFrameSettings;
                 if (additionalCameraData)
                 {
-                    additionalCameraData.UpdateDirtyFrameSettings(assetFrameSettingsIsDirty, m_Asset.GetFrameSettings());
                     if (camera.cameraType != CameraType.Reflection)
                     {
-                        srcFrameSettings = additionalCameraData.GetFrameSettings().Override(m_Asset.GetFrameSettings());
+                        //reflection camera must already have their framesettings correctly set at this point
+                        additionalCameraData.UpdateDirtyFrameSettings(assetFrameSettingsIsDirty, m_Asset.GetFrameSettings());
                     }
-                    else 
-                    {
-                        //reflection camera use different framesettings as base for their override
-                        //handled in ReflectionSystemInternal
-                        srcFrameSettings = additionalCameraData.GetFrameSettings();
-                    }
+                    srcFrameSettings = additionalCameraData.GetFrameSettings();
                 }
                 else
                 {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.cs
@@ -46,6 +46,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     // The settings here are per frame settings.
     // Each camera must have its own per frame settings
     [Serializable]
+    [System.Diagnostics.DebuggerDisplay("FrameSettings overriding {overrides.ToString(\"X\")}")]
     public class FrameSettings
     {
         static Dictionary<FrameSettingsOverrides, Action<FrameSettings, FrameSettings>> s_Overrides = new Dictionary<FrameSettingsOverrides, Action<FrameSettings, FrameSettings>>
@@ -198,6 +199,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
 
             result.lightLoopSettings = lightLoopSettings.Override(overridedFrameSettings.lightLoopSettings);
+
+            //propagate override to be chained
+            result.overrides = overrides | overridedFrameSettings.overrides;
             return result;
         }
 


### PR DESCRIPTION
### Purpose of this PR
Fix the debug menu that display value before overrides of frame settings apply.

---
### Release Notes
Fix the debug menu that display value before overrides of frame settings apply.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: Tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low
(few lines of code modified)

**Halo Effect**: High
(potentially impact every rendering)

---
### Comments to reviewers
