### PR TITLE
Add dependency on ugui package

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Unity.RenderPipelines.HighDefinition.Runtime.asmdef
+++ b/com.unity.render-pipelines.high-definition/Runtime/Unity.RenderPipelines.HighDefinition.Runtime.asmdef
@@ -2,7 +2,8 @@
     "name": "Unity.RenderPipelines.HighDefinition.Runtime",
     "references": [
         "Unity.RenderPipelines.Core.Runtime",
-        "Unity.Postprocessing.Runtime"
+        "Unity.Postprocessing.Runtime",
+        "Unity.ugui"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -5,6 +5,7 @@
     "unity": "2019.1",
     "displayName": "High Definition RP",
     "dependencies": {
+        "com.unity.ugui": "0.0.0-builtin",
         "com.unity.postprocessing": "2.0.16-preview",
         "com.unity.render-pipelines.core": "5.1.0-preview",
         "com.unity.shadergraph": "5.1.0-preview"


### PR DESCRIPTION

Create a new PR to be able to launch katana: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2469

### Purpose of this PR
in 2019.1 ugui will be a core package. HDRP tests depend on ugui so the hdrp package will need to depend on the ugui package
---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
