### PR TITLE
Remove derivative map unpacking.

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
@@ -6,7 +6,7 @@ using UnityEditor.ShaderGraph.Drawing.Controls;
 namespace UnityEditor.ShaderGraph
 {    
     [Title("Input", "Texture", "Sample Texture 2D LOD")]
-    public class SampleTexture2DLODNode : AbstractMaterialNode, IGeneratesBodyCode, IMayRequireMeshUV, IMayRequireTangent, IMayRequireBitangent
+    public class SampleTexture2DLODNode : AbstractMaterialNode, IGeneratesBodyCode, IMayRequireMeshUV
     {
         public const int OutputSlotRGBAId = 0;
         public const int OutputSlotRId = 5;
@@ -77,22 +77,6 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        [SerializeField]
-        private bool m_DerivativeMap = false;
-
-        [ToggleControl]
-        public ToggleData derivativeMap
-        {
-            get { return new ToggleData(m_DerivativeMap); }
-            set
-            {
-                if (m_DerivativeMap == value.isOn)
-                    return;
-                m_DerivativeMap = value.isOn;
-                Dirty(ModificationScope.Graph);
-            }
-        }
-
         public sealed override void UpdateNodeAfterDeserialization()
         {
             AddSlot(new Vector4MaterialSlot(OutputSlotRGBAId, kOutputSlotRGBAName, kOutputSlotRGBAName, SlotType.Output, Vector4.zero, ShaderStageCapability.All));
@@ -142,27 +126,11 @@ namespace UnityEditor.ShaderGraph
             {
                 if (normalMapSpace == NormalMapSpace.Tangent)
                 {
-                    if (derivativeMap.isOn)
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}2 deriv = UnpackDerivativeNormalRGorAG({1});", precision, GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = SurfaceGradientFromTBN(deriv, IN.WorldSpaceTangent, IN.WorldSpaceBiTangent);", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
-                    else
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
+                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
                 }
                 else
                 {
-                    if (derivativeMap.isOn)
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}2 deriv = UnpackDerivativeNormalRGB({1});", precision, GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = SurfaceGradientFromTBN(deriv, IN.WorldSpaceTangent, IN.WorldSpaceBiTangent);", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
-                    else
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
+                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
                 }
             }
 
@@ -182,16 +150,6 @@ namespace UnityEditor.ShaderGraph
                     return true;
             }
             return false;
-        }
-
-        public NeededCoordinateSpace RequiresTangent(ShaderStageCapability stageCapability)
-        {
-            return (textureType == TextureType.Normal && derivativeMap.isOn) ? NeededCoordinateSpace.World : NeededCoordinateSpace.None;
-        }
-
-        public NeededCoordinateSpace RequiresBitangent(ShaderStageCapability stageCapability)
-        {
-            return (textureType == TextureType.Normal && derivativeMap.isOn) ? NeededCoordinateSpace.World : NeededCoordinateSpace.None;
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DNode.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.ShaderGraph
 
     [FormerName("UnityEditor.ShaderGraph.Texture2DNode")]
     [Title("Input", "Texture", "Sample Texture 2D")]
-    public class SampleTexture2DNode : AbstractMaterialNode, IGeneratesBodyCode, IMayRequireMeshUV, IMayRequireTangent, IMayRequireBitangent
+    public class SampleTexture2DNode : AbstractMaterialNode, IGeneratesBodyCode, IMayRequireMeshUV
     {
         public const int OutputSlotRGBAId = 0;
         public const int OutputSlotRId = 4;
@@ -82,22 +82,6 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        [SerializeField]
-        private bool m_DerivativeMap = false; 
-
-        [ToggleControl]
-        public ToggleData derivativeMap
-        {
-            get { return new ToggleData(m_DerivativeMap); }
-            set
-            {
-                if (m_DerivativeMap == value.isOn)
-                    return;
-                m_DerivativeMap = value.isOn;
-                Dirty(ModificationScope.Graph);
-            }
-        }
-
         public sealed override void UpdateNodeAfterDeserialization()
         {
             AddSlot(new Vector4MaterialSlot(OutputSlotRGBAId, kOutputSlotRGBAName, kOutputSlotRGBAName, SlotType.Output, Vector4.zero, ShaderStageCapability.Fragment));
@@ -142,27 +126,11 @@ namespace UnityEditor.ShaderGraph
             {
                 if (normalMapSpace == NormalMapSpace.Tangent)
                 {
-                    if (derivativeMap.isOn)
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}2 deriv = UnpackDerivativeNormalRGorAG({1});", precision, GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = SurfaceGradientFromTBN(deriv, IN.WorldSpaceTangent, IN.WorldSpaceBiTangent);", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
-                    else
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
+                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
                 }
                 else
                 {
-                    if (derivativeMap.isOn)
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}2 deriv = UnpackDerivativeNormalRGB({1});", precision, GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = SurfaceGradientFromTBN(deriv, IN.WorldSpaceTangent, IN.WorldSpaceBiTangent);", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
-                    else
-                    {
-                        visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
-                    }
+                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
                 }
             }
 
@@ -182,16 +150,6 @@ namespace UnityEditor.ShaderGraph
                     return true;
             }
             return false;
