### PR TITLE
Fix for refraction plane model

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/Refraction.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Refraction.hlsl
@@ -63,7 +63,7 @@ RefractionModelResult RefractionModelPlane(real3 V, float3 positionWS, real3 nor
     RefractionModelResult result;
     result.dist = dist;
     result.positionWS = positionWS + R * dist;
-    result.rayWS = -V;
+    result.rayWS = R;
 
     return result;
 }


### PR DESCRIPTION
### Purpose of this PR
Fix for plane refraction model. It was using the wrong output direction. 

---
### Release Notes
Fix for plane refraction model. 

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=fix-plane-model-for-refraction&automation-tools_branch=master&unity_branch=2018.3%2Fstaging 


---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: None
