### PR TITLE
Fix HasFocus() function when the target is a TextInputBaseField.

### DIFF
--- a/com.unity.visualeffectgraph/Editor/Controls/VFXSliderField.cs
+++ b/com.unity.visualeffectgraph/Editor/Controls/VFXSliderField.cs
@@ -79,7 +79,7 @@ namespace UnityEditor.VFX.UIElements
 
         protected bool m_IgnoreNotification;
 
-        public abstract bool HasFocus();
+        public abstract bool hasFocus { get; }
         public void OnValueChanged(EventCallback<ChangeEvent<T>> callback)
         {
             RegisterCallback(callback);
@@ -107,7 +107,7 @@ namespace UnityEditor.VFX.UIElements
         {
             m_IgnoreNotification = true;
             m_Value = newValue;
-            if (!(m_Field as VisualElement).HasFocus())
+            if (!hasFocus)
                 m_Field.value = newValue;
             m_Slider.value = ValueToFloat(value);
             m_IgnoreNotification = false;
@@ -148,9 +148,9 @@ namespace UnityEditor.VFX.UIElements
         VisualElement m_IndeterminateLabel;
         FloatField m_FloatField;
 
-        public override bool HasFocus()
+        public override bool hasFocus
         {
-            return (m_Field as FloatField).HasFocus();
+            get { return (m_Field as FloatField).HasFocus(); }
         }
 
         protected override float ValueToFloat(float value)
@@ -205,9 +205,9 @@ namespace UnityEditor.VFX.UIElements
             RegisterCallBack();
         }
 
-        public override bool HasFocus()
+        public override bool hasFocus
         {
-            return (m_Field as IntegerField).HasFocus();
+            get {return (m_Field as IntegerField).HasFocus(); }
         }
 
         protected override float ValueToFloat(int value)
@@ -238,9 +238,9 @@ namespace UnityEditor.VFX.UIElements
             RegisterCallBack();
         }
 
-        public override bool HasFocus()
+        public override bool hasFocus
         {
-            return (m_Field as LongField).HasFocus();
+            get { return (m_Field as LongField).HasFocus(); }
         }
 
         protected override float ValueToFloat(long value)

--- a/com.unity.visualeffectgraph/Editor/VisualElementExtensions.cs
+++ b/com.unity.visualeffectgraph/Editor/VisualElementExtensions.cs
@@ -1,8 +1,10 @@
-using UnityEngine;
-using UnityEditor;
-using UnityEngine.UIElements;
+using System.Linq;
 using System.Reflection;
 
+using UnityEngine;
+using UnityEngine.UIElements;
+
+using UnityEditor;
 
 static class VisualElementExtensions
 {
@@ -26,9 +28,16 @@ static class VisualElementExtensions
         return (GUIView)m_OwnerPropertyInfo.GetValue(panel, new object[] {});
     }
 
+    // HasFocus on textField should really see if the child TextInput hasFocus
+    public static bool HasFocus<T>(this TextInputBaseField<T> texInput)
+    {
+        return ((VisualElement)texInput.Query(TextInputBaseField<T>.textInputUssName)).HasFocus();
+    }
+
     public static bool HasFocus(this VisualElement visualElement)
     {
         if (visualElement.panel == null) return false;
+
         return visualElement.panel.focusController.focusedElement == visualElement;
     }
 


### PR DESCRIPTION
### Purpose of this PR
Fix regresssion caused by new UIElements where the focus on TextField was not correctly computed.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=vfx%2Ffix%2Fhasfocus-textfield&unity_branch=84f9b5a9b69fcb4b7254aa31e5558f4d0e4edf45&automation-tools_branch=add-platform-filter
**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
