### PR TITLE
Fixed an floatfield be parsed according to OS locale settings

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -85,4 +85,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The Lightweight PBR subshader now generates the correct meta pass.
 - Both PBR subshaders can now generate indirect light from emission.
 - Shader graphs now support the SRP batcher.
+- Fixed an issue where floatfield would be parsed according to OS locale settings with .NET 4.6
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/FloatField.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/FloatField.cs
@@ -1,4 +1,5 @@
 using UnityEditor.Experimental.UIElements;
+using System.Globalization;
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -6,7 +7,7 @@ namespace UnityEditor.ShaderGraph.Drawing
     {
         protected override string ValueToString(double v)
         {
-            return ((float)v).ToString();
+            return ((float)v).ToString(CultureInfo.InvariantCulture.NumberFormat);
         }
     }
 }


### PR DESCRIPTION
Fixed an issue where floatfield would be parsed according to OS locale settings with .NET 4.6 (fogbugz 1089361). Similar changes were done in trunk to fix similar issues: https://ono.unity3d.com/unity/unity/pull-request/76520/_/editor/tech/1089361/invariantculture-for-decimal-values.

### Purpose of this PR
Have the same behaviour with .NET 4.6 than previous versions when parsing floats when Non-English Locale are used on Windows. Prevents comma to be interpreted as a decimal point.  

---
### Release Notes
Fixed an issue where floatfield would be parsed according to OS locale settings with .NET 4.6 
---
### Testing status
Manual test
---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
Bob Donovan (bobd@unity3d.com)