### PR TITLE
float4 only in unityPerDraw

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl
@@ -31,7 +31,7 @@ float3 SampleBakedGI(float3 positionRWS, float3 normalWS, float2 uvStaticLightma
     else
     {
         return SampleProbeVolumeSH4(TEXTURE3D_PARAM(unity_ProbeVolumeSH, samplerunity_ProbeVolumeSH), positionRWS, normalWS, GetProbeVolumeWorldToObject(),
-                                    unity_ProbeVolumeParams.y, unity_ProbeVolumeParams.z, unity_ProbeVolumeMin, unity_ProbeVolumeSizeInv);
+                                    unity_ProbeVolumeParams.y, unity_ProbeVolumeParams.z, unity_ProbeVolumeMin.xyz, unity_ProbeVolumeSizeInv.xyz);
     }
 
 #else
@@ -85,7 +85,7 @@ float4 SampleShadowMask(float3 positionRWS, float2 uvStaticLightmap) // normalWS
     if (unity_ProbeVolumeParams.x == 1.0)
     {
         rawOcclusionMask = SampleProbeOcclusion(TEXTURE3D_PARAM(unity_ProbeVolumeSH, samplerunity_ProbeVolumeSH), positionRWS, GetProbeVolumeWorldToObject(),
-                                                unity_ProbeVolumeParams.y, unity_ProbeVolumeParams.z, unity_ProbeVolumeMin, unity_ProbeVolumeSizeInv);
+                                                unity_ProbeVolumeParams.y, unity_ProbeVolumeParams.z, unity_ProbeVolumeMin.xyz, unity_ProbeVolumeSizeInv.xyz);
     }
     else
     {

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -81,8 +81,8 @@ CBUFFER_START(UnityPerDraw)
     // z = Texel size on U texture coordinate
     float4 unity_ProbeVolumeParams;
     float4x4 unity_ProbeVolumeWorldToObject;
-    float3 unity_ProbeVolumeSizeInv;
-    float3 unity_ProbeVolumeMin;
+    float4 unity_ProbeVolumeSizeInv;
+    float4 unity_ProbeVolumeMin;
 
     // This contain occlusion factor from 0 to 1 for dynamic objects (no SH here)
     float4 unity_ProbesOcclusion;

--- a/com.unity.shadergraph/ShaderGraphLibrary/ShaderVariables.hlsl
+++ b/com.unity.shadergraph/ShaderGraphLibrary/ShaderVariables.hlsl
@@ -124,8 +124,8 @@ CBUFFER_START(UnityPerDraw : register(b0))
     // z = Texel size on U texture coordinate
     float4 unity_ProbeVolumeParams;
     float4x4 unity_ProbeVolumeWorldToObject;
-    float3 unity_ProbeVolumeSizeInv;
-    float3 unity_ProbeVolumeMin;
+    float4 unity_ProbeVolumeSizeInv;
+    float4 unity_ProbeVolumeMin;
 
     // This contain occlusion factor from 0 to 1 for dynamic objects (no SH here)
     float4 unity_ProbesOcclusion;

--- a/com.unity.shadergraph/ShaderGraphLibrary/ShaderVariables.hlsl
+++ b/com.unity.shadergraph/ShaderGraphLibrary/ShaderVariables.hlsl
@@ -124,8 +124,8 @@ CBUFFER_START(UnityPerDraw : register(b0))
     // z = Texel size on U texture coordinate
     float4 unity_ProbeVolumeParams;
     float4x4 unity_ProbeVolumeWorldToObject;
-    float4 unity_ProbeVolumeSizeInv;
-    float4 unity_ProbeVolumeMin;
+    float3 unity_ProbeVolumeSizeInv;
+    float3 unity_ProbeVolumeMin;
 
     // This contain occlusion factor from 0 to 1 for dynamic objects (no SH here)
     float4 unity_ProbesOcclusion;


### PR DESCRIPTION
### Purpose of this PR
our UnityPerDraw used some float3 in UnityPerDraw. Up coming SRP batcher change will check that we only use float4 or float4x4 in UnityPerDraw

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
