### PR TITLE
changing *LitInput.hlsl CBUFFER values to float precision

### DIFF
--- a/com.unity.render-pipelines.lightweight/Shaders/LitInput.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/LitInput.hlsl
@@ -7,15 +7,15 @@
 
 CBUFFER_START(UnityPerMaterial)
 float4 _MainTex_ST;
-half4 _Color;
-half4 _SpecColor;
-half4 _EmissionColor;
-half _Cutoff;
-half _Glossiness;
-half _GlossMapScale;
-half _Metallic;
-half _BumpScale;
-half _OcclusionStrength;
+float4 _Color;
+float4 _SpecColor;
+float4 _EmissionColor;
+float _Cutoff;
+float _Glossiness;
+float _GlossMapScale;
+float _Metallic;
+float _BumpScale;
+float _OcclusionStrength;
 CBUFFER_END
 
 TEXTURE2D(_OcclusionMap);       SAMPLER(sampler_OcclusionMap);

--- a/com.unity.render-pipelines.lightweight/Shaders/SimpleLitInput.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/SimpleLitInput.hlsl
@@ -6,11 +6,11 @@
 
 CBUFFER_START(UnityPerMaterial)
 float4 _MainTex_ST;
-half4 _Color;
-half4 _SpecColor;
-half4 _EmissionColor;
-half _Cutoff;
-half _Shininess;
+float4 _Color;
+float4 _SpecColor;
+float4 _EmissionColor;
+float _Cutoff;
+float _Shininess;
 CBUFFER_END
 
 TEXTURE2D(_SpecGlossMap);       SAMPLER(sampler_SpecGlossMap);

--- a/com.unity.render-pipelines.lightweight/Shaders/UnlitInput.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/UnlitInput.hlsl
@@ -5,10 +5,10 @@
 
 CBUFFER_START(UnityPerMaterial)
 float4 _MainTex_ST;
-half4 _Color;
-half _Cutoff;
-half _Glossiness;
-half _Metallic;
+float4 _Color;
+float _Cutoff;
+float _Glossiness;
+float _Metallic;
 CBUFFER_END
 
 #endif


### PR DESCRIPTION
### Purpose of this PR
SRP Batcher on metal doesn't support half values in CBUFFER structs. Therefore, changing the precision enables user's to use SRP Batcher to increase perf and etc.

Changes were introduced in the Megacity mobile demo.

### Testing status
**Katana Tests**: running katana at the moment

**Manual Tests**: checked performance/visual correctness on megacity example

---
### Overall Product Risks
**Technical Risk**: low (might affect performance/mem usage a little bit

**Halo Effect**: low (most other platforms already use float)

---
### Comments to reviewers
Notes for the reviewers you have assigned.
