### PR TITLE
Exposed max LightLoop settings in hd asset

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/GlobalDecalSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/GlobalDecalSettingsUI.cs
@@ -1,3 +1,6 @@
+using UnityEngine.Experimental.Rendering.HDPipeline;
+using UnityEngine;
+
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     using _ = CoreEditorUtils;
@@ -33,6 +36,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUILayout.PropertyField(d.atlasWidth, _.GetContent("Atlas Width"));
             EditorGUILayout.PropertyField(d.atlasHeight, _.GetContent("Atlas Height"));
             EditorGUILayout.PropertyField(d.perChannelMask, _.GetContent("Enable Metal and AO properties"));
+
+            // Clamp input values
+            d.drawDistance.intValue = Mathf.Max(d.drawDistance.intValue, 0);
+            d.atlasWidth.intValue = Mathf.Max(d.atlasWidth.intValue, 0);
+            d.atlasHeight.intValue = Mathf.Max(d.atlasHeight.intValue, 0);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/GlobalLightLoopSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/GlobalLightLoopSettingsUI.cs
@@ -30,7 +30,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     "Sky",
                     (s, d, o) => s.isSectionExpendedSkySettings,
                     FoldoutOption.None,
-                    SectionSky)
+                    SectionSky),
+                CED.FoldoutGroup(
+                    "LightLoop",
+                    (s, d, o) => s.isSectionExpendedLightLoopSettings,
+                    FoldoutOption.None,
+                    SectionLightLoop)
                 );
         }
 
@@ -39,17 +44,20 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public static readonly CED.IDrawer SectionCookies = CED.Action(Drawer_SectionCookies);
         public static readonly CED.IDrawer SectionReflection = CED.Action(Drawer_SectionReflection);
         public static readonly CED.IDrawer SectionSky = CED.Action(Drawer_SectionSky);
+        public static readonly CED.IDrawer SectionLightLoop = CED.Action(Drawer_LightLoop);
 
         public AnimBool isSectionExpandedCoockiesSettings { get { return m_AnimBools[0]; } }
         public AnimBool isSectionExpandedReflectionSettings { get { return m_AnimBools[1]; } }
         public AnimBool isSectionExpendedSkySettings { get { return m_AnimBools[2]; } }
+        public AnimBool isSectionExpendedLightLoopSettings { get { return m_AnimBools[3]; } }
 
         public GlobalLightLoopSettingsUI()
-            : base(3)
+            : base(4)
         {
             isSectionExpandedCoockiesSettings.value = true;
             isSectionExpandedReflectionSettings.value = true;
             isSectionExpendedSkySettings.value = true;
+            isSectionExpendedLightLoopSettings.value = true;
         }
 
         static string HumanizeWeight(long weightInByte)
@@ -177,6 +185,21 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 EditorGUILayout.HelpBox("Be careful, Sky Lighting Override Mask is set to Everything. This is most likely a mistake as it serves no purpose.", MessageType.Warning);
             }
             EditorGUILayout.Space();
