### PR TITLE
Fixed Shadow bias calculations and Camera FinalBlit issue.

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [5.1.0-preview] - 2018-10-18
 ### Fixed
 - LWRP now respects the iOS Player setting **Force hard shadows**. When you enable this setting, hardware filtering of shadows is disabled.
+- Shadow bias calculation was incorrect with both Shadergraph shaders and Terrain, this is now corrected.
+- If a camera was rendering into a target texture, it could create a FinalBlit pass which was not needed.
 
 ### Added
 

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/lightweightPBRExtraPasses.template
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/lightweightPBRExtraPasses.template
@@ -37,8 +37,6 @@ ${VertexOutputStruct}
         UNITY_VERTEX_INPUT_INSTANCE_ID
 	};
 
-    // x: global clip space bias, y: normal world space bias
-    float4 _ShadowBias;
     float3 _LightDirection;
 
     VertexOutput ShadowPassVertex(GraphVertexInput v)
@@ -62,15 +60,7 @@ ${VertexShaderOutputs}
 	    float3 positionWS = TransformObjectToWorld(v.vertex.xyz);
         float3 normalWS = TransformObjectToWorldDir(v.normal);
 
-        float invNdotL = 1.0 - saturate(dot(_LightDirection, normalWS));
-        float scale = invNdotL * _ShadowBias.y;
-
-        // normal bias is negative since we want to apply an inset normal offset
-        positionWS = normalWS * scale.xxx + positionWS;
-        float4 clipPos = TransformWorldToHClip(positionWS);
-
-        // _ShadowBias.x sign depens on if platform has reversed z buffer
-        clipPos.z += _ShadowBias.x;
+        float4 clipPos = TransformWorldToHClip(ApplyShadowBias(positionWS, normalWS, _LightDirection));
 
 	#if UNITY_REVERSED_Z
 	    clipPos.z = min(clipPos.z, clipPos.w * UNITY_NEAR_CLIP_VALUE);

--- a/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
@@ -163,13 +163,18 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 renderer.EnqueuePass(m_ScreenSpaceShadowResolvePass);
             }
 
-            bool requiresRenderToTexture = RequiresIntermediateColorTexture(ref renderingData.cameraData, baseDescriptor)
-                    || m_AfterDepthpasses.Count != 0
-                    || m_AfterOpaquePasses.Count != 0
-                    || m_AfterOpaquePostProcessPasses.Count != 0
-                    || m_AfterSkyboxPasses.Count != 0
-                    || m_AfterTransparentPasses.Count != 0
-                    || m_AfterRenderPasses.Count != 0;
+            bool requiresRenderToTexture = false;
+
+            if (renderingData.cameraData.camera.targetTexture == null || renderingData.cameraData.camera.cameraType == CameraType.SceneView)
+            {
+                requiresRenderToTexture = RequiresIntermediateColorTexture(ref renderingData.cameraData, baseDescriptor)
+                                          || m_AfterDepthpasses.Count != 0
+                                          || m_AfterOpaquePasses.Count != 0
+                                          || m_AfterOpaquePostProcessPasses.Count != 0
+                                          || m_AfterSkyboxPasses.Count != 0
+                                          || m_AfterTransparentPasses.Count != 0
+                                          || m_AfterRenderPasses.Count != 0;
+            }
 
             RenderTargetHandle colorHandle = RenderTargetHandle.CameraTarget;
             RenderTargetHandle depthHandle = RenderTargetHandle.CameraTarget;

--- a/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
@@ -163,18 +163,13 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 renderer.EnqueuePass(m_ScreenSpaceShadowResolvePass);
             }
 
-            bool requiresRenderToTexture = false;
-
-            if (renderingData.cameraData.camera.targetTexture == null || renderingData.cameraData.camera.cameraType == CameraType.SceneView)
-            {
-                requiresRenderToTexture = RequiresIntermediateColorTexture(ref renderingData.cameraData, baseDescriptor)
-                                          || m_AfterDepthpasses.Count != 0
-                                          || m_AfterOpaquePasses.Count != 0
-                                          || m_AfterOpaquePostProcessPasses.Count != 0
-                                          || m_AfterSkyboxPasses.Count != 0
-                                          || m_AfterTransparentPasses.Count != 0
-                                          || m_AfterRenderPasses.Count != 0;
-            }
+            bool requiresRenderToTexture = RequiresIntermediateColorTexture(ref renderingData.cameraData, baseDescriptor)
+                    || m_AfterDepthpasses.Count != 0
+                    || m_AfterOpaquePasses.Count != 0
+                    || m_AfterOpaquePostProcessPasses.Count != 0
+                    || m_AfterSkyboxPasses.Count != 0
+                    || m_AfterTransparentPasses.Count != 0
+                    || m_AfterRenderPasses.Count != 0;
 
             RenderTargetHandle colorHandle = RenderTargetHandle.CameraTarget;
             RenderTargetHandle depthHandle = RenderTargetHandle.CameraTarget;

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Shadows.hlsl
@@ -52,6 +52,8 @@ half4       _AdditionalShadowOffset3;
 float4      _AdditionalShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
 CBUFFER_END
 
