### PR TITLE
Add an explicit call to VFXManager.ProcessCamera

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -868,6 +868,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     lastCameraFromGroup = (camera.targetTexture != cameras[cameraIndex + 1].targetTexture);
 
                 UnityEngine.Rendering.RenderPipeline.BeginCameraRendering(camera);
+                UnityEngine.Experimental.VFX.VFXManager.ProcessCamera(camera); //Visual Effect Graph is not yet a required package but calling this method when there isn't any VisualEffect component has no effect (but needed for Camera sorting in Visual Effect Graph context)
 
                 // First, get aggregate of frame settings base on global settings, camera frame settings and debug settings
                 // Note: the SceneView camera will never have additionalCameraData


### PR DESCRIPTION
### Purpose of this PR
- Add an explicit call to *UnityEngine.Experimental.VFX.VFXManager.ProcessCamera* since it has been unplugged on last trunk.
It fixes Camera Sort for VisualEffectGraph and last master (these tests are still waiting on vfx/master, we have an issue UnityShaderCompiler crash)

---
### Testing status
Waiting for katana test : https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=fix/missing-call-vfx-process-camera&automation-tools_branch=add-platform-filter&unity_branch=trunk
