### PR TITLE
Hdrp/save materials collapsable state

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
@@ -27,7 +27,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     {
                         using (new Handles.DrawingScope(Matrix4x4.TRS(Vector3.zero, Quaternion.identity, Vector3.one)))
                         {
-                            Vector3 offsetWorld = probe.transform.position + probe.transform.rotation * probe.influenceVolume.offset;
                             EditorGUI.BeginChangeCheck();
                             var newCapturePosition = Handles.PositionHandle(probe.transform.position, probe.transform.rotation);
                             if (EditorGUI.EndChangeCheck())

--- a/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFUI.cs
@@ -6,8 +6,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class AxFGUI : BaseUnlitGUI
     {
-        static Expendable state = Expendable.Base | Expendable.Detail | Expendable.Emissive | Expendable.Input | Expendable.Other | Expendable.Tesselation | Expendable.Transparency | Expendable.VertexAnimation;
-        protected override uint expendedState { get { return (uint)state; } set { state = (Expendable)value; } }
+        protected override uint defaultExpendedState { get { return (uint)(Expendable.Base | Expendable.Detail | Expendable.Emissive | Expendable.Input | Expendable.Other | Expendable.Tesselation | Expendable.Transparency | Expendable.VertexAnimation); } }
 
         protected static class Styles
         {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Decal/DecalUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Decal/DecalUI.cs
@@ -13,8 +13,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             Input = 1 << 0
         }
-        static Expendable state = Expendable.Input;
-        protected override uint expendedState { get { return (uint)state; } set { state = (Expendable)value; } }
+        protected override uint defaultExpendedState { get { return (uint)Expendable.Input; } }
 
         protected static class Styles
         {
@@ -269,6 +268,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             m_MaterialEditor = materialEditor;
+
+            // We should always register the key used to keep collapsable state
+            InitExpendableState(materialEditor);
+
             // We should always do this call at the beginning
             m_MaterialEditor.serializedObject.Update();
             

--- a/com.unity.render-pipelines.high-definition/Editor/Material/ExpendableAreaMaterial.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/ExpendableAreaMaterial.cs
@@ -6,13 +6,22 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
     //should be base for al material in hdrp. It will add the collapsable mecanisme on them
     abstract class ExpendableAreaMaterial : ShaderGUI
     {
-        protected interface IExpendableArea
+        private const string k_KeyPrefix = "HDRP:Material:UI_State:";
+        private string m_StateKey;
+        
+        protected virtual uint expendedState
         {
-            bool GetExpendedAreas(uint mask);
-            void SetExpendedAreas(uint mask, bool value);
+            get
+            {
+                return (uint)EditorPrefs.GetInt(m_StateKey);
+            }
+            set
+            {
+                EditorPrefs.SetInt(m_StateKey, (int)value);
+            }
         }
 
-        protected abstract uint expendedState { get; set; }
+        protected virtual uint defaultExpendedState { get { return 0xFFFFFFFF; } } //all opened by default
 
         protected struct HeaderScope : IDisposable
         {
@@ -85,6 +94,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
 
             expendedState = state;
+        }
+
+        protected void InitExpendableState(MaterialEditor editor)
+        {
+            m_StateKey = k_KeyPrefix + ((Material)editor.target).shader.name;
+            if(!EditorPrefs.HasKey(m_StateKey))
+            {
+                EditorPrefs.SetInt(m_StateKey, (int)defaultExpendedState);
+            }
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/FabricUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/FabricUI.cs
@@ -7,8 +7,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class FabricGUI : BaseLitGUI
     {
-        static Expendable state = Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Other;
-        protected override uint expendedState { get { return (uint)state; } set { state = (Expendable)value; } }
+        protected override uint defaultExpendedState { get { return (uint)(Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Other); } }
 
         protected static class Styles
         {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitUI.cs
@@ -31,10 +31,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             LayeringOption3 = 1 << 30
         }
 
-        static uint state = (uint)(Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Other | Expendable.Tesselation)
-            + (uint)(LayerExpendable.MaterialReferences | LayerExpendable.MainInput | LayerExpendable.MainDetail);
-
-        protected override uint expendedState { get { return (uint)state; } set { state = value; } }
+        protected override uint defaultExpendedState { get { return (uint)(Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Other | Expendable.Tesselation) + (uint)(LayerExpendable.MaterialReferences | LayerExpendable.MainInput | LayerExpendable.MainDetail); } }
         
         public enum VertexColorMode
         {
@@ -742,6 +739,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             FindMaterialProperties(props);
 
             m_MaterialEditor = materialEditor;
+
+            // We should always register the key used to keep collapsable state
+            InitExpendableState(materialEditor);
+
             // We should always do this call at the beginning
             m_MaterialEditor.serializedObject.Update();
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitUI.cs
@@ -7,8 +7,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class LitGUI : BaseLitGUI
     {
-        static Expendable state = Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Tesselation;
-        protected override uint expendedState { get { return (uint)state; } set { state = (Expendable)value; } }
+        protected override uint defaultExpendedState { get { return (uint)(Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Tesselation); } }
 
         protected static class Styles
         {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/StackLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/StackLitUI.cs
@@ -10,7 +10,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         protected static class StylesStackLit
         {
-            public const string stackOptionText = "Stack Option";
+            public const string stackOptionText = "Stack Options";
 
             public static GUIContent useLocalPlanarMapping = new GUIContent("Use Local Planar Mapping", "Use local space for planar/triplanar mapping instead of world space");
         };

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/StackLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/StackLitUI.cs
@@ -6,8 +6,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class StackLitGUI : BaseMaterialGUI
     {
-        static Expendable state = Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Other;
-        protected override uint expendedState { get { return (uint)state; } set { state = (Expendable)value; } }
+        protected override uint defaultExpendedState { get { return (uint)(Expendable.Base | Expendable.Input | Expendable.VertexAnimation | Expendable.Detail | Expendable.Emissive | Expendable.Transparency | Expendable.Other); } }
 
         protected static class StylesStackLit
         {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/TerrainLit/TerrainLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/TerrainLit/TerrainLitUI.cs
@@ -9,8 +9,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class TerrainLitGUI : LitGUI, ITerrainLayerCustomUI
     {
-        static Expendable state = 0;
-        protected override uint expendedState { get { return (uint)state; } set { state = (Expendable)value; } }
+        protected override uint defaultExpendedState { get { return 0u; } }
 
         private class StylesLayer
         {
@@ -111,6 +110,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             FindMaterialProperties(props);
 
             m_MaterialEditor = materialEditor;
+
+            // We should always register the key used to keep collapsable state
+            InitExpendableState(materialEditor);
+
             // We should always do this call at the beginning
             m_MaterialEditor.serializedObject.Update();
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitUI.cs
@@ -667,6 +667,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             m_MaterialEditor = materialEditor;
+
+            // We should always register the key used to keep collapsable state
+            InitExpendableState(materialEditor);
+
             // We should always do this call at the beginning
             m_MaterialEditor.serializedObject.Update();
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitUI.cs
@@ -6,8 +6,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class UnlitGUI : BaseUnlitGUI
     {
-        static Expendable state = Expendable.Base | Expendable.Input | Expendable.Transparency;
-        protected override uint expendedState { get { return (uint)state; } set { state = (Expendable)value; } }
+        protected override uint defaultExpendedState { get { return (uint)(Expendable.Base | Expendable.Input | Expendable.Transparency); }  }
 
         protected static class Styles
         {

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
@@ -20,13 +20,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static readonly GUIContent volumeLayerMaskContent = CoreEditorUtils.GetContent("Volume Layer Mask");
         static readonly GUIContent volumeAnchorOverrideContent = CoreEditorUtils.GetContent("Volume Anchor Override");
-
-        static readonly GUIContent projectionContent = CoreEditorUtils.GetContent("Projection");
+        
         static readonly GUIContent nearClipPlaneContent = CoreEditorUtils.GetContent("Near Clip Plane");
         static readonly GUIContent farClipPlaneContent = CoreEditorUtils.GetContent("Far Clip Plane");
         static readonly GUIContent fieldOfViewContent = CoreEditorUtils.GetContent("Field Of View");
         static readonly GUIContent fieldOfViewDefault = CoreEditorUtils.GetContent("Automatic|Computed depending on point of view");
-        static readonly GUIContent orthographicSizeContent = CoreEditorUtils.GetContent("Size");
 
         static readonly GUIContent renderingPathContent = CoreEditorUtils.GetContent("Rendering Path");
 


### PR DESCRIPTION
### Purpose of this PR
Save the collapsed state of material inspector in EditorPrefs

---
### Release Notes
HDRP material collapsed area state is now saved by user and by shader.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low
(few lines of code)

**Halo Effect**: Low
(only hdrp materials' inspectors are concerned)
---
### Comments to reviewers
