### PR TITLE
Hdrp/fix probe sphere influence gizmo clamp

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed distortion filtering (was point filtering, now trilinear)
 - Fixed contact shadow for large distance
 - Fixed depth pyramid debug view mode
+- Fixed sphere shaped influence handles clamping in reflection probes
+- Fixed reflection probes data migration for project created before using hdrp
 
 ### Changed
 - Use samplerunity_ShadowMask instead of samplerunity_samplerLightmap for shadow mask

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
@@ -70,25 +70,25 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     break;
                 case EditInfluenceShape:
                     InfluenceVolumeUI.DrawGizmos(
-                    s.influenceVolume,
-                    d.influenceVolume,
-                    mat,
-                    InfluenceVolumeUI.HandleType.Influence,
-                    InfluenceVolumeUI.HandleType.All);
+                        s.influenceVolume,
+                        d.influenceVolume,
+                        mat,
+                        InfluenceVolumeUI.HandleType.Influence,
+                        InfluenceVolumeUI.HandleType.All);
                     break;
                 case EditInfluenceNormalShape:
                     InfluenceVolumeUI.DrawGizmos(
-                    s.influenceVolume,
-                    d.influenceVolume,
-                    mat,
-                    InfluenceVolumeUI.HandleType.InfluenceNormal,
-                    InfluenceVolumeUI.HandleType.All);
+                        s.influenceVolume,
+                        d.influenceVolume,
+                        mat,
+                        InfluenceVolumeUI.HandleType.InfluenceNormal,
+                        InfluenceVolumeUI.HandleType.All);
                     break;
                 default:
                 {
                     var showedHandles = s.influenceVolume.showInfluenceHandles
                         ? InfluenceVolumeUI.HandleType.All
-                        : InfluenceVolumeUI.HandleType.Base;
+                        : InfluenceVolumeUI.HandleType.Base | InfluenceVolumeUI.HandleType.Influence;
                     InfluenceVolumeUI.DrawGizmos(
                         s.influenceVolume,
                         d.influenceVolume,

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Handles.cs
@@ -198,6 +198,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static void DrawSphereFadeHandle(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o, Object sourceAsset, HierarchicalSphere sphere, SerializedProperty blend)
         {
+            //init parent sphere for clamping
+            s.sphereBaseHandle.center = d.offset.vector3Value;
+            s.sphereBaseHandle.radius = d.sphereRadius.floatValue;
             sphere.center = d.offset.vector3Value;
             sphere.radius = d.sphereRadius.floatValue - blend.floatValue;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/HDAdditionalReflectionData.Migration.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/HDAdditionalReflectionData.Migration.cs
@@ -7,7 +7,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         enum Version
         {
             First,
-            HDProbeChild = 2,
+            RemoveUsageOfLegacyProbeParamsForStocking,
+            HDProbeChild,
             UseInfluenceVolume,
             MergeEditors,
             AddCaptureSettingsAndFrameSettings,
@@ -16,14 +17,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         static readonly MigrationDescription<Version, HDAdditionalReflectionData> k_Migration
             = MigrationDescription.New(
-                MigrationStep.New(Version.MergeEditors, (HDAdditionalReflectionData t) =>
+                MigrationStep.New(Version.RemoveUsageOfLegacyProbeParamsForStocking, (HDAdditionalReflectionData t) =>
                 {
-                    t.infiniteProjection = !t.reflectionProbe.boxProjection;
-                    t.reflectionProbe.boxProjection = false;
+#pragma warning disable 618 // Type or member is obsolete
+                    t.m_ObsoleteBlendDistancePositive = t.m_ObsoleteBlendDistanceNegative = Vector3.one * t.reflectionProbe.blendDistance;
+                    t.weight = t.reflectionProbe.importance;
+                    t.multiplier = t.reflectionProbe.intensity;
+                    // size and center were kept in legacy until Version.UseInfluenceVolume
+                    //   and mode until Version.ModeAndTextures
+                    //   and all capture settings are done in Version.AddCaptureSettingsAndFrameSettings
+#pragma warning restore 618 // Type or member is obsolete
                 }),
                 MigrationStep.New(Version.UseInfluenceVolume, (HDAdditionalReflectionData t) =>
                 {
                     t.influenceVolume.boxSize = t.reflectionProbe.size;
+                    t.influenceVolume.offset = t.reflectionProbe.center;
 #pragma warning disable 618 // Type or member is obsolete
                     t.influenceVolume.sphereRadius = t.m_ObsoleteInfluenceSphereRadius;
                     t.influenceVolume.shape = t.m_ObsoleteInfluenceShape;
@@ -38,6 +46,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 #pragma warning restore 618 // Type or member is obsolete
                     //Note: former editor parameters will be recreated as if non existent.
                     //User will lose parameters corresponding to non used mode between simplified and advanced
+                }),
+                MigrationStep.New(Version.MergeEditors, (HDAdditionalReflectionData t) =>
+                {
+                    t.infiniteProjection = !t.reflectionProbe.boxProjection;
+                    t.reflectionProbe.boxProjection = false;
                 }),
                 MigrationStep.New(Version.AddCaptureSettingsAndFrameSettings, (HDAdditionalReflectionData t) =>
                 {


### PR DESCRIPTION
### Purpose of this PR
Bug fixes
- Fix issue with clamping in the sphere shaped influence blend handles
- Show blend shape too in probes as requested by @laurenth-unity 
- Fix data migrated from projected started prior to hdrp https://fogbugz.unity3d.com/f/cases/1094081/

---
### Release Notes
Fix issue with clamping in the sphere shaped influence blend handles.
Fix data migrated from projected started prior to hdrp https://fogbugz.unity3d.com/f/cases/1094081/

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-probe-sphere-influence-gizmo-clamp&automation-tools_branch=add-platform-filter&unity_branch=trunk

**Manual Tests**: Tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low (few lines of code)

**Halo Effect**: Low 
(only affect probes gizmo and adding a migration step for project created before switching to hdrp)

---
### Comments to reviewers
