### PR TITLE
[case 1092354] Fixed errors of Material doesn't have a texture property...

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Removed the `supportedShaderFeatures` property from LWRP core. The shader stripper now figures out which variants to strip based on the current assigned pipeline Asset in the Graphics settings.
 ### Fixed
+- When you select a material with the Lit shader, this no longer causes the following error in the console: ("Material doesn't have..."). [case 1092354](https://fogbugz.unity3d.com/f/cases/1092354/)
 - In the Simple Lit shader, per-vertex additional lights are now shaded properly.
 - Shader variant stripping now works when you're building a Project with Cloud Build. This greatly reduces build times from Cloud Build.
 - Dynamic Objects now receive lighting when the light mode is set to mixed.

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGUI/LitShaderGUI.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGUI/LitShaderGUI.cs
@@ -301,8 +301,6 @@ namespace UnityEditor.Experimental.Rendering.LightweightPipeline
             CoreUtils.SetKeyword(material, "_GLOSSYREFLECTIONS_OFF", material.GetFloat("_GlossyReflections") == 0.0f);
 
             CoreUtils.SetKeyword(material, "_OCCLUSIONMAP", material.GetTexture("_OcclusionMap"));
-            CoreUtils.SetKeyword(material, "_PARALLAXMAP", material.GetTexture("_ParallaxMap"));
-            CoreUtils.SetKeyword(material, "_DETAIL_MULX2", material.GetTexture("_DetailAlbedoMap") || material.GetTexture("_DetailNormalMap"));
 
             CoreUtils.SetKeyword(material, "_RECEIVE_SHADOWS_OFF", material.GetFloat("_ReceiveShadows") == 0.0f);
 


### PR DESCRIPTION
### Purpose of this PR
 Fix the following issue: https://issuetracker.unity3d.com/issues/lwrps-lit-material-does-not-contain-detailnormalmap-detailalbedomap-parallaxmap-parameters

---
### Release Notes
Added

---
### Testing status
**Katana Tests**: Not needed

**Manual Tests**: Tested myself

**Automated Tests**: Nothing added

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None. Just removed reference to unused properties in the material

**Halo Effect**: None. Specific to the UI of Lit shader in LWRP.

---
### Comments to reviewers
 The following properties are not serialized in the lit shader.
