### PR TITLE
Wave intrinsics renaming

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -11,8 +11,7 @@
 #define INTRINSIC_WaveReadLaneFirst
 #define WaveReadLaneFirst ReadFirstLane
 #define INTRINSIC_MAD24
-#define Mad24Int mad24
-#define Mad24Uint mad24
+#define Mad24 mad24
 #define INTRINSIC_MINMAX3
 #define Min3 min3
 #define Max3 max3

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -8,8 +8,8 @@
 #define BitFieldExtractSignExtend __v_bfe_i32
 #define INTRINSIC_BITFIELD_INSERT
 #define BitFieldInsert __v_bfi_b32
-#define INTRINSIC_WAVEREADFIRSTLANE
-#define WaveReadFirstLane ReadFirstLane
+#define INTRINSIC_WaveReadLaneFirst
+#define WaveReadLaneFirst ReadFirstLane
 #define INTRINSIC_MAD24
 #define Mad24Int mad24
 #define Mad24Uint mad24

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -8,7 +8,7 @@
 #define BitFieldExtractSignExtend __v_bfe_i32
 #define INTRINSIC_BITFIELD_INSERT
 #define BitFieldInsert __v_bfi_b32
-#define INTRINSIC_WaveReadLaneFirst
+#define INTRINSIC_WAVEREADFIRSTLANE
 #define WaveReadLaneFirst ReadFirstLane
 #define INTRINSIC_MAD24
 #define Mad24 mad24

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -18,19 +18,15 @@
 #define Max3 max3
 #define INTRINSIC_CUBEMAP_FACE_ID
 #define INTRINSIC_WAVE_MINMAX
-#define WaveMinInt CrossLaneMin
-#define WaveMinUint CrossLaneMin
-#define WaveMinFloat CrossLaneMin
-#define WaveMaxInt CrossLaneMax
-#define WaveMaxUint CrossLaneMax
-#define WaveMaxFloat CrossLaneMax
+#define WaveActiveMin CrossLaneMin
+#define WaveActiveMax CrossLaneMax
 #define INTRINSIC_BALLOT
-#define Ballot ballot
+#define WaveActiveBallot ballot
 #define INTRINSIC_WAVE_SUM
-#define WaveAdd CrossLaneAdd
+#define WaveActiveSum CrossLaneAdd
 #define INTRINSIC_WAVE_LOGICAL_OPS
-#define WaveAnd CrossLaneAnd
-#define WaveOr CrossLaneOr
+#define WaveActiveBitAnd CrossLaneAnd
+#define WaveActiveBitOr CrossLaneOr
 
 
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -20,8 +20,8 @@
 // Intrinsics
 #define SUPPORTS_WAVE_INTRINSICS
 
-#define INTRINSIC_WAVEREADFIRSTLANE
-#define WaveReadFirstLane __XB_MakeUniform
+#define INTRINSIC_WaveReadLaneFirst
+#define WaveReadLaneFirst __XB_MakeUniform
 #define INTRINSIC_MINMAX3
 #define Min3 __XB_Min3_F32
 #define Max3 __XB_Max3_F32

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -1,3 +1,5 @@
+#include "Macros.hlsl"
+
 // This file assume SHADER_API_XBOXONE is defined
 
 #define UNITY_UV_STARTS_AT_TOP 1
@@ -34,20 +36,25 @@
 #define BitFieldExtractSignExtend __XB_IBFE
 #define INTRINSIC_BITFIELD_INSERT
 #define BitFieldInsert __XB_BFI
-#define INTRINSIC_WAVE_MINMAX
-#define WaveMinInt __XB_WaveMin_I32
-#define WaveMinUint __XB_WaveMin_U32
-#define WaveMinFloat __XB_WaveMin_F32
-#define WaveMaxInt __XB_WaveMax_I32
-#define WaveMaxUint __XB_WaveMax_U32
-#define WaveMaxFloat __XB_WaveMax_F32
 #define INTRINSIC_BALLOT
-#define Ballot __XB_Ballot64
-#define INTRINSIC_WAVE_SUM
-#define WaveAdd __XB_WaveAdd_F32
+#define WaveActiveBallot __XB_WaveActiveBallot64
 #define INTRINSIC_WAVE_LOGICAL_OPS
