### PR TITLE
Add more gpu intrinsics for GCN consoles

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -1,5 +1,7 @@
 // This file assume SHADER_API_D3D11 is defined
 
+#define SUPPORTS_WAVE_INTRINSICS
+
 #define INTRINSIC_BITFIELD_EXTRACT
 #define BitFieldExtract __v_bfe_u32
 #define INTRINSIC_BITFIELD_EXTRACT_SIGN_EXTEND

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -9,11 +9,28 @@
 #define INTRINSIC_WAVEREADFIRSTLANE
 #define WaveReadFirstLane ReadFirstLane
 #define INTRINSIC_MAD24
-#define Mad24 mad24
+#define Mad24Int mad24
+#define Mad24Uint mad24
 #define INTRINSIC_MINMAX3
 #define Min3 min3
 #define Max3 max3
 #define INTRINSIC_CUBEMAP_FACE_ID
+#define INTRINSIC_WAVE_MINMAX
+#define WaveMinInt CrossLaneMin
+#define WaveMinUint CrossLaneMin
+#define WaveMinFloat CrossLaneMin
+#define WaveMaxInt CrossLaneMax
+#define WaveMaxUint CrossLaneMax
+#define WaveMaxFloat CrossLaneMax
+#define INTRINSIC_BALLOT
+#define Ballot ballot
+#define INTRINSIC_WAVE_SUM
+#define WaveAdd CrossLaneAdd
+#define INTRINSIC_WAVE_LOGICAL_OPS
+#define WaveAnd CrossLaneAnd
+#define WaveOr CrossLaneOr
+
+
 
 #define UNITY_UV_STARTS_AT_TOP 1
 #define UNITY_REVERSED_Z 1

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -15,6 +15,8 @@
 #define CBUFFER_END };
 
 // Intrinsics
+#define SUPPORTS_WAVE_INTRINSICS
+
 #define INTRINSIC_WAVEREADFIRSTLANE
 #define WaveReadFirstLane __XB_MakeUniform
 #define INTRINSIC_MINMAX3

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -21,13 +21,28 @@
 #define Min3 __XB_Min3_F32
 #define Max3 __XB_Max3_F32
 #define INTRINSIC_MAD24
-#define Mad24 __XB_MadU24
+#define Mad24Int __XB_MadI24
+#define Mad24Uint __XB_MadU24
 #define INTRINSIC_BITFIELD_EXTRACT
 #define BitFieldExtract __XB_UBFE
 #define INTRINSIC_BITFIELD_EXTRACT_SIGN_EXTEND
 #define BitFieldExtractSignExtend __XB_IBFE
 #define INTRINSIC_BITFIELD_INSERT
 #define BitFieldInsert __XB_BFI
+#define INTRINSIC_WAVE_MINMAX
+#define WaveMinInt __XB_WaveMin_I32
+#define WaveMinUint __XB_WaveMin_U32
+#define WaveMinFloat __XB_WaveMin_F32
+#define WaveMaxInt __XB_WaveMax_I32
+#define WaveMaxUint __XB_WaveMax_U32
+#define WaveMaxFloat __XB_WaveMax_F32
+#define INTRINSIC_BALLOT
+#define Ballot __XB_Ballot64
+#define INTRINSIC_WAVE_SUM
+#define WaveAdd __XB_WaveAdd_F32
+#define INTRINSIC_WAVE_LOGICAL_OPS
+#define WaveAnd __XB_WaveAND
+#define WaveOr __XB_WaveOR
 
 // flow control attributes
 #define UNITY_BRANCH        [branch]

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -180,8 +180,8 @@
 #define LODDitheringTransition ERROR_ON_UNSUPPORTED_FUNC(LODDitheringTransition)
 #endif
 
-// On non-consoles we error on cross-lane operations
-#if !defined(SHADER_API_PSSL) && !defined(SHADER_API_XBOXONE)
+// On everything but GCN consoles we error on cross-lane operations
+#ifndef SUPPORTS_WAVE_INTRINSICS
 #define WaveMinInt ERROR_ON_UNSUPPORTED_FUNC(WaveMinInt)
 #define WaveMinUint ERROR_ON_UNSUPPORTED_FUNC(WaveMinUint)
 #define WaveMinFloat ERROR_ON_UNSUPPORTED_FUNC(WaveMinFloat)

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -180,6 +180,20 @@
 #define LODDitheringTransition ERROR_ON_UNSUPPORTED_FUNC(LODDitheringTransition)
 #endif
 
