### PR TITLE
Perform a small optimization of HDRP shader compile times [On Hold]

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
@@ -261,7 +261,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected override void BaseMaterialPropertiesGUI()
         {
             base.BaseMaterialPropertiesGUI();
-            
+
             // This follow double sided option
             if (doubleSidedEnable != null && doubleSidedEnable.floatValue > 0.0f)
             {
@@ -285,7 +285,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (supportDecals != null)
             {
                 m_MaterialEditor.ShaderProperty(supportDecals, StylesBaseLit.supportDecalsText);
-            }            
+            }
 
             if (enableGeometricSpecularAA != null)
             {
@@ -451,6 +451,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             SetupBaseUnlitKeywords(material);
 
+            int materialInstanceFlags = 0;
+
             bool doubleSidedEnable = material.HasProperty(kDoubleSidedEnable) ? material.GetFloat(kDoubleSidedEnable) > 0.0f : false;
             if (doubleSidedEnable)
             {
@@ -507,8 +509,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 bool displacementLockTilingScale = material.GetFloat(kDisplacementLockTilingScale) > 0.0;
                 // Tessellation reuse vertex flag.
                 CoreUtils.SetKeyword(material, "_VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE", displacementLockObjectScale && (enableVertexDisplacement || enableTessellationDisplacement));
-                CoreUtils.SetKeyword(material, "_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE", displacementLockObjectScale && enablePixelDisplacement);
                 CoreUtils.SetKeyword(material, "_DISPLACEMENT_LOCK_TILING_SCALE", displacementLockTilingScale && enableDisplacement);
+
+                bool ppdLockObjectScale = enablePixelDisplacement && displacementLockObjectScale;
+                materialInstanceFlags |= ppdLockObjectScale ? (int)MaterialInstanceFlags.PerPixelDisplacementLockObjectScale : 0;
 
                 // Depth offset is only enabled if per pixel displacement is
                 bool depthOffsetEnable = (material.GetFloat(kDepthOffsetEnable) > 0.0f) && enablePixelDisplacement;
@@ -530,6 +534,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             CoreUtils.SetKeyword(material, "_DISABLE_DECALS", material.HasProperty(kSupportDecals) && material.GetFloat(kSupportDecals) == 0.0);
             CoreUtils.SetKeyword(material, "_DISABLE_SSR", material.HasProperty(kReceivesSSR) && material.GetFloat(kReceivesSSR) == 0.0);
             CoreUtils.SetKeyword(material, "_ENABLE_GEOMETRIC_SPECULAR_AA", material.HasProperty(kEnableGeometricSpecularAA) && material.GetFloat(kEnableGeometricSpecularAA) == 1.0);
+
+            material.SetInt("_MaterialInstanceFlags", materialInstanceFlags);
         }
 
         static public void SetupBaseLitMaterialPass(Material material)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitUI.cs
@@ -509,10 +509,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 bool displacementLockTilingScale = material.GetFloat(kDisplacementLockTilingScale) > 0.0;
                 // Tessellation reuse vertex flag.
                 CoreUtils.SetKeyword(material, "_VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE", displacementLockObjectScale && (enableVertexDisplacement || enableTessellationDisplacement));
-                CoreUtils.SetKeyword(material, "_DISPLACEMENT_LOCK_TILING_SCALE", displacementLockTilingScale && enableDisplacement);
 
                 bool ppdLockObjectScale = enablePixelDisplacement && displacementLockObjectScale;
                 materialInstanceFlags |= ppdLockObjectScale ? (int)MaterialInstanceFlags.PerPixelDisplacementLockObjectScale : 0;
+
+                bool lockTilingScale = enableDisplacement && displacementLockTilingScale;
+                materialInstanceFlags |= lockTilingScale ? (int)MaterialInstanceFlags.DisplacementLockTilingScale : 0;
 
                 // Depth offset is only enabled if per pixel displacement is
                 bool depthOffsetEnable = (material.GetFloat(kDepthOffsetEnable) > 0.0f) && enablePixelDisplacement;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -5,6 +5,9 @@ Shader "HDRenderPipeline/LayeredLit"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bitfield containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -360,7 +363,6 @@ Shader "HDRenderPipeline/LayeredLit"
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _VERTEX_WIND
 
     #pragma shader_feature _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -362,7 +362,6 @@ Shader "HDRenderPipeline/LayeredLit"
     #pragma shader_feature _DOUBLESIDED_ON
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
     #pragma shader_feature _VERTEX_WIND
 
     #pragma shader_feature _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
@@ -403,24 +403,27 @@ void GetLayerTexCoord(FragInputs input, inout LayerTexCoord layerTexCoord)
 void ApplyDisplacementTileScale(inout float height0, inout float height1, inout float height2, inout float height3)
 {
     // When we change the tiling, we have want to conserve the ratio with the displacement (and this is consistent with per pixel displacement)
-#ifdef _DISPLACEMENT_LOCK_TILING_SCALE
-    float tileObjectScale = 1.0;
+    bool lockTilingScale = HasFlag(asuint(_MaterialInstanceFlags), MATERIALINSTANCEFLAGS_DISPLACEMENT_LOCK_TILING_SCALE);
+
+    if (lockTilingScale)
+    {
+        float tileObjectScale = 1.0;
     #ifdef _LAYER_TILING_COUPLED_WITH_UNIFORM_OBJECT_SCALE
-    // Extract scaling from world transform
-    float4x4 worldTransform = GetObjectToWorldMatrix();
-    // assuming uniform scaling, take only the first column
-    tileObjectScale = length(float3(worldTransform._m00, worldTransform._m01, worldTransform._m02));
+        // Extract scaling from world transform
+        float4x4 worldTransform = GetObjectToWorldMatrix();
+        // assuming uniform scaling, take only the first column
+        tileObjectScale = length(float3(worldTransform._m00, worldTransform._m01, worldTransform._m02));
     #endif
 
-    // TODO: precompute all these scaling factors!
-    height0 *= _InvTilingScale0;
+        // TODO: precompute all these scaling factors!
+        height0 *= _InvTilingScale0;
     #if !defined(_MAIN_LAYER_INFLUENCE_MODE)
-    height0 /= tileObjectScale;  // We only affect layer0 in case we are not in influence mode (i.e we should not change the base object)
+        height0 /= tileObjectScale;  // We only affect layer0 in case we are not in influence mode (i.e we should not change the base object)
     #endif
-    height1 = (height1 / tileObjectScale) * _InvTilingScale1;
-    height2 = (height2 / tileObjectScale) * _InvTilingScale2;
-    height3 = (height3 / tileObjectScale) * _InvTilingScale3;
-#endif
+        height1 = (height1 / tileObjectScale) * _InvTilingScale1;
+        height2 = (height2 / tileObjectScale) * _InvTilingScale2;
+        height3 = (height3 / tileObjectScale) * _InvTilingScale3;
+    }
 }
 
 // This function is just syntaxic sugar to nullify height not used based on heightmap avaibility and layer

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -372,7 +372,6 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
     #pragma shader_feature _DOUBLESIDED_ON
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT _TESSELLATION_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
     #pragma shader_feature _VERTEX_WIND
     #pragma shader_feature _TESSELLATION_PHONG
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -5,6 +5,9 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bitfield containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -370,7 +373,6 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT _TESSELLATION_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _VERTEX_WIND
     #pragma shader_feature _TESSELLATION_PHONG
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -5,6 +5,9 @@ Shader "HDRenderPipeline/Lit"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bitfield containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -222,7 +225,6 @@ Shader "HDRenderPipeline/Lit"
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _VERTEX_WIND
     #pragma shader_feature _ _REFRACTION_PLANE _REFRACTION_SPHERE
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -224,7 +224,6 @@ Shader "HDRenderPipeline/Lit"
     #pragma shader_feature _DOUBLESIDED_ON
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
     #pragma shader_feature _VERTEX_WIND
     #pragma shader_feature _ _REFRACTION_PLANE _REFRACTION_SPHERE
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDataDisplacement.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDataDisplacement.hlsl
@@ -19,11 +19,19 @@ float3 GetDisplacementObjectScale(bool vertexDisplacement)
     }
 
     objectScale.x = length(float3(worldTransform._m00, worldTransform._m01, worldTransform._m02));
-    // In the specific case of pixel displacement mapping, to get a consistent behavior compare to tessellation we require to not take into account y scale if lock object scale is not enabled
-#if !defined(_PIXEL_DISPLACEMENT) || (defined(_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE))
-    objectScale.y = length(float3(worldTransform._m10, worldTransform._m11, worldTransform._m12));
-#endif
     objectScale.z = length(float3(worldTransform._m20, worldTransform._m21, worldTransform._m22));
+
+    // In the specific case of pixel displacement mapping, to get a consistent behavior compare to tessellation we require to not take into account y scale if lock object scale is not enabled
+#if defined(_PIXEL_DISPLACEMENT)
+    bool lockObjectScale = HasFlag(asuint(_MaterialInstanceFlags), MATERIALINSTANCEFLAGS_PER_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE);
+#else
+    bool lockObjectScale = true;
+#endif
+
+    if (lockObjectScale)
+    {
+        objectScale.y = length(float3(worldTransform._m10, worldTransform._m11, worldTransform._m12));
+    }
 
     return objectScale;
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitProperties.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitProperties.hlsl
@@ -100,6 +100,7 @@ SAMPLER(sampler_LayerInfluenceMaskMap);
 CBUFFER_START(UnityPerMaterial)
 
 // shared constant between lit and layered lit
+int   _MaterialInstanceFlags;
 float _AlphaCutoff;
 float _AlphaCutoffPrepass;
 float _AlphaCutoffPostpass;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -234,7 +234,6 @@ Shader "HDRenderPipeline/LitTessellation"
     #pragma shader_feature _DOUBLESIDED_ON
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT _TESSELLATION_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
     #pragma shader_feature _VERTEX_WIND
     #pragma shader_feature _ _TESSELLATION_PHONG
     #pragma shader_feature _ _REFRACTION_PLANE _REFRACTION_SPHERE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -5,6 +5,9 @@ Shader "HDRenderPipeline/LitTessellation"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bitfield containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -232,7 +235,6 @@ Shader "HDRenderPipeline/LitTessellation"
     #pragma shader_feature _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT _TESSELLATION_DISPLACEMENT
     #pragma shader_feature _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature _VERTEX_WIND
     #pragma shader_feature _ _TESSELLATION_PHONG
     #pragma shader_feature _ _REFRACTION_PLANE _REFRACTION_SPHERE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl
@@ -9,6 +9,8 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/CommonMaterial.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/EntityLighting.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
+
+#include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl"
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/AtmosphericScattering/AtmosphericScattering.hlsl"
 
 // Guidelines for Material Keyword.

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs
@@ -1,0 +1,11 @@
+using UnityEngine.Experimental.Rendering;
+
+namespace UnityEditor.Experimental.Rendering.HDPipeline
+{
+    [GenerateHLSL]
+    public enum MaterialInstanceFlags
+    {
+        PerPixelDisplacementLockObjectScale = 1,
+        Bla = 2
+    }
+} // namespace UnityEditor

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs
@@ -6,6 +6,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
     public enum MaterialInstanceFlags
     {
         PerPixelDisplacementLockObjectScale = 1,
-        Bla = 2
+        DisplacementLockTilingScale = 2
     }
 } // namespace UnityEditor

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl
@@ -8,7 +8,7 @@
 // UnityEditor.Experimental.Rendering.HDPipeline.MaterialInstanceFlags:  static fields
 //
 #define MATERIALINSTANCEFLAGS_PER_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE (1)
-#define MATERIALINSTANCEFLAGS_BLA (2)
+#define MATERIALINSTANCEFLAGS_DISPLACEMENT_LOCK_TILING_SCALE (2)
 
 
 #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl
@@ -1,0 +1,14 @@
+//
+// This file was automatically generated. Please don't edit by hand.
+//
+
+#ifndef MATERIALINSTANCEFLAGS_CS_HLSL
+#define MATERIALINSTANCEFLAGS_CS_HLSL
+//
+// UnityEditor.Experimental.Rendering.HDPipeline.MaterialInstanceFlags:  static fields
+//
+#define MATERIALINSTANCEFLAGS_PER_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE (1)
+#define MATERIALINSTANCEFLAGS_BLA (2)
+
+
+#endif

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8d1e864d4465ab14cb62ba0962bb59f4
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a24d2e1a10bf2e841a72fa12654d25db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
- Add 'MaterialInstanceFlags' which are used for conversion of Shader Features into uniform branches
- Remove '_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE' and '_DISPLACEMENT_LOCK_TILING_SCALE' as an example

## Testing status
**Katana Tests**: soon (tm)

### Comments to reviewers
Upgrading old materials needs to be tested.
