### PR TITLE
LW enable postprocessing for XR (case 1087137)

### DIFF
--- a/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
@@ -245,7 +245,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             // we need to stay in a RT
             if (afterRenderExists)
             {
-                // perform post with src / dest the same
+                // perform post with src / dest the same 
                 if (!renderingData.cameraData.isStereoEnabled && renderingData.cameraData.postProcessEnabled)
                 {
                     m_CreatePostTransparentColorPass.Setup(baseDescriptor, m_ColorAttachmentAfterTransparentPost, sampleCount);

--- a/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
@@ -245,8 +245,8 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             // we need to stay in a RT
             if (afterRenderExists)
             {
-                // perform post with src / dest the same 
-                if (!renderingData.cameraData.isStereoEnabled && renderingData.cameraData.postProcessEnabled)
+                // perform post with src / dest the same
+                if (renderingData.cameraData.postProcessEnabled)
                 {
                     m_CreatePostTransparentColorPass.Setup(baseDescriptor, m_ColorAttachmentAfterTransparentPost, sampleCount);
                     renderer.EnqueuePass(m_CreatePostTransparentColorPass);
@@ -270,9 +270,9 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             }
             else
             {
-                if (!renderingData.cameraData.isStereoEnabled && renderingData.cameraData.postProcessEnabled)
+                if (renderingData.cameraData.postProcessEnabled)
                 {
-                    m_PostProcessPass.Setup(baseDescriptor, colorHandle, RenderTargetHandle.CameraTarget, false, (!renderingData.cameraData.isStereoEnabled && renderingData.cameraData.camera.targetTexture == null));
+                    m_PostProcessPass.Setup(baseDescriptor, colorHandle, RenderTargetHandle.CameraTarget, false, renderingData.cameraData.camera.targetTexture == null);
                     renderer.EnqueuePass(m_PostProcessPass);
                 }
                 else if (colorHandle != RenderTargetHandle.CameraTarget)


### PR DESCRIPTION
### Purpose of this PR

Re-enable postprocessing with XR in LW. The PR for single-pass instancing and postprocessing landed recently, therefore postprocessing works with XR and LW. 
See PR: https://github.com/Unity-Technologies/PostProcessing/pull/685

---
### Release Notes
Fix for postprocessing is not applied when using LWRP with XR: 
https://fogbugz.unity3d.com/f/cases/1087137

---
### Testing status
**Katana Tests**:
All Tests Passed: [Katana](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lw/xr-enable-postprocessing&automation-tools_branch=add-platform-filter&unity_branch=trunk)

**Manual Tests**: 
Tested on Oculus Rift with LW and postprocessing in Standalone Player and Editor, with single-pass instancing and double-wide.

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
