### PR TITLE
Fix compilation issue with on non editor build in HDRenderPipelineAsset.cs

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -303,6 +303,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
 #endif
         }
-    }
 #endif
+    }
 }


### PR DESCRIPTION
### Purpose of this PR

Moving the endif as it was hiding the brace that closed class definition in non-editor builds.  This fixes a compilation issue when launching a non-editor build. 

---
### Release Notes
Fix compilation error in non-editor builds. 

---
### Testing status

**Manual Tests**:  Launched on PS4 and Xbox One. 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None