-        }
-
-        public NeededCoordinateSpace RequiresTangent(ShaderStageCapability stageCapability)
-        {
-            return (textureType == TextureType.Normal && derivativeMap.isOn) ? NeededCoordinateSpace.World : NeededCoordinateSpace.None;
-        }
-
-        public NeededCoordinateSpace RequiresBitangent(ShaderStageCapability stageCapability)
-        {
-            return (textureType == TextureType.Normal && derivativeMap.isOn) ? NeededCoordinateSpace.World : NeededCoordinateSpace.None;
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
@@ -59,22 +59,6 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        [SerializeField]
-        private bool m_DerivativeMap = false;
-
-        [ToggleControl]
-        public ToggleData derivativeMap
-        {
-            get { return new ToggleData(m_DerivativeMap); }
-            set
-            {
-                if (m_DerivativeMap == value.isOn)
-                    return;
-                m_DerivativeMap = value.isOn;
-                Dirty(ModificationScope.Graph);
-            }
-        }
-
         public sealed override void UpdateNodeAfterDeserialization()
         {
             AddSlot(new Vector4MaterialSlot(OutputSlotId, kOutputSlotName, kOutputSlotName, SlotType.Output, Vector4.zero, ShaderStageCapability.Fragment));
@@ -116,58 +100,23 @@ namespace UnityEditor.ShaderGraph
                     GetSlotValue(NormalInputId, generationMode), GetSlotValue(BlendInputId, generationMode));
                     sb.AppendLine("{0}_Blend /= ({0}_Blend.x + {0}_Blend.y + {0}_Blend.z ).xxx;", GetVariableNameForNode());
 
-                    if (derivativeMap.isOn)
-                    {
-                        sb.AppendLine("{0}2 deriv_zy = UnpackDerivativeNormalRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.zy));"
-                        , precision
-                        , GetVariableNameForNode()
-                        , id
-                        , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
+                    sb.AppendLine("{0}3 {1}_X = UnpackNormalmapRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.zy));"
+                    , precision
+                    , GetVariableNameForNode()
+                    , id
+                    , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
 
-                        sb.AppendLine("{0}3 {1}_X = SurfaceGradientFromTBN(deriv_zy, IN.WorldSpaceTangent, IN.WorldSpaceBiTangent);"
-                        , precision
-                        , GetVariableNameForNode());
+                    sb.AppendLine("{0}3 {1}_Y = UnpackNormalmapRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.xz));"
+                    , precision
+                    , GetVariableNameForNode()
+                    , id
+                    , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
 
-                        sb.AppendLine("{0}2 deriv_xz = UnpackDerivativeNormalRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.xz));"
-                        , precision
-                        , GetVariableNameForNode()
-                        , id
-                        , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
-
-                        sb.AppendLine("{0}3 {1}_Y = SurfaceGradientFromTBN(deriv_xz, IN.WorldSpaceTangent, IN.WorldSpaceBiTangent);"
-                        , precision
-                        , GetVariableNameForNode());
-
-                        sb.AppendLine("{0}2 deriv_xy = UnpackDerivativeNormalRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.xy));"
-                        , precision
-                        , GetVariableNameForNode()
-                        , id
-                        , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
-
-                        sb.AppendLine("{0}3 {1}_Z = SurfaceGradientFromTBN(deriv_xy, IN.WorldSpaceTangent, IN.WorldSpaceBiTangent);"
-                        , precision
-                        , GetVariableNameForNode());
-                    }
-                    else
-                    {
-                        sb.AppendLine("{0}3 {1}_X = UnpackNormalmapRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.zy));"
-                        , precision
-                        , GetVariableNameForNode()
-                        , id
-                        , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
-
-                        sb.AppendLine("{0}3 {1}_Y = UnpackNormalmapRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.xz));"
-                        , precision
-                        , GetVariableNameForNode()
-                        , id
-                        , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
-
-                        sb.AppendLine("{0}3 {1}_Z = UnpackNormalmapRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.xy));"
-                        , precision
-                        , GetVariableNameForNode()
-                        , id
-                        , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
-                    }
+                    sb.AppendLine("{0}3 {1}_Z = UnpackNormalmapRGorAG(SAMPLE_TEXTURE2D({2}, {3}, {1}_UV.xy));"
+                    , precision
+                    , GetVariableNameForNode()
+                    , id
+                    , edgesSampler.Any() ? GetSlotValue(SamplerInputId, generationMode) : "sampler" + id);
 
                     sb.AppendLine("{0}_X = {1}3({0}_X.xy + {2}.zy, abs({0}_X.z) * {2}.x);"
                     , GetVariableNameForNode()


### PR DESCRIPTION
### Purpose of this PR
Remove option to unpack derivative maps from ShaderGraph. This ability will likely be replaced with more abstracted ability to work with "Bump influences" at a later point in time.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
Tested all affected nodes.

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low

**Halo Effect**: None, Low, Medium, High?
Low
---
### Comments to reviewers
Notes for the reviewers you have assigned.
