### PR TITLE
Fix fatarrow not supported in all .Net

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugUI.Fields.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugUI.Fields.cs
@@ -219,7 +219,7 @@ namespace UnityEngine.Experimental.Rendering
                     m_EnumType = value;
                 }
 
-                get => m_EnumType;
+                get { return m_EnumType; }
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR
Fix notation not supported in all supported .Net core (fatarrow)

---
### Release Notes

---
### Testing status
**Katana Tests**:

**Manual Tests**: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
@Chman this notation is not yet well supported
