### PR TITLE
Hdrp/fix planar offset and custom probes

### DIFF
--- a/com.unity.render-pipelines.core/Editor/CoreEditorUtils.cs
+++ b/com.unity.render-pipelines.core/Editor/CoreEditorUtils.cs
@@ -38,6 +38,11 @@ namespace UnityEditor.Experimental.Rendering
         }
 
         // Serialization helpers
+        /// <summary>
+        /// To use with extreme caution. It not really get the property but try to find a field with similar name
+        /// Hence inheritance override of property is not supported.
+        /// Also variable rename will silently break the search.
+        /// </summary>
         public static string FindProperty<T, TValue>(Expression<Func<T, TValue>> expr)
         {
             // Get the field path as a string

--- a/com.unity.render-pipelines.core/Editor/PropertyFetcher.cs
+++ b/com.unity.render-pipelines.core/Editor/PropertyFetcher.cs
@@ -18,7 +18,12 @@ namespace UnityEditor.Experimental.Rendering
         {
             return obj.FindProperty(str);
         }
-
+        
+        /// <summary>
+        /// To use with extreme caution. It not really get the property but try to find a field with similar name
+        /// Hence inheritance override of property is not supported.
+        /// Also variable rename will silently break the search.
+        /// </summary>
         public SerializedProperty Find<TValue>(Expression<Func<T, TValue>> expr)
         {
             string path = CoreEditorUtils.FindProperty(expr);
@@ -46,6 +51,11 @@ namespace UnityEditor.Experimental.Rendering
             return obj.FindPropertyRelative(str);
         }
 
+        /// <summary>
+        /// To use with extreme caution. It not really get the property but try to find a field with similar name
+        /// Hence inheritance override of property is not supported.
+        /// Also variable rename will silently break the search.
+        /// </summary>
         public SerializedProperty Find<TValue>(Expression<Func<T, TValue>> expr)
         {
             string path = CoreEditorUtils.FindProperty(expr);
@@ -60,12 +70,22 @@ namespace UnityEditor.Experimental.Rendering
 
     public static class PropertyFetcherExtensions
     {
+        /// <summary>
+        /// To use with extreme caution. It not really get the property but try to find a field with similar name
+        /// Hence inheritance override of property is not supported.
+        /// Also variable rename will silently break the search.
+        /// </summary>
         public static SerializedProperty Find<TSource, TValue>(this SerializedObject obj, Expression<Func<TSource, TValue>> expr)
         {
             var path = CoreEditorUtils.FindProperty(expr);
             return obj.FindProperty(path);
         }
 
+        /// <summary>
+        /// To use with extreme caution. It not really get the property but try to find a field with similar name
+        /// Hence inheritance override of property is not supported.
+        /// Also variable rename will silently break the search.
+        /// </summary>
         public static SerializedProperty Find<TSource, TValue>(this SerializedProperty obj, Expression<Func<TSource, TValue>> expr)
         {
             var path = CoreEditorUtils.FindProperty(expr);

--- a/com.unity.render-pipelines.high-definition/Editor/Core/CollapsableState.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/CollapsableState.cs
@@ -1,0 +1,68 @@
+using System;
+using UnityEditor;
+
+namespace UnityEngine.Experimental.Rendering.HDPipeline
+{
+    /// <summary>Used in editor drawer part to store the state of expendable areas.</summary>
+    /// <typeparam name="TState">An enum to use to describe the state.</typeparam>
+    /// <typeparam name="TTarget">A type given to automatically compute the key.</typeparam>
+    internal class ExpendedState<TState, TTarget>
+        where TState : Enum, IConvertible
+    {
+        /// <summary>Key is automatically computed regarding the target type given</summary>
+        public readonly string stateKey;
+
+        /// <summary>Constructor will create the key to store in the EditorPref the state given generic type passed.</summary>
+        /// <param name="defaultValue">If key did not exist, it will be created with this value for initialization.</param>
+        public ExpendedState(TState defaultValue)
+        {
+            stateKey = string.Format("HDRP:{0}:UI_State", typeof(TTarget).Name);
+
+            //register key if not already there
+            if (!EditorPrefs.HasKey(stateKey))
+            {
+                EditorPrefs.SetInt(stateKey, (int)(object)defaultValue);
+            }
+        }
+        
+        uint expendedState { get { return (uint)EditorPrefs.GetInt(stateKey); } set { EditorPrefs.SetInt(stateKey, (int)value); } }
+        
+        /// <summary>Get or set the state given the mask.</summary>
+        public bool this[TState mask]
+        {
+            get { return GetExpendedAreas(mask); }
+            set { SetExpendedAreas(mask, value); }
+        }
+
+        /// <summary>Accessor to the expended state of this specific mask.</summary>
+        public bool GetExpendedAreas(TState mask)
+        {
+            // note on cast:
+            //   - to object always ok
+            //   - to int ok because of IConvertible. Cannot directly go to uint
+            return (expendedState & (uint)(int)(object)mask) > 0;
+        }
+
+        /// <summary>Setter to the expended state.</summary>
+        public void SetExpendedAreas(TState mask, bool value)
+        {
+            uint state = expendedState;
+            // note on cast:
+            //   - to object always ok
+            //   - to int ok because of IConvertible. Cannot directly go to uint
+            uint workMask = (uint)(int)(object)mask;
+
+            if (value)
+            {
+                state |= workMask;
+            }
+            else
+            {
+                workMask = ~workMask;
+                state &= workMask;
+            }
+
+            expendedState = state;
+        }
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Editor/Core/CollapsableState.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/CollapsableState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe761d3d66bd1254780e2c9a6af897e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
@@ -17,6 +17,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 case EditBaseShape:
                     //important: following will init the container for box.
                     //This must be done before drawing the contained handles
+                    if(o is PlanarReflectionProbeEditor && (InfluenceShape)d.influenceVolume.shape.intValue == InfluenceShape.Box)
+                    {
+                        //Planar need to update its transform position.
+                        //Let PlanarReflectionProbeUI.Handle do this work.
+                        break;
+                    }
                     InfluenceVolumeUI.DrawHandles_EditBase(s.influenceVolume, d.influenceVolume, o, mat, probe);
                     break;
                 case EditInfluenceShape:
@@ -63,6 +69,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             switch (EditMode.editMode)
             {
                 case EditBaseShape:
+                    if (d is PlanarReflectionProbe && (InfluenceShape)d.influenceVolume.shape == InfluenceShape.Box)
+                    {
+                        //Planar need to update its transform position.
+                        //Let PlanarReflectionProbeUI.Handle do this work.
+                        break;
+                    }
                     InfluenceVolumeUI.DrawGizmos(
                         s.influenceVolume, d.influenceVolume, mat,
                         InfluenceVolumeUI.HandleType.Base,

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Handles.cs
@@ -33,6 +33,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     break;
                 case EditCenter:
                     {
+                        if (o is PlanarReflectionProbeEditor && (InfluenceShape)d.influenceVolume.shape.intValue == InfluenceShape.Box)
+                        {
+                            //Planar need to update its transform position.
+                            //Let PlanarReflectionProbeUI.Handle do this work.
+                            break;
+                        }
                         using (new Handles.DrawingScope(Matrix4x4.TRS(Vector3.zero, Quaternion.identity, Vector3.one)))
                         {
                             EditorGUI.BeginChangeCheck();

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Skin.cs
@@ -12,14 +12,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
     {
         static readonly GUIContent proxyVolumeContent = CoreEditorUtils.GetContent("Proxy Volume");
         protected static readonly GUIContent useInfiniteProjectionContent = CoreEditorUtils.GetContent("Same As Influence Volume|If enabled, parallax correction will occure, causing reflections to appear to change based on the object's position within the probe's box, while still using a single probe as the source of the reflection. This works well for reflections on objects that are moving through enclosed spaces such as corridors and rooms. When disabled, the cubemap reflection will be treated as coming from infinitely far away. Note that this feature can be globally disabled from Graphics Settings -> Tier Settings");
-        
-        protected static readonly GUIContent fieldCaptureTypeContent = CoreEditorUtils.GetContent("Type");
-        protected static readonly GUIContent resolutionContent = CoreEditorUtils.GetContent("Resolution");
-        protected static readonly GUIContent shadowDistanceContent = CoreEditorUtils.GetContent("Shadow Distance");
-        protected static readonly GUIContent cullingMaskContent = CoreEditorUtils.GetContent("Culling Mask");
-        protected static readonly GUIContent useOcclusionCullingContent = CoreEditorUtils.GetContent("Use Occlusion Culling");
-        protected static readonly GUIContent nearClipCullingContent = CoreEditorUtils.GetContent("Near Clip");
-        protected static readonly GUIContent farClipCullingContent = CoreEditorUtils.GetContent("Far Clip");
 
         static readonly GUIContent weightContent = CoreEditorUtils.GetContent("Weight|Blend weight applied on this reflection probe. This can be used for fading in or out a reflection probe.");
         static readonly GUIContent multiplierContent = CoreEditorUtils.GetContent("Intensity Multiplier|Allows you to boost or dimmer the reflected cubemap. Values above 1 will make reflections brighter and values under 1 will make reflections darker. Using values different than 1 is not physically correct.");
@@ -31,8 +23,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         const string proxyInfluenceShapeMismatchHelpBoxText = "Proxy volume and influence volume have different shapes, this is not supported.";
 
         const string proxySettingsHeader = "Projection Settings";
-        //influenceVolume have its own header
-        protected const string captureSettingsHeader = "Capture Settings";
         const string additionnalSettingsHeader = "Custom Settings";
 
         static Dictionary<ToolBar, GUIContent> s_Toolbar_Contents = null;

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeEditor.cs
@@ -48,6 +48,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected override void OnSceneGUI()
         {
             base.OnSceneGUI();
+            PlanarReflectionProbeUI.DrawHandlesOverride(m_UIState as PlanarReflectionProbeUI, m_SerializedHDProbe as SerializedPlanarReflectionProbe, this);
 
             SceneViewOverlay_Window(_.GetContent("Planar Probe"), OnOverlayGUI, -100, target);
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeUI.Handles.cs
@@ -78,16 +78,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                                 );
                             if (EditorGUI.EndChangeCheck())
                             {
-                                Vector3 newOffset = Quaternion.Inverse(probe.transform.rotation) * (newCapturePosition - probe.transform.position);
                                 Undo.RecordObjects(new Object[] { probe, probe.transform }, "Translate Influence Position");
                                 Vector3 delta = newCapturePosition - probe.transform.position;
                                 Matrix4x4 oldLocalToWorld = Matrix4x4.TRS(probe.transform.position, probe.transform.rotation, Vector3.one);
-
-                                //call modification to legacy ReflectionProbe
-                                probe.influenceVolume.offset = newOffset;
-
                                 probe.transform.position = newCapturePosition;
-                                d.influenceVolume.offset.vector3Value -= oldLocalToWorld.inverse.MultiplyVector(delta);
+                                Vector3 offset = d.influenceVolume.offset.vector3Value - oldLocalToWorld.inverse.MultiplyVector(delta);
+
+                                //clamp offset value
+                                float extend = probe.influenceVolume.boxSize.y * 0.5f;
+                                offset.y = Mathf.Clamp(offset.y, -extend, extend);
+                                d.influenceVolume.offset.vector3Value = offset;
+
                                 d.influenceVolume.Apply();
                             }
                         }
@@ -149,6 +150,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     Vector3.one);
             Gizmos.color = Color.white;
             Gizmos.DrawWireCube(Vector3.zero, new Vector3(d.influenceVolume.boxSize.z, d.influenceVolume.boxSize.x, 0));
+            Color c2 = InfluenceVolumeUI.k_GizmoThemeColorInfluenceNormal.linear;
+            c2.a = 1f;
+            Gizmos.color = c2;
+            Gizmos.DrawLine(Vector3.zero, Vector3.forward);
             Gizmos.color = k_GizmoMirrorPlaneCamera;
             Gizmos.DrawCube(Vector3.zero, new Vector3(d.influenceVolume.boxSize.z, d.influenceVolume.boxSize.x, 0));
 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeUI.cs
@@ -44,10 +44,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             Inspector[Inspector.Length - 1] = CED.noop; //hide bake button
 
             //override SectionInfluenceVolume to remove normals settings
-            Inspector[3] = CED.Select(
-                (s, d, o) => s.influenceVolume,
-                (s, d, o) => d.influenceVolume,
-                InfluenceVolumeUI.SectionFoldoutShapePlanar
+            Inspector[3] = HeaderMaker(
+                InfluenceVolumeUI.influenceVolumeHeader,
+                Expendable.InfluenceVolume,
+                CED.Select(
+                    (s, d, o) => s.influenceVolume,
+                    (s, d, o) => d.influenceVolume,
+                    InfluenceVolumeUI.InnerInspector(UnityEngine.Experimental.Rendering.HDPipeline.ReflectionProbeType.PlanarReflection)
+                    )
                 );
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/PlanarReflectionProbeUI.cs
@@ -58,7 +58,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         internal PlanarReflectionProbeUI()
         {
             //remove normal edition tool and capture point for planar
-            toolBars = new[] { ToolBar.InfluenceShape | ToolBar.Blend }; 
+            toolBars = new[] { ToolBar.InfluenceShape | ToolBar.Blend, ToolBar.CapturePosition }; 
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/SerializedHDProbe.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/SerializedHDProbe.cs
@@ -35,7 +35,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         internal SerializedHDProbe(SerializedObject serializedObject)
         {
             this.serializedObject = serializedObject;
-
+            
+            //Find do not support inheritance override:
+            //customBakedTexture will be assigned again in SerializedHDReflectionProbe
             customBakedTexture = serializedObject.Find((HDProbe p) => p.customTexture);
             renderDynamicObjects = serializedObject.Find((HDProbe p) => p.renderDynamicObjects);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/SerializedHDReflectionProbe.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/SerializedHDReflectionProbe.cs
@@ -30,6 +30,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             farClip = legacyProbe.FindProperty("m_FarClip");
             legacyBlendDistance = legacyProbe.FindProperty("m_BlendDistance");
             legacyMode = legacyProbe.FindProperty("m_Mode");
+
+            //assigning it again due to inheritance override and Find incompatibility (see parent class)
+            customBakedTexture = legacyProbe.FindProperty("m_CustomBakedTexture");
         }
 
         internal override void Update()

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Drawers.cs
@@ -20,7 +20,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 case ReflectionProbeType.PlanarReflection:
                     return CED.Group(
                         CED.Action(Drawer_InfluenceAdvancedSwitch),
-                        CED.space,
                         CED.Action(Drawer_FieldShapeType),
                         CED.FadeGroup(
                             (s, d, o, i) => s.IsSectionExpanded_Shape((InfluenceShape)i),
@@ -32,7 +31,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 case ReflectionProbeType.ReflectionProbe:
                     return CED.Group(
                         CED.Action(Drawer_InfluenceAdvancedSwitch),
-                        CED.space,
                         CED.Action(Drawer_FieldShapeType),
                         CED.FadeGroup(
                             (s, d, o, i) => s.IsSectionExpanded_Shape((InfluenceShape)i),
@@ -63,8 +61,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
 
                 bool advanced = d.editorAdvancedModeEnabled.boolValue;
-                advanced = !GUILayout.Toggle(!advanced, normalModeContent, EditorStyles.miniButtonLeft, GUILayout.Width(60f), GUILayout.ExpandWidth(false));
-                advanced = GUILayout.Toggle(advanced, advancedModeContent, EditorStyles.miniButtonRight, GUILayout.Width(60f), GUILayout.ExpandWidth(false));
+                advanced = GUILayout.Toggle(advanced, advancedModeContent, EditorStyles.miniButton, GUILayout.Width(60f), GUILayout.ExpandWidth(false));
                 if (d.editorAdvancedModeEnabled.boolValue ^ advanced)
                 {
                     d.editorAdvancedModeEnabled.boolValue = advanced;

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Drawers.cs
@@ -8,21 +8,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
     partial class InfluenceVolumeUI
     {
-        //[TODO: planar / non planar will be redone in next PR]
-        internal static readonly CED.IDrawer SectionFoldoutShapePlanar;
-        internal static readonly CED.IDrawer SectionFoldoutShape;
         static readonly CED.IDrawer SectionShapeBoxPlanar = CED.Action((s, p, o) => Drawer_SectionShapeBox( s, p, o, false, false, false));
         static readonly CED.IDrawer SectionShapeBox = CED.Action((s, p, o) => Drawer_SectionShapeBox(s, p, o, true, true, true));
         static readonly CED.IDrawer SectionShapeSpherePlanar = CED.Action((s, p, o) => Drawer_SectionShapeSphere(s, p, o, false, false));
         static readonly CED.IDrawer SectionShapeSphere = CED.Action((s, p, o) => Drawer_SectionShapeSphere(s, p, o, true, true));
 
-        static InfluenceVolumeUI()
+        internal static CED.IDrawer InnerInspector(ReflectionProbeType type)
         {
-            SectionFoldoutShapePlanar = CED.Group(
-                    CED.FoldoutGroup(
-                        influenceVolumeHeader,
-                        (s, d, o) => s.isSectionExpandedShape,
-                        FoldoutOption.Indent,
+            switch (type)
+            {
+                case ReflectionProbeType.PlanarReflection:
+                    return CED.Group(
                         CED.Action(Drawer_InfluenceAdvancedSwitch),
                         CED.space,
                         CED.Action(Drawer_FieldShapeType),
@@ -32,13 +28,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                             SectionShapeBoxPlanar,
                             SectionShapeSpherePlanar
                             )
-                        )
-                    );
-            SectionFoldoutShape = CED.Group(
-                    CED.FoldoutGroup(
-                        influenceVolumeHeader,
-                        (s, d, o) => s.isSectionExpandedShape,
-                        FoldoutOption.Indent,
+                        );
+                case ReflectionProbeType.ReflectionProbe:
+                    return CED.Group(
                         CED.Action(Drawer_InfluenceAdvancedSwitch),
                         CED.space,
                         CED.Action(Drawer_FieldShapeType),
@@ -48,8 +40,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                             SectionShapeBox,
                             SectionShapeSphere
                             )
-                        )
-                    );
+                        );
+                default:
+                    throw new System.ArgumentException("Unknown probe type");
+            }
         }
 
         static void Drawer_FieldShapeType(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o)

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Drawers.cs
@@ -90,7 +90,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
-        static void Drawer_SectionShapeBox(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o, bool drawOffset, bool drawNormal, bool drawFace)
+        static void Drawer_SectionShapeBox(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o, bool drawAllOffset, bool drawNormal, bool drawFace)
         {
             bool advanced = d.editorAdvancedModeEnabled.boolValue;
             var maxFadeDistance = d.boxSize.vector3Value * 0.5f;
@@ -141,10 +141,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             HDProbeUI.Drawer_ToolBarButton(HDProbeUI.ToolBar.InfluenceShape, o, GUILayout.Width(28f), GUILayout.MinHeight(22f));
             EditorGUILayout.EndHorizontal();
 
-            if (drawOffset)
-            {
-                Drawer_Offset(s, d, o);
-            }
+            Drawer_Offset(s, d, o, drawAllOffset);
             
             GUILayout.Space(EditorGUIUtility.standardVerticalSpacing);
             
@@ -232,18 +229,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             GUILayout.EndVertical();
         }
 
-        static void Drawer_SectionShapeSphere(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o, bool drawOffset, bool drawNormal)
+        static void Drawer_SectionShapeSphere(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o, bool drawOffset, bool drawAllOffset)
         {
 
             EditorGUILayout.BeginHorizontal();
             EditorGUILayout.PropertyField(d.sphereRadius, radiusContent);
             HDProbeUI.Drawer_ToolBarButton(HDProbeUI.ToolBar.InfluenceShape, o, GUILayout.Width(28f), GUILayout.MinHeight(22f));
             EditorGUILayout.EndHorizontal();
-
-            if(drawOffset)
-            {
-                Drawer_Offset(s, d, o);
-            }
+            
+            Drawer_Offset(s, d, o, drawAllOffset);
 
             EditorGUILayout.Space();
             var maxBlendDistance = d.sphereRadius.floatValue;
@@ -258,7 +252,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             HDProbeUI.Drawer_ToolBarButton(HDProbeUI.ToolBar.Blend, o, GUILayout.ExpandHeight(true), GUILayout.Width(28f), GUILayout.MinHeight(22f), GUILayout.MaxHeight(EditorGUIUtility.singleLineHeight + 3));
             EditorGUILayout.EndHorizontal();
 
-            if (drawNormal)
+            if (drawAllOffset)
             {
                 EditorGUILayout.BeginHorizontal();
                 EditorGUI.BeginChangeCheck();
@@ -272,17 +266,32 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
-        static void Drawer_Offset(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o)
+        static void Drawer_Offset(InfluenceVolumeUI s, SerializedInfluenceVolume d, Editor o, bool drawAllOffset)
         {
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(d.offset, offsetContent);
+            float y = 0f;
+            if (drawAllOffset)
+            {
+                EditorGUILayout.PropertyField(d.offset, offsetContent);
+            }
+            else
+            {
+                y = EditorGUILayout.FloatField(yOffsetContent, d.offset.vector3Value.y);
+            }
             if(EditorGUI.EndChangeCheck())
             {
                 //call the offset setter as it will update legacy reflection probe
                 HDProbeEditor editor = (HDProbeEditor)o;
                 InfluenceVolume influenceVolume = editor.GetTarget(editor.target).influenceVolume;
-                influenceVolume.offset = d.offset.vector3Value;
+                if (drawAllOffset)
+                {
+                    influenceVolume.offset = d.offset.vector3Value;
+                }
+                else
+                {
+                    influenceVolume.offset = new Vector3(0, y, 0);
+                }
             }
             HDProbeUI.Drawer_ToolBarButton(HDProbeUI.ToolBar.CapturePosition, o, GUILayout.Width(28f), GUILayout.MinHeight(22f));
             EditorGUILayout.EndHorizontal();

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Skin.cs
@@ -23,6 +23,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         static readonly GUIContent shapeContent = CoreEditorUtils.GetContent("Shape");
         static readonly GUIContent boxSizeContent = CoreEditorUtils.GetContent("Box Size|The size of the box in which the reflections will be applied to objects. The value is not affected by the Transform of the Game Object.");
         static readonly GUIContent offsetContent = CoreEditorUtils.GetContent("Offset|The center of the InfluenceVolume in which the reflections will be applied to objects. The value is relative to the position of the Game Object.");
+        static readonly GUIContent yOffsetContent = CoreEditorUtils.GetContent("Y Offset|The center of the InfluenceVolume in which the reflections will be applied to objects. The value is relative to the position of the Game Object.");
         static readonly GUIContent blendDistanceContent = CoreEditorUtils.GetContent("Blend Distance|Area around the probe where it is blended with other probes. Only used in deferred probes.");
         static readonly GUIContent blendNormalDistanceContent = CoreEditorUtils.GetContent("Blend Normal Distance|Area around the probe where the normals influence the probe. Only used in deferred probes.");
         static readonly GUIContent faceFadeContent = CoreEditorUtils.GetContent("Face fade|Fade faces of the cubemap.");

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Skin.cs
@@ -9,7 +9,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
  
         static readonly Color k_GizmoThemeColorBase = new Color(230 / 255f, 229 / 255f, 148 / 255f, 8 / 255f).gamma;
         static readonly Color k_GizmoThemeColorInfluence = new Color(83 / 255f, 255 / 255f, 95 / 255f, 8 / 255f).gamma;
-        static readonly Color k_GizmoThemeColorInfluenceNormal = new Color(128 / 255f, 128 / 255f, 255 / 255f, 8 / 255f).gamma;
+        internal static readonly Color k_GizmoThemeColorInfluenceNormal = new Color(128 / 255f, 128 / 255f, 255 / 255f, 8 / 255f).gamma;
         internal static readonly Color[] k_HandlesColor = new Color[]
         {
             Color.red,

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/Volume/InfluenceVolumeUI.Skin.cs
@@ -32,6 +32,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         static readonly GUIContent normalModeContent = CoreEditorUtils.GetContent("Normal|Normal parameters mode (only change for box shape).");
         static readonly GUIContent advancedModeContent = CoreEditorUtils.GetContent("Advanced|Advanced parameters mode (only change for box shape).");
         
-        static readonly string influenceVolumeHeader = "Influence Volume";
+        internal static readonly string influenceVolumeHeader = "Influence Volume";
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
@@ -9,7 +9,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
     partial class CaptureSettingsUI : BaseUI<SerializedCaptureSettings>
     {
-        const string captureSettingsHeaderContent = "Capture Settings";
+        internal const string captureSettingsHeaderContent = "Capture Settings";
 
         static readonly GUIContent clearColorModeContent = CoreEditorUtils.GetContent("Clear Mode");
         static readonly GUIContent backgroundColorHDRContent = CoreEditorUtils.GetContent("Background Color");
@@ -30,13 +30,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static readonly GUIContent shadowDistanceContent = CoreEditorUtils.GetContent("Shadow Distance");
 
-        public static CED.IDrawer SectionCaptureSettings = CED.FoldoutGroup(
-                captureSettingsHeaderContent,
-                (s, p, o) => s.isSectionExpandedCaptureSettings,
-                FoldoutOption.Indent,
-                CED.LabelWidth(150, CED.Action((s, p, o) => Drawer_SectionCaptureSettings(s, p, o)))
-                //no space as FrameSettings is rendered here and will handle it
-                );
+        public static CED.IDrawer SectionCaptureSettings = CED.LabelWidth(150, CED.Action((s, p, o) => Drawer_SectionCaptureSettings(s, p, o)));
 
         public AnimBool isSectionExpandedCaptureSettings { get { return m_AnimBools[0]; } }
 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/CaptureSettingsUI.cs
@@ -28,7 +28,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         static readonly GUIContent renderingPathContent = CoreEditorUtils.GetContent("Rendering Path");
 
-        static readonly GUIContent shadowDistanceContent = CoreEditorUtils.GetContent("Shadow Distance");
+        static readonly GUIContent shadowDistanceContent = CoreEditorUtils.GetContent("Shadow Distance|DEPRECATED: Still available for baked and custom probe.\nWill be soon replaced by volume usage.\nTo set up volume, create a layer used in probe capture settings as volume layer mask and not in the camera layer mask.\nCreate a volume on this specific layer affecting shadow distance.");
 
         public static CED.IDrawer SectionCaptureSettings = CED.LabelWidth(150, CED.Action((s, p, o) => Drawer_SectionCaptureSettings(s, p, o)));
 
@@ -61,8 +61,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 area.Add(p.fieldOfview, fieldOfViewContent, () => p.overridesFieldOfview, a => p.overridesFieldOfview = a, () => (owner is PlanarReflectionProbeEditor), defaultValue: (owner is PlanarReflectionProbeEditor) ? fieldOfViewDefault : null, forceOverride: true);
             }
-            
-            area.Add(p.shadowDistance, shadowDistanceContent, () => p.overridesShadowDistance, a => p.overridesShadowDistance = a);
+
+            area.Add(p.shadowDistance, shadowDistanceContent, () => p.overridesShadowDistance, a => p.overridesShadowDistance = a, () => owner is HDProbeEditor && (owner as HDProbeEditor).GetTarget(owner.target).mode != UnityEngine.Rendering.ReflectionProbeMode.Realtime);
             area.Add(p.renderingPath, renderingPathContent, () => p.overridesRenderingPath, a => p.overridesRenderingPath = a);
             EditorGUI.BeginChangeCheck();
             area.Draw(withOverride: false);
@@ -81,6 +81,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 rp.cullingMask = p.cullingMask.intValue;
                 rp.nearClipPlane = p.nearClipPlane.floatValue;
                 rp.farClipPlane = p.farClipPlane.floatValue;
+                rp.shadowDistance = p.shadowDistance.floatValue;
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -66,7 +66,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         FrameSettings m_BakedOrCustomReflectionFrameSettings = new FrameSettings();
 
         [SerializeField]
-        FrameSettings m_RealtimeReflectionFrameSettings = new FrameSettings();
+        FrameSettings m_RealtimeReflectionFrameSettings = new FrameSettings()
+        {
+            //deactivating some feature by for default realtime probe framesettings
+            enableRoughRefraction = false,
+            enableDistortion = false,
+            enablePostprocess = false,
+            enableContactShadows = false,
+            enableShadowMask = false,
+            enableSSAO = false,
+            enableAtmosphericScattering = false
+        };
         
         bool m_frameSettingsIsDirty = true;
         public bool frameSettingsIsDirty


### PR DESCRIPTION
### Purpose of this PR
- Fix cubemap assignation on custom ReflectoinProbe (also add comment in code due to Find function strange comportment that could leed to miss use)
- Feature/Fix y offset issue on PlanarReflectionProbe:
  + Reactivate offset (only on y)
  + Fix handles to work with y offset
  + Add offset tool
- Update default FrameSettings for realtime probes at  HDRPAsset creation
- Fix reflection probe's capture settings's shadow distance (only activated for baked and custom that still use legacy. Updated tooltip to explain how to do it for realtime and how it will be done later for all modes)

---
### Release Notes
Fix cubemap assignation on custom ReflectoinProbe
Add y offset for PlanarReflectionProbe and offset tool
Fix reflection probe's capture settings's shadow distance

---
### Testing status
**Katana Tests**: Katana running

**Manual Tests**: tested locally

**Automated Tests**: Launched GraphicTests: all green as in master

---
### Overall Product Risks
**Technical Risk**: Medium-High)
(Several files and line of code modified)

**Halo Effect**: Low-Medium
(should only affect reflection probe)

---
### Comments to reviewers
