### PR TITLE
PCSS sampling improvements

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/Random.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Random.hlsl
@@ -90,6 +90,16 @@ float2 InitRandom(float2 input)
     return r;
 }
 
+//From  Next Generation Post Processing in Call of Duty: Advanced Warfare [Jimenez 2014]
+// http://advances.realtimerendering.com/s2014/index.html
+float InterleavedGradientNoise(float2 uv, uint frameCount)
+{
+    const float3 magic = float3(0.06711056f, 0.00583715f, 52.9829189f);
+    float2 frameMagicScale = float2(2.083f, 4.867f);
+    uv += frameCount * frameMagicScale;
+    return frac(magic.z * frac(dot(uv, magic.xy)));
+}
+
 #endif // SHADER_API_GLES
 
 #endif // UNITY_RANDOM_INCLUDED

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Shadow quality settings are setup to "All" when using HDRP (Not visile in UI when using SRP). Avoid to have disabled shadow.
 - Internally use premultiplied alpha for all fog
 - Updated default FrameSettings used for realtime reflection probe (at HDRenderPipelineAsset creation)
+- Improved PCSS sampling quality. 
 
 ## [5.0.0-preview] - 2018-09-28
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightEvaluation.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightEvaluation.hlsl
@@ -247,7 +247,7 @@ void EvaluateLight_Punctual(LightLoopContext lightLoopContext, PositionInputs po
 
     if ((light.shadowIndex >= 0) && (light.shadowDimmer > 0))
     {
-        shadow = GetPunctualShadowAttenuation(lightLoopContext.shadowContext, positionWS, N, light.shadowIndex, L, distances.x, light.lightType == GPULIGHTTYPE_POINT, light.lightType != GPULIGHTTYPE_PROJECTOR_BOX);
+        shadow = GetPunctualShadowAttenuation(lightLoopContext.shadowContext, posInput.positionSS, positionWS, N, light.shadowIndex, L, distances.x, light.lightType == GPULIGHTTYPE_POINT, light.lightType != GPULIGHTTYPE_PROJECTOR_BOX);
 
         // Transparents have no contact shadow information
     #ifndef _SURFACE_TYPE_TRANSPARENT

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/HDShadow.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/HDShadow.hlsl
@@ -16,17 +16,17 @@
 
 # include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowContext.hlsl"
 
-float GetDirectionalShadowAttenuation(HDShadowContext shadowContext, float3 positionWS, float3 normalWS, int shadowDataIndex, float3 L)
+float GetDirectionalShadowAttenuation(HDShadowContext shadowContext, float2 positionSS, float3 positionWS, float3 normalWS, int shadowDataIndex, float3 L)
 {
-    return EvalShadow_CascadedDepth_Blend(shadowContext, _ShadowmapCascadeAtlas, sampler_ShadowmapCascadeAtlas, positionWS, normalWS, shadowDataIndex, L);
+    return EvalShadow_CascadedDepth_Blend(shadowContext, _ShadowmapCascadeAtlas, sampler_ShadowmapCascadeAtlas, positionSS, positionWS, normalWS, shadowDataIndex, L);
 }
 
 float GetDirectionalShadowAttenuation(HDShadowContext shadowContext, float3 positionWS, float3 normalWS, int shadowDataIndex, float3 L, float2 positionSS)
 {
-    return GetDirectionalShadowAttenuation(shadowContext, positionWS, normalWS, shadowDataIndex, L);
+    return GetDirectionalShadowAttenuation(shadowContext, positionSS, positionWS, normalWS, shadowDataIndex, L);
 }
 
-float GetPunctualShadowAttenuation(HDShadowContext shadowContext, float3 positionWS, float3 normalWS, int shadowDataIndex, float3 L, float L_dist, bool pointLight, bool perspecive)
+float GetPunctualShadowAttenuation(HDShadowContext shadowContext, float2 positionSS, float3 positionWS, float3 normalWS, int shadowDataIndex, float3 L, float L_dist, bool pointLight, bool perspecive)
 {
     // Note: Here we assume that all the shadow map cube faces have been added contiguously in the buffer to retreive the shadow information
     HDShadowData sd = shadowContext.shadowDatas[shadowDataIndex];
@@ -39,12 +39,12 @@ float GetPunctualShadowAttenuation(HDShadowContext shadowContext, float3 positio
         sd.atlasOffset = shadowContext.shadowDatas[shadowDataIndex + CubeMapFaceID(-L)].atlasOffset;
     }
 
-    return EvalShadow_PunctualDepth(sd, _ShadowmapAtlas, sampler_ShadowmapAtlas, positionWS, normalWS, L, L_dist, perspecive);
+    return EvalShadow_PunctualDepth(sd, _ShadowmapAtlas, sampler_ShadowmapAtlas, positionSS, positionWS, normalWS, L, L_dist, perspecive);
 }
 
 float GetPunctualShadowAttenuation(HDShadowContext shadowContext, float3 positionWS, float3 normalWS, int shadowDataIndex, float3 L, float L_dist, float2 positionSS, bool pointLight, bool perspecive)
 {
-    return GetPunctualShadowAttenuation(shadowContext, positionWS, normalWS, shadowDataIndex, L, L_dist, pointLight, perspecive);
+    return GetPunctualShadowAttenuation(shadowContext, positionSS, positionWS, normalWS, shadowDataIndex, L, L_dist, pointLight, perspecive);
 }
 
 float GetPunctualShadowClosestDistance(HDShadowContext shadowContext, SamplerState sampl, real3 positionWS, int shadowDataIndex, float3 L, float3 lightPositionWS, bool pointLight)

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -2480,11 +2480,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 float contactShadowFadeEnd = m_ContactShadows.maxDistance;
                 float contactShadowOneOverFadeRange = 1.0f / Math.Max(1e-6f, contactShadowRange);
                 Vector4 contactShadowParams = new Vector4(m_ContactShadows.length, m_ContactShadows.distanceScaleFactor, contactShadowFadeEnd, contactShadowOneOverFadeRange);
-                var postProcessLayer = hdCamera.camera.GetComponent<PostProcessLayer>();
-                bool taaEnabled = hdCamera.camera.cameraType == CameraType.Game &&
-                                  HDUtils.IsTemporalAntialiasingActive(postProcessLayer);
-                float timeVaryingNoise = taaEnabled ? 1.0f : 0.0f;
-                Vector4 contactShadowParams2 = new Vector4(m_ContactShadows.opacity, timeVaryingNoise, firstMipOffsetY, 0.0f);
+                Vector4 contactShadowParams2 = new Vector4(m_ContactShadows.opacity, firstMipOffsetY, 0.0f, 0.0f);
                 cmd.SetComputeVectorParam(screenSpaceShadowComputeShader, HDShaderIDs._ContactShadowParamsParameters, contactShadowParams);
                 cmd.SetComputeVectorParam(screenSpaceShadowComputeShader, HDShaderIDs._ContactShadowParamsParameters2, contactShadowParams2);
                 cmd.SetComputeIntParam(screenSpaceShadowComputeShader, HDShaderIDs._DirectionalContactShadowSampleCount, m_ContactShadows.sampleCount);

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDPCSS.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDPCSS.hlsl
@@ -1,74 +1,101 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
 
-#define POISSON_DISK_SAMPLE_COUNT 64
+#define DISK_SAMPLE_COUNT 64
+// Fibonacci Spiral Disk Sampling Pattern
+// https://people.irisa.fr/Ricardo.Marques/articles/2013/SF_CGF.pdf
+//
+// Normalized direction vector portion of fibonacci spiral can be baked into a LUT, regardless of sampleCount.
+// This allows us to treat the directions as a progressive sequence, using any sampleCount in range [0, n <= LUT_LENGTH]
+// the radius portion of spiral construction is coupled to sample count, but is fairly cheap to compute at runtime per sample.
+// Generated (in javascript) with:
+// var res = "";
+// for (var i = 0; i < 64; ++i)
+// {
+//     var a = Math.PI * (3.0 - Math.sqrt(5.0));
+//     var b = a / (2.0 * Math.PI);
+//     var c = i * b;
+//     var theta = (c - Math.floor(c)) * 2.0 * Math.PI;
+//     res += "float2 (" + Math.cos(theta) + ", " + Math.sin(theta) + "),\n";
+// }
 
-static const float2 poissonDisk64[POISSON_DISK_SAMPLE_COUNT] =
+static const float2 fibonacciSpiralDirection64[64] =
 {
-    float2 ( 0.1187053,   0.7951565),
-    float2 ( 0.1173675,   0.6087878),
-    float2 (-0.09958518,  0.7248842),
-    float2 ( 0.4259812,   0.6152718),
-    float2 ( 0.3723574,   0.8892787),
-    float2 (-0.02289676,  0.9972908),
-    float2 (-0.08234791,  0.5048386),
-    float2 ( 0.1821235,   0.9673787),
-    float2 (-0.2137264,   0.9011746),
-    float2 ( 0.3115066,   0.4205415),
-    float2 ( 0.1216329,   0.383266),
-    float2 ( 0.5948939,   0.7594361),
-    float2 ( 0.7576465,   0.5336417),
-    float2 (-0.521125,    0.7599803),
-    float2 (-0.2923127,   0.6545699),
-    float2 ( 0.6782473,   0.22385),
-    float2 (-0.3077152,   0.4697627),
-    float2 ( 0.4484913,   0.2619455),
-    float2 (-0.5308799,   0.4998215),
-    float2 (-0.7379634,   0.5304936),
-    float2 ( 0.02613133,  0.1764302),
-    float2 (-0.1461073,   0.3047384),
-    float2 (-0.8451027,   0.3249073),
-    float2 (-0.4507707,   0.2101997),
-    float2 (-0.6137282,   0.3283674),
-    float2 (-0.2385868,   0.08716244),
-    float2 ( 0.3386548,   0.01528411),
-    float2 (-0.04230833, -0.1494652),
-    float2 ( 0.167115,   -0.1098648),
-    float2 (-0.525606,    0.01572019),
-    float2 (-0.7966855,   0.1318727),
-    float2 ( 0.5704287,   0.4778273),
-    float2 (-0.9516637,   0.002725032),
-    float2 (-0.7068223,  -0.1572321),
-    float2 ( 0.2173306,  -0.3494083),
-    float2 ( 0.06100426, -0.4492816),
-    float2 ( 0.2333982,   0.2247189),
-    float2 ( 0.07270987, -0.6396734),
-    float2 ( 0.4670808,  -0.2324669),
-    float2 ( 0.3729528,  -0.512625),
-    float2 ( 0.5675077,  -0.4054544),
-    float2 (-0.3691984,  -0.128435),
-    float2 ( 0.8752473,   0.2256988),
-    float2 (-0.2680127,  -0.4684393),
-    float2 (-0.1177551,  -0.7205751),
-    float2 (-0.1270121,  -0.3105424),
-    float2 ( 0.5595394,  -0.06309237),
-    float2 (-0.9299136,  -0.1870008),
-    float2 ( 0.974674,    0.03677348),
-    float2 ( 0.7726735,  -0.06944724),
-    float2 (-0.4995361,  -0.3663749),
-    float2 ( 0.6474168,  -0.2315787),
-    float2 ( 0.1911449,  -0.8858921),
-    float2 ( 0.3671001,  -0.7970535),
-    float2 (-0.6970353,  -0.4449432),
-    float2 (-0.417599,   -0.7189326),
-    float2 (-0.5584748,  -0.6026504),
-    float2 (-0.02624448, -0.9141423),
-    float2 ( 0.565636,   -0.6585149),
-    float2 (-0.874976,   -0.3997879),
-    float2 ( 0.9177843,  -0.2110524),
-    float2 ( 0.8156927,  -0.3969557),
-    float2 (-0.2833054,  -0.8395444),
-    float2 ( 0.799141,   -0.5886372)
+    float2 (1, 0),
+    float2 (-0.7373688780783197, 0.6754902942615238),
+    float2 (0.08742572471695988, -0.9961710408648278),
+    float2 (0.6084388609788625, 0.793600751291696),
+    float2 (-0.9847134853154288, -0.174181950379311),
+    float2 (0.8437552948123969, -0.5367280526263233),
+    float2 (-0.25960430490148884, 0.9657150743757782),
+    float2 (-0.46090702471337114, -0.8874484292452536),
+    float2 (0.9393212963241182, 0.3430386308741014),
+    float2 (-0.924345556137805, 0.3815564084749356),
+    float2 (0.423845995047909, -0.9057342725556143),
+    float2 (0.29928386444487326, 0.9541641203078969),
+    float2 (-0.8652112097532296, -0.501407581232427),
+    float2 (0.9766757736281757, -0.21471942904125949),
+    float2 (-0.5751294291397363, 0.8180624302199686),
+    float2 (-0.12851068979899202, -0.9917081236973847),
+    float2 (0.764648995456044, 0.6444469828838233),
+    float2 (-0.9991460540072823, 0.04131782619737919),
+    float2 (0.7088294143034162, -0.7053799411794157),
+    float2 (-0.04619144594036213, 0.9989326054954552),
+    float2 (-0.6407091449636957, -0.7677836880006569),
+    float2 (0.9910694127331615, 0.1333469877603031),
+    float2 (-0.8208583369658855, 0.5711318504807807),
+    float2 (0.21948136924637865, -0.9756166914079191),
+    float2 (0.4971808749652937, 0.8676469198750981),
+    float2 (-0.952692777196691, -0.30393498034490235),
+    float2 (0.9077911335843911, -0.4194225289437443),
+    float2 (-0.38606108220444624, 0.9224732195609431),
+    float2 (-0.338452279474802, -0.9409835569861519),
+    float2 (0.8851894374032159, 0.4652307598491077),
+    float2 (-0.9669700052147743, 0.25489019011123065),
+    float2 (0.5408377383579945, -0.8411269468800827),
+    float2 (0.16937617250387435, 0.9855514761735877),
+    float2 (-0.7906231749427578, -0.6123030256690173),
+    float2 (0.9965856744766464, -0.08256508601054027),
+    float2 (-0.6790793464527829, 0.7340648753490806),
+    float2 (0.0048782771634473775, -0.9999881011351668),
+    float2 (0.6718851669348499, 0.7406553331023337),
+    float2 (-0.9957327006438772, -0.09228428288961682),
+    float2 (0.7965594417444921, -0.6045602168251754),
+    float2 (-0.17898358311978044, 0.9838520605119474),
+    float2 (-0.5326055939855515, -0.8463635632843003),
+    float2 (0.9644371617105072, 0.26431224169867934),
+    float2 (-0.8896863018294744, 0.4565723210368687),
+    float2 (0.34761681873279826, -0.9376366819478048),
+    float2 (0.3770426545691533, 0.9261958953890079),
+    float2 (-0.9036558571074695, -0.4282593745796637),
+    float2 (0.9556127564793071, -0.2946256262683552),
+    float2 (-0.50562235513749, 0.8627549095688868),
+    float2 (-0.2099523790012021, -0.9777116131824024),
+    float2 (0.8152470554454873, 0.5791133210240138),
+    float2 (-0.9923232342597708, 0.12367133357503751),
+    float2 (0.6481694844288681, -0.7614961060013474),
+    float2 (0.036443223183926, 0.9993357251114194),
+    float2 (-0.7019136816142636, -0.7122620188966349),
+    float2 (0.998695384655528, 0.05106396643179117),
+    float2 (-0.7709001090366207, 0.6369560596205411),
+    float2 (0.13818011236605823, -0.9904071165669719),
+    float2 (0.5671206801804437, 0.8236347091470047),
+    float2 (-0.9745343917253847, -0.22423808629319533),
+    float2 (0.8700619819701214, -0.49294233692210304),
+    float2 (-0.30857886328244405, 0.9511987621603146),
+    float2 (-0.4149890815356195, -0.9098263912451776),
+    float2 (0.9205789302157817, 0.3905565685566777)
 };
+
+real2 ComputeFibonacciSpiralDiskSample(const in int sampleIndex, const in real diskRadius, const in real sampleCountInverse, const in real sampleCountBias)
+{
+    // Note: To sample uniformly within the disk we would compute radius as:
+    // radius = lightArea * sqrt((real)i * sampleCountInverse + sampleCountBias);
+    // For performance we drop the sqrt(), resulting in a higher sample density toward the center of the disk.
+    // Visually resulting in a curved falloff function.
+    real sampleRadius = diskRadius * ((real)sampleIndex * sampleCountInverse + sampleCountBias);
+    real2 sampleDirection = fibonacciSpiralDirection64[sampleIndex];
+    return sampleDirection * sampleRadius;
+}
 
 real PenumbraSize(real Reciever, real Blocker)
 {
@@ -78,10 +105,15 @@ real PenumbraSize(real Reciever, real Blocker)
 bool BlockerSearch(inout real averageBlockerDepth, inout real numBlockers, real lightArea, real3 coord, real2 sampleJitter, real2 sampleBias, Texture2D shadowMap, SamplerState pointSampler, int sampleCount)
 {
     real blockerSum = 0.0;
-    for (int i = 0; i < sampleCount && i < POISSON_DISK_SAMPLE_COUNT; ++i)
+    real sampleCountInverse = rcp((real)sampleCount);
+    real sampleCountBias = 0.5 * sampleCountInverse;
+    real ditherRotation = sampleJitter.x;
+
+    for (int i = 0; i < sampleCount && i < DISK_SAMPLE_COUNT; ++i)
     {
-        real2 offset = real2(poissonDisk64[i].x *  sampleJitter.y + poissonDisk64[i].y * sampleJitter.x,
-                             poissonDisk64[i].x * -sampleJitter.x + poissonDisk64[i].y * sampleJitter.y) * lightArea;
+        real2 offset = ComputeFibonacciSpiralDiskSample(i, lightArea, sampleCountInverse, sampleCountBias);
+        offset = real2(offset.x *  sampleJitter.y + offset.y * sampleJitter.x,
+                       offset.x * -sampleJitter.x + offset.y * sampleJitter.y);
 
         real shadowMapDepth = SAMPLE_TEXTURE2D_LOD(shadowMap, pointSampler, coord.xy + offset, 0.0).x;
 
@@ -105,10 +137,15 @@ real PCSS(real3 coord, real filterRadius, real2 scale, real2 offset, real2 sampl
     real VMax = offset.y + scale.y;
 
     real sum = 0.0;
-    for (int i = 0; i < sampleCount && i < POISSON_DISK_SAMPLE_COUNT; ++i)
+    real sampleCountInverse = rcp((real)sampleCount);
+    real sampleCountBias = 0.5 * sampleCountInverse;
+    real ditherRotation = sampleJitter.x;
+
+    for (int i = 0; i < sampleCount && i < DISK_SAMPLE_COUNT; ++i)
     {
-        real2 offset = real2(poissonDisk64[i].x *  sampleJitter.y + poissonDisk64[i].y * sampleJitter.x,
-                             poissonDisk64[i].x * -sampleJitter.x + poissonDisk64[i].y * sampleJitter.y) * filterRadius;
+        real2 offset = ComputeFibonacciSpiralDiskSample(i, filterRadius, sampleCountInverse, sampleCountBias);
+        offset = real2(offset.x *  sampleJitter.y + offset.y * sampleJitter.x,
+                       offset.x * -sampleJitter.x + offset.y * sampleJitter.y);
 
         real U = coord.x + offset.x;
         real V = coord.y + offset.y;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDPCSS.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDPCSS.hlsl
@@ -18,7 +18,7 @@
 //     res += "float2 (" + Math.cos(theta) + ", " + Math.sin(theta) + "),\n";
 // }
 
-static const float2 fibonacciSpiralDirection64[64] =
+static const float2 fibonacciSpiralDirection[DISK_SAMPLE_COUNT] =
 {
     float2 (1, 0),
     float2 (-0.7373688780783197, 0.6754902942615238),
@@ -93,7 +93,7 @@ real2 ComputeFibonacciSpiralDiskSample(const in int sampleIndex, const in real d
     // For performance we drop the sqrt(), resulting in a higher sample density toward the center of the disk.
     // Visually resulting in a curved falloff function.
     real sampleRadius = diskRadius * ((real)sampleIndex * sampleCountInverse + sampleCountBias);
-    real2 sampleDirection = fibonacciSpiralDirection64[sampleIndex];
+    real2 sampleDirection = fibonacciSpiralDirection[sampleIndex];
     return sampleDirection * sampleRadius;
 }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAlgorithms.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAlgorithms.hlsl
@@ -9,23 +9,23 @@
 #endif
 
 #ifdef PUNCTUAL_SHADOW_LOW
-#define PUNCTUAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_3x3(_ShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
+#define PUNCTUAL_FILTER_ALGORITHM(sd, posSS, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_3x3(_ShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
 #endif
 #ifdef PUNCTUAL_SHADOW_MEDIUM
-#define PUNCTUAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_5x5(_ShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
+#define PUNCTUAL_FILTER_ALGORITHM(sd, posSS, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_5x5(_ShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
 #endif
 #ifdef PUNCTUAL_SHADOW_HIGH
-#define PUNCTUAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp) SampleShadow_PCSS(posTC, sd.shadowMapSize.xy * _ShadowAtlasSize.zw, sd.atlasOffset, sampleBias, sd.shadowFilterParams0.x, asint(sd.shadowFilterParams0.y), asint(sd.shadowFilterParams0.z), tex, samp, s_point_clamp_sampler)
+#define PUNCTUAL_FILTER_ALGORITHM(sd, posSS, posTC, sampleBias, tex, samp) SampleShadow_PCSS(posTC, posSS, sd.shadowMapSize.xy * _ShadowAtlasSize.zw, sd.atlasOffset, sampleBias, sd.shadowFilterParams0.x, asint(sd.shadowFilterParams0.y), asint(sd.shadowFilterParams0.z), tex, samp, s_point_clamp_sampler)
 #endif
 
 #ifdef DIRECTIONAL_SHADOW_LOW
-#define DIRECTIONAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_5x5(_CascadeShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
+#define DIRECTIONAL_FILTER_ALGORITHM(sd, posSS, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_5x5(_CascadeShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
 #endif
 #ifdef DIRECTIONAL_SHADOW_MEDIUM
-#define DIRECTIONAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_7x7(_CascadeShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
+#define DIRECTIONAL_FILTER_ALGORITHM(sd, posSS, posTC, sampleBias, tex, samp) SampleShadow_PCF_Tent_7x7(_CascadeShadowAtlasSize.zwxy, posTC, sampleBias, tex, samp)
 #endif
 #ifdef DIRECTIONAL_SHADOW_HIGH
-#define DIRECTIONAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp) SampleShadow_PCSS(posTC, sd.shadowMapSize.xy * _CascadeShadowAtlasSize.zw, sd.atlasOffset, sampleBias, sd.shadowFilterParams0.x, asint(sd.shadowFilterParams0.y), asint(sd.shadowFilterParams0.z), tex, samp, s_point_clamp_sampler)
+#define DIRECTIONAL_FILTER_ALGORITHM(sd, posSS, posTC, sampleBias, tex, samp) SampleShadow_PCSS(posTC, posSS, sd.shadowMapSize.xy * _CascadeShadowAtlasSize.zw, sd.atlasOffset, sampleBias, sd.shadowFilterParams0.x, asint(sd.shadowFilterParams0.y), asint(sd.shadowFilterParams0.z), tex, samp, s_point_clamp_sampler)
 #endif
 
 #ifndef PUNCTUAL_FILTER_ALGORITHM
@@ -256,7 +256,7 @@ float2 EvalShadow_SampleBias_Ortho(float3 normalWS)                             
 //
 //  Point shadows
 //
-float EvalShadow_PunctualDepth(HDShadowData sd, Texture2D tex, SamplerComparisonState samp, float3 positionWS, float3 normalWS, float3 L, float L_dist, bool perspective)
+float EvalShadow_PunctualDepth(HDShadowData sd, Texture2D tex, SamplerComparisonState samp, float2 positionSS, float3 positionWS, float3 normalWS, float3 L, float L_dist, bool perspective)
 {
     /* bias the world position */
     float recvBiasWeight = EvalShadow_ReceiverBiasWeight(sd, _ShadowAtlasSize.zw, sd.atlasOffset, sd.viewBias, sd.edgeTolerance, sd.flags, tex, samp, positionWS, normalWS, L, L_dist, perspective);
@@ -266,7 +266,7 @@ float EvalShadow_PunctualDepth(HDShadowData sd, Texture2D tex, SamplerComparison
     /* get the per sample bias */
     float2 sampleBias = EvalShadow_SampleBias_Persp(positionWS, normalWS, posTC);
     /* sample the texture */
-    return PUNCTUAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp);
+    return PUNCTUAL_FILTER_ALGORITHM(sd, positionSS, posTC, sampleBias, tex, samp);
 }
 
 //
@@ -316,7 +316,7 @@ void LoadDirectionalShadowDatas(inout HDShadowData sd, HDShadowContext shadowCon
     sd.atlasOffset = shadowContext.shadowDatas[index].atlasOffset;
 }
 
-float EvalShadow_CascadedDepth_Blend(HDShadowContext shadowContext, Texture2D tex, SamplerComparisonState samp, float3 positionWS, float3 normalWS, int index, float3 L)
+float EvalShadow_CascadedDepth_Blend(HDShadowContext shadowContext, Texture2D tex, SamplerComparisonState samp, float2 positionSS, float3 positionWS, float3 normalWS, int index, float3 L)
 {
     float   alpha;
     int     cascadeCount;
@@ -337,7 +337,7 @@ float EvalShadow_CascadedDepth_Blend(HDShadowContext shadowContext, Texture2D te
         float3 posTC = EvalShadow_GetTexcoordsAtlas(sd, _CascadeShadowAtlasSize.zw, positionWS, false);
         /* evalute the first cascade */
         float2 sampleBias = EvalShadow_SampleBias_Ortho(normalWS);
-        shadow            = DIRECTIONAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp);
+        shadow            = DIRECTIONAL_FILTER_ALGORITHM(sd, positionSS, posTC, sampleBias, tex, samp);
         float  shadow1    = 1.0;
     
         shadowSplitIndex++;
@@ -356,7 +356,7 @@ float EvalShadow_CascadedDepth_Blend(HDShadowContext shadowContext, Texture2D te
     
                 UNITY_BRANCH
                 if (all(abs(posNDC.xy) <= (1.0 - sd.shadowMapSize.zw * 0.5)))
-                    shadow1 = DIRECTIONAL_FILTER_ALGORITHM(sd, posTC, sampleBias, tex, samp);
+                    shadow1 = DIRECTIONAL_FILTER_ALGORITHM(sd, positionSS, posTC, sampleBias, tex, samp);
             }
         }
         shadow = lerp(shadow, shadow1, alpha);

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowSampling.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowSampling.hlsl
@@ -260,20 +260,12 @@ float SampleShadow_MSM_1tap(float3 tcs, float lightLeakBias, float momentBias, f
 
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDPCSS.hlsl"
 
-float InterleavedGradientNoise2(float2 uv, uint frameCount)
-{
-    const float3 magic = float3(0.06711056f, 0.00583715f, 52.9829189f);
-    float2 frameMagicScale = float2(2.083f, 4.867f);
-    uv += frameCount * frameMagicScale;
-    return frac(magic.z * frac(dot(uv, magic.xy)));
-}
-
 //
 //                  PCSS sampling
 //
 float SampleShadow_PCSS(float3 tcs, float2 posSS, float2 scale, float2 offset, float2 sampleBias, float shadowSoftness, int blockerSampleCount, int filterSampleCount, Texture2D tex, SamplerComparisonState compSamp, SamplerState samp)
 {
-    float sampleJitterAngle = InterleavedGradientNoise2(posSS.xy, _FrameCount%8) * 2.0 * PI;
+    float sampleJitterAngle = InterleavedGradientNoise(posSS.xy, (_FrameCount % 8) * _TaaEnabled) * 2.0 * PI;
     float2 sampleJitter = float2(sin(sampleJitterAngle), cos(sampleJitterAngle));
 
     //1) Blocker Search

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowSampling.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowSampling.hlsl
@@ -260,13 +260,21 @@ float SampleShadow_MSM_1tap(float3 tcs, float lightLeakBias, float momentBias, f
 
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDPCSS.hlsl"
 
+float InterleavedGradientNoise2(float2 uv, uint frameCount)
+{
+    const float3 magic = float3(0.06711056f, 0.00583715f, 52.9829189f);
+    float2 frameMagicScale = float2(2.083f, 4.867f);
+    uv += frameCount * frameMagicScale;
+    return frac(magic.z * frac(dot(uv, magic.xy)));
+}
+
 //
 //                  PCSS sampling
 //
-float SampleShadow_PCSS(float3 tcs, float2 scale, float2 offset, float2 sampleBias, float shadowSoftness, int blockerSampleCount, int filterSampleCount, Texture2D tex, SamplerComparisonState compSamp, SamplerState samp)
+float SampleShadow_PCSS(float3 tcs, float2 posSS, float2 scale, float2 offset, float2 sampleBias, float shadowSoftness, int blockerSampleCount, int filterSampleCount, Texture2D tex, SamplerComparisonState compSamp, SamplerState samp)
 {
-    float2 sampleJitter = float2(sin(GenerateHashedRandomFloat(tcs.x)),
-                               cos(GenerateHashedRandomFloat(tcs.y)));
+    float sampleJitterAngle = InterleavedGradientNoise2(posSS.xy, _FrameCount%8) * 2.0 * PI;
+    float2 sampleJitter = float2(sin(sampleJitterAngle), cos(sampleJitterAngle));
 
     //1) Blocker Search
     float averageBlockerDepth = 0.0;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowSampling.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowSampling.hlsl
@@ -265,7 +265,8 @@ float SampleShadow_MSM_1tap(float3 tcs, float lightLeakBias, float momentBias, f
 //
 float SampleShadow_PCSS(float3 tcs, float2 posSS, float2 scale, float2 offset, float2 sampleBias, float shadowSoftness, int blockerSampleCount, int filterSampleCount, Texture2D tex, SamplerComparisonState compSamp, SamplerState samp)
 {
-    float sampleJitterAngle = InterleavedGradientNoise(posSS.xy, (_FrameCount % 8) * _TaaEnabled) * 2.0 * PI;
+    uint taaFrameIndex = _TaaFrameInfo.z;
+    float sampleJitterAngle = InterleavedGradientNoise(posSS.xy, taaFrameIndex) * 2.0 * PI;
     float2 sampleJitter = float2(sin(sampleJitterAngle), cos(sampleJitterAngle));
 
     //1) Blocker Search

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/PCSS.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/PCSS.hlsl
@@ -1,72 +1,100 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
 
-static const float2 poissonDisk64[64] =
+// Fibonacci Spiral Disk Sampling Pattern
+// https://people.irisa.fr/Ricardo.Marques/articles/2013/SF_CGF.pdf
+//
+// Normalized direction vector portion of fibonacci spiral can be baked into a LUT, regardless of sampleCount.
+// This allows us to treat the directions as a progressive sequence, using any sampleCount in range [0, n <= LUT_LENGTH]
+// the radius portion of spiral construction is coupled to sample count, but is fairly cheap to compute at runtime per sample.
+// Generated (in javascript) with:
+// var res = "";
+// for (var i = 0; i < 64; ++i)
+// {
+//     var a = Math.PI * (3.0 - Math.sqrt(5.0));
+//     var b = a / (2.0 * Math.PI);
+//     var c = i * b;
+//     var theta = (c - Math.floor(c)) * 2.0 * Math.PI;
+//     res += "float2 (" + Math.cos(theta) + ", " + Math.sin(theta) + "),\n";
+// }
+
+static const float2 fibonacciSpiralDirection64[64] =
 {
-    float2 ( 0.1187053,   0.7951565),
-    float2 ( 0.1173675,   0.6087878),
-    float2 (-0.09958518,  0.7248842),
-    float2 ( 0.4259812,   0.6152718),
-    float2 ( 0.3723574,   0.8892787),
-    float2 (-0.02289676,  0.9972908),
-    float2 (-0.08234791,  0.5048386),
-    float2 ( 0.1821235,   0.9673787),
-    float2 (-0.2137264,   0.9011746),
-    float2 ( 0.3115066,   0.4205415),
-    float2 ( 0.1216329,   0.383266),
-    float2 ( 0.5948939,   0.7594361),
-    float2 ( 0.7576465,   0.5336417),
-    float2 (-0.521125,    0.7599803),
-    float2 (-0.2923127,   0.6545699),
-    float2 ( 0.6782473,   0.22385),
-    float2 (-0.3077152,   0.4697627),
-    float2 ( 0.4484913,   0.2619455),
-    float2 (-0.5308799,   0.4998215),
-    float2 (-0.7379634,   0.5304936),
-    float2 ( 0.02613133,  0.1764302),
-    float2 (-0.1461073,   0.3047384),
-    float2 (-0.8451027,   0.3249073),
-    float2 (-0.4507707,   0.2101997),
-    float2 (-0.6137282,   0.3283674),
-    float2 (-0.2385868,   0.08716244),
-    float2 ( 0.3386548,   0.01528411),
-    float2 (-0.04230833, -0.1494652),
-    float2 ( 0.167115,   -0.1098648),
-    float2 (-0.525606,    0.01572019),
-    float2 (-0.7966855,   0.1318727),
-    float2 ( 0.5704287,   0.4778273),
-    float2 (-0.9516637,   0.002725032),
-    float2 (-0.7068223,  -0.1572321),
-    float2 ( 0.2173306,  -0.3494083),
-    float2 ( 0.06100426, -0.4492816),
-    float2 ( 0.2333982,   0.2247189),
-    float2 ( 0.07270987, -0.6396734),
-    float2 ( 0.4670808,  -0.2324669),
-    float2 ( 0.3729528,  -0.512625),
-    float2 ( 0.5675077,  -0.4054544),
-    float2 (-0.3691984,  -0.128435),
-    float2 ( 0.8752473,   0.2256988),
-    float2 (-0.2680127,  -0.4684393),
-    float2 (-0.1177551,  -0.7205751),
-    float2 (-0.1270121,  -0.3105424),
-    float2 ( 0.5595394,  -0.06309237),
-    float2 (-0.9299136,  -0.1870008),
-    float2 ( 0.974674,    0.03677348),
-    float2 ( 0.7726735,  -0.06944724),
-    float2 (-0.4995361,  -0.3663749),
-    float2 ( 0.6474168,  -0.2315787),
-    float2 ( 0.1911449,  -0.8858921),
-    float2 ( 0.3671001,  -0.7970535),
-    float2 (-0.6970353,  -0.4449432),
-    float2 (-0.417599,   -0.7189326),
-    float2 (-0.5584748,  -0.6026504),
-    float2 (-0.02624448, -0.9141423),
-    float2 ( 0.565636,   -0.6585149),
-    float2 (-0.874976,   -0.3997879),
-    float2 ( 0.9177843,  -0.2110524),
-    float2 ( 0.8156927,  -0.3969557),
-    float2 (-0.2833054,  -0.8395444),
-    float2 ( 0.799141,   -0.5886372)
+    float2 (1, 0),
+    float2 (-0.7373688780783197, 0.6754902942615238),
+    float2 (0.08742572471695988, -0.9961710408648278),
+    float2 (0.6084388609788625, 0.793600751291696),
+    float2 (-0.9847134853154288, -0.174181950379311),
+    float2 (0.8437552948123969, -0.5367280526263233),
+    float2 (-0.25960430490148884, 0.9657150743757782),
+    float2 (-0.46090702471337114, -0.8874484292452536),
+    float2 (0.9393212963241182, 0.3430386308741014),
+    float2 (-0.924345556137805, 0.3815564084749356),
+    float2 (0.423845995047909, -0.9057342725556143),
+    float2 (0.29928386444487326, 0.9541641203078969),
+    float2 (-0.8652112097532296, -0.501407581232427),
+    float2 (0.9766757736281757, -0.21471942904125949),
+    float2 (-0.5751294291397363, 0.8180624302199686),
+    float2 (-0.12851068979899202, -0.9917081236973847),
+    float2 (0.764648995456044, 0.6444469828838233),
+    float2 (-0.9991460540072823, 0.04131782619737919),
+    float2 (0.7088294143034162, -0.7053799411794157),
+    float2 (-0.04619144594036213, 0.9989326054954552),
+    float2 (-0.6407091449636957, -0.7677836880006569),
+    float2 (0.9910694127331615, 0.1333469877603031),
+    float2 (-0.8208583369658855, 0.5711318504807807),
+    float2 (0.21948136924637865, -0.9756166914079191),
+    float2 (0.4971808749652937, 0.8676469198750981),
+    float2 (-0.952692777196691, -0.30393498034490235),
+    float2 (0.9077911335843911, -0.4194225289437443),
+    float2 (-0.38606108220444624, 0.9224732195609431),
+    float2 (-0.338452279474802, -0.9409835569861519),
+    float2 (0.8851894374032159, 0.4652307598491077),
+    float2 (-0.9669700052147743, 0.25489019011123065),
+    float2 (0.5408377383579945, -0.8411269468800827),
+    float2 (0.16937617250387435, 0.9855514761735877),
+    float2 (-0.7906231749427578, -0.6123030256690173),
+    float2 (0.9965856744766464, -0.08256508601054027),
+    float2 (-0.6790793464527829, 0.7340648753490806),
+    float2 (0.0048782771634473775, -0.9999881011351668),
+    float2 (0.6718851669348499, 0.7406553331023337),
+    float2 (-0.9957327006438772, -0.09228428288961682),
+    float2 (0.7965594417444921, -0.6045602168251754),
+    float2 (-0.17898358311978044, 0.9838520605119474),
+    float2 (-0.5326055939855515, -0.8463635632843003),
+    float2 (0.9644371617105072, 0.26431224169867934),
+    float2 (-0.8896863018294744, 0.4565723210368687),
+    float2 (0.34761681873279826, -0.9376366819478048),
+    float2 (0.3770426545691533, 0.9261958953890079),
+    float2 (-0.9036558571074695, -0.4282593745796637),
+    float2 (0.9556127564793071, -0.2946256262683552),
+    float2 (-0.50562235513749, 0.8627549095688868),
+    float2 (-0.2099523790012021, -0.9777116131824024),
+    float2 (0.8152470554454873, 0.5791133210240138),
+    float2 (-0.9923232342597708, 0.12367133357503751),
+    float2 (0.6481694844288681, -0.7614961060013474),
+    float2 (0.036443223183926, 0.9993357251114194),
+    float2 (-0.7019136816142636, -0.7122620188966349),
+    float2 (0.998695384655528, 0.05106396643179117),
+    float2 (-0.7709001090366207, 0.6369560596205411),
+    float2 (0.13818011236605823, -0.9904071165669719),
+    float2 (0.5671206801804437, 0.8236347091470047),
+    float2 (-0.9745343917253847, -0.22423808629319533),
+    float2 (0.8700619819701214, -0.49294233692210304),
+    float2 (-0.30857886328244405, 0.9511987621603146),
+    float2 (-0.4149890815356195, -0.9098263912451776),
+    float2 (0.9205789302157817, 0.3905565685566777)
 };
+
+real2 ComputeFibonacciSpiralDiskSample(const in int sampleIndex, const in real diskRadius, const in real sampleCountInverse, const in real sampleCountBias)
+{
+    // Note: To sample uniformly within the disk we would compute radius as:
+    // radius = lightArea * sqrt((real)i * sampleCountInverse + sampleCountBias);
+    // For performance we drop the sqrt(), resulting in a higher sample density toward the center of the disk.
+    // Visually resulting in a curved falloff function.
+    real sampleRadius = diskRadius * ((real)sampleIndex * sampleCountInverse + sampleCountBias);
+    real2 sampleDirection = fibonacciSpiralDirection64[sampleIndex];
+    return sampleDirection * sampleRadius;
+}
 
 real PenumbraSize(real Reciever, real Blocker)
 {
@@ -76,10 +104,16 @@ real PenumbraSize(real Reciever, real Blocker)
 bool BlockerSearch(inout real averageBlockerDepth, inout real numBlockers, real lightArea, real3 coord, real2 sampleJitter, real2 sampleBias, ShadowContext shadowContext, float slice, uint texIdx, uint sampIdx, int sampleCount)
 {
     real blockerSum = 0.0;
+
+    real sampleCountInverse = rcp((real)sampleCount);
+    real sampleCountBias = 0.5 * sampleCountInverse;
+    real ditherRotation = sampleJitter.x;
+
     for (int i = 0; i < sampleCount; ++i)
     {
-        real2 offset = real2(poissonDisk64[i].x *  sampleJitter.y + poissonDisk64[i].y * sampleJitter.x,
-                             poissonDisk64[i].x * -sampleJitter.x + poissonDisk64[i].y * sampleJitter.y) * lightArea;
+        real2 offset = ComputeFibonacciSpiralDiskSample(i, lightArea, sampleCountInverse, sampleCountBias);
+        offset = real2(offset.x *  sampleJitter.y + offset.y * sampleJitter.x,
+            offset.x * -sampleJitter.x + offset.y * sampleJitter.y);
 
         real shadowMapDepth = SampleShadow_T2DA(shadowContext, texIdx, sampIdx, coord.xy + offset, slice).x;
 
@@ -97,10 +131,15 @@ bool BlockerSearch(inout real averageBlockerDepth, inout real numBlockers, real 
 bool BlockerSearch(inout real averageBlockerDepth, inout real numBlockers, real lightArea, real3 coord, float slice, real2 sampleJitter, real2 sampleBias, Texture2DArray shadowMap, SamplerState PointSampler, int sampleCount)
 {
     real blockerSum = 0.0;
+    real sampleCountInverse = rcp((real)sampleCount);
+    real sampleCountBias = 0.5 * sampleCountInverse;
+    real ditherRotation = sampleJitter.x;
+
     for (int i = 0; i < sampleCount; ++i)
     {
-        real2 offset = real2(poissonDisk64[i].x *  sampleJitter.y + poissonDisk64[i].y * sampleJitter.x,
-                             poissonDisk64[i].x * -sampleJitter.x + poissonDisk64[i].y * sampleJitter.y) * lightArea;
+        real2 offset = ComputeFibonacciSpiralDiskSample(i, lightArea, sampleCountInverse, sampleCountBias);
+        offset = real2(offset.x *  sampleJitter.y + offset.y * sampleJitter.x,
+            offset.x * -sampleJitter.x + offset.y * sampleJitter.y);
 
         real shadowMapDepth = SAMPLE_TEXTURE2D_ARRAY_LOD(shadowMap, PointSampler, coord.xy + offset, slice, 0.0).x;
 
@@ -124,10 +163,15 @@ real PCSS(real3 coord, real filterRadius, real4 scaleOffset, float slice, real2 
     real VMax = scaleOffset.w + scaleOffset.y;
 
     real sum = 0.0;
+    real sampleCountInverse = rcp((real)sampleCount);
+    real sampleCountBias = 0.5 * sampleCountInverse;
+    real ditherRotation = sampleJitter.x;
+
     for(int i = 0; i < sampleCount; ++i)
     {
-        real2 offset = real2(poissonDisk64[i].x *  sampleJitter.y + poissonDisk64[i].y * sampleJitter.x,
-                             poissonDisk64[i].x * -sampleJitter.x + poissonDisk64[i].y * sampleJitter.y) * filterRadius;
+        real2 offset = ComputeFibonacciSpiralDiskSample(i, filterRadius, sampleCountInverse, sampleCountBias);
+        offset = real2(offset.x *  sampleJitter.y + offset.y * sampleJitter.x,
+                        offset.x * -sampleJitter.x + offset.y * sampleJitter.y);
 
         real U = coord.x + offset.x;
         real V = coord.y + offset.y;
@@ -153,10 +197,15 @@ real PCSS(real3 coord, real filterRadius, real4 scaleOffset, float slice, real2 
     real VMax = scaleOffset.w + scaleOffset.y;
 
     real sum = 0.0;
+    real sampleCountInverse = rcp((real)sampleCount);
+    real sampleCountBias = 0.5 * sampleCountInverse;
+    real ditherRotation = sampleJitter.x;
+
     for(int i = 0; i < sampleCount; ++i)
     {
-        real2 offset = real2(poissonDisk64[i].x *  sampleJitter.y + poissonDisk64[i].y * sampleJitter.x,
-                             poissonDisk64[i].x * -sampleJitter.x + poissonDisk64[i].y * sampleJitter.y) * filterRadius;
+        real2 offset = ComputeFibonacciSpiralDiskSample(i, filterRadius, sampleCountInverse, sampleCountBias);
+        offset = real2(offset.x *  sampleJitter.y + offset.y * sampleJitter.x,
+                       offset.x * -sampleJitter.x + offset.y * sampleJitter.y);
 
         real U = coord.x + offset.x;
         real V = coord.y + offset.y;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/ScreenSpaceShadow.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/ScreenSpaceShadow.compute
@@ -36,21 +36,11 @@ CBUFFER_END
 #define _ContactShadowFadeEnd               _ContactShadowParamsParameters.z
 #define _ContactShadowFadeOneOverRange      _ContactShadowParamsParameters.w
 #define _ContactShadowOpacity               _ContactShadowParamsParameters2.x
-#define _EnableTimeDependentNoise           _ContactShadowParamsParameters2.y
-#define _RenderTargetHeight                 _ContactShadowParamsParameters2.z
+#define _RenderTargetHeight                 _ContactShadowParamsParameters2.y
 
 #define DEFERRED_SHADOW_TILE_SIZE 16
 
 
-//From  Next Generation Post Processing in Call of Duty: Advanced Warfare [Jimenez 2014]
-// http://advances.realtimerendering.com/s2014/index.html
-float InterleavedGradientNoise(float2 uv, uint frameCount)
-{
-    const float3 magic = float3(0.06711056f, 0.00583715f, 52.9829189f);
-    float2 frameMagicScale = _EnableTimeDependentNoise * float2(2.083f, 4.867f);
-    uv += frameCount * frameMagicScale;
-    return frac(magic.z * frac(dot(uv, magic.xy)));
-}
 
 float SampleDepth(float2 UV, bool HalfRes)
 {
@@ -73,7 +63,7 @@ float ScreenSpaceShadowRayCast(float3 positionWS, float3 rayDirWS, float rayLeng
     float ditherBias = 0.5f;
     // With a mod of 8 and taa we'd get no visible flickering, but the stitching pattern is more noticeable. With %16 we do get a bit of visible flickering, but a smoother gradient.
     // If TAA is off, the noise pattern does not vary over time. 
-    float dither = InterleavedGradientNoise(positionSS, _FrameCount % 16u) - ditherBias;
+    float dither = InterleavedGradientNoise(positionSS, (_FrameCount % 16u) * _TaaEnabled) - ditherBias;
 
     float3 rayStartWS = positionWS;
     float3 rayEndWS = rayStartWS + rayDirWS * rayLength;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/ScreenSpaceShadow.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/ScreenSpaceShadow.compute
@@ -62,8 +62,9 @@ float ScreenSpaceShadowRayCast(float3 positionWS, float3 rayDirWS, float rayLeng
     // Dither pattern is shifted by 0.5 because we want to jitter the ray starting position backward and forward (so we need values between -0.5 and 0.5)
     float ditherBias = 0.5f;
     // With a mod of 8 and taa we'd get no visible flickering, but the stitching pattern is more noticeable. With %16 we do get a bit of visible flickering, but a smoother gradient.
-    // If TAA is off, the noise pattern does not vary over time. 
-    float dither = InterleavedGradientNoise(positionSS, (_FrameCount % 16u) * _TaaEnabled) - ditherBias;
+    // If TAA is off, the noise pattern does not vary over time.
+    uint taaEnabled = _TaaFrameInfo.w;
+    float dither = InterleavedGradientNoise(positionSS, (_FrameCount % 16u) * taaEnabled) - ditherBias;
 
     float3 rayStartWS = positionWS;
     float3 rayEndWS = rayStartWS + rayDirWS * rayLength;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -173,7 +173,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _CosTime        = Shader.PropertyToID("_CosTime");
         public static readonly int unity_DeltaTime = Shader.PropertyToID("unity_DeltaTime");
 
-        public static readonly int _TAAEnabled     = Shader.PropertyToID("_TaaEnabled");
 
 
         public static readonly int _EnvLightSkyEnabled = Shader.PropertyToID("_EnvLightSkyEnabled");
@@ -248,7 +247,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _ScreenToTargetScale = Shader.PropertyToID("_ScreenToTargetScale");
         public static readonly int _PrevViewProjMatrix = Shader.PropertyToID("_PrevViewProjMatrix");
         public static readonly int _FrustumPlanes = Shader.PropertyToID("_FrustumPlanes");
-        public static readonly int _TaaFrameRotation = Shader.PropertyToID("_TaaFrameRotation");
+        public static readonly int _TaaFrameInfo = Shader.PropertyToID("_TaaFrameInfo");
 
         public static readonly int _ViewMatrixStereo = Shader.PropertyToID("_ViewMatrixStereo");
         public static readonly int _ProjMatrixStereo = Shader.PropertyToID("_ProjMatrixStereo");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -173,6 +173,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _CosTime        = Shader.PropertyToID("_CosTime");
         public static readonly int unity_DeltaTime = Shader.PropertyToID("unity_DeltaTime");
 
+        public static readonly int _TAAEnabled     = Shader.PropertyToID("_TaaEnabled");
+
+
         public static readonly int _EnvLightSkyEnabled = Shader.PropertyToID("_EnvLightSkyEnabled");
         public static readonly int _AmbientOcclusionParam = Shader.PropertyToID("_AmbientOcclusionParam");
         public static readonly int _SkyTexture = Shader.PropertyToID("_SkyTexture");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -173,8 +173,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _CosTime        = Shader.PropertyToID("_CosTime");
         public static readonly int unity_DeltaTime = Shader.PropertyToID("unity_DeltaTime");
 
-
-
         public static readonly int _EnvLightSkyEnabled = Shader.PropertyToID("_EnvLightSkyEnabled");
         public static readonly int _AmbientOcclusionParam = Shader.PropertyToID("_AmbientOcclusionParam");
         public static readonly int _SkyTexture = Shader.PropertyToID("_SkyTexture");

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -255,6 +255,7 @@ CBUFFER_START(UnityGlobal)
 
     // TAA Frame Index ranges from 0 to 7. This gives you two rotations per cycle.
     float4 _TaaFrameRotation;           // { sin(taaFrame * PI/2), cos(taaFrame * PI/2), 0, 0 }
+    int _TaaEnabled;
     // t = animateMaterials ? Time.realtimeSinceStartup : 0.
     float4 _Time;                       // { t/20, t, t*2, t*3 }
     float4 _LastTime;                   // { t/20, t, t*2, t*3 }

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -254,9 +254,8 @@ CBUFFER_START(UnityGlobal)
     float4 _FrustumPlanes[6];           // { (a, b, c) = N, d = -dot(N, P) } [L, R, T, B, N, F]
 
     // TAA Frame Index ranges from 0 to 7.
-    // First two channels of this gives you two rotations per cycle. Third channel is the frame index unprocessed and fourth channel is 1 if TAA is enabled.
-    float4 _TaaFrameInfo;           // { sin(taaFrame * PI/2), cos(taaFrame * PI/2), 0, 0 }
-    int _TaaEnabled;
+    // First two channels of this gives you two rotations per cycle. 
+    float4 _TaaFrameInfo;           // { sin(taaFrame * PI/2), cos(taaFrame * PI/2), taaFrame, taaEnabled ? 1 : 0 }
     // t = animateMaterials ? Time.realtimeSinceStartup : 0.
     float4 _Time;                       // { t/20, t, t*2, t*3 }
     float4 _LastTime;                   // { t/20, t, t*2, t*3 }

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -253,8 +253,9 @@ CBUFFER_START(UnityGlobal)
 
     float4 _FrustumPlanes[6];           // { (a, b, c) = N, d = -dot(N, P) } [L, R, T, B, N, F]
 
-    // TAA Frame Index ranges from 0 to 7. This gives you two rotations per cycle.
-    float4 _TaaFrameRotation;           // { sin(taaFrame * PI/2), cos(taaFrame * PI/2), 0, 0 }
+    // TAA Frame Index ranges from 0 to 7.
+    // First two channels of this gives you two rotations per cycle. Third channel is the frame index unprocessed and fourth channel is 1 if TAA is enabled.
+    float4 _TaaFrameInfo;           // { sin(taaFrame * PI/2), cos(taaFrame * PI/2), 0, 0 }
     int _TaaEnabled;
     // t = animateMaterials ? Time.realtimeSinceStartup : 0.
     float4 _Time;                       // { t/20, t, t*2, t*3 }


### PR DESCRIPTION
### Purpose of this PR

This PR contains the following: 

- Mainly @pastasfuture  changes from https://github.com/Unity-Technologies/ScriptableRenderPipeline/commit/de9dc1955b9e0ccd81d7902ab2a522f227571c31  ported to the current state of HDRP. 

- Changed the hash function used for the above to interleaved gradient noise, this is the difference (click to check original sized image): 

![image](https://user-images.githubusercontent.com/43168857/48216060-01315a80-e384-11e8-863f-32410a0cf2b9.png)


Final comparison ( old vs change with fibonacci spiral disk sampling + Interleaved Gradient Noise) 

![image](https://user-images.githubusercontent.com/43168857/48216340-bb28c680-e384-11e8-9c46-d54ee20ce3a3.png)


- Moved Interleaved gradient noise to Random.hlsl as it is now used in two places already, and generally, it is a very handy function.  

---
### Release Notes

Improved quality of PCSS.

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=pcss-sampling-improvements&automation-tools_branch=add-platform-filter&unity_branch=trunk# [Still running]

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**:  Medium

