### PR TITLE
Added clearer info about bug reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## NOTE: We have migrated reported issues to fogbugz. Please log futher issues via the Unity bug tracker. For more information on this process please look [here](https://unity3d.com/unity/qa/bug-reporting).
+## NOTE: We have migrated reported issues to fogbugz. Please log further issues via the Unity bug tracker. For more information on this process please look [here](https://unity3d.com/unity/qa/bug-reporting).
 
 # Unity Scriptable Render Pipeline
 The Scriptable Render Pipeline (SRP) is a new Unity feature in active development. SRP has been designed to give artists and developers the tools they need to create modern, high-fidelity graphics in Unity. Including a built-in Lightweight Render Pipeline for use on all platforms, and a High Definition Render Pipeline (HDRP) for use on compute shader compatible platforms. These features are available in Unity 2018.1+.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## NOTE: We have migrate reported issues to fogbugz. Please log issues via the in unity bug tracker.
+## NOTE: We have migrated reported issues to fogbugz. Please log futher issues via the Unity bug tracker. For more information on this process please look [here](https://unity3d.com/unity/qa/bug-reporting).
 
 # Unity Scriptable Render Pipeline
 The Scriptable Render Pipeline (SRP) is a new Unity feature in active development. SRP has been designed to give artists and developers the tools they need to create modern, high-fidelity graphics in Unity. Including a built-in Lightweight Render Pipeline for use on all platforms, and a High Definition Render Pipeline (HDRP) for use on compute shader compatible platforms. These features are available in Unity 2018.1+.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## NOTE: We have migrated reported issues to fogbugz. Please log further issues via the Unity bug tracker. For more information on this process please look [here](https://unity3d.com/unity/qa/bug-reporting).
+## NOTE: We have migrated reported issues to FogBugz. You can only log further issues via the Unity bug tracker. To see how, read [this](https://unity3d.com/unity/qa/bug-reporting).
 
 # Unity Scriptable Render Pipeline
 The Scriptable Render Pipeline (SRP) is a new Unity feature in active development. SRP has been designed to give artists and developers the tools they need to create modern, high-fidelity graphics in Unity. Including a built-in Lightweight Render Pipeline for use on all platforms, and a High Definition Render Pipeline (HDRP) for use on compute shader compatible platforms. These features are available in Unity 2018.1+.


### PR DESCRIPTION
### Purpose of this PR
The bug reporting message at the top of the readme was a little unclear and needed to explain it more in-depth for those not accustomed to the bug reporting in Unity.

---
### Release Notes
Made the bug reporting note more clear, added a link to Unitys bug reporting page.

---
### Testing status
**Katana Tests**: None needed

**Manual Tests**: Previewed the MD file

**Automated Tests**: None needed

---
### Overall Product Risks
**Technical Risk**: None, only readme changed

**Halo Effect**: None, only readme changed

---
### Comments to reviewers
N/A