### PR TITLE
Fix for Exception when opening unity after having closed it with a vf…

### DIFF
--- a/com.unity.visualeffectgraph/Editor/Utils/VFXResources.cs
+++ b/com.unity.visualeffectgraph/Editor/Utils/VFXResources.cs
@@ -38,7 +38,14 @@ namespace UnityEditor.VFX
         private static void Initialize()
         {
 
-            var asset = Object.FindObjectOfType<VFXResources>();
+            string[] guids = AssetDatabase.FindAssets("t:VFXResources");
+
+
+            VFXResources asset = null;
+
+            if (guids.Length > 0)
+                asset = AssetDatabase.LoadAssetAtPath<VFXResources>(AssetDatabase.GUIDToAssetPath(guids[0]));
+
             if (asset == null)
             {
                 Debug.LogWarning("Could not find " + defaultFileName + ", creating...");


### PR DESCRIPTION
…x loaded in the vfx window

### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Fix a problem with VFXResource.asset reloading, which was causing the exception when trying to restore the vfx window.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=vfx%2Ffix%2Fvfxresource-find-fix&unity_branch=trunk&automation-tools_branch=add-platform-filter

Currently running


**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low
**Halo Effect**: None, Low, Medium, High?
Low
---
### Comments to reviewers
Notes for the reviewers you have assigned.
