### PR TITLE
Fix contact shadow bias miscalculation

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/ScreenSpaceShadow.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/ScreenSpaceShadow.compute
@@ -83,7 +83,7 @@ float ScreenSpaceShadowRayCast(float3 positionWS, float3 rayDirWS, float rayLeng
 
     // Here we compute a ray perpendicular to view space. This is the ray we use to compute the threshold for rejecting samples.
     // This is done this way so that the threshold is less dependent of ray slope.
-    float4 rayOrthoViewSpace = rayStartCS + GetViewToHClipMatrix()[2];
+    float4 rayOrthoViewSpace = rayStartCS + float4(GetViewToHClipMatrix()[0][2], GetViewToHClipMatrix()[1][2], GetViewToHClipMatrix()[2][2], GetViewToHClipMatrix()[3][2]) * rayLength;
     rayOrthoViewSpace = rayOrthoViewSpace / rayOrthoViewSpace.w;
 
     rayStartCS.xyz = rayStartCS.xyz / rayStartCS.w;
@@ -93,7 +93,7 @@ float ScreenSpaceShadowRayCast(float3 positionWS, float3 rayDirWS, float rayLeng
     float3 rayDirCS = rayEndCS.xyz - rayStartCS.xyz;
 
     float step = 1.0f / _SampleCount;
-    float compareThreshold = abs(rayOrthoViewSpace.z - rayStartCS.z) * max(0.05f, step);
+    float compareThreshold = abs(rayOrthoViewSpace.z - rayStartCS.z) * max(0.07f, step);
 
     float occluded = 0.0f;
 


### PR DESCRIPTION
### Purpose of this PR

This fixes a regression with contact shadows at a distance. 
Main reason is that I am stupid and messed my matrix mul order when working out on paper optimizations 😄 

---
### Release Notes
Fix issue with contact shadows at longer distances. 
---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=contact-shadows-fix-for-distance-issue&automation-tools_branch=add-platform-filter&unity_branch=2018.3%2Fstaging  [ still running ] 

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: None

