### PR TITLE
Lw/bugfix/fix pipeline asset ui

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [5.1.0-preview] - 2018-10-18
 ### Fixed
 - LWRP now respects the iOS Player setting **Force hard shadows**. When you enable this setting, hardware filtering of shadows is disabled.
+- When you select `Per Vertex` option for `Additional Lights`, the `Per Object Limit` option is not greyed out anymore.
 
 ### Added
 

--- a/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineAssetEditor.cs
@@ -50,7 +50,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             public static GUIContent shaderVariantLogLevel = EditorGUIUtility.TrTextContent("Shader Variant Log Level", "Controls the level logging in of shader variants information is outputted when a build is performed. Information will appear in the Unity console when the build finishes.");
 
             // Dropdown menu options
-            public static string[] mainLightOptions = { "None", "Pixel Lighting" };
+            public static string[] mainLightOptions = { "Disabled", "Per Pixel" };
 
             public static string[] shadowCascadeOptions = {"No Cascades", "Two Cascades", "Four Cascades"};
             public static string[] opaqueDownsamplingOptions = {"None", "2x (Bilinear)", "4x (Box)", "4x (Bilinear)"};
@@ -214,12 +214,12 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 m_AdditionalLightsRenderingModeProp.intValue = (int)selectedLightRenderingMode;
                 EditorGUI.indentLevel++;
 
-                disableGroup = m_AdditionalLightsRenderingModeProp.intValue != (int)LightRenderingMode.PerPixel;
+                disableGroup = m_AdditionalLightsRenderingModeProp.intValue == (int)LightRenderingMode.Disabled;
                 EditorGUI.BeginDisabledGroup(disableGroup);
                 m_AdditionalLightsPerObjectLimitProp.intValue = EditorGUILayout.IntSlider(Styles.perObjectLimit, m_AdditionalLightsPerObjectLimitProp.intValue, 0, LightweightRenderPipeline.maxPerObjectLightCount);
                 EditorGUI.EndDisabledGroup();
 
-                disableGroup |= m_AdditionalLightsPerObjectLimitProp.intValue == 0;
+                disableGroup |= (m_AdditionalLightsPerObjectLimitProp.intValue == 0 || m_AdditionalLightsRenderingModeProp.intValue != (int)LightRenderingMode.PerPixel);
                 EditorGUI.BeginDisabledGroup(disableGroup);
                 EditorGUILayout.PropertyField(m_AdditionalLightShadowsSupportedProp, Styles.supportsAdditionalShadowsText);
                 EditorGUI.EndDisabledGroup();


### PR DESCRIPTION
### Purpose of this PR
 Fixed Main Light and Additional Lights drop down menu with different option names.
 Fixed issue that was causing the Per Object Limit to be greyed out when selecting Per Vertex Light.
---
### Release Notes
 Added

---
### Testing status
**Katana Tests**: Not necessary to run.

**Manual Tests**: Tested manually myself.

**Automated Tests**: UI is not covered by automated tests.

Any test projects to go with this to help reviewers? Works on any scene

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
The rule for greying out the object light limit was wrong. updated other UI dropdowns to be consistent.