+        }
+
+        static void Drawer_LightLoop(GlobalLightLoopSettingsUI s, SerializedGlobalLightLoopSettings d, Editor o)
+        {
+            EditorGUILayout.PropertyField(d.maxDirectionalLightsOnScreen, _.GetContent("Max Directional Lights On Screen"));
+            EditorGUILayout.PropertyField(d.maxPunctualLightsOnScreen, _.GetContent("Max Punctual Lights On Screen"));
+            EditorGUILayout.PropertyField(d.maxAreaLightsOnScreen, _.GetContent("Max Area Lights On Screen"));
+            EditorGUILayout.PropertyField(d.maxEnvLightsOnScreen, _.GetContent("Max Env Lights On Screen"));
+            EditorGUILayout.PropertyField(d.maxDecalsOnScreen, _.GetContent("Max Decals On Screen"));
+            
+            d.maxDirectionalLightsOnScreen.intValue = Mathf.Clamp(d.maxDirectionalLightsOnScreen.intValue, 1, LightLoop.k_MaxDirectionalLightsOnScreen);
+            d.maxPunctualLightsOnScreen.intValue = Mathf.Clamp(d.maxPunctualLightsOnScreen.intValue, 1, LightLoop.k_MaxPunctualLightsOnScreen);
+            d.maxAreaLightsOnScreen.intValue = Mathf.Clamp(d.maxAreaLightsOnScreen.intValue, 1, LightLoop.k_MaxAreaLightsOnScreen);
+            d.maxEnvLightsOnScreen.intValue = Mathf.Clamp(d.maxEnvLightsOnScreen.intValue, 1, LightLoop.k_MaxEnvLightsOnScreen);
+            d.maxDecalsOnScreen.intValue = Mathf.Clamp(d.maxDecalsOnScreen.intValue, 1, LightLoop.k_MaxDecalsOnScreen);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedGlobalLightLoopSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedGlobalLightLoopSettings.cs
@@ -19,6 +19,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedProperty skyReflectionSize;
         public SerializedProperty skyLightingOverrideLayerMask;
         public SerializedProperty supportFabricConvolution;
+        public SerializedProperty maxDirectionalLightsOnScreen;
+        public SerializedProperty maxPunctualLightsOnScreen;
+        public SerializedProperty maxAreaLightsOnScreen; 
+        public SerializedProperty maxEnvLightsOnScreen;
+        public SerializedProperty maxDecalsOnScreen;
 
         public SerializedGlobalLightLoopSettings(SerializedProperty root)
         {
@@ -40,6 +45,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             skyReflectionSize = root.Find((GlobalLightLoopSettings s) => s.skyReflectionSize);
             skyLightingOverrideLayerMask = root.Find((GlobalLightLoopSettings s) => s.skyLightingOverrideLayerMask);
             supportFabricConvolution = root.Find((GlobalLightLoopSettings s) => s.supportFabricConvolution);
+
+            maxDirectionalLightsOnScreen = root.Find((GlobalLightLoopSettings s) => s.maxDirectionalLightsOnScreen);
+            maxPunctualLightsOnScreen = root.Find((GlobalLightLoopSettings s) => s.maxPunctualLightsOnScreen);
+            maxAreaLightsOnScreen = root.Find((GlobalLightLoopSettings s) => s.maxAreaLightsOnScreen);
+            maxEnvLightsOnScreen = root.Find((GlobalLightLoopSettings s) => s.maxEnvLightsOnScreen);
+            maxDecalsOnScreen = root.Find((GlobalLightLoopSettings s) => s.maxDecalsOnScreen);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/GlobalLightLoopSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/GlobalLightLoopSettings.cs
@@ -76,5 +76,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public SkyResolution skyReflectionSize = SkyResolution.SkyResolution256;
         public LayerMask skyLightingOverrideLayerMask = 0;
         public bool supportFabricConvolution = false;
+
+        public int maxDirectionalLightsOnScreen = 4;
+        public int maxPunctualLightsOnScreen    = 512;
+        public int maxAreaLightsOnScreen        = 64;
+        public int maxEnvLightsOnScreen         = 64;
+        public int maxDecalsOnScreen            = 512;
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/GlobalLightLoopSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/GlobalLightLoopSettings.cs
@@ -77,7 +77,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public LayerMask skyLightingOverrideLayerMask = 0;
         public bool supportFabricConvolution = false;
 
-        public int maxDirectionalLightsOnScreen = 4;
+        public int maxDirectionalLightsOnScreen = 16;
         public int maxPunctualLightsOnScreen    = 512;
         public int maxAreaLightsOnScreen        = 64;
         public int maxEnvLightsOnScreen         = 64;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -154,12 +154,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public const int k_MaxPunctualLightsOnScreen    = 512;
         public const int k_MaxAreaLightsOnScreen        = 64;
         public const int k_MaxDecalsOnScreen = 512;
-        public const int k_MaxLightsOnScreen = k_MaxDirectionalLightsOnScreen + k_MaxPunctualLightsOnScreen + k_MaxAreaLightsOnScreen + k_MaxDecalsOnScreen;
+        public const int k_MaxLightsOnScreen = k_MaxDirectionalLightsOnScreen + k_MaxPunctualLightsOnScreen + k_MaxAreaLightsOnScreen + k_MaxEnvLightsOnScreen;
         public const int k_MaxEnvLightsOnScreen = 64;
-        public const int k_MaxShadowOnScreen = 16;
-        public const int k_MaxCascadeCount = 4; //Should be not less than m_Settings.directionalLightCascadeCount;
         public const int k_MaxStereoEyes = 2;
         public static readonly Vector3 k_BoxCullingExtentThreshold = Vector3.one * 0.01f;
+
+        public int m_MaxDirectionalLightsOnScreen;
+        public int m_MaxPunctualLightsOnScreen;
+        public int m_MaxAreaLightsOnScreen;
+        public int m_MaxDecalsOnScreen;
+        public int m_MaxLightsOnScreen;
+        public int m_MaxEnvLightsOnScreen;
 
         // Static keyword is required here else we get a "DestroyBuffer can only be called from the main thread"
         ComputeBuffer m_DirectionalLightDatas = null;
@@ -418,21 +423,29 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public void Build(HDRenderPipelineAsset hdAsset, IBLFilterBSDF[] iBLFilterBSDFArray)
         {
             m_Resources = hdAsset.renderPipelineResources;
+            var lightLoopSettings = hdAsset.renderPipelineSettings.lightLoopSettings;
 
             m_DebugViewTilesMaterial = CoreUtils.CreateEngineMaterial(m_Resources.shaders.debugViewTilesPS);
             m_DebugHDShadowMapMaterial = CoreUtils.CreateEngineMaterial(m_Resources.shaders.debugHDShadowMapPS);
             m_CubeToPanoMaterial = CoreUtils.CreateEngineMaterial(m_Resources.shaders.cubeToPanoPS);
 
+            m_MaxDirectionalLightsOnScreen = lightLoopSettings.maxDirectionalLightsOnScreen;
+            m_MaxPunctualLightsOnScreen = lightLoopSettings.maxPunctualLightsOnScreen;
+            m_MaxAreaLightsOnScreen = lightLoopSettings.maxAreaLightsOnScreen;
+            m_MaxDecalsOnScreen = lightLoopSettings.maxDecalsOnScreen;
+            m_MaxEnvLightsOnScreen = lightLoopSettings.maxEnvLightsOnScreen;
+            m_MaxLightsOnScreen = m_MaxDirectionalLightsOnScreen + m_MaxPunctualLightsOnScreen + m_MaxAreaLightsOnScreen + m_MaxEnvLightsOnScreen;
+
             m_lightList = new LightList();
             m_lightList.Allocate();
             m_Env2DCaptureVP.Clear();
-            for (int i = 0, c = Mathf.Max(1, hdAsset.renderPipelineSettings.lightLoopSettings.planarReflectionProbeCacheSize); i < c; ++i)
+            for (int i = 0, c = Mathf.Max(1, lightLoopSettings.planarReflectionProbeCacheSize); i < c; ++i)
                 m_Env2DCaptureVP.Add(Matrix4x4.identity);
 
-            m_DirectionalLightDatas = new ComputeBuffer(k_MaxDirectionalLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(DirectionalLightData)));
-            m_LightDatas = new ComputeBuffer(k_MaxPunctualLightsOnScreen + k_MaxAreaLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(LightData)));
-            m_EnvLightDatas = new ComputeBuffer(k_MaxEnvLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(EnvLightData)));
-            m_DecalDatas = new ComputeBuffer(k_MaxDecalsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(DecalData)));
+            m_DirectionalLightDatas = new ComputeBuffer(m_MaxDirectionalLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(DirectionalLightData)));
+            m_LightDatas = new ComputeBuffer(m_MaxPunctualLightsOnScreen + m_MaxAreaLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(LightData)));
+            m_EnvLightDatas = new ComputeBuffer(m_MaxEnvLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(EnvLightData)));
+            m_DecalDatas = new ComputeBuffer(m_MaxDecalsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(DecalData)));
 
             GlobalLightLoopSettings gLightLoopSettings = hdAsset.GetRenderPipelineSettings().lightLoopSettings;
             m_CookieTexArray = new TextureCache2D("Cookie");
