### PR TITLE
Switch support

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [5.3.0-preview] - 2018-11-xx
 
+### Changed
+- ColorPyramid compute shader passes is swapped to pixel shader passes on platforms where the later is faster (Nintendo Switch).
+
 ## [5.2.0-preview] - 2018-11-27
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -384,7 +384,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _Source = Shader.PropertyToID("_Source");
         public static readonly int _Destination = Shader.PropertyToID("_Destination");
         public static readonly int _Mip0 = Shader.PropertyToID("_Mip0");
+        public static readonly int _SourceMip = Shader.PropertyToID("_SourceMip");
         public static readonly int _SrcOffsetAndLimit = Shader.PropertyToID("_SrcOffsetAndLimit");
+        public static readonly int _SrcScaleBias = Shader.PropertyToID("_SrcScaleBias");
+        public static readonly int _SrcUvLimits = Shader.PropertyToID("_SrcUvLimits");
         public static readonly int _DstOffset         = Shader.PropertyToID("_DstOffset");
         public static readonly int _DepthMipChain = Shader.PropertyToID("_DepthMipChain");
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/ColorPyramidPS.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/ColorPyramidPS.shader
@@ -1,0 +1,78 @@
+Shader "ColorPyramidPS"
+{
+    HLSLINCLUDE
+
+        #pragma target 4.5
+        #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+        #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
+
+        TEXTURE2D(_Source);
+        SamplerState sampler_LinearClamp;
+        uniform float4 _SrcScaleBias;
+        uniform float4 _SrcUvLimits; // {xy: max uv, zw: direction of blurfor 1 texel }
+        uniform float _SourceMip;
+
+        struct Attributes
+        {
+            uint vertexID : SV_VertexID;
+        };
+
+        struct Varyings
+        {
+            float4 positionCS : SV_POSITION;
+            float2 texcoord   : TEXCOORD0;
+        };
+
+        Varyings Vert(Attributes input)
+        {
+            Varyings output;
+            output.positionCS = GetFullScreenTriangleVertexPosition(input.vertexID);
+            output.texcoord   = GetFullScreenTriangleTexCoord(input.vertexID) * _SrcScaleBias.xy + _SrcScaleBias.zw;
+            return output;
+        }
+
+        float4 FragBilinear(Varyings input) : SV_Target
+        {
+            // Gaussian weights for 9 texel kernel from center textel to furthest texel. Keep in sync with ColorPyramid.compute
+            const float gaussWeights[] = { 0.27343750, 0.21875000, 0.10937500, 0.03125000, 0.00390625 };
+
+            float2 offset = _SrcUvLimits.zw;
+            float2 offset1 = offset * (1.0 + (gaussWeights[2] / (gaussWeights[1] + gaussWeights[2])));
+            float2 offset2 = offset * (3.0 + (gaussWeights[4] / (gaussWeights[3] + gaussWeights[4])));
+
+            float2 uv_m2 = input.texcoord.xy - offset2;
+            float2 uv_m1 = input.texcoord.xy - offset1;
+            float2 uv_p0 = input.texcoord.xy;
+            float2 uv_p1 = min(_SrcUvLimits.xy, input.texcoord.xy + offset1);
+            float2 uv_p2 = min(_SrcUvLimits.xy, input.texcoord.xy + offset2);
+
+            return
+              + SAMPLE_TEXTURE2D_LOD(_Source, sampler_LinearClamp, uv_m2, _SourceMip) * (gaussWeights[3] + gaussWeights[4])
+              + SAMPLE_TEXTURE2D_LOD(_Source, sampler_LinearClamp, uv_m1, _SourceMip) * (gaussWeights[1] + gaussWeights[2])
+              + SAMPLE_TEXTURE2D_LOD(_Source, sampler_LinearClamp, uv_p0, _SourceMip) *  gaussWeights[0]
+              + SAMPLE_TEXTURE2D_LOD(_Source, sampler_LinearClamp, uv_p1, _SourceMip) * (gaussWeights[1] + gaussWeights[2])
+              + SAMPLE_TEXTURE2D_LOD(_Source, sampler_LinearClamp, uv_p2, _SourceMip) * (gaussWeights[3] + gaussWeights[4]);
+        }
+
+    ENDHLSL
+
+    SubShader
+    {
+        Tags{ "RenderPipeline" = "HDRenderPipeline" }
+
+        // 0: Bilinear tri
+        Pass
+        {
+            ZWrite Off ZTest Always Blend Off Cull Off
+
+            HLSLPROGRAM
+                #pragma vertex Vert
+                #pragma fragment FragBilinear
+            ENDHLSL
+        }
+
+    }
+
+    Fallback Off
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/ColorPyramidPS.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/ColorPyramidPS.shader
@@ -7,11 +7,11 @@ Shader "ColorPyramidPS"
         #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
         #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
 
-        TEXTURE2D(_Source);
+        TEXTURE2D_HALF(_Source);
         SamplerState sampler_LinearClamp;
-        uniform float4 _SrcScaleBias;
-        uniform float4 _SrcUvLimits; // {xy: max uv, zw: direction of blurfor 1 texel }
-        uniform float _SourceMip;
+        uniform half4 _SrcScaleBias;
+        uniform half4 _SrcUvLimits; // {xy: max uv, zw: offset of blur for 1 texel }
+        uniform half _SourceMip;
 
         struct Attributes
         {
@@ -32,20 +32,20 @@ Shader "ColorPyramidPS"
             return output;
         }
 
-        float4 FragBilinear(Varyings input) : SV_Target
+        half4 Frag(Varyings input) : SV_Target
         {
             // Gaussian weights for 9 texel kernel from center textel to furthest texel. Keep in sync with ColorPyramid.compute
-            const float gaussWeights[] = { 0.27343750, 0.21875000, 0.10937500, 0.03125000, 0.00390625 };
+            const half gaussWeights[] = { 0.27343750, 0.21875000, 0.10937500, 0.03125000, 0.00390625 };
 
-            float2 offset = _SrcUvLimits.zw;
-            float2 offset1 = offset * (1.0 + (gaussWeights[2] / (gaussWeights[1] + gaussWeights[2])));
-            float2 offset2 = offset * (3.0 + (gaussWeights[4] / (gaussWeights[3] + gaussWeights[4])));
+            half2 offset = _SrcUvLimits.zw;
+            half2 offset1 = offset * (1.0 + (gaussWeights[2] / (gaussWeights[1] + gaussWeights[2])));
+            half2 offset2 = offset * (3.0 + (gaussWeights[4] / (gaussWeights[3] + gaussWeights[4])));
 
-            float2 uv_m2 = input.texcoord.xy - offset2;
-            float2 uv_m1 = input.texcoord.xy - offset1;
-            float2 uv_p0 = input.texcoord.xy;
-            float2 uv_p1 = min(_SrcUvLimits.xy, input.texcoord.xy + offset1);
-            float2 uv_p2 = min(_SrcUvLimits.xy, input.texcoord.xy + offset2);
+            half2 uv_m2 = input.texcoord.xy - offset2;
+            half2 uv_m1 = input.texcoord.xy - offset1;
+            half2 uv_p0 = input.texcoord.xy;
+            half2 uv_p1 = min(_SrcUvLimits.xy, input.texcoord.xy + offset1);
+            half2 uv_p2 = min(_SrcUvLimits.xy, input.texcoord.xy + offset2);
 
             return
               + SAMPLE_TEXTURE2D_LOD(_Source, sampler_LinearClamp, uv_m2, _SourceMip) * (gaussWeights[3] + gaussWeights[4])
@@ -68,7 +68,7 @@ Shader "ColorPyramidPS"
 
             HLSLPROGRAM
                 #pragma vertex Vert
-                #pragma fragment FragBilinear
+                #pragma fragment Frag
             ENDHLSL
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/ColorPyramidPS.shader.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/ColorPyramidPS.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 2fcfb8d92f45e4549b3f0bad5d0654bf
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
@@ -27,6 +27,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // Lighting
             public Shader deferredPS;
             public ComputeShader colorPyramidCS;
+            public Shader colorPyramidPS;
             public ComputeShader depthPyramidCS;
             public ComputeShader copyChannelCS;
             public ComputeShader applyDistortionCS;
@@ -150,6 +151,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Lighting
                 deferredPS = Load<Shader>(HDRenderPipelinePath + "Lighting/Deferred.Shader"),
                 colorPyramidCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/RenderPass/ColorPyramid.compute"),
+                colorPyramidPS = Load<Shader>(HDRenderPipelinePath + "RenderPipeline/RenderPass/ColorPyramidPS.Shader"),
                 depthPyramidCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/RenderPass/DepthPyramid.compute"),
                 copyChannelCS = Load<ComputeShader>(CorePath + "CoreResources/GPUCopy.compute"),
                 applyDistortionCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/RenderPass/Distortion/ApplyDistorsion.compute"),

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineResources.asset
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineResources.asset
@@ -9,10 +9,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
+  m_GeneratorAsset: {fileID: 0}
   m_Script: {fileID: 11500000, guid: 8b6f86e1523e69a4282e92d393be89a4, type: 3}
   m_Name: HDRenderPipelineResources
   m_EditorClassIdentifier: 
-  m_Version: 4
   shaders:
     defaultPS: {fileID: 4800000, guid: 6e4ae4064600d784cac1e41a9e6f2e59, type: 3}
     debugDisplayLatlongPS: {fileID: 4800000, guid: c1d1d149a043a5349ba367da6c2051ba,
@@ -29,9 +29,9 @@ MonoBehaviour:
       type: 3}
     deferredPS: {fileID: 4800000, guid: 00dd221e34a6ab349a1196b0f2fab693, type: 3}
     colorPyramidCS: {fileID: 7200000, guid: 4e3267a1135742441a14298d8dcac04a, type: 3}
+    colorPyramidPS: {fileID: 4800000, guid: 2fcfb8d92f45e4549b3f0bad5d0654bf, type: 3}
     depthPyramidCS: {fileID: 7200000, guid: 64a553bb564274041906f78ffba955e4, type: 3}
     copyChannelCS: {fileID: 7200000, guid: a4d45eda75e8e474dbe24a31f741f3b4, type: 3}
-    texturePaddingCS: {fileID: 7200000, guid: 6736f53014c69f84aa2130aeae99730b, type: 3}
     applyDistortionCS: {fileID: 7200000, guid: 2fa6c0e3fe6dc3145a4156f21913fe5c, type: 3}
     screenSpaceReflectionsCS: {fileID: 7200000, guid: d1de9ac7d9016204da289affe9677942,
       type: 3}
@@ -94,7 +94,6 @@ MonoBehaviour:
     shadowClearPS: {fileID: 4800000, guid: e3cab24f27741f44d8af1e94d006267c, type: 3}
     shadowBlurMomentsCS: {fileID: 7200000, guid: fb36979473602464fa32deacb9630c08,
       type: 3}
-    debugShadowMapPS: {fileID: 4800000, guid: ee25e539f5594f44085e0a9000c15d9b, type: 3}
     debugHDShadowMapPS: {fileID: 4800000, guid: 93d40cc9a6e13994f86f576a624efa18,
       type: 3}
     decalNormalBufferPS: {fileID: 4800000, guid: fd532bf1795188c4daaa66ea798b8b0a,
@@ -109,11 +108,5 @@ MonoBehaviour:
     defaultTerrainMat: {fileID: 2100000, guid: 22ff8771d87ef27429e670136399094b, type: 2}
   textures:
     debugFontTex: {fileID: 2800000, guid: a3ad2df0e49aaa341a3b3a80f93b3f66, type: 3}
-  shaderGraphs:
-    autodeskInteractiveSG: {fileID: 4800000, guid: 7252379db4c18b641b517f2c91bb57e1,
-      type: 3}
-    autodeskInteractiveTransparentSG: {fileID: 4800000, guid: ee2ce0be66f45d9449d71ba9b49c2acd,
-      type: 3}
-    autodeskInteractiveMaskedSG: {fileID: 4800000, guid: 29c4adff654862b40a2e9fb2015a42c3,
-      type: 3}
-    colorGradient: {fileID: 2800000, guid: 4ea52e665573c1644bf05dd9b11fd2a4, type: 3}
+    colorGradient: {fileID: 0}
+  m_Version: 4


### PR DESCRIPTION
### Purpose of this PR
This PR optimizes ColorPyramid pass for Switch, and possibly other platforms (to be tested).
On Switch, the compute shader version of the pass runs at 5.0ms on a 720p render-target RGBA16F (undocked mode). The new fragment shader version runs at 1.7ms.

The compute shader is also currently broken on Switch, due to the generated GLSL code expecting a RGBA32F texture to be sampled, but given an RGBA16F (incorrect sampling from RWImage2D).

---
### Release Notes

---
### Testing status
**Katana Tests**: Katana is likely not setup to run Switch

**Manual Tests**:
Comparing the reference result from the (locally fixed) compute shader with the new fragment shader implementation, the blurred mipmap chain look the same.

**Automated Tests**: No automated test was run.

---
### Overall Product Risks
**Technical Risk**: Low
Other platforms that Switch are not touched. Previous implementation is broken on Switch too.

**Halo Effect**: Low

---
### Comments to reviewers
This optimization may benefit other platforms too, I only tested Geforce GTX 1050 on my laptop (it was a 33% win on Vulkan platform).
More saving are possible and will be committed later:
- render-targets should be R11G11B10, this would move the cost down to 1.35ms.
- copy of the base mipmap should be skipped (cost 0.6ms out of the 1.7ms)
- it may possible to reorganize the sub-passes (downsample, horizonal blur, vertical blur) and remove most of the GPU barriers, possibly saving a further  an additional ~0.2ms. This will however remove accumulation of blur though the mipmap chain, so further discussion is needed.
