### PR TITLE
Fix folder exception

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Non-exposed properties in the blackboard no longer have a green dot next to them.
 - Default reference name for shader properties are now serialized. You cannot change them after initial creation.
 - When you save Shader Graph and Sub Graph files, they're now automatically checked out on version control.
+- Shader Graph no longer throws an exception when a folder is double-clicked in the Project window.
 
 ## [5.0.0-preview] - 2018-09-28
 

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Non-exposed properties in the blackboard no longer have a green dot next to them.
 - Default reference name for shader properties are now serialized. You cannot change them after initial creation.
 - When you save Shader Graph and Sub Graph files, they're now automatically checked out on version control.
-- Shader Graph no longer throws an exception when a folder is double-clicked in the Project window.
+- Shader Graph no longer throws an exception when you double-click a folder in the Project window.
 
 ## [5.0.0-preview] - 2018-09-28
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporterEditor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporterEditor.cs
@@ -25,7 +25,7 @@ namespace UnityEditor.ShaderGraph
         {
             var guid = AssetDatabase.AssetPathToGUID(path);
             var extension = Path.GetExtension(path);
-            if (extension == null)
+            if (string.IsNullOrEmpty(extension))
                 return false;
             // Path.GetExtension returns the extension prefixed with ".", so we remove it. We force lower case such that
             // the comparison will be case-insensitive.


### PR DESCRIPTION
### Purpose of this PR
This exception would throw when double clicking a folder in the Project window if Shader Graph was installed:
```
Exception thrown while invoking [OnOpenAssetAttribute] method 'UnityEditor.ShaderGraph.ShaderGraphImporterEditor:OnOpenAsset (int,int)' : ArgumentOutOfRangeException: Argument is out of range.
Parameter name: startIndex
System.String.Substring (Int32 startIndex) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System/String.cs:333)
UnityEditor.ShaderGraph.ShaderGraphImporterEditor.ShowGraphEditWindow (System.String path) (at Library/PackageCache/com.unity.shadergraph@5.0.0-preview/Editor/Importers/ShaderGraphImporterEditor.cs:32)
UnityEditor.ShaderGraph.ShaderGraphImporterEditor.OnOpenAsset (Int32 instanceID, Int32 line) (at Library/PackageCache/com.unity.shadergraph@5.0.0-preview/Editor/Importers/ShaderGraphImporterEditor.cs:60)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
```

Introduced by this change: https://github.com/Unity-Technologies/ScriptableRenderPipeline/commit/64f36a0acc3aa11aa42b2d75087a2c5603a07c62#diff-b9f5f4df403bafa611e71cf539877d4dR28

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Ffix-folder-exception&automation-tools_branch=add-platform-filter&unity_branch=trunk

**Manual Tests**: Verified that before the fix the exception is thrown, and after the fix it is not thrown.

**Automated Tests**: Nothing

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None