### PR TITLE
Fix locale issue with vector1 property

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
@@ -84,7 +84,7 @@ namespace UnityEditor.ShaderGraph
                     result.Append("\", Float) = ");
                     break;
             }
-            result.Append(value);
+            result.Append(NodeUtils.FloatToShaderValue(value));
             return result.ToString();
         }
 


### PR DESCRIPTION
replaced value with NodeUtils.FloatToShaderValue(value)

### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Vector1 shader properties can fail to compile on some systems because of locale decimal symbol
---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.
fix : decimal symbol for vector1 shader property
---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
It's a very small change, I didn't run tests
**Manual Tests**: What did you do?
We used this fix on the vfx demo project where some people weren't able to compile some graphs and this fixed the issue.
**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
I started a thread on the shadergraph slack channel and Peter replied this is an appropriate fix