@@ -472,9 +485,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // TODO: Maybe in stereo, we will only support half as many lights total, in order to minimize buffer size waste.
             // Alternatively, we could re-size these buffers if any stereo camera is active, instead of unilaterally increasing buffer size.
             // TODO: I don't think k_MaxLightsOnScreen corresponds to the actual correct light count for cullable light types (punctual, area, env, decal)
-            s_AABBBoundsBuffer = new ComputeBuffer(k_MaxStereoEyes * 2 * k_MaxLightsOnScreen, 4 * sizeof(float));
-            s_ConvexBoundsBuffer = new ComputeBuffer(k_MaxStereoEyes * k_MaxLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(SFiniteLightBound)));
-            s_LightVolumeDataBuffer = new ComputeBuffer(k_MaxStereoEyes * k_MaxLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(LightVolumeData)));
+            s_AABBBoundsBuffer = new ComputeBuffer(k_MaxStereoEyes * 2 * m_MaxLightsOnScreen, 4 * sizeof(float));
+            s_ConvexBoundsBuffer = new ComputeBuffer(k_MaxStereoEyes * m_MaxLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(SFiniteLightBound)));
+            s_LightVolumeDataBuffer = new ComputeBuffer(k_MaxStereoEyes * m_MaxLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(LightVolumeData)));
             s_DispatchIndirectBuffer = new ComputeBuffer(LightDefinitions.s_NumFeatureVariants * 3, sizeof(uint), ComputeBufferType.IndirectArguments);
 
             // Cluster
