### PR TITLE
fix build player not building in HDRP

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjectorComponent.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjectorComponent.cs
@@ -45,7 +45,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (m_Material == null)
             {
                 var hdrp = GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset;
+#if UNITY_EDITOR
                 m_Material = hdrp != null ? hdrp.GetDefaultDecalMaterial() : null;
+#else
+                m_Material = null;
+#endif
             }
 
             if (m_Handle != null)
@@ -146,9 +150,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (m_Material == null)
                 return false;
 
+#if UNITY_EDITOR
             var hdrp = GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset;
             if ((hdrp != null) && (m_Material == hdrp.GetDefaultDecalMaterial()))
                 return false;
+#endif
 
             return true;
         }


### PR DESCRIPTION
This PR fix an issue with build player not building because the decal code want to access default decal material that is now editor only.

Manual build of a player (this is not done automatically by katana, this is somethin we should add).