-#define WaveAnd __XB_WaveAND
-#define WaveOr __XB_WaveOR
+#define WaveActiveBitAnd __XB_WaveAND
+#define WaveActiveBitOr __XB_WaveOR
+
+#define INTRINSIC_WAVE_MINMAX
+TEMPLATE_1_REAL(WaveActiveMin, value, return __XB_WaveMin_F32(value))
+TEMPLATE_1_INT(WaveActiveMin, value, return __XB_WaveMin_I32(value))
+TEMPLATE_1_UINT(WaveActiveMin, value, return __XB_WaveMin_U32(value))
+TEMPLATE_1_REAL(WaveActiveMax, value, return __XB_WaveMax_F32(value))
+TEMPLATE_1_INT(WaveActiveMax, value, return __XB_WaveMax_I32(value))
+TEMPLATE_1_UINT(WaveActiveMax, value, return __XB_WaveMax_U32(value))
+
+#define INTRINSIC_WAVE_SUM
+TEMPLATE_1_REAL(WaveActiveSum, value, return __XB_WaveAdd_F32(value))
+TEMPLATE_1_INT(WaveActiveSum, value, return __XB_WaveAdd_I32(value))
+TEMPLATE_1_UINT(WaveActiveSum, value, return __XB_WaveAdd_U32(value))
+
 
 // flow control attributes
 #define UNITY_BRANCH        [branch]

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -1,4 +1,4 @@
-#include "Macros.hlsl"
+#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Macros.hlsl"
 
 // This file assume SHADER_API_XBOXONE is defined
 
@@ -24,12 +24,6 @@
 
 #define INTRINSIC_WaveReadLaneFirst
 #define WaveReadLaneFirst __XB_MakeUniform
-#define INTRINSIC_MINMAX3
-#define Min3 __XB_Min3_F32
-#define Max3 __XB_Max3_F32
-#define INTRINSIC_MAD24
-#define Mad24Int __XB_MadI24
-#define Mad24Uint __XB_MadU24
 #define INTRINSIC_BITFIELD_EXTRACT
 #define BitFieldExtract __XB_UBFE
 #define INTRINSIC_BITFIELD_EXTRACT_SIGN_EXTEND
@@ -42,19 +36,31 @@
 #define WaveActiveBitAnd __XB_WaveAND
 #define WaveActiveBitOr __XB_WaveOR
 
+#define INTRINSIC_MINMAX3
+TEMPLATE_3_REAL(Min3, a, b, c, return __XB_Min3_F32(a, b, c))
+TEMPLATE_3_INT(Min3, a, b, c, return __XB_Min3_I32(a, b, c))
+TEMPLATE_3_UINT(Min3, a, b, c, return __XB_Min3_U32(a, b, c))
+TEMPLATE_3_REAL(Max3, a, b, c, return __XB_Max3_F32(a, b, c))
+TEMPLATE_3_INT(Max3, a, b, c, return __XB_Max3_I32(a, b, c))
+TEMPLATE_3_UINT(Max3, a, b, c, return __XB_Max3_U32(a, b, c))
+ 
+
 #define INTRINSIC_WAVE_MINMAX
 TEMPLATE_1_REAL(WaveActiveMin, value, return __XB_WaveMin_F32(value))
 TEMPLATE_1_INT(WaveActiveMin, value, return __XB_WaveMin_I32(value))
 TEMPLATE_1_UINT(WaveActiveMin, value, return __XB_WaveMin_U32(value))
 TEMPLATE_1_REAL(WaveActiveMax, value, return __XB_WaveMax_F32(value))
-TEMPLATE_1_INT(WaveActiveMax, value, return __XB_WaveMax_I32(value))
 TEMPLATE_1_UINT(WaveActiveMax, value, return __XB_WaveMax_U32(value))
 
+TEMPLATE_1_INT(WaveActiveMax, value, return __XB_WaveMax_I32(value))
 #define INTRINSIC_WAVE_SUM
 TEMPLATE_1_REAL(WaveActiveSum, value, return __XB_WaveAdd_F32(value))
 TEMPLATE_1_INT(WaveActiveSum, value, return __XB_WaveAdd_I32(value))
 TEMPLATE_1_UINT(WaveActiveSum, value, return __XB_WaveAdd_U32(value))
 
+#define INTRINSIC_MAD24
+TEMPLATE_3_INT(Mad24, a, b, c, return __XB_MadI24(a,b,c))
+TEMPLATE_3_UINT(Mad24, a, b, c, return __XB_MadU24(a, b, c))
 
 // flow control attributes
 #define UNITY_BRANCH        [branch]

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -22,7 +22,7 @@
 // Intrinsics
 #define SUPPORTS_WAVE_INTRINSICS
 
-#define INTRINSIC_WaveReadLaneFirst
+#define INTRINSIC_WAVEREADFIRSTLANE
 #define WaveReadLaneFirst __XB_MakeUniform
 #define INTRINSIC_BITFIELD_EXTRACT
 #define BitFieldExtract __XB_UBFE

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -246,7 +246,7 @@ void ToggleBit(inout uint data, uint offset)
 }
 #endif
 
-#ifndef INTRINSIC_WaveReadLaneFirst
+#ifndef INTRINSIC_WAVEREADFIRSTLANE
     // Warning: for correctness, the argument's value must be the same across all lanes of the wave.
     TEMPLATE_1_REAL(WaveReadLaneFirst, scalarValue, return scalarValue)
     TEMPLATE_1_INT(WaveReadLaneFirst, scalarValue, return scalarValue)

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -182,16 +182,12 @@
 
 // On everything but GCN consoles we error on cross-lane operations
 #ifndef SUPPORTS_WAVE_INTRINSICS
