### PR TITLE
Fix metallic value of converted material

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/StandardsToHDLitMaterialUpgrader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/StandardsToHDLitMaterialUpgrader.cs
@@ -55,10 +55,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             Texture metallicMap = TextureCombiner.TextureFromColor(Color.black);
             if ((srcMaterial.shader.name == Standard) || (srcMaterial.shader.name == Standard_Rough))
             {
-                // Convert _Metallic value from Gamma to Linear
-                float metallicValue = Mathf.Pow(srcMaterial.GetFloat("_Metallic"), 2.2f);
-                dstMaterial.SetFloat("_Metallic", metallicValue);
-
                 hasMetallic = srcMaterial.GetTexture("_MetallicGlossMap") != null;
                 if (hasMetallic)
                 {
@@ -68,6 +64,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 {
                     metallicMap = TextureCombiner.TextureFromColor(Color.white);
                 }
+
+                // Convert _Metallic value from Gamma to Linear, or set to 1 if a map is used
+                float metallicValue = Mathf.Pow(srcMaterial.GetFloat("_Metallic"), 2.2f);
+                dstMaterial.SetFloat("_Metallic", hasMetallic? 1f : metallicValue);
             }
 
             // Occlusion
@@ -205,16 +205,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
 
             Color hdrEmission = srcMaterial.GetColor("_EmissionColor");
-            
+
             // Get the _EMISSION keyword of the Standard shader
             if ( !srcMaterial.IsKeywordEnabled("_EMISSION") )
                 hdrEmission = Color.black;
-            
+
             // Emission toggle of Particle Standard Surface
             if( srcMaterial.HasProperty("_EmissionEnabled") )
                 if (srcMaterial.GetFloat("_EmissionEnabled") == 0)
                     hdrEmission = Color.black;
-            
+
             dstMaterial.SetColor("_EmissiveColor", hdrEmission);
 
             HDEditorUtils.ResetMaterialKeywords(dstMaterial);


### PR DESCRIPTION
### Purpose of this PR
The metallic value of a converted material is now set to 1 if a map is used. Before it was using the value set in the "_Metallic" property of the standard shader, but it was ignored if a map was set.

---
### Testing status
**Katana Tests**: No test, editor only tool.

**Manual Tests**: Tested proper value conversion.

**Automated Tests**: No.

---
### Overall Product Risks
**Technical Risk**: None.

**Halo Effect**: None.
