### PR TITLE
add dependency on ugui package

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Unity.RenderPipelines.HighDefinition.Runtime.asmdef
+++ b/com.unity.render-pipelines.high-definition/Runtime/Unity.RenderPipelines.HighDefinition.Runtime.asmdef
@@ -2,7 +2,8 @@
     "name": "Unity.RenderPipelines.HighDefinition.Runtime",
     "references": [
         "Unity.RenderPipelines.Core.Runtime",
-        "Unity.Postprocessing.Runtime"
+        "Unity.Postprocessing.Runtime",
+        "Unity.ugui"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -5,6 +5,7 @@
     "unity": "2019.1",
     "displayName": "High Definition RP",
     "dependencies": {
+        "com.unity.ugui": "0.0.0-builtin",
         "com.unity.postprocessing": "2.0.16-preview",
         "com.unity.render-pipelines.core": "5.1.0-preview",
         "com.unity.shadergraph": "5.1.0-preview"


### PR DESCRIPTION
Local version of PR https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2442 to be able to launch katana

https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrp-add-dependency-on-ugui-package&automation-tools_branch=add-platform-filter&unity_branch=ui%2Fdev%2Fpkg

Katana for trunk once PR is merged:
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrp-add-dependency-on-ugui-package&automation-tools_branch=add-platform-filter&unity_branch=trunk