### PR TITLE
Hdrp/fix debug menu materials

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugWindow.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugWindow.cs
@@ -502,7 +502,7 @@ namespace UnityEditor.Experimental.Rendering
             public static float s_DefaultLabelWidth = 0.5f;
 
             public readonly GUIStyle sectionScrollView = "PreferencesSectionBox";
-            public readonly GUIStyle sectionElement = "PreferencesSection";
+            public readonly GUIStyle sectionElement = new GUIStyle("PreferencesSection");
             public readonly GUIStyle selected = "OL SelectedRow";
             public readonly GUIStyle sectionHeader = new GUIStyle(EditorStyles.largeLabel);
             public readonly Color skinBackgroundColor;
@@ -511,6 +511,8 @@ namespace UnityEditor.Experimental.Rendering
             {
                 sectionScrollView = new GUIStyle(sectionScrollView);
                 sectionScrollView.overflow.bottom += 1;
+
+                sectionElement.alignment = TextAnchor.MiddleLeft;
 
                 sectionHeader.fontStyle = FontStyle.Bold;
                 sectionHeader.fontSize = 18;

--- a/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugWindow.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugWindow.cs
@@ -28,6 +28,12 @@ namespace UnityEditor.Experimental.Rendering
     public sealed class DebugWindow : EditorWindow
     {
         static Styles s_Styles;
+        static GUIStyle s_SplitterLeft;
+
+        static float splitterPos = 150f;
+        const float minSideBarWidth = 100;
+        const float minContentWidth = 100;
+        bool dragging = false;
 
         [SerializeField]
         WidgetStateDictionary m_WidgetStates;
@@ -46,7 +52,7 @@ namespace UnityEditor.Experimental.Rendering
         static bool s_TypeMapDirty;
         static Dictionary<Type, Type> s_WidgetStateMap; // DebugUI.Widget type -> DebugState type
         static Dictionary<Type, DebugUIDrawer> s_WidgetDrawerMap; // DebugUI.Widget type -> DebugUIDrawer
-
+        
         [DidReloadScripts]
         static void OnEditorReload()
         {
@@ -311,7 +317,10 @@ namespace UnityEditor.Experimental.Rendering
         void OnGUI()
         {
             if (s_Styles == null)
+            {
                 s_Styles = new Styles();
+                s_SplitterLeft = new GUIStyle();
+            }
 
             var panels = DebugManager.instance.panels;
             int itemCount = panels.Count(x => !x.isRuntimeOnly && x.children.Count(w => !w.isRuntimeOnly) > 0);
@@ -334,7 +343,7 @@ namespace UnityEditor.Experimental.Rendering
             using (new EditorGUILayout.HorizontalScope())
             {
                 // Side bar
-                using (var scrollScope = new EditorGUILayout.ScrollViewScope(m_PanelScroll, s_Styles.sectionScrollView, GUILayout.Width(150f)))
+                using (var scrollScope = new EditorGUILayout.ScrollViewScope(m_PanelScroll, s_Styles.sectionScrollView, GUILayout.Width(splitterPos)))
                 {
                     GUILayout.Space(40f);
 
@@ -384,6 +393,9 @@ namespace UnityEditor.Experimental.Rendering
 
                     m_PanelScroll = scrollScope.scrollPosition;
                 }
+                
+                Rect splitterRect = new Rect(splitterPos - 3, 0, 6, Screen.height);
+                GUI.Box(splitterRect, "", s_SplitterLeft);
 
                 GUILayout.Space(10f);
 
@@ -407,6 +419,35 @@ namespace UnityEditor.Experimental.Rendering
                     if (changedScope.changed)
                         m_Settings.currentStateHash = ComputeStateHash();
                 }
+
+                // Splitter events
+                if (Event.current != null)
+                {
+                    switch (Event.current.rawType)
+                    {
+                        case EventType.MouseDown:
+                            if (splitterRect.Contains(Event.current.mousePosition))
+                            {
+                                dragging = true;
+                            }
+                            break;
+                        case EventType.MouseDrag:
+                            if (dragging)
+                            {
+                                splitterPos += Event.current.delta.x;
+                                splitterPos = Mathf.Clamp(splitterPos, minSideBarWidth, Screen.width - minContentWidth);
+                                Repaint();
+                            }
+                            break;
+                        case EventType.MouseUp:
+                            if (dragging)
+                            {
+                                dragging = false;
+                            }
+                            break;
+                    }
+                }
+                EditorGUIUtility.AddCursorRect(splitterRect, MouseCursor.ResizeHorizontal);
             }
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugUI.Fields.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugUI.Fields.cs
@@ -115,6 +115,7 @@ namespace UnityEngine.Experimental.Rendering
         {
             public GUIContent[] enumNames;
             public int[] enumValues;
+            public int[] quickSeparators;
 
             public Type autoEnum
             {
@@ -129,6 +130,32 @@ namespace UnityEngine.Experimental.Rendering
                     enumValues = new int[values.Length];
                     for (int i = 0; i < values.Length; i++)
                         enumValues[i] = (int)values.GetValue(i);
+
+                    InitQuickSeparators();
+                }
+            }
+
+            public void InitQuickSeparators()
+            {
+                var enumNamesPrefix = enumNames.Select(x =>
+                {
+                    string[] splitted = x.text.Split('/');
+                    if (splitted.Length == 1)
+                        return "";
+                    else
+                        return splitted[0];
+                });
+                quickSeparators = new int[enumNamesPrefix.Distinct().Count()];
+                string lastPrefix = null;
+                for (int i = 0, wholeNameIndex = 0; i < quickSeparators.Length; ++i)
+                {
+                    var currentTestedPrefix = enumNamesPrefix.ElementAt(wholeNameIndex);
+                    while (lastPrefix == currentTestedPrefix)
+                    {
+                        currentTestedPrefix = enumNamesPrefix.ElementAt(++wholeNameIndex);
+                    }
+                    lastPrefix = currentTestedPrefix;
+                    quickSeparators[i] = wholeNameIndex++;
                 }
             }
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/Prefabs/Scripts/DebugUIHandlerEnumField.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/Prefabs/Scripts/DebugUIHandlerEnumField.cs
@@ -44,9 +44,38 @@ namespace UnityEngine.Experimental.Rendering.UI
             int index = Array.IndexOf(array, m_Field.GetValue());
 
             if (index == array.Length - 1)
+            {
                 index = 0;
+            }
             else
-                index += 1;
+            {
+                if (fast)
+                {
+                    //check if quickSeparators have not been constructed
+                    //it is thecase when not constructed with autoenum
+                    var separators = m_Field.quickSeparators;
+                    if(separators == null)
+                    {
+                        m_Field.InitQuickSeparators();
+                        separators = m_Field.quickSeparators;
+                    }
+
+                    int idxSup = 0;
+                    for (; idxSup < separators.Length && index + 1 > separators[idxSup]; ++idxSup) ;
+                    if(idxSup == separators.Length)
+                    {
+                        index = 0;
+                    }
+                    else
+                    {
+                        index = separators[idxSup];
+                    }
+                }
+                else
+                {
+                    index += 1;
+                }
+            }
 
             m_Field.SetValue(array[index]);
             UpdateValueLabel();
@@ -61,9 +90,47 @@ namespace UnityEngine.Experimental.Rendering.UI
             int index = Array.IndexOf(array, m_Field.GetValue());
 
             if (index == 0)
-                index = array.Length - 1;
+            {
+                if(fast)
+                {
+                    //check if quickSeparators have not been constructed
+                    //it is thecase when not constructed with autoenum
+                    var separators = m_Field.quickSeparators;
+                    if (separators == null)
+                    {
+                        m_Field.InitQuickSeparators();
+                        separators = m_Field.quickSeparators;
+                    }
+
+                    index = separators[separators.Length - 1];
+                }
+                else
+                {
+                    index = array.Length - 1;
+                }
+            }
             else
-                index -= 1;
+            {
+                if (fast)
+                {
+                    //check if quickSeparators have not been constructed
+                    //it is thecase when not constructed with autoenum
+                    var separators = m_Field.quickSeparators;
+                    if (separators == null)
+                    {
+                        m_Field.InitQuickSeparators();
+                        separators = m_Field.quickSeparators;
+                    }
+
+                    int idxInf = separators.Length - 1;
+                    for (; idxInf > 0 && index <= separators[idxInf]; --idxInf) ;
+                    index = separators[idxInf];
+                }
+                else
+                {
+                    index -= 1;
+                }
+            }
 
             m_Field.SetValue(array[index]);
             UpdateValueLabel();

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/CoreUnsafeUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Utilities/CoreUnsafeUtils.cs
@@ -31,7 +31,7 @@ namespace UnityEngine.Experimental.Rendering
         public static unsafe void QuickSort(uint[] arr, int left, int right)
         {
             fixed (uint* ptr = arr)
-                CoreUnsafeUtils.QuickSort<uint>(ptr, left, right);
+                QuickSort<uint>(ptr, left, right);
         }
 
         public static void QuickSort<T>(void* data, int left, int right)
@@ -51,7 +51,7 @@ namespace UnityEngine.Experimental.Rendering
         }
 
         // Just a sort function that doesn't allocate memory
-        // Note: Shoud be repalc by a radix sort for positive integer
+        // Note: Should be replace by a radix sort for positive integer
         static int Partition<T>(void* data, int left, int right)
             where T : struct, IComparable<T>
         {
@@ -79,6 +79,21 @@ namespace UnityEngine.Experimental.Rendering
                     return right;
                 }
             }
+        }
+
+        public static unsafe bool HaveDuplicates(int[] arr)
+        {
+            int* copy = stackalloc int[arr.Length];
+            arr.CopyTo<int>(copy, arr.Length);
+            QuickSort<int>(arr.Length, copy);
+            for (int i = arr.Length - 1; i > 0; --i)
+            {
+                if (UnsafeUtility.ReadArrayElement<int>(copy, i).CompareTo(UnsafeUtility.ReadArrayElement<int>(copy, i - 1)) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Fix wrong looping in materials enum of DebugMenu at runtime.
Add quick displacement for enum based on prefix at runtime.
Make the DebugMenu inspector sidebar resizeable.

---
### Release Notes
Fix wrong looping in materials enum of DebugMenu at runtime.
Add quick displacement for enum based on prefix at runtime.
Make the DebugMenu inspector sidebar resizeable.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low-Medium
(few lines of code)

**Halo Effect**: Low
(Only affect DebugMenu)

---
### Comments to reviewers
Resizeable sidebar code is pretty rough. Currently, it seams that it is easier to do this with UIElement. But in order to not change everything, I based my solution on events. Also I didn't found any public (or even private) API that can manage the dragging of a splitter.