+// On non-consoles we error on cross-lane operations
+#if !defined(SHADER_API_PSSL) && !defined(SHADER_API_XBOXONE)
+#define WaveMinInt ERROR_ON_UNSUPPORTED_FUNC(WaveMinInt)
+#define WaveMinUint ERROR_ON_UNSUPPORTED_FUNC(WaveMinUint)
+#define WaveMinFloat ERROR_ON_UNSUPPORTED_FUNC(WaveMinFloat)
+#define WaveMaxInt ERROR_ON_UNSUPPORTED_FUNC(WaveMaxInt)
+#define WaveMaxUint ERROR_ON_UNSUPPORTED_FUNC(WaveMaxUint)
+#define WaveMaxFloat ERROR_ON_UNSUPPORTED_FUNC(WaveMaxFloat)
+#define Ballot ERROR_ON_UNSUPPORTED_FUNC(Ballot)
+#define WaveAdd ERROR_ON_UNSUPPORTED_FUNC(WaveAdd)
+#define WaveAnd ERROR_ON_UNSUPPORTED_FUNC(WaveAnd)
+#define WaveOr ERROR_ON_UNSUPPORTED_FUNC(WaveOr)
+#endif
+
 #if !defined(SHADER_API_GLES)
 
 #ifndef INTRINSIC_BITFIELD_EXTRACT
@@ -247,7 +261,8 @@ void ToggleBit(inout uint data, uint offset)
 #endif // INTRINSIC_MUL24
 
 #ifndef INTRINSIC_MAD24
-    TEMPLATE_3_INT(Mad24, a, b, c, return a * b + c)
+    TEMPLATE_3_INT(Mad24Int, a, b, c, return a * b + c)
+    TEMPLATE_3_INT(Mad24Uint, a, b, c, return a * b + c)
 #endif // INTRINSIC_MAD24
 
 #ifndef INTRINSIC_MINMAX3

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/BuildProbabilityTables.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/BuildProbabilityTables.compute
@@ -40,7 +40,7 @@ RWTexture2D<float> conditionalDensities;  // [TEXTURE_WIDTH x TEXTURE_HEIGHT]
         GroupMemoryBarrierWithGroupSync();                      \
                                                                 \
         /*** a1 = (2 * i + 1) * offset - 1 */                   \
-        uint a1 = Mad24(Mad24(2, i, 1), offset, -1);            \
+        uint a1 = Mad24Uint(Mad24Uint(2u, i, 1), offset, -1);   \
         uint a2 = a1 + offset;                                  \
                                                                 \
         if (a2 < n)                                             \
@@ -68,7 +68,7 @@ RWTexture2D<float> conditionalDensities;  // [TEXTURE_WIDTH x TEXTURE_HEIGHT]
         GroupMemoryBarrierWithGroupSync();                      \
                                                                 \
         /*** a1 = (2 * i + 1) * offset - 1 */                   \
-        uint a1 = Mad24(Mad24(2, i, 1), offset, -1);            \
+        uint a1 = Mad24Uint(Mad24Uint(2u, i, 1), offset, -1);   \
         uint a2 = a1 + offset;                                  \
                                                                 \
         if (a2 < n)                                             \

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/BuildProbabilityTables.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/BuildProbabilityTables.compute
@@ -30,56 +30,56 @@ RWTexture2D<float> conditionalDensities;  // [TEXTURE_WIDTH x TEXTURE_HEIGHT]
 
 // Performs a block-level parallel scan.
 // Ref: GPU Gems 3, Chapter 39: "Parallel Prefix Sum (Scan) with CUDA".