-#define WaveMinInt ERROR_ON_UNSUPPORTED_FUNC(WaveMinInt)
-#define WaveMinUint ERROR_ON_UNSUPPORTED_FUNC(WaveMinUint)
-#define WaveMinFloat ERROR_ON_UNSUPPORTED_FUNC(WaveMinFloat)
-#define WaveMaxInt ERROR_ON_UNSUPPORTED_FUNC(WaveMaxInt)
-#define WaveMaxUint ERROR_ON_UNSUPPORTED_FUNC(WaveMaxUint)
-#define WaveMaxFloat ERROR_ON_UNSUPPORTED_FUNC(WaveMaxFloat)
-#define Ballot ERROR_ON_UNSUPPORTED_FUNC(Ballot)
-#define WaveAdd ERROR_ON_UNSUPPORTED_FUNC(WaveAdd)
-#define WaveAnd ERROR_ON_UNSUPPORTED_FUNC(WaveAnd)
-#define WaveOr ERROR_ON_UNSUPPORTED_FUNC(WaveOr)
+#define WaveActiveMin ERROR_ON_UNSUPPORTED_FUNC(WaveActiveMin)
+#define WaveActiveMax ERROR_ON_UNSUPPORTED_FUNC(WaveActiveMax)
+#define WaveActiveBallot ERROR_ON_UNSUPPORTED_FUNC(WaveActiveBallot)
+#define WaveActiveSum ERROR_ON_UNSUPPORTED_FUNC(WaveActiveSum)
+#define WaveActiveBitAnd ERROR_ON_UNSUPPORTED_FUNC(WaveActiveBitAnd)
+#define WaveActiveBitOr ERROR_ON_UNSUPPORTED_FUNC(WaveActiveBitOr)
 #endif
 
 #if !defined(SHADER_API_GLES)

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -199,7 +199,7 @@
 #ifndef INTRINSIC_BITFIELD_EXTRACT
 // Unsigned integer bit field extraction.
 // Note that the intrinsic itself generates a vector instruction.
