### PR TITLE
Fix compilation using .Net 3.5

### DIFF
--- a/com.unity.testframework.graphics/Runtime/ImageAssert.cs
+++ b/com.unity.testframework.graphics/Runtime/ImageAssert.cs
@@ -26,7 +26,7 @@ namespace UnityEngine.TestTools.Graphics
         public static void AreEqual(Texture2D expected, Camera camera, ImageComparisonSettings settings = null)
         {
             if (camera == null)
-                throw new ArgumentNullException(nameof(camera));
+                throw new ArgumentNullException("Camera");
 
             AreEqual(expected, new List<Camera>{camera}, settings);
         }
@@ -40,7 +40,7 @@ namespace UnityEngine.TestTools.Graphics
         public static void AreEqual(Texture2D expected, IEnumerable<Camera> cameras, ImageComparisonSettings settings = null)
         {
             if (cameras == null)
-                throw new ArgumentNullException(nameof(cameras));
+                throw new ArgumentNullException("cameras");
 
             if (settings == null)
                 settings = new ImageComparisonSettings();


### PR DESCRIPTION
### Purpose of this PR
Fix compilation using .Net 3.5, nameof isn't available, VisualEffectGraph project is still using 3.5

It's a part of more major update of vfx/master which is in progress (we have a recent issue with a graphicTest HDRPFog which blocking this merge request).

I tried to migrate this project to 4.x but it fails because this code seems ignored : 
```[assembly: InternalsVisibleTo("Unity.VisualEffectGraph.Editor")]
[assembly: InternalsVisibleTo("Unity.VisualEffectGraph.Editor-testable")]
[assembly: InternalsVisibleTo("Unity.VisualEffectGraph.EditorTests")]
[assembly: InternalsVisibleTo("Unity.VisualEffectGraph.EditorTests-testable")]