### PR TITLE
Fixed broken link

### DIFF
--- a/com.unity.render-pipelines.lightweight/Documentation~/autodesk-interactive-masked-shader.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/autodesk-interactive-masked-shader.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/autodesk-interactive-shader.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/autodesk-interactive-shader.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/autodesk-interactive-transparent-shader.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/autodesk-interactive-transparent-shader.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/baked-lit-shader.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/baked-lit-shader.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/camera-inspector.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/camera-inspector.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/camera.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/camera.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/forward-renderer.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/forward-renderer.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/integration-with-post-processing.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/integration-with-post-processing.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/integration-with-terrain.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/integration-with-terrain.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/integrations-with-shader-graph.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/integrations-with-shader-graph.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/light-inspector.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/light-inspector.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/lwrp-internal-flowchart.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/lwrp-internal-flowchart.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/particles-baked-lit-shader.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/particles-baked-lit-shader.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/particles-lit-shader.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/particles-lit-shader.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/particles-simple-lit-shader.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/particles-simple-lit-shader.md
@@ -1,1 +1,1 @@
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.

--- a/com.unity.render-pipelines.lightweight/Documentation~/shader-stripping-keywords.md
+++ b/com.unity.render-pipelines.lightweight/Documentation~/shader-stripping-keywords.md
@@ -1,4 +1,4 @@
 
 
-**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](#TableOfContents.md) file to see the linked pages.
+**Important:** This page is still a work in progress. To read our most current documentation, open the [*TableOfContents.md*](TableOfContents.md) file to see the linked pages.
 


### PR DESCRIPTION
Fixed the link to the TableOfContents.md file in empty pages. It now directs correctly.

### Purpose of this PR
Because the empty pages in the Documentation~folder link to the Table of Contents, so users can see which pages they can "rely" on. This fixes the redirection link.


### Overall Product Risks
None


