### PR TITLE
Quick UX tweak for scene settings

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Volume/VolumeProfileFactory.cs
+++ b/com.unity.render-pipelines.core/Editor/Volume/VolumeProfileFactory.cs
@@ -64,6 +64,7 @@ namespace UnityEditor.Rendering
             where T : VolumeComponent
         {
             var comp = profile.Add<T>(overrides);
+            comp.hideFlags = HideFlags.HideInInspector | HideFlags.HideInHierarchy;
             AssetDatabase.AddObjectToAsset(comp, profile);
 
             if (saveAsset)


### PR DESCRIPTION
The scene settings asset doesn't have proper hide flags for sub-components which doesn't look good in the project view.

Before/after:

![image](https://user-images.githubusercontent.com/849090/49151129-5de2be00-f30f-11e8-8649-469cb8c5b79d.png)

No test ran, zero halo effect, it's purely cosmetic on the editor side.