+float4 _ShadowBias; // x: depth bias, y: normal bias
+
 #if UNITY_REVERSED_Z
 #define BEYOND_SHADOW_FAR(shadowCoord) shadowCoord.z <= UNITY_RAW_FAR_CLIP_VALUE
 #else
@@ -216,6 +218,17 @@ float4 GetShadowCoord(VertexPositionInputs vertexInput)
 #else
     return TransformWorldToShadowCoord(vertexInput.positionWS);
 #endif
+}
+
+float3 ApplyShadowBias(float3 positionWS, float3 normalWS, float3 lightDirection)
+{
+    float invNdotL = 1.0 - saturate(dot(lightDirection, normalWS));
+    float scale = invNdotL * _ShadowBias.y;
+
+    // normal bias is negative since we want to apply an inset normal offset
+    positionWS = lightDirection * _ShadowBias.xxx + positionWS;
+    positionWS = normalWS * scale.xxx + positionWS;
+    return positionWS;
 }
 
 #endif

--- a/com.unity.render-pipelines.lightweight/Shaders/ShadowCasterPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/ShadowCasterPass.hlsl
@@ -2,8 +2,8 @@
 #define LIGHTWEIGHT_SHADOW_CASTER_PASS_INCLUDED
 
 #include "Packages/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl"
+#include "Packages/com.unity.render-pipelines.lightweight/ShaderLibrary/Shadows.hlsl"
 
-float4 _ShadowBias; // x: depth bias, y: normal bias
 float3 _LightDirection;
 
 struct Attributes
@@ -25,13 +25,7 @@ float4 GetShadowPositionHClip(Attributes input)
     float3 positionWS = TransformObjectToWorld(input.positionOS.xyz);
     float3 normalWS = TransformObjectToWorldDir(input.normalOS);
 
-    float invNdotL = 1.0 - saturate(dot(_LightDirection, normalWS));
-    float scale = invNdotL * _ShadowBias.y;
-
-    // normal bias is negative since we want to apply an inset normal offset
-    positionWS = _LightDirection * _ShadowBias.xxx + positionWS;
-    positionWS = normalWS * scale.xxx + positionWS;
-    float4 positionCS = TransformWorldToHClip(positionWS);
+    float4 positionCS = TransformWorldToHClip(ApplyShadowBias(positionWS, normalWS, _LightDirection));
 
 #if UNITY_REVERSED_Z
     positionCS.z = min(positionCS.z, positionCS.w * UNITY_NEAR_CLIP_VALUE);

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -247,7 +247,6 @@ half4 SplatmapFragment(VertexOutput IN) : SV_TARGET
 // Shadow pass
 
 // x: global clip space bias, y: normal world space bias
-float4 _ShadowBias;
 float3 _LightDirection;
 
 struct VertexInputLean
@@ -266,15 +265,7 @@ float4 ShadowPassVertex(VertexInputLean v) : SV_POSITION
     float3 positionWS = TransformObjectToWorld(v.position.xyz);
     float3 normalWS = TransformObjectToWorldDir(v.normal);
 
-    float invNdotL = 1.0 - saturate(dot(_LightDirection, normalWS));
-    float scale = invNdotL * _ShadowBias.y;
-
-    // normal bias is negative since we want to apply an inset normal offset
-    positionWS = normalWS * scale.xxx + positionWS;
-    float4 clipPos = TransformWorldToHClip(positionWS);
-
-    // _ShadowBias.x sign depens on if platform has reversed z buffer
-    clipPos.z += _ShadowBias.x;
+    float4 clipPos = TransformWorldToHClip(ApplyShadowBias(positionWS, normalWS, _LightDirection));
 
 #if UNITY_REVERSED_Z
     clipPos.z = min(clipPos.z, clipPos.w * UNITY_NEAR_CLIP_VALUE);

--- a/com.unity.render-pipelines.lightweight/Shaders/Utils/Blit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Utils/Blit.shader
@@ -8,7 +8,9 @@ Shader "Hidden/Lightweight Render Pipeline/Blit"
         Pass
         {
             Name "Blit"
-            ZTest Always ZWrite Off
+            ZTest Always
+            ZWrite Off
+            Cull Off
 
             HLSLPROGRAM
             // Required to compile gles 2.0 with standard srp library


### PR DESCRIPTION
### Purpose of this PR
There are two fixes in this PR.
1) Fixed Shadow bias calculations for Shadergraph and Terrain shaders, they had not been updated to use the new shadow bias changes done recently.
2) Fixed issue where FinalBlit was called when a camera was rendering to a target texture, this caused issue with Boat Attack not rendering the planar reflections as the FinalBlit pass was killing the render texture data.

---
### Release Notes
None, just bug fix notes in changelog

---
### Testing status
**Katana Tests**: Running...[Katana](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lw%2Fassorted-fixes&automation-tools_branch=add-platform-filter&unity_branch=trunk)

**Manual Tests**: Tested with Boat attack demo project

**Automated Tests**: None at this point, will be adding more mixed tests to the repo in a big batch next month.

---
### Overall Product Risks
**Technical Risk**: Low - this is just reusing existing code that was added before, just now also added to all the shaders in LWRP.

**Halo Effect**: Medium - it does change all shadow casting in LWRP so if something went wrong it could ruin a lot of things.

---
### Comments to reviewers
@Katstodian Can you please check the changelog and let me know what you need changed