### PR TITLE
Expose "Receives SSR" option to Shader Graph

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -454,6 +454,20 @@ namespace UnityEditor.ShaderGraph
         }
 
         [SerializeField]
+        bool m_ReceivesSSR = true;
+        public ToggleData receiveSSR
+        {
+            get { return new ToggleData(m_ReceivesSSR); }
+            set
+            {
+                if (m_ReceivesSSR == value.isOn)
+                    return;
+                m_ReceivesSSR = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
         bool m_EnergyConservingSpecular = true;
 
         public ToggleData energyConservingSpecular
@@ -782,5 +796,29 @@ namespace UnityEditor.ShaderGraph
 
             base.CollectShaderProperties(collector, generationMode);
         }
+
+        public int GetStencilWriteMask()
+        {
+            int stencilWriteMask = (int)HDRenderPipeline.StencilBitMask.LightingMask;
+            if (!m_ReceivesSSR)
+            {
+                stencilWriteMask |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
+            }
+            return stencilWriteMask;
+        }
+        public int GetStencilRef()
+        {
+            int stencilRef = (int)StencilLightingUsage.RegularLighting;
+            if (RequiresSplitLighting())
+            {
+                stencilRef = (int)StencilLightingUsage.SplitLighting;
+            }
+            if (!m_ReceivesSSR)
+            {
+                stencilRef |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
+            }
+            return stencilRef;
+        }
+
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
@@ -232,6 +232,15 @@ namespace UnityEditor.ShaderGraph.Drawing
                 });
             });
 
+            ps.Add(new PropertyRow(CreateLabel("Receives SSR", indentLevel)), (row) =>
+            {
+                row.Add(new Toggle(), (toggle) =>
+                {
+                    toggle.value = m_Node.receiveSSR.isOn;
+                    toggle.OnToggleChanged(ChangeSSR);
+                });
+            });
+
             ps.Add(new PropertyRow(CreateLabel("Specular AA", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
@@ -407,6 +416,14 @@ namespace UnityEditor.ShaderGraph.Drawing
             ToggleData td = m_Node.receiveDecals;
             td.isOn = evt.newValue;
             m_Node.receiveDecals = td;
+        }
+
+        void ChangeSSR(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("SSR Change");
+            ToggleData td = m_Node.receiveSSR;
+            td.isOn = evt.newValue;
+            m_Node.receiveSSR = td;
         }
 
         void ChangeSpecularAA(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
@@ -77,8 +77,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     "// Stencil setup",
                     "Stencil",
                     "{",
-                    "   WriteMask 7",
-                        masterNode.RequiresSplitLighting() ? "   Ref  1" : "   Ref  2",
+                    "   WriteMask " + masterNode.GetStencilWriteMask().ToString(),
+                    "   Ref  " + masterNode.GetStencilRef().ToString(),
                     "   Comp Always",
                     "   Pass Replace",
                     "}"
@@ -673,6 +673,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (masterNode.receiveDecals.isOn)
             {
                 activeFields.Add("Decals");
+            }
+
+            if (masterNode.receiveSSR.isOn)
+            {
+                activeFields.Add("SSR");
             }
 
             if (masterNode.specularAA.isOn && pass.PixelShaderUsesSlot(HDLitMasterNode.SpecularAAThresholdSlotId) && pass.PixelShaderUsesSlot(HDLitMasterNode.SpecularAAScreenSpaceVarianceSlotId))


### PR DESCRIPTION
### Purpose of this PR

Exposes the option "Receives SSR" to shader graph. Used to occasion to change how the stencil mask and ref was passed to the shader, making it a bit more robust to future changes, instead of hard coded values. It now also matches the logic of the non-graph shader w.r.t. the stencil ref/mask. 

In the image: left plane has a material with Receives SSR enabled, the right plane has it disabled.  
![image](https://user-images.githubusercontent.com/43168857/47225120-95c81e80-d3bd-11e8-8edc-16afa42c6a36.png)

---
### Release Notes
Exposes the option "Receives SSR" to shader graph.

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=expose-receives-ssr-option-to-shader-graph&automation-tools_branch=master&unity_branch=2018.3%2Fstaging [Running]

**Manual Tests**:  Tried to turn on/off the option from a material created with the shader graph. 

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**:  Low
