### PR TITLE
Fix comparaison to null

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -36,6 +36,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 #if UNITY_EDITOR
         HDRenderPipelineEditorResources m_RenderPipelineEditorResources;
 
+
         public HDRenderPipelineEditorResources renderPipelineEditorResources
         {
             get
@@ -45,7 +46,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // - constructor only called at asset creation
                 // - cannot rely on OnEnable
                 //thus fallback with lazy init for them
-                if (m_RenderPipelineEditorResources == null)
+                if (m_RenderPipelineEditorResources.Equals(null))
                     m_RenderPipelineEditorResources = UnityEditor.AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
                 return m_RenderPipelineEditorResources;
             }


### PR DESCRIPTION
### Purpose of this PR
Prevent false editor resources detection while being destroyed (cause crash later in execution)

---
### Release Notes

---
### Testing status
**Katana Tests**: 

**Manual Tests**: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
