### PR TITLE
[WIP] Scalarise buffer loads for LightData

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -140,6 +140,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 
     #ifdef LIGHTLOOP_TILE_PASS
         GetCountAndStart(posInput, LIGHTCATEGORY_PUNCTUAL, lightStart, lightCount);
+        lightStart = WaveReadFirstLane(lightStart);
     #else
         lightCount = _PunctualLightCount;
         lightStart = 0;
@@ -163,6 +164,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 
     #ifdef LIGHTLOOP_TILE_PASS
         GetCountAndStart(posInput, LIGHTCATEGORY_AREA, lightStart, lightCount);
+        lightStart = WaveReadFirstLane(lightStart);
     #else
         lightCount = _AreaLightCount;
         lightStart = _PunctualLightCount;


### PR DESCRIPTION
### Purpose of this PR

This removes lots of vector buffer loads, reducing waits on vector memory and making few uncoherent branches coherent.
On PS4, I measured a win around 10-15%. 

An example of change: 

**Scalar ALU**: 349 -> 423 
**Scalar Memory**: 181 -> 229 
**Vector Memory**:  123 -> 88
**Unconditional branches**:  13 -> 20

---
### Release Notes

Optimized the forward rendering pass by scalarizing vector buffer loads. 

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=scalarize-lightdata-loads&automation-tools_branch=add-platform-filter&unity_branch=2018.3%2Fstaging [Running]


---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**:  Low