-#define PARALLEL_SCAN(i, n, temp, sum)                          \
-{                                                               \
-    uint offset;                                                \
-                                                                \
-    /* Execute the up-sweep phase. */                           \
-    for (offset = 1; offset <= n / 2; offset *= 2)              \
-    {                                                           \
-        GroupMemoryBarrierWithGroupSync();                      \
-                                                                \
-        /*** a1 = (2 * i + 1) * offset - 1 */                   \
-        uint a1 = Mad24Uint(Mad24Uint(2u, i, 1), offset, -1);   \
-        uint a2 = a1 + offset;                                  \
-                                                                \
-        if (a2 < n)                                             \
-        {                                                       \
-            temp[SHARED_MEM(a2)] += temp[SHARED_MEM(a1)];       \
-        }                                                       \
-    }                                                           \
-                                                                \
-    GroupMemoryBarrierWithGroupSync();                          \
-                                                                \
-    /* Prevent NaNs arising from the division of 0 by 0. */     \
-    sum = max(temp[SHARED_MEM(n - 1)], FLT_EPS);                \
-                                                                \
-    GroupMemoryBarrierWithGroupSync();                          \
-                                                                \
-    /* The exclusive scan requires the last element to be 0. */ \
-    if (i == 0)                                                 \
-    {                                                           \
-        temp[SHARED_MEM(n - 1)] = 0.0;                          \
-    }                                                           \
-                                                                \
-    /* Execute the down-sweep phase. */                         \
-    for (offset = n / 2; offset > 0; offset /= 2)               \
-    {                                                           \
-        GroupMemoryBarrierWithGroupSync();                      \
-                                                                \
-        /*** a1 = (2 * i + 1) * offset - 1 */                   \
-        uint a1 = Mad24Uint(Mad24Uint(2u, i, 1), offset, -1);   \
-        uint a2 = a1 + offset;                                  \
-                                                                \
-        if (a2 < n)                                             \
-        {                                                       \
-            float t1 = temp[SHARED_MEM(a1)];                    \
-            temp[SHARED_MEM(a1)]  = temp[SHARED_MEM(a2)];       \
-            temp[SHARED_MEM(a2)] += t1;                         \
-        }                                                       \
-    }                                                           \
-                                                                \
-    GroupMemoryBarrierWithGroupSync();                          \
+#define PARALLEL_SCAN(i, n, temp, sum)                                          \
+{                                                                               \
+    uint offset;                                                                \
+                                                                                \
+    /* Execute the up-sweep phase. */                                           \
+    for (offset = 1; offset <= n / 2; offset *= 2)                              \
+    {                                                                           \
+        GroupMemoryBarrierWithGroupSync();                                      \
+                                                                                \
+        /*** a1 = (2 * i + 1) * offset - 1 */                                   \
+        uint a1 = (uint)Mad24Int((int)Mad24Uint(2u, i, 1u), (int)offset, -1);   \
+        uint a2 = a1 + offset;                                                  \
+                                                                                \
+        if (a2 < n)                                                             \
+        {                                                                       \
+            temp[SHARED_MEM(a2)] += temp[SHARED_MEM(a1)];                       \
+        }                                                                       \
+    }                                                                           \
+                                                                                \
+    GroupMemoryBarrierWithGroupSync();                                          \
+                                                                                \
+    /* Prevent NaNs arising from the division of 0 by 0. */                     \
+    sum = max(temp[SHARED_MEM(n - 1)], FLT_EPS);                                \
+                                                                                \
+    GroupMemoryBarrierWithGroupSync();                                          \
+                                                                                \
+    /* The exclusive scan requires the last element to be 0. */                 \
+    if (i == 0)                                                                 \
+    {                                                                           \
+        temp[SHARED_MEM(n - 1)] = 0.0;                                          \
+    }                                                                           \
+                                                                                \
+    /* Execute the down-sweep phase. */                                         \
+    for (offset = n / 2; offset > 0; offset /= 2)                               \
+    {                                                                           \
+        GroupMemoryBarrierWithGroupSync();                                      \
+                                                                                \
+        /*** a1 = (2 * i + 1) * offset - 1 */                                   \
+        uint a1 = (uint)Mad24Int((int)Mad24Uint(2u, i, 1u), (int)offset, -1);   \
+        uint a2 = a1 + offset;                                                  \
+                                                                                \
+        if (a2 < n)                                                             \
+        {                                                                       \
+            float t1 = temp[SHARED_MEM(a1)];                                    \
+            temp[SHARED_MEM(a1)]  = temp[SHARED_MEM(a2)];                       \
+            temp[SHARED_MEM(a2)] += t1;                                         \
+        }                                                                       \
+    }                                                                           \
+                                                                                \
+    GroupMemoryBarrierWithGroupSync();                                          \
 }
 
 #pragma kernel ComputeConditionalDensities

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.compute
@@ -81,7 +81,7 @@ groupshared bool   processGroup;
 #if SSS_USE_LDS_CACHE
 void StoreSampleToCacheMemory(float4 value, int2 cacheCoord)
 {
-    int linearCoord = Mad24(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
+    int linearCoord = Mad24Int(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
 
     textureCache0[linearCoord] = value.rg;
     textureCache1[linearCoord] = value.ba;
@@ -89,7 +89,7 @@ void StoreSampleToCacheMemory(float4 value, int2 cacheCoord)
 
 float4 LoadSampleFromCacheMemory(int2 cacheCoord)
 {
-    int linearCoord = Mad24(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
+    int linearCoord = Mad24Int(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
 
     return float4(textureCache0[linearCoord],
                   textureCache1[linearCoord]);


### PR DESCRIPTION
### Purpose of this PR
Add few more intrinsics for GCN consoles. Note that I don't have an immediate use case in mind for all of them, but since I needed to add a couple, I used to occasion to add few useful ones. 

I also had to make explicit type variants as the Xbox intrinsics specify them in function name and it is quite strict. For the same reason, I needed to add some explict casting in BuildProbabilityTables.compute .

This has release/2018.3 as base

---
### Release Notes
Add support for more GPU intrinsics on GCN consoles.

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=add-more-gpu-intrinsics&automation-tools_branch=add-platform-filter&unity_branch=2018.3%2Fstaging [Running]

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**:  Low