-// Wrap this function with WaveReadFirstLane() to get scalar output.
+// Wrap this function with WaveReadLaneFirst() to get scalar output.
 uint BitFieldExtract(uint data, uint offset, uint numBits)
 {
     uint mask = (1u << numBits) - 1u;
@@ -210,7 +210,7 @@ uint BitFieldExtract(uint data, uint offset, uint numBits)
 #ifndef INTRINSIC_BITFIELD_EXTRACT_SIGN_EXTEND
 // Integer bit field extraction with sign extension.
 // Note that the intrinsic itself generates a vector instruction.
-// Wrap this function with WaveReadFirstLane() to get scalar output.
+// Wrap this function with WaveReadLaneFirst() to get scalar output.
 int BitFieldExtractSignExtend(int data, uint offset, uint numBits)
 {
     int  shifted = data >> offset;      // Sign-extending (arithmetic) shift
@@ -250,10 +250,10 @@ void ToggleBit(inout uint data, uint offset)
 }
 #endif
 
-#ifndef INTRINSIC_WAVEREADFIRSTLANE
+#ifndef INTRINSIC_WaveReadLaneFirst
     // Warning: for correctness, the argument's value must be the same across all lanes of the wave.
-    TEMPLATE_1_REAL(WaveReadFirstLane, scalarValue, return scalarValue)
-    TEMPLATE_1_INT(WaveReadFirstLane, scalarValue, return scalarValue)
+    TEMPLATE_1_REAL(WaveReadLaneFirst, scalarValue, return scalarValue)
+    TEMPLATE_1_INT(WaveReadLaneFirst, scalarValue, return scalarValue)
 #endif
 
 #ifndef INTRINSIC_MUL24

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -250,22 +250,26 @@ void ToggleBit(inout uint data, uint offset)
     // Warning: for correctness, the argument's value must be the same across all lanes of the wave.
     TEMPLATE_1_REAL(WaveReadLaneFirst, scalarValue, return scalarValue)
     TEMPLATE_1_INT(WaveReadLaneFirst, scalarValue, return scalarValue)
+    TEMPLATE_1_UINT(WaveReadLaneFirst, scalarValue, return scalarValue)
 #endif
 
 #ifndef INTRINSIC_MUL24
     TEMPLATE_2_INT(Mul24, a, b, return a * b)
+    TEMPLATE_2_UINT(Mul24, a, b, return a * b)
 #endif // INTRINSIC_MUL24
 
 #ifndef INTRINSIC_MAD24
-    TEMPLATE_3_INT(Mad24Int, a, b, c, return a * b + c)
-    TEMPLATE_3_INT(Mad24Uint, a, b, c, return a * b + c)
+    TEMPLATE_3_INT(Mad24, a, b, c, return a * b + c)
+    TEMPLATE_3_UINT(Mad24, a, b, c, return a * b + c)
 #endif // INTRINSIC_MAD24
 
 #ifndef INTRINSIC_MINMAX3
     TEMPLATE_3_REAL(Min3, a, b, c, return min(min(a, b), c))
     TEMPLATE_3_INT(Min3, a, b, c, return min(min(a, b), c))
+    TEMPLATE_3_UINT(Min3, a, b, c, return min(min(a, b), c))
     TEMPLATE_3_REAL(Max3, a, b, c, return max(max(a, b), c))
     TEMPLATE_3_INT(Max3, a, b, c, return max(max(a, b), c))
+    TEMPLATE_3_UINT(Max3, a, b, c, return max(max(a, b), c))
 #endif // INTRINSIC_MINMAX3
 
 TEMPLATE_SWAP(Swap) // Define a Swap(a, b) function for all types
@@ -337,6 +341,7 @@ real RadToDeg(real rad)
 // Square functions for cleaner code
 TEMPLATE_1_REAL(Sq, x, return x * x)
 TEMPLATE_1_INT(Sq, x, return x * x)
+TEMPLATE_1_UINT(Sq, x, return x * x)
 
 bool IsPower2(uint x)
 {

--- a/com.unity.render-pipelines.core/ShaderLibrary/Macros.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Macros.hlsl
@@ -74,6 +74,12 @@
     uint2  FunctionName(uint2  Parameter1) { FunctionBody; } \
     uint3  FunctionName(uint3  Parameter1) { FunctionBody; } \
     uint4  FunctionName(uint4  Parameter1) { FunctionBody; }
+
+    #define TEMPLATE_1_UINT(FunctionName, Parameter1, FunctionBody) \
+    uint   FunctionName(uint   Parameter1) { FunctionBody; } \
+    uint2  FunctionName(uint2  Parameter1) { FunctionBody; } \
+    uint3  FunctionName(uint3  Parameter1) { FunctionBody; } \
+    uint4  FunctionName(uint4  Parameter1) { FunctionBody; }
 #endif
 
 #define TEMPLATE_2_FLT(FunctionName, Parameter1, Parameter2, FunctionBody) \

--- a/com.unity.render-pipelines.core/ShaderLibrary/Macros.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Macros.hlsl
@@ -58,23 +58,16 @@
     float3 FunctionName(float3 Parameter1) { FunctionBody; } \
     float4 FunctionName(float4 Parameter1) { FunctionBody; }
 
-#ifdef SHADER_API_GLES
-    #define TEMPLATE_1_INT(FunctionName, Parameter1, FunctionBody) \
+
+#define TEMPLATE_1_INT(FunctionName, Parameter1, FunctionBody) \
     int    FunctionName(int    Parameter1) { FunctionBody; } \
     int2   FunctionName(int2   Parameter1) { FunctionBody; } \
     int3   FunctionName(int3   Parameter1) { FunctionBody; } \
     int4   FunctionName(int4   Parameter1) { FunctionBody; }
-#else
-    #define TEMPLATE_1_INT(FunctionName, Parameter1, FunctionBody) \
-    int    FunctionName(int    Parameter1) { FunctionBody; } \
-    int2   FunctionName(int2   Parameter1) { FunctionBody; } \
-    int3   FunctionName(int3   Parameter1) { FunctionBody; } \
-    int4   FunctionName(int4   Parameter1) { FunctionBody; } \
-    uint   FunctionName(uint   Parameter1) { FunctionBody; } \
-    uint2  FunctionName(uint2  Parameter1) { FunctionBody; } \
-    uint3  FunctionName(uint3  Parameter1) { FunctionBody; } \
-    uint4  FunctionName(uint4  Parameter1) { FunctionBody; }
 
+#ifdef SHADER_API_GLES
+    #define TEMPLATE_1_UINT(FunctionName, Parameter1, FunctionBody) 
+#else
     #define TEMPLATE_1_UINT(FunctionName, Parameter1, FunctionBody) \
     uint   FunctionName(uint   Parameter1) { FunctionBody; } \
     uint2  FunctionName(uint2  Parameter1) { FunctionBody; } \
@@ -98,24 +91,23 @@
     float3 FunctionName(float3 Parameter1, float3 Parameter2) { FunctionBody; } \
     float4 FunctionName(float4 Parameter1, float4 Parameter2) { FunctionBody; }
 
-
-#ifdef SHADER_API_GLES
-    #define TEMPLATE_2_INT(FunctionName, Parameter1, Parameter2, FunctionBody) \
+#define TEMPLATE_2_INT(FunctionName, Parameter1, Parameter2, FunctionBody) \
     int    FunctionName(int    Parameter1, int    Parameter2) { FunctionBody; } \
     int2   FunctionName(int2   Parameter1, int2   Parameter2) { FunctionBody; } \
     int3   FunctionName(int3   Parameter1, int3   Parameter2) { FunctionBody; } \
     int4   FunctionName(int4   Parameter1, int4   Parameter2) { FunctionBody; }
+
+#ifdef SHADER_API_GLES
+    #define TEMPLATE_2_UINT(FunctionName, Parameter1, Parameter2, FunctionBody)  
 #else
-    #define TEMPLATE_2_INT(FunctionName, Parameter1, Parameter2, FunctionBody) \
-    int    FunctionName(int    Parameter1, int    Parameter2) { FunctionBody; } \
-    int2   FunctionName(int2   Parameter1, int2   Parameter2) { FunctionBody; } \
-    int3   FunctionName(int3   Parameter1, int3   Parameter2) { FunctionBody; } \
-    int4   FunctionName(int4   Parameter1, int4   Parameter2) { FunctionBody; } \
-    uint   FunctionName(uint   Parameter1, uint   Parameter2) { FunctionBody; } \
-    uint2  FunctionName(uint2  Parameter1, uint2  Parameter2) { FunctionBody; } \
-    uint3  FunctionName(uint3  Parameter1, uint3  Parameter2) { FunctionBody; } \
-    uint4  FunctionName(uint4  Parameter1, uint4  Parameter2) { FunctionBody; }
+    #define TEMPLATE_2_UINT(FunctionName, Parameter1, Parameter2, FunctionBody) \
+    uint    FunctionName(uint    Parameter1, uint    Parameter2) { FunctionBody; } \
+    uint2   FunctionName(uint2   Parameter1, uint2   Parameter2) { FunctionBody; } \
+    uint3   FunctionName(uint3   Parameter1, uint3   Parameter2) { FunctionBody; } \
+    uint4   FunctionName(uint4   Parameter1, uint4   Parameter2) { FunctionBody; }
 #endif
+
+
 
 #define TEMPLATE_3_FLT(FunctionName, Parameter1, Parameter2, Parameter3, FunctionBody) \
     float  FunctionName(float  Parameter1, float  Parameter2, float  Parameter3) { FunctionBody; } \
@@ -133,18 +125,16 @@
     float3 FunctionName(float3 Parameter1, float3 Parameter2, float3 Parameter3) { FunctionBody; } \
     float4 FunctionName(float4 Parameter1, float4 Parameter2, float4 Parameter3) { FunctionBody; }
 
-#ifdef SHADER_API_GLES
-    #define TEMPLATE_3_INT(FunctionName, Parameter1, Parameter2, Parameter3, FunctionBody) \
+#define TEMPLATE_3_INT(FunctionName, Parameter1, Parameter2, Parameter3, FunctionBody) \
     int    FunctionName(int    Parameter1, int    Parameter2, int    Parameter3) { FunctionBody; } \
     int2   FunctionName(int2   Parameter1, int2   Parameter2, int2   Parameter3) { FunctionBody; } \
     int3   FunctionName(int3   Parameter1, int3   Parameter2, int3   Parameter3) { FunctionBody; } \
     int4   FunctionName(int4   Parameter1, int4   Parameter2, int4   Parameter3) { FunctionBody; }
+
+#ifdef SHADER_API_GLES
+    #define TEMPLATE_3_UINT(FunctionName, Parameter1, Parameter2, Parameter3, FunctionBody) 
 #else
-    #define TEMPLATE_3_INT(FunctionName, Parameter1, Parameter2, Parameter3, FunctionBody) \
-    int    FunctionName(int    Parameter1, int    Parameter2, int    Parameter3) { FunctionBody; } \
-    int2   FunctionName(int2   Parameter1, int2   Parameter2, int2   Parameter3) { FunctionBody; } \
-    int3   FunctionName(int3   Parameter1, int3   Parameter2, int3   Parameter3) { FunctionBody; } \
-    int4   FunctionName(int4   Parameter1, int4   Parameter2, int4   Parameter3) { FunctionBody; } \
+    #define TEMPLATE_3_UINT(FunctionName, Parameter1, Parameter2, Parameter3, FunctionBody) \
     uint   FunctionName(uint   Parameter1, uint   Parameter2, uint   Parameter3) { FunctionBody; } \
     uint2  FunctionName(uint2  Parameter1, uint2  Parameter2, uint2  Parameter3) { FunctionBody; } \
     uint3  FunctionName(uint3  Parameter1, uint3  Parameter2, uint3  Parameter3) { FunctionBody; } \

--- a/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPreprocessShaders.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPreprocessShaders.cs
@@ -98,10 +98,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         // Track list of materials asking for specific preprocessor step
         List<BaseShaderPreprocessor> materialList;
 
-
-        int m_TotalVariantsInputCount;
-        int m_TotalVariantsOutputCount;
-
         public HDRPreprocessShaders()
         {
             // TODO: Grab correct configuration/quality asset.
@@ -112,24 +108,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             materialList = HDEditorUtils.GetBaseShaderPreprocessorList();
         }
 
-        void LogShaderVariants(Shader shader, ShaderSnippetData snippetData, int prevVariantsCount, int currVariantsCount)
-        {
-            // TODO: Use logging levels? 
-            if (shader.name.Contains("HDRenderPipeline"))
-            {
-                float percentageCurrent = ((float)currVariantsCount / (float)prevVariantsCount) * 100.0f;
-                float percentageTotal = ((float)m_TotalVariantsOutputCount / (float)m_TotalVariantsInputCount) * 100.0f;
-
-                string result = string.Format("STRIPPING: {0} ({1} pass) ({2}) -" +
-                        " Remaining shader variants = {3}/{4} = {5}% - Total = {6}/{7} = {8}%",
-                        shader.name, snippetData.passName, snippetData.shaderType.ToString(), currVariantsCount,
-                        prevVariantsCount, percentageCurrent, m_TotalVariantsOutputCount, m_TotalVariantsInputCount,
-                        percentageTotal);
-                Debug.Log(result);
-            }
-        }
-
-
         public int callbackOrder { get { return 0; } }
         public void OnProcessShader(Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> inputData)
         {
@@ -137,8 +115,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             HDRenderPipelineAsset hdPipelineAsset = GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset;
             if (hdPipelineAsset == null)
                 return;
-
-            int preStrippingCount = inputData.Count;
 
             // This test will also return if we are not using HDRenderPipelineAsset
             if (hdPipelineAsset == null || !hdPipelineAsset.allowShaderVariantStripping)
@@ -164,10 +140,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     inputData.RemoveAt(i);
                     i--;
                 }
-
-                m_TotalVariantsInputCount += preStrippingCount;
-                m_TotalVariantsOutputCount += inputData.Count;
-                LogShaderVariants(shader, snippet, preStrippingCount, inputData.Count);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPreprocessShaders.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPreprocessShaders.cs
@@ -98,6 +98,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         // Track list of materials asking for specific preprocessor step
         List<BaseShaderPreprocessor> materialList;
 
+
+        int m_TotalVariantsInputCount;
+        int m_TotalVariantsOutputCount;
+
         public HDRPreprocessShaders()
         {
             // TODO: Grab correct configuration/quality asset.
@@ -108,6 +112,24 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             materialList = HDEditorUtils.GetBaseShaderPreprocessorList();
         }
 
+        void LogShaderVariants(Shader shader, ShaderSnippetData snippetData, int prevVariantsCount, int currVariantsCount)
+        {
+            // TODO: Use logging levels? 
+            if (shader.name.Contains("HDRenderPipeline"))
+            {
+                float percentageCurrent = ((float)currVariantsCount / (float)prevVariantsCount) * 100.0f;
+                float percentageTotal = ((float)m_TotalVariantsOutputCount / (float)m_TotalVariantsInputCount) * 100.0f;
+
+                string result = string.Format("STRIPPING: {0} ({1} pass) ({2}) -" +
+                        " Remaining shader variants = {3}/{4} = {5}% - Total = {6}/{7} = {8}%",
+                        shader.name, snippetData.passName, snippetData.shaderType.ToString(), currVariantsCount,
+                        prevVariantsCount, percentageCurrent, m_TotalVariantsOutputCount, m_TotalVariantsInputCount,
+                        percentageTotal);
+                Debug.Log(result);
+            }
+        }
+
+
         public int callbackOrder { get { return 0; } }
         public void OnProcessShader(Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> inputData)
         {
@@ -115,6 +137,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             HDRenderPipelineAsset hdPipelineAsset = GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset;
             if (hdPipelineAsset == null)
                 return;
+
+            int preStrippingCount = inputData.Count;
 
             // This test will also return if we are not using HDRenderPipelineAsset
             if (hdPipelineAsset == null || !hdPipelineAsset.allowShaderVariantStripping)
@@ -140,6 +164,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     inputData.RemoveAt(i);
                     i--;
                 }
+
+                m_TotalVariantsInputCount += preStrippingCount;
+                m_TotalVariantsOutputCount += inputData.Count;
+                LogShaderVariants(shader, snippet, preStrippingCount, inputData.Count);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -149,7 +149,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 #if SCALARIZE_LIGHT_LOOP
         // Fast path is when we all pixels in a wave are accessing same tile or cluster.
         uint lightStartLane0 = WaveReadLaneFirst(lightStart);
-        fastPath = all(Ballot(lightStart == lightStartLane0) == ~0);
+        fastPath = all(WaveActiveBallot(lightStart == lightStartLane0) == ~0);
 #endif
 
 #else   // LIGHTLOOP_TILE_PASS
@@ -180,8 +180,8 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
             if (!fastPath)
             {
                 // If we are not in fast path, v_lightIdx is not scalar, so we need to query the Min value across the wave. 
-                s_lightIdx = WaveMinUint(v_lightIdx);
-                // If WaveMinUint returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
+                s_lightIdx = WaveActiveMin(v_lightIdx);
+                // If WaveActiveMin returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
                // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveMin
                 if (s_lightIdx == -1)
                 {
@@ -195,7 +195,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
             LightData s_lightData = FetchLight(s_lightIdx);
 
             // If current scalar and vector light index match, we process the light. The v_lightListOffset for current thread is increased.
-            // Note that the following should really be ==, however, since helper lanes are not considered by WaveMinUint, such helper lanes could
+            // Note that the following should really be ==, however, since helper lanes are not considered by WaveActiveMin, such helper lanes could
             // end up with a unique v_lightIdx value that is smaller than s_lightIdx hence being stuck in a loop. All the active lanes will not have this problem.
             if (s_lightIdx >= v_lightIdx)
             {
@@ -285,7 +285,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
     #if SCALARIZE_LIGHT_LOOP
         // Fast path is when we all pixels in a wave is accessing same tile or cluster.
         uint envStartFirstLane = WaveReadLaneFirst(envLightStart);
-        fastPath = all(Ballot(envLightStart == envStartFirstLane) == ~0);
+        fastPath = all(WaveActiveBallot(envLightStart == envStartFirstLane) == ~0);
     #endif
 
 #else   // LIGHTLOOP_TILE_PASS
@@ -345,9 +345,9 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
             #if SCALARIZE_LIGHT_LOOP
                 if (!fastPath)
                 {
-                    s_envLightIdx = WaveMinUint(v_envLightIdx);
+                    s_envLightIdx = WaveActiveMin(v_envLightIdx);
                     // If we are not in fast path, s_envLightIdx is not scalar
-                   // If WaveMinUint returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
+                   // If WaveActiveMin returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
                    // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveMin
                     if (s_envLightIdx == -1)
                     {
@@ -363,7 +363,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
                 EnvLightData s_envLightData = FetchEnvLight(s_envLightIdx);    // Scalar load.
 
                 // If current scalar and vector light index match, we process the light. The v_envLightListOffset for current thread is increased.
-                // Note that the following should really be ==, however, since helper lanes are not considered by WaveMinUint, such helper lanes could
+                // Note that the following should really be ==, however, since helper lanes are not considered by WaveActiveMin, such helper lanes could
                 // end up with a unique v_envLightIdx value that is smaller than s_envLightIdx hence being stuck in a loop. All the active lanes will not have this problem.
                 if (s_envLightIdx >= v_envLightIdx)
                 {

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -148,7 +148,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 
 #if SCALARIZE_LIGHT_LOOP
         // Fast path is when we all pixels in a wave are accessing same tile or cluster.
-        uint lightStartLane0 = WaveReadFirstLane(lightStart);
+        uint lightStartLane0 = WaveReadLaneFirst(lightStart);
         fastPath = all(Ballot(lightStart == lightStartLane0) == ~0);
 #endif
 
@@ -188,9 +188,9 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
                     break;
                 }
             }
-            // Note that the WaveReadFirstLane should not be needed, but the compiler might insist in putting the result in VGPR.
+            // Note that the WaveReadLaneFirst should not be needed, but the compiler might insist in putting the result in VGPR.
             // However, we are certain at this point that the index is scalar.
-            s_lightIdx = WaveReadFirstLane(s_lightIdx);
+            s_lightIdx = WaveReadLaneFirst(s_lightIdx);
 #endif
             LightData s_lightData = FetchLight(s_lightIdx);
 
@@ -284,7 +284,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 
     #if SCALARIZE_LIGHT_LOOP
         // Fast path is when we all pixels in a wave is accessing same tile or cluster.
-        uint envStartFirstLane = WaveReadFirstLane(envLightStart);
+        uint envStartFirstLane = WaveReadLaneFirst(envLightStart);
         fastPath = all(Ballot(envLightStart == envStartFirstLane) == ~0);
     #endif
 
@@ -354,9 +354,9 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
                         break;
                     }
                 }
-                // Note that the WaveReadFirstLane should not be needed, but the compiler might insist in putting the result in VGPR.
+                // Note that the WaveReadLaneFirst should not be needed, but the compiler might insist in putting the result in VGPR.
                 // However, we are certain at this point that the index is scalar.
-                s_envLightIdx = WaveReadFirstLane(s_envLightIdx);
+                s_envLightIdx = WaveReadLaneFirst(s_envLightIdx);
 
             #endif
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -182,7 +182,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
                 // If we are not in fast path, v_lightIdx is not scalar, so we need to query the Min value across the wave. 
                 s_lightIdx = WaveActiveMin(v_lightIdx);
                 // If WaveActiveMin returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
-               // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveMin
+               // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveActiveMin
                 if (s_lightIdx == -1)
                 {
                     break;
@@ -348,7 +348,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
                     s_envLightIdx = WaveActiveMin(v_envLightIdx);
                     // If we are not in fast path, s_envLightIdx is not scalar
                    // If WaveActiveMin returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
-                   // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveMin
+                   // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveActiveMin
                     if (s_envLightIdx == -1)
                     {
                         break;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
@@ -216,7 +216,7 @@ DecalSurfaceData GetDecalSurfaceData(PositionInputs posInput, inout float alpha)
 
     #if SCALARIZE_LIGHT_LOOP
     // Fast path is when we all pixels in a wave are accessing same tile or cluster.
-    uint decalStartLane0 = WaveReadFirstLane(decalStart);
+    uint decalStartLane0 = WaveReadLaneFirst(decalStart);
     bool fastPath = all(Ballot(decalStart == decalStartLane0) == ~0);
     #endif
 
@@ -261,9 +261,9 @@ DecalSurfaceData GetDecalSurfaceData(PositionInputs posInput, inout float alpha)
                 break;
             }
         }
-        // Note that the WaveReadFirstLane should not be needed, but the compiler might insist in putting the result in VGPR.
+        // Note that the WaveReadLaneFirst should not be needed, but the compiler might insist in putting the result in VGPR.
         // However, we are certain at this point that the index is scalar.
-        s_decalIdx = WaveReadFirstLane(s_decalIdx);
+        s_decalIdx = WaveReadLaneFirst(s_decalIdx);
 
 #endif // SCALARIZE_LIGHT_LOOP
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
@@ -255,7 +255,7 @@ DecalSurfaceData GetDecalSurfaceData(PositionInputs posInput, inout float alpha)
             // If we are not in fast path, v_lightIdx is not scalar, so we need to query the Min value across the wave. 
             s_decalIdx = WaveActiveMin(v_decalIdx);
             // If WaveActiveMin returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
-            // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveMin
+            // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveActiveMin
             if (s_decalIdx == -1)
             {
                 break;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/BuildProbabilityTables.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/BuildProbabilityTables.compute
@@ -40,7 +40,7 @@ RWTexture2D<float> conditionalDensities;  // [TEXTURE_WIDTH x TEXTURE_HEIGHT]
         GroupMemoryBarrierWithGroupSync();                                      \
                                                                                 \
         /*** a1 = (2 * i + 1) * offset - 1 */                                   \
-        uint a1 = (uint)Mad24Int((int)Mad24Uint(2u, i, 1u), (int)offset, -1);   \
+        uint a1 = Mad24(Mad24(2u, i, 1u), offset, -1);                          \
         uint a2 = a1 + offset;                                                  \
                                                                                 \
         if (a2 < n)                                                             \
@@ -68,7 +68,7 @@ RWTexture2D<float> conditionalDensities;  // [TEXTURE_WIDTH x TEXTURE_HEIGHT]
         GroupMemoryBarrierWithGroupSync();                                      \
                                                                                 \
         /*** a1 = (2 * i + 1) * offset - 1 */                                   \
-        uint a1 = (uint)Mad24Int((int)Mad24Uint(2u, i, 1u), (int)offset, -1);   \
+        uint a1 = Mad24(Mad24(2u, i, 1u), offset, -1);                          \
         uint a2 = a1 + offset;                                                  \
                                                                                 \
         if (a2 < n)                                                             \

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.compute
@@ -235,7 +235,7 @@ void SubsurfaceScattering(uint2 groupId       : SV_GroupID,
     groupThreadId &= GROUP_SIZE_2D - 1; // Help the compiler
 
     // Note: any factor of 64 is a suitable wave size for our algorithm.
-    uint waveIndex = WaveReadFirstLane(groupThreadId / 64);
+    uint waveIndex = WaveReadLaneFirst(groupThreadId / 64);
     uint laneIndex = groupThreadId % 64;
     uint quadIndex = laneIndex / 4;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.compute
@@ -81,7 +81,7 @@ groupshared bool   processGroup;
 #if SSS_USE_LDS_CACHE
 void StoreSampleToCacheMemory(float4 value, int2 cacheCoord)
 {
-    int linearCoord = Mad24Int(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
+    int linearCoord = Mad24(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
 
     textureCache0[linearCoord] = value.rg;
     textureCache1[linearCoord] = value.ba;
@@ -89,7 +89,7 @@ void StoreSampleToCacheMemory(float4 value, int2 cacheCoord)
 
 float4 LoadSampleFromCacheMemory(int2 cacheCoord)
 {
-    int linearCoord = Mad24Int(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
+    int linearCoord = Mad24(TEXTURE_CACHE_SIZE_1D, cacheCoord.y, cacheCoord.x);
 
     return float4(textureCache0[linearCoord],
                   textureCache1[linearCoord]);


### PR DESCRIPTION
### Purpose of this PR
Renaming wave intrinsics so they match SM 6.0. 

This required having TEMPLATE definitions in XboxOne.hlsl since xbox intrinsics specify argument type in the name explicitly. This also required to split TEMPLATE definitions for INT and UINT. 

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=wave-intrinsics-renaming&automation-tools_branch=add-platform-filter&unity_branch=trunk [still running]

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**:  Low

---
### Comments to reviewers


EDIT: Please wait before merging, I have found an issue that needs fixing.