### PR TITLE
Backport: Fix instancing defines in HD Shader Graph Shaders

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.2.0-preview] - 2018-10-xx
 
+### Added
+- Added a define for determining if any instancing path is taken.
+
 ## [4.1.0-preview] - 2018-10-18
 
 ### Changed

--- a/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
@@ -27,6 +27,7 @@
 // - UNITY_INSTANCING_ENABLED               Defined if instancing path is taken.
 // - UNITY_PROCEDURAL_INSTANCING_ENABLED    Defined if procedural instancing path is taken.
 // - UNITY_STEREO_INSTANCING_ENABLED        Defined if stereo instancing path is taken.
+// - UNITY_ANY_INSTANCING_ENABLED           Defined if any instancing path is taken
 #if defined(UNITY_SUPPORT_INSTANCING) && defined(INSTANCING_ON)
     #define UNITY_INSTANCING_ENABLED
 #endif
@@ -35,6 +36,12 @@
 #endif
 #if defined(UNITY_SUPPORT_STEREO_INSTANCING) && defined(STEREO_INSTANCING_ON)
     #define UNITY_STEREO_INSTANCING_ENABLED
+#endif
+
+#if defined(UNITY_INSTANCING_ENABLED) || defined(UNITY_PROCEDURAL_INSTANCING_ENABLED) || defined(UNITY_STEREO_INSTANCING_ENABLED)
+    #define UNITY_ANY_INSTANCING_ENABLED 1
+#else
+    #define UNITY_ANY_INSTANCING_ENABLED 0
 #endif
 
 #if defined(SHADER_API_GLES3) || defined(SHADER_API_GLCORE) || defined(SHADER_API_METAL) || defined(SHADER_API_VULKAN)

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated default FrameSettings used for realtime reflection probe (at HDRenderPipelineAsset creation)
 - Remove multi-camera support (this will not be supported by LW or HDRP)
+- Updated Shader Graph subshaders to use the new instancing define
 
 ## [4.1.0-preview] - 2018-10-18
 

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -20,7 +20,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             [Semantic("TEXCOORD2")][Optional]       Vector4 uv2;
             [Semantic("TEXCOORD3")][Optional]       Vector4 uv3;
             [Semantic("COLOR")][Optional]           Vector4 color;
-            [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("INSTANCING_ON")] uint instanceID;
+            [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("UNITY_ANY_INSTANCING_ENABLED")] uint instanceID;
         };
 
         [InterpolatorPack]
@@ -35,7 +35,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             [Optional]                                                              Vector4 texCoord2;
             [Optional]                                                              Vector4 texCoord3;
             [Optional]                                                              Vector4 color;
-            [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("INSTANCING_ON")]     uint instanceID;
+            [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("UNITY_ANY_INSTANCING_ENABLED")] uint instanceID;
             [Optional][Semantic("FRONT_FACE_SEMANTIC")][OverrideType("FRONT_FACE_TYPE")][PreprocessorIf("SHADER_STAGE_FRAGMENT")] bool cullFace;
 
             public static Dependency[] tessellationDependencies = new Dependency[]
@@ -76,7 +76,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             [Optional]      Vector4 texCoord2;
             [Optional]      Vector4 texCoord3;
             [Optional]      Vector4 color;
-            [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("INSTANCING_ON")] uint instanceID;
+            [Semantic("INSTANCEID_SEMANTIC")] [PreprocessorIf("UNITY_ANY_INSTANCING_ENABLED")] uint instanceID;
 
             public static Dependency[] tessellationDependencies = new Dependency[]
             {


### PR DESCRIPTION
Backport #2335 to `release/2018.3`

Tests: Green
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=backport%2Fsg%2Ffix-instancing-defines&automation-tools_branch=add-platform-filter&unity_branch=2018.3%2Fstaging#