### PR TITLE
VFX fix exposed behavior *Waiting for PR (in trunk merge queue...)* (CreateComponentWithAllBasicTypeExposed)

### DIFF
--- a/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXComponentTest.cs
+++ b/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXComponentTest.cs
@@ -677,7 +677,7 @@ namespace UnityEditor.VFX.Test
                 return left.colorKeys.Length == right.colorKeys.Length;
             };
 
-            //Check default Value_A & change to Value_B
+            //Check default Value_A & change to Value_B (At this stage, it's useless to access with SerializedProperty)
             foreach (var parameter in VFXLibrary.GetParameters())
             {
                 VFXValueType type = types.FirstOrDefault(e => VFXExpression.GetVFXValueTypeFromType(parameter.model.type) == e);
@@ -687,8 +687,8 @@ namespace UnityEditor.VFX.Test
                 var baseValue = GetValue_A_Type(parameter.model.type);
                 var newValue = GetValue_B_Type(parameter.model.type);
 
-                Assert.IsTrue(fnHas(type, vfxComponent, currentName));
-                var currentValue = fnGet(type, vfxComponent, currentName);
+                Assert.IsTrue(fnHas_UsingBindings(type, vfxComponent, currentName));
+                var currentValue = fnGet_UsingBindings(type, vfxComponent, currentName);
                 if (type == VFXValueType.ColorGradient)
                 {
                     Assert.IsTrue(fnCompareGradient((Gradient)baseValue, (Gradient)currentValue));
@@ -706,7 +706,7 @@ namespace UnityEditor.VFX.Test
                 {
                     Assert.AreEqual(baseValue, currentValue);
                 }
-                fnSet(type, vfxComponent, currentName, newValue);
+                fnSet_UsingBindings(type, vfxComponent, currentName, newValue);
 
                 yield return null;
             }

--- a/com.unity.visualeffectgraph/Editor/Inspector/VisualEffectEditor.cs
+++ b/com.unity.visualeffectgraph/Editor/Inspector/VisualEffectEditor.cs
@@ -134,62 +134,6 @@ namespace UnityEditor.VFX
 
         protected const float overrideWidth = 16;
 
-        SerializedProperty GetFakeProperty(ref VFXParameterInfo parameter)
-        {
-            if (parameter.defaultValue == null)
-                return null;
-            Type type = parameter.defaultValue.type;
-            if (type == null)
-                return null;
-
-            if (typeof(float) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("aFloat");
-            }
-            else if (typeof(Vector2) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("aVector2");
-            }
-            else if (typeof(Vector3) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("aVector3");
-            }
-            else if (typeof(Vector4) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("aVector4");
-            }
-            else if (typeof(Color) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("aColor");
-            }
-            else if (typeof(Gradient) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("aGradient");
-            }
-            else if (typeof(AnimationCurve) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("anAnimationCurve");
-            }
-            else if (typeof(UnityObject).IsAssignableFrom(type))
-            {
-                return s_FakeObjectSerializedCache.FindProperty("anObject");
-            }
-            else if (typeof(int) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("anInt");
-            }
-            else if (typeof(uint) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("anUInt");
-            }
-            else if (typeof(bool) == type)
-            {
-                return s_FakeObjectSerializedCache.FindProperty("aBool");
-            }
-
-            return null;
-        }
-
         static void DisplayProperty(ref VFXParameterInfo parameter, GUIContent nameContent, SerializedProperty overridenProperty, SerializedProperty valueProperty, bool animated)
         {
             EditorGUILayout.BeginHorizontal();


### PR DESCRIPTION
### Purpose of this PR
Change behavior of Inspector & Fix editor test.
Linked to this PR : https://ono.unity3d.com/unity/unity/pull-request/78044/_/graphics/vfx-editor/fix-exposed-behavior

In short, inspector now considers that entry is not always existing in actual visual effect property sheet, and thus, adds it when you start modifying it.

Here, the concerned favro card : https://favro.com/organization/c564ede4ed3337f7b17986b6/4ab0cf9c9a0d6d61242bd015?card=Uni-42892

---
### Release Notes
Has to be sync with PR from trunk, do not merge it before PR landing !

---
### Testing status

Awaiting for this : https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=vfx-fix-exposed-behavior&unity_branch=graphics%2Fvfx-editor%2Ffix-exposed-behavior&automation-tools_branch=add-platform-filter
... it's 🍏 !

⚠️ This is not valid on trunk yet ! ⚠️ 

---
### Overall Product Risks
**Technical Risk**: High
**Halo Effect**: Low (Visual Effect Inspector is impacted)