### PR TITLE
Backport of (#2219) and (#2218) from release/2018.3

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
@@ -52,14 +52,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             CaptureSettingsUI.SectionCaptureSettings
             );
 
-        public static readonly CED.IDrawer SectionFrameSettings = CED.FadeGroup(
-            (s, d, o, i) => s.isFrameSettingsOverriden,
-            FadeOption.None,
-            CED.Select(
-                (s, d, o) => s.frameSettings,
-                (s, d, o) => d.frameSettings,
-                FrameSettingsUI.Inspector(withOverride: true))
-            );
+        public static readonly CED.IDrawer SectionFrameSettings = CED.Action((s, d, o) =>
+        {
+            if (s.captureSettings.isSectionExpandedCaptureSettings.target)
+            {
+                if (s.isFrameSettingsOverriden.target && s.captureSettings.isSectionExpandedCaptureSettings.target)
+                    FrameSettingsUI.Inspector(withOverride: true).Draw(s.frameSettings, d.frameSettings, o);
+                else
+                    EditorGUILayout.Space();
+            }
+        });
+
 
         public static readonly CED.IDrawer SectionFoldoutAdditionalSettings = CED.FoldoutGroup(
             additionnalSettingsHeader,
@@ -79,8 +82,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 SectionInfluenceVolume,
                 SectionShapeCheck,
                 SectionCaptureSettings,
-                SectionFoldoutAdditionalSettings,
                 SectionFrameSettings,
+                SectionFoldoutAdditionalSettings,
                 SectionBakeButton
             };
         }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Camera/HDCameraUI.Drawers.cs
@@ -18,11 +18,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 CED.space,
                 SectionGeneralSettings,
+                SectionFrameSettings,
                 // Not used for now
                 //SectionPhysicalSettings,
                 SectionOutputSettings,
-                SectionXRSettings,
-                SectionRenderLoopSettings
+                SectionXRSettings
             };
         }
 
@@ -42,8 +42,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 CED.Action(Drawer_FieldClippingPlanes),
                 CED.space,
                 CED.Action(Drawer_CameraWarnings),
-                CED.Action(Drawer_FieldRenderingPath),
-                CED.space
+                CED.Action(Drawer_FieldRenderingPath)
+                //no space as FrameSettings is drawn just under
                 );
 
         public static readonly CED.IDrawer SectionPhysicalSettings = CED.FoldoutGroup(
@@ -76,14 +76,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     FoldoutOption.Indent,
                     CED.Action(Drawer_FieldVR),
                     CED.Action(Drawer_FieldTargetEye)));
-
-        public static readonly CED.IDrawer SectionRenderLoopSettings = CED.FadeGroup(
-                (s, d, o, i) => s.isSectionAvailableRenderLoopSettings,
-                FadeOption.None,
-                CED.Select(
-                    (s, d, o) => s.frameSettingsUI,
-                    (s, d, o) => d.frameSettings,
-                    FrameSettingsUI.Inspector()));
+        
+        public static readonly CED.IDrawer SectionFrameSettings = CED.Action((s, d, o) =>
+        {
+            if (s.isSectionExpandedGeneralSettings.target)
+            {
+                if (s.isSectionAvailableRenderLoopSettings.target)
+                    FrameSettingsUI.Inspector().Draw(s.frameSettingsUI, d.frameSettings, o);
+                else
+                    EditorGUILayout.Space();
+            }
+        });
 
         static void Drawer_FieldBackgroundColorHDR(HDCameraUI s, SerializedHDCamera p, Editor owner)
         {

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
@@ -34,8 +34,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 captureSettingsHeaderContent,
                 (s, p, o) => s.isSectionExpandedCaptureSettings,
                 FoldoutOption.Indent,
-                CED.LabelWidth(150, CED.Action((s, p, o) => Drawer_SectionCaptureSettings(s, p, o))),
-                CED.space
+                CED.LabelWidth(150, CED.Action((s, p, o) => Drawer_SectionCaptureSettings(s, p, o)))
+                //no space as FrameSettings is rendered here and will handle it
                 );
 
         public AnimBool isSectionExpandedCaptureSettings { get { return m_AnimBools[0]; } }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
@@ -70,7 +70,24 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             
             area.Add(p.shadowDistance, shadowDistanceContent, () => p.overridesShadowDistance, a => p.overridesShadowDistance = a);
             area.Add(p.renderingPath, renderingPathContent, () => p.overridesRenderingPath, a => p.overridesRenderingPath = a);
+            EditorGUI.BeginChangeCheck();
             area.Draw(withOverride: false);
+
+
+
+
+            //hack while we rely on legacy probe for baking.
+            //to remove once we do not rely on them
+            if (EditorGUI.EndChangeCheck() && owner is HDReflectionProbeEditor)
+            {
+                ReflectionProbe rp = owner.target as ReflectionProbe;
+                rp.clearFlags = p.clearColorMode.enumValueIndex == (int)HDAdditionalCameraData.ClearColorMode.Sky ? UnityEngine.Rendering.ReflectionProbeClearFlags.Skybox : UnityEngine.Rendering.ReflectionProbeClearFlags.SolidColor;
+                rp.backgroundColor = p.backgroundColorHDR.colorValue;
+                rp.hdr = true;
+                rp.cullingMask = p.cullingMask.intValue;
+                rp.nearClipPlane = p.nearClipPlane.floatValue;
+                rp.farClipPlane = p.farClipPlane.floatValue;
+            }
         }
     }
 }


### PR DESCRIPTION
- Move FrameSettings inspector position (#2219)
- Fix capture settings usage for baked probes (#2218)