### PR TITLE
Backport: Fix Shader Graph UV dimension when used in VS

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed d3d debug layer warning
 - Fixed PCSS sampling quality
 - Fixed the Subsurface and transmission material feature enabling for fabric shader
+- Fixed Shader Graph UV node dimension when used in vertex shader
 
 ### Changed
 - Updated default FrameSettings used for realtime reflection probe (at HDRenderPipelineAsset creation)

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/VertexAnimation.template.hlsl
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/VertexAnimation.template.hlsl
@@ -26,10 +26,10 @@ VertexDescriptionInputs AttributesMeshToVertexDescriptionInputs(AttributesMesh i
     $VertexDescriptionInputs.TangentSpaceViewDirection: float3x3 tangentSpaceTransform =     float3x3(output.WorldSpaceTangent,output.WorldSpaceBiTangent,output.WorldSpaceNormal);
     $VertexDescriptionInputs.TangentSpaceViewDirection: output.TangentSpaceViewDirection =   mul(tangentSpaceTransform, output.WorldSpaceViewDirection);
     $VertexDescriptionInputs.ScreenPosition:            output.ScreenPosition =              ComputeScreenPos(TransformWorldToHClip(output.WorldSpacePosition), _ProjectionParams.x);
-    $VertexDescriptionInputs.uv0:                       output.uv0 =                         float4(input.uv0, 0.0f, 0.0f);
-    $VertexDescriptionInputs.uv1:                       output.uv1 =                         float4(input.uv1, 0.0f, 0.0f);
-    $VertexDescriptionInputs.uv2:                       output.uv2 =                         float4(input.uv2, 0.0f, 0.0f);
-    $VertexDescriptionInputs.uv3:                       output.uv3 =                         float4(input.uv3, 0.0f, 0.0f);
+    $VertexDescriptionInputs.uv0:                       output.uv0 =                         input.uv0;
+    $VertexDescriptionInputs.uv1:                       output.uv1 =                         input.uv1;
+    $VertexDescriptionInputs.uv2:                       output.uv2 =                         input.uv2;
+    $VertexDescriptionInputs.uv3:                       output.uv3 =                         input.uv3;
     $VertexDescriptionInputs.VertexColor:               output.VertexColor =                 input.color;
 
     return output;


### PR DESCRIPTION
### Purpose of this PR
Backport #2404 to `2018.3/staging`

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
Running
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=backport%2Fsg%2Ffix-hd-vertex-uv&automation-tools_branch=add-platform-filter&unity_branch=2018.3%2Fstaging#