@@ -798,7 +811,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool GetDirectionalLightData(CommandBuffer cmd, GPULightType gpuLightType, VisibleLight light, Light lightComponent, HDAdditionalLightData additionalLightData, AdditionalShadowData additionalShadowData, int lightIndex, int shadowIndex, DebugDisplaySettings debugDisplaySettings, int sortedIndex)
         {
             // Clamp light list to the maximum allowed lights on screen to avoid ComputeBuffer overflow
-            if (m_lightList.directionalLights.Count >= k_MaxDirectionalLightsOnScreen)
+            if (m_lightList.directionalLights.Count >= m_MaxDirectionalLightsOnScreen)
                 return false;
 
             bool contributesToLighting = ((additionalLightData.lightDimmer > 0) && (additionalLightData.affectDiffuse || additionalLightData.affectSpecular)) || (additionalLightData.volumetricDimmer > 0);
@@ -925,7 +938,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             int lightIndex, int shadowIndex, ref Vector3 lightDimensions, DebugDisplaySettings debugDisplaySettings)
         {
             // Clamp light list to the maximum allowed lights on screen to avoid ComputeBuffer overflow
-            if (m_lightList.lights.Count >= k_MaxPunctualLightsOnScreen + k_MaxAreaLightsOnScreen)
+            if (m_lightList.lights.Count >= m_MaxPunctualLightsOnScreen + m_MaxAreaLightsOnScreen)
                 return false;
 
             // Both of these positions are non-camera-relative.
@@ -1623,7 +1636,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     int punctualLightcount = 0;
                     int areaLightCount = 0;
 
-                    int lightCount = Math.Min(cullResults.visibleLights.Count, k_MaxLightsOnScreen);
+                    int lightCount = Math.Min(cullResults.visibleLights.Count, m_MaxLightsOnScreen);
                     UpdateSortKeysArray(lightCount);
                     int sortCount = 0;
                     for (int lightIndex = 0, numLights = cullResults.visibleLights.Count; (lightIndex < numLights) && (sortCount < lightCount); ++lightIndex)
@@ -1648,7 +1661,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             switch (light.lightType)
                             {
                                 case LightType.Spot:
-                                    if (punctualLightcount >= k_MaxPunctualLightsOnScreen)
+                                    if (punctualLightcount >= m_MaxPunctualLightsOnScreen)
                                         continue;
                                     switch (additionalData.spotLightShape)
                                     {
@@ -1671,7 +1684,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                     break;
 
                                 case LightType.Directional:
-                                    if (directionalLightcount >= k_MaxDirectionalLightsOnScreen)
+                                    if (directionalLightcount >= m_MaxDirectionalLightsOnScreen)
                                         continue;
                                     gpuLightType = GPULightType.Directional;
                                     // No need to add volume, always visible
@@ -1679,7 +1692,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                     break;
 
                                 case LightType.Point:
-                                    if (punctualLightcount >= k_MaxPunctualLightsOnScreen)
+                                    if (punctualLightcount >= m_MaxPunctualLightsOnScreen)
                                         continue;
                                     gpuLightType = GPULightType.Point;
                                     lightVolumeType = LightVolumeType.Sphere;
@@ -1697,14 +1710,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             switch (additionalData.lightTypeExtent)
                             {
                                 case LightTypeExtent.Rectangle:
-                                    if (areaLightCount >= k_MaxAreaLightsOnScreen)
+                                    if (areaLightCount >= m_MaxAreaLightsOnScreen)
                                         continue;
                                     gpuLightType = GPULightType.Rectangle;
                                     lightVolumeType = LightVolumeType.Box;
                                     break;
 
                                 case LightTypeExtent.Line:
-                                    if (areaLightCount >= k_MaxAreaLightsOnScreen)
+                                    if (areaLightCount >= m_MaxAreaLightsOnScreen)
                                         continue;
                                     gpuLightType = GPULightType.Line;
                                     lightVolumeType = LightVolumeType.Box;
@@ -1850,11 +1863,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     m_areaLightCount = areaLightCount;
 
                     // Redo everything but this time with envLights
-                    Debug.Assert(k_MaxEnvLightsOnScreen <= 256); //for key construction
+                    Debug.Assert(m_MaxEnvLightsOnScreen <= 256); //for key construction
                     int envLightCount = 0;
 
                     var totalProbes = cullResults.visibleReflectionProbes.Count + reflectionProbeCullResults.visiblePlanarReflectionProbeCount;
-                    int probeCount = Math.Min(totalProbes, k_MaxEnvLightsOnScreen);
+                    int probeCount = Math.Min(totalProbes, m_MaxEnvLightsOnScreen);
                     UpdateSortKeysArray(probeCount);
                     sortCount = 0;
 
@@ -1866,7 +1879,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             HDAdditionalReflectionData additional = probe.probe.GetComponent<HDAdditionalReflectionData>();
 
                             // probe.texture can be null when we are adding a reflection probe in the editor
-                            if (probe.texture == null || envLightCount >= k_MaxEnvLightsOnScreen)
+                            if (probe.texture == null || envLightCount >= m_MaxEnvLightsOnScreen)
                                 continue;
 
                             // Work around the culling issues. TODO: fix culling in C++.
@@ -1895,7 +1908,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             var probe = reflectionProbeCullResults.visiblePlanarReflectionProbes[planarProbeIndex];
 
                             // probe.texture can be null when we are adding a reflection probe in the editor
-                            if (probe.currentTexture == null || envLightCount >= k_MaxEnvLightsOnScreen)
+                            if (probe.currentTexture == null || envLightCount >= m_MaxEnvLightsOnScreen)
                                 continue;
 
                             var lightVolumeType = LightVolumeType.Box;
@@ -1952,7 +1965,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     }
                 }
 
-                int decalDatasCount = Math.Min(DecalSystem.m_DecalDatasCount, k_MaxDecalsOnScreen);
+                int decalDatasCount = Math.Min(DecalSystem.m_DecalDatasCount, m_MaxDecalsOnScreen);
                 if (decalDatasCount > 0)
                 {
                     for (int i = 0; i < decalDatasCount; i++)
@@ -2049,7 +2062,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetComputeBufferParam(buildPerVoxelLightListShader, s_ClearVoxelAtomicKernel, HDShaderIDs.g_LayeredSingleIdxBuffer, s_GlobalLightListAtomic);
             cmd.DispatchCompute(buildPerVoxelLightListShader, s_ClearVoxelAtomicKernel, 1, 1, 1);
 
-            int decalDatasCount = Math.Min(DecalSystem.m_DecalDatasCount, k_MaxDecalsOnScreen);
+            int decalDatasCount = Math.Min(DecalSystem.m_DecalDatasCount, m_MaxDecalsOnScreen);
 
             bool isOrthographic = camera.orthographic;
             cmd.SetComputeIntParam(buildPerVoxelLightListShader, HDShaderIDs.g_isOrthographic, isOrthographic ? 1 : 0);
@@ -2359,7 +2372,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_DirectionalLightDatas.SetData(m_lightList.directionalLights);
             m_LightDatas.SetData(m_lightList.lights);
             m_EnvLightDatas.SetData(m_lightList.envLights);
-            m_DecalDatas.SetData(DecalSystem.m_DecalDatas, 0, 0, Math.Min(DecalSystem.m_DecalDatasCount, k_MaxDecalsOnScreen)); // don't add more than the size of the buffer
+            m_DecalDatas.SetData(DecalSystem.m_DecalDatas, 0, 0, Math.Min(DecalSystem.m_DecalDatasCount, m_MaxDecalsOnScreen)); // don't add more than the size of the buffer
 
             // These two buffers have been set in Rebuild()
             s_ConvexBoundsBuffer.SetData(m_lightList.bounds);

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -150,7 +150,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         };
 
         internal const int k_MaxCacheSize = 2000000000; //2 GigaByte
-        public const int k_MaxDirectionalLightsOnScreen = 4;
+        public const int k_MaxDirectionalLightsOnScreen = 16;
         public const int k_MaxPunctualLightsOnScreen    = 512;
         public const int k_MaxAreaLightsOnScreen        = 64;
         public const int k_MaxDecalsOnScreen = 512;


### PR DESCRIPTION
### Purpose of this PR
Exposed LightLoop max values in hdrp asset
---
### Release Notes
![image](https://user-images.githubusercontent.com/6877923/47152083-f0894980-d2db-11e8-8536-1773df6bbb60.png)

---
### Testing status
Manual tests only
---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**:  Low
