### PR TITLE
Hdrp/tmp fix cone light gizmo

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Core/Lighting/CoreLightEditorUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/Lighting/CoreLightEditorUtilities.cs
@@ -58,7 +58,31 @@ namespace UnityEditor.Experimental.Rendering
             GUI.changed |= temp;
             return angleValue;
         }
-        
+
+        static int s_SliderSpotAngleId;
+
+        static float SizeSliderSpotAngle(Vector3 position, Vector3 forward, Vector3 axis, float range, float spotAngle)
+        {
+            if (Math.Abs(spotAngle) <= 0.05f && GUIUtility.hotControl != s_SliderSpotAngleId)
+                return spotAngle;
+            var angledForward = Quaternion.AngleAxis(Mathf.Max(spotAngle, 0.05f) * 0.5f, axis) * forward;
+            var centerToLeftOnSphere = (angledForward * range + position) - (position + forward * range);
+            bool temp = GUI.changed;
+            GUI.changed = false;
+            var newMagnitude = Mathf.Max(0f, SliderLineHandle(position + forward * range, centerToLeftOnSphere.normalized, centerToLeftOnSphere.magnitude));
+            if (GUI.changed)
+            {
+                s_SliderSpotAngleId = GUIUtility.hotControl;
+                centerToLeftOnSphere = centerToLeftOnSphere.normalized * newMagnitude;
+                angledForward = (centerToLeftOnSphere + (position + forward * range) - position).normalized;
+                spotAngle = Mathf.Clamp(Mathf.Acos(Vector3.Dot(forward, angledForward)) * Mathf.Rad2Deg * 2, 0f, 179f);
+                if (spotAngle <= 0.05f || float.IsNaN(spotAngle))
+                    spotAngle = 0f;
+            }
+            GUI.changed |= temp;
+            return spotAngle;
+        }
+
         public static Color GetLightHandleColor(Color wireframeColor)
         {
             Color color = wireframeColor;
@@ -216,7 +240,28 @@ namespace UnityEditor.Experimental.Rendering
             float innerAngle = outerAngleInnerAngleRange.y;
             float range = outerAngleInnerAngleRange.z;
 
-            //[TO BE COMPLETED] @martint I'll let you put your handle here when ready, I only redone the wireframe to patch as soon as possible
+            var outerDiscRadius = range * Mathf.Sin(outerAngle * Mathf.Deg2Rad * 0.5f);
+            var outerDiscDistance = Mathf.Cos(Mathf.Deg2Rad * outerAngle * 0.5f) * range;
+            var vectorLineUp = Vector3.Normalize(Vector3.forward * outerDiscDistance + Vector3.up * outerDiscRadius);
+            var vectorLineLeft = Vector3.Normalize(Vector3.forward * outerDiscDistance + Vector3.left * outerDiscRadius);
+
+            if (innerAngle > 0f)
+            {
+                var innerDiscRadius = range * Mathf.Sin(innerAngle * Mathf.Deg2Rad * 0.5f);
+                var innerDiscDistance = Mathf.Cos(Mathf.Deg2Rad * innerAngle * 0.5f) * range;
+
+                innerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.right, range, innerAngle);
+                innerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.left, range, innerAngle);
+                innerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.up, range, innerAngle);
+                innerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.down, range, innerAngle);
+            }
+
+            outerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.right, range, outerAngle);
+            outerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.left, range, outerAngle);
+            outerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.up, range, outerAngle);
+            outerAngle = SizeSliderSpotAngle(Vector3.zero, Vector3.forward, Vector3.down, range, outerAngle);
+
+            range = SliderLineHandle(Vector3.zero, Vector3.forward, range);
 
             return new Vector3(outerAngle, innerAngle, range);
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
@@ -249,6 +249,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_SerializedAdditionalLightData.Update();
             m_SerializedAdditionalShadowData.Update();
 
+            //add space before the first collapsable area
+            EditorGUILayout.Space();
+
             // Disable the default light editor for the release, it is just use for development
             /*
             // Temporary toggle to go back to the old editor & separated additional datas
@@ -283,9 +286,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             if (settings.shadowsType.enumValueIndex != (int)LightShadows.None)
                 DrawFoldout(settings.shadowsType, "Shadows", DrawShadows);
-
-            CoreEditorUtils.DrawSplitter();
-            EditorGUILayout.Space();
 
             m_SerializedAdditionalShadowData.ApplyModifiedProperties();
             m_SerializedAdditionalLightData.ApplyModifiedProperties();


### PR DESCRIPTION

### Purpose of this PR
Temporary solution to have cone spot light handles.

---
### Release Notes
Fix cone spot light handles.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: Tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low
(few lines of code)

**Halo Effect**: Low
(only affect cone spot light gizmo)

---
### Comments to reviewers
Branching @martint-unity arc handle from lw/inner-cone-angle to have a temporary handle on the cone sport light. This will need to be updated later.