### PR TITLE
[LWRP]Fixed Cast Shadows overlapping with other UI elements in the Inspector for Area Light

### DIFF
--- a/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineLightEditor.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineLightEditor.cs
@@ -169,8 +169,8 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
         {
             // Shadows drop-down. Area lights can only be baked and always have shadows.
             float show = 1.0f - m_AnimAreaOptions.faded;
-            using (new EditorGUILayout.FadeGroupScope(show))
-                settings.DrawShadowsType();
+
+			settings.DrawShadowsType();
 
             EditorGUI.indentLevel += 1;
             show *= m_AnimShadowOptions.faded;


### PR DESCRIPTION
### Purpose of this PR

Changing the SRP to LWRP would cause _Cast Shadows_ to overlap with elements underneath it in the Area Light Inspector settings as documented by case #1085363. 

### Release Notes

*Reverted Cast Shadows setting to the way it is in Editor code to fix.

---
### Testing status
**Katana Tests**: 
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=add-platform-filter&ScriptableRenderLoop_branch=lw%2Ffixinspectorverlap&unity_branch=trunk

**Manual Tests**: Checked if the component looks fine by resizing the inspector, changing around light types.

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None
