### PR TITLE
Vfx/fix/float4 depth prepass

### DIFF
--- a/com.unity.visualeffectgraph/Shaders/ParticleHexahedron/PassDepth.template
+++ b/com.unity.visualeffectgraph/Shaders/ParticleHexahedron/PassDepth.template
@@ -29,11 +29,11 @@ Pass
 	${VFXInclude("Shaders/ParticleHexahedron/Pass.template")}	
 		
 	#pragma fragment frag
-	float frag(ps_input i) : SV_Target0
+	float4 frag(ps_input i) : SV_Target0
 	{
 		float alpha = VFXGetFragmentColor(i).a;		
 		VFXClipFragmentColor(alpha,i);
-		return 0;
+		return (float4)0;
 	}
 	ENDHLSL
 }

--- a/com.unity.visualeffectgraph/Shaders/ParticleLines/PassDepth.template
+++ b/com.unity.visualeffectgraph/Shaders/ParticleLines/PassDepth.template
@@ -25,11 +25,11 @@ Pass
 	${VFXInclude("Shaders/ParticleLines/Pass.template")}	
 		
 	#pragma fragment frag
-	float frag(ps_input i) : SV_TARGET
+	float4 frag(ps_input i) : SV_TARGET
 	{
 		float alpha = VFXGetFragmentColor(i);
 		VFXClipFragmentColor(alpha,i);
-		return 0;
+		return (float4)0;
 	}
 	ENDHLSL
 }

--- a/com.unity.visualeffectgraph/Shaders/ParticleLinesSW/PassDepth.template
+++ b/com.unity.visualeffectgraph/Shaders/ParticleLinesSW/PassDepth.template
@@ -25,11 +25,11 @@ Pass
 	${VFXInclude("Shaders/ParticleLinesSW/Pass.template")}	
 		
 	#pragma fragment frag
-	float frag(ps_input i) : SV_TARGET
+	float4 frag(ps_input i) : SV_TARGET
 	{
 		float alpha = VFXGetFragmentColor(i);
 		VFXClipFragmentColor(alpha,i);
-		return 0;
+		return (float4)0;
 	}
 	ENDHLSL
 }

--- a/com.unity.visualeffectgraph/Shaders/ParticleMeshes/PassDepth.template
+++ b/com.unity.visualeffectgraph/Shaders/ParticleMeshes/PassDepth.template
@@ -35,12 +35,12 @@ Pass
 	${VFXInclude("Shaders/ParticleMeshes/Pass.template")}	
 		
 	#pragma fragment frag
-	float frag(ps_input i) : SV_TARGET
+	float4 frag(ps_input i) : SV_TARGET
 	{
 		float alpha = VFXGetFragmentColor(i).a;
 		alpha *= VFXGetTextureColor(VFX_SAMPLER(mainTexture),i).a;		
 		VFXClipFragmentColor(alpha,i);
-		return 0;
+		return (float4)0;
 	}
 	ENDHLSL
 }

--- a/com.unity.visualeffectgraph/Shaders/ParticlePoints/PassDepth.template
+++ b/com.unity.visualeffectgraph/Shaders/ParticlePoints/PassDepth.template
@@ -27,11 +27,11 @@ Pass
 	${VFXInclude("Shaders/ParticlePoints/Pass.template")}	
 		
 	#pragma fragment frag
-	float frag(ps_input i) : SV_TARGET
+	float4 frag(ps_input i) : SV_TARGET
 	{
 		float alpha = VFXGetFragmentColor(i).a;
 		VFXClipFragmentColor(alpha,i);
-		return 0;
+		return (float4)0;
 	}
 	ENDHLSL
 }

--- a/com.unity.visualeffectgraph/Shaders/ParticleQuads/PassDepth.template
+++ b/com.unity.visualeffectgraph/Shaders/ParticleQuads/PassDepth.template
@@ -35,12 +35,12 @@ Pass
 	${VFXInclude("Shaders/ParticleQuads/Pass.template")}	
 		
 	#pragma fragment frag
-	float frag(ps_input i) : SV_TARGET
+	float4 frag(ps_input i) : SV_TARGET
 	{
 		float alpha = VFXGetFragmentColor(i).a;
 		alpha *= VFXGetTextureColor(VFX_SAMPLER(mainTexture),i).a;		
 		VFXClipFragmentColor(alpha,i);
-		return 0;
+		return (float4)0;
 	}
 	ENDHLSL
 }


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Fix errors on Mac when unlit shaders are used : return a float4 in the frag shader function even for the depth prepass where said value is ignored.
---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.