### PR TITLE
WaveActive[All/Any]True and improve scalarized lightloop fast path decision making

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -27,6 +27,16 @@
 #define WaveActiveBitAnd CrossLaneAnd
 #define WaveActiveBitOr CrossLaneOr
 
+#define INTRINSIC_WAVE_ACTIVE_ALL_ANY
+bool WaveActiveAllTrue(bool expression)
+{
+    return (__s_read_exec() == WaveActiveBallot(expression));
+}
+
+bool WaveActiveAnyTrue(bool expression)
+{
+    return (popcnt(WaveActiveBallot(expression))) != 0;
+}
 
 
 #define UNITY_UV_STARTS_AT_TOP 1

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -52,7 +52,7 @@
 #define INTRINSIC_WAVE_ACTIVE_ALL_ANY
 bool WaveActiveAllTrue(bool expression)
 {
-    return (WaveActiveBallot(true) == WaveActiveBallot(expression));
+    return all(WaveActiveBallot(true) == WaveActiveBallot(expression));
 }
 
 bool WaveActiveAnyTrue(bool expression)

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -49,6 +49,18 @@
 #define WaveActiveBitAnd __XB_WaveAND
 #define WaveActiveBitOr __XB_WaveOR
 
+#define INTRINSIC_WAVE_ACTIVE_ALL_ANY
+bool WaveActiveAllTrue(bool expression)
+{
+    return (WaveActiveBallot(true) == WaveActiveBallot(expression));
+}
+
+bool WaveActiveAnyTrue(bool expression)
+{
+    return (__XB_S_BCNT1_U64(WaveActiveBallot(expression))) != 0;
+}
+
+
 #define INTRINSIC_MINMAX3
 GENERATE_INTRINSIC_VARIANTS_3_ARGS(Min3, __XB_Min3_, a, b, c);
 GENERATE_INTRINSIC_VARIANTS_3_ARGS(Max3, __XB_Max3_, a, b, c);

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -182,6 +182,8 @@
 
 // On everything but GCN consoles we error on cross-lane operations
 #ifndef SUPPORTS_WAVE_INTRINSICS
+#define WaveActiveAllTrue ERROR_ON_UNSUPPORTED_FUNC(WaveActiveAllTrue)
+#define WaveActiveAnyTrue ERROR_ON_UNSUPPORTED_FUNC(WaveActiveAnyTrue)
 #define WaveActiveMin ERROR_ON_UNSUPPORTED_FUNC(WaveActiveMin)
 #define WaveActiveMax ERROR_ON_UNSUPPORTED_FUNC(WaveActiveMax)
 #define WaveActiveBallot ERROR_ON_UNSUPPORTED_FUNC(WaveActiveBallot)

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -149,7 +149,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
 #if SCALARIZE_LIGHT_LOOP
         // Fast path is when we all pixels in a wave are accessing same tile or cluster.
         uint lightStartLane0 = WaveReadLaneFirst(lightStart);
-        fastPath = all(WaveActiveBallot(lightStart == lightStartLane0) == ~0);
+        fastPath = WaveActiveAllTrue(lightStart == lightStartLane0); 
 #endif
 
 #else   // LIGHTLOOP_TILE_PASS
@@ -285,7 +285,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
     #if SCALARIZE_LIGHT_LOOP
         // Fast path is when we all pixels in a wave is accessing same tile or cluster.
         uint envStartFirstLane = WaveReadLaneFirst(envLightStart);
-        fastPath = all(WaveActiveBallot(envLightStart == envStartFirstLane) == ~0);
+        fastPath = WaveActiveAllTrue(envLightStart == envStartFirstLane); 
     #endif
 
 #else   // LIGHTLOOP_TILE_PASS

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
@@ -217,7 +217,7 @@ DecalSurfaceData GetDecalSurfaceData(PositionInputs posInput, inout float alpha)
     #if SCALARIZE_LIGHT_LOOP
     // Fast path is when we all pixels in a wave are accessing same tile or cluster.
     uint decalStartLane0 = WaveReadLaneFirst(decalStart);
-    bool fastPath = all(WaveActiveBallot(decalStart == decalStartLane0) == ~0);
+    bool fastPath = WaveActiveAllTrue(decalStart == decalStartLane0);
     #endif
 
 #else // LIGHTLOOP_TILE_PASS


### PR DESCRIPTION
### Purpose of this PR

Implemented WaveActiveAllTrue and WaveActiveAnyTrue with the intrinsics we currently have and used WaveActiveAllTrue  to make a better decision on when to go with the fast path in the lightloop scalarization. 

---
### Release Notes
Added WaveActiveAllTrue and WaveActiveAnyTrue intrinsics to GCN platforms. 

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=add-waveactivealltrue-and-use-it-for-scalar-fast-path&automation-tools_branch=add-platform-filter&unity_branch=trunk [ Running ] 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low