### PR TITLE
Remove FullscreenPassthrough path on camera

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use samplerunity_ShadowMask instead of samplerunity_samplerLightmap for shadow mask
 - Allow to resize reflection probe gizmo's size
 - Improve quality of screen space shadow
+- Remove FullscreenPassthrough path on camera user should use additionalCameraData.ExecuteCustomRender event instead
 
 ## [4.0.0-preview] - 2018-09-28
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDAdditionalCameraData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDAdditionalCameraData.cs
@@ -26,12 +26,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // Default is the default rendering path define by the HDRendeRPipelineAsset FrameSettings.
         // Custom allow users to define the FrameSettigns for this path
         // Then enum can contain either preset of FrameSettings or hard coded path
-        // FullscreenPassthrough below is a hard coded path (a path that can't be implemented only with FrameSettings)
         public enum RenderingPath
         {
             UseGraphicsSettings,
             Custom,  // Fine grained
-            FullscreenPassthrough  // Hard coded path
         };
 
         public enum ClearColorMode

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -889,15 +889,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // This is the main command buffer used for the frame.
                 var cmd = CommandBufferPool.Get("");
 
-                // Specific pass to simply display the content of the camera buffer if users have fill it themselves (like video player)
-                if (additionalCameraData && additionalCameraData.renderingPath == HDAdditionalCameraData.RenderingPath.FullscreenPassthrough)
-                {
-                    renderContext.ExecuteCommandBuffer(cmd);
-                    CommandBufferPool.Release(cmd);
-                    renderContext.Submit();
-                    continue;
-                }
-
                 // Don't render reflection in Preview, it prevent them to display
                 if (camera.cameraType != CameraType.Reflection && camera.cameraType != CameraType.Preview
                     // Planar probes rendering is not currently supported for orthographic camera


### PR DESCRIPTION
Remove FullscreenPassthrough path on camera
user should use additionalCameraData.ExecuteCustomRender(renderContext, hdCamera); instead
