### PR TITLE
Hdrp/fix density volume shape handle moving too fast

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Core/Gizmo/HierarchicalSphere.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/Gizmo/HierarchicalSphere.cs
@@ -151,9 +151,7 @@ namespace UnityEditor.Experimental.Rendering
                 //Handles.DrawWireDisc(Vector3.zero, Vector3.right, radius);
                 //Handles.DrawWireDisc(Vector3.zero, Vector3.forward, radius);
                 Handles.DrawWireDisc(drawCenter, viewPlaneNormal, drawnRadius);
-                Color c = Handles.color;
-                c.a = 0.2f;
-                Handles.color = c;
+                Handles.color = m_WireframeColorBehind;
                 Handles.zTest = UnityEngine.Rendering.CompareFunction.Greater;
                 Handles.DrawWireDisc(Vector3.zero, Vector3.up, radius);
                 //Handles.DrawWireDisc(Vector3.zero, Vector3.right, radius);

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDReflectionProbeEditor.Gizmos.cs
@@ -20,7 +20,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (e == null)
                 return;
 
-            var reflectionData = reflectionProbe.GetComponent<HDAdditionalReflectionData>();
             if (reflectionProbe == e.target)
             {
                 //will draw every preview, thus no need to do it multiple times
@@ -29,8 +28,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             if (!e.sceneViewEditing)
                 return;
-
-
 
             DrawVerticalRay(reflectionProbe.transform);
         }


### PR DESCRIPTION
### Purpose of this PR
Fix handle moving too fast in DensityVolume's shape.
Fix warnings.

---
### Release Notes

---
### Testing status
**Katana Tests**: 

**Manual Tests**: Tested manually

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low
(few lines of code moved)

**Halo Effect**: None-Low
(Only affect handles of DensityVolume)

---
### Comments to reviewers
