### PR TITLE
Fix and cleanup pass on HDRP master node (Unlit, Fabric, lit, stacklit, PBR)

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -20,9 +20,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed divide by 0 in refraction causing NaN
 - Fixed disable rough refraction support
 - Fixed refraction, SSS and atmospheric scattering for VR
-- Fixed forward clustered lighting for VR (double-wide)
+- Fixed forward clustered lighting for VR (double-wide).
 - Fixed Light's UX to not allow negative intensity
 - Fixed HDRenderPipelineAsset inspector broken when displaying its FrameSettings from project windows.
+- Fixed forward clustered lighting for VR (double-wide).
+- Fixed HDRenderPipelineAsset inspector broken when displaying its FrameSettings from project windows.
+- Fixed Decals and SSR diable flags for all shader graph master node (Lit, Fabric, StackLit, PBR)
+- Fixed Distortion blend mode for shader graph master node (Lit, StackLit)
+- Fixed bent Normal for Fabric master node in shader graph
+- Fixed PBR master node lightlayers
 
 ### Changed
 - Rename "Regular" in Diffusion profile UI "Thick Object"

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
@@ -64,13 +64,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public const int AlphaSlotId = 13;
 
         public const string AlphaClipThresholdSlotName = "AlphaClipThreshold";
-        public const int AlphaThresholdSlotId = 14;
+        public const int AlphaClipThresholdSlotId = 14;
 
-        public const string AlphaClipThresholdDepthPrepassSlotName = "AlphaClipThresholdDepthPrepass";
-        public const int AlphaThresholdDepthPrepassSlotId = 15;
-
-        public const string AlphaClipThresholdDepthPostpassSlotName = "AlphaClipThresholdDepthPostpass";
-        public const int AlphaThresholdDepthPostpassSlotId = 16;
+        public const string BentNormalSlotName = "BentNormal";
+        public const int BentNormalSlotId = 15;
 
 
         public enum MaterialType
@@ -106,13 +103,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             Anisotropy = 1 << AnisotropySlotId,
             Emission = 1 << EmissionSlotId,
             Alpha = 1 << AlphaSlotId,
-            AlphaThreshold = 1 << AlphaThresholdSlotId,
-            AlphaThresholdDepthPrepass = 1 << AlphaThresholdDepthPrepassSlotId,
-            AlphaThresholdDepthPostpass = 1 << AlphaThresholdDepthPostpassSlotId
+            AlphaClipThreshold = 1 << AlphaClipThresholdSlotId,
+            BentNormal = 1 << BentNormalSlotId
         }
 
-        const SlotMask CottonWoolSlotMask = SlotMask.Position | SlotMask.Albedo | SlotMask.SpecularOcclusion | SlotMask.Normal | SlotMask.Smoothness | SlotMask.Occlusion | SlotMask.Specular | SlotMask.DiffusionProfile | SlotMask.SubsurfaceMask | SlotMask.Thickness | SlotMask.Emission | SlotMask.Alpha | SlotMask.AlphaThreshold | SlotMask.AlphaThresholdDepthPrepass | SlotMask.AlphaThresholdDepthPostpass;
-        const SlotMask SilkSlotMask = SlotMask.Position | SlotMask.Albedo | SlotMask.SpecularOcclusion | SlotMask.Normal | SlotMask.Smoothness | SlotMask.Occlusion | SlotMask.Specular | SlotMask.DiffusionProfile | SlotMask.SubsurfaceMask | SlotMask.Thickness | SlotMask.Tangent | SlotMask.Anisotropy | SlotMask.Emission | SlotMask.Alpha | SlotMask.AlphaThreshold | SlotMask.AlphaThresholdDepthPrepass | SlotMask.AlphaThresholdDepthPostpass;
+        const SlotMask CottonWoolSlotMask = SlotMask.Position | SlotMask.Albedo | SlotMask.SpecularOcclusion | SlotMask.Normal | SlotMask.Smoothness | SlotMask.Occlusion | SlotMask.Specular | SlotMask.DiffusionProfile | SlotMask.SubsurfaceMask | SlotMask.Thickness | SlotMask.Emission | SlotMask.Alpha | SlotMask.AlphaClipThreshold | SlotMask.BentNormal;
+        const SlotMask SilkSlotMask = SlotMask.Position | SlotMask.Albedo | SlotMask.SpecularOcclusion | SlotMask.Normal | SlotMask.Smoothness | SlotMask.Occlusion | SlotMask.Specular | SlotMask.DiffusionProfile | SlotMask.SubsurfaceMask | SlotMask.Thickness | SlotMask.Tangent | SlotMask.Anisotropy | SlotMask.Emission | SlotMask.Alpha | SlotMask.AlphaClipThreshold | SlotMask.BentNormal;
 
         // This could also be a simple array. For now, catch any mismatched data.
         SlotMask GetActiveSlotMask()
@@ -465,6 +461,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 validSlots.Add(NormalSlotId);
             }
 
+            // BentNormal
+            if (MaterialTypeUsesSlotMask(SlotMask.BentNormal))
+            {
+                AddSlot(new NormalMaterialSlot(BentNormalSlotId, BentNormalSlotName, BentNormalSlotName, CoordinateSpace.Tangent, ShaderStageCapability.Fragment));
+                validSlots.Add(BentNormalSlotId);
+            }
+
             // Smoothness
             if (MaterialTypeUsesSlotMask(SlotMask.Smoothness))
             {
@@ -536,24 +539,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
 
             // Alpha threshold
-            if (MaterialTypeUsesSlotMask(SlotMask.AlphaThreshold) && alphaTest.isOn)
+            if (MaterialTypeUsesSlotMask(SlotMask.AlphaClipThreshold) && alphaTest.isOn)
             {
-                AddSlot(new Vector1MaterialSlot(AlphaThresholdSlotId, AlphaClipThresholdSlotName, AlphaClipThresholdSlotName, SlotType.Input, 0.0f, ShaderStageCapability.Fragment));
-                validSlots.Add(AlphaThresholdSlotId);
-            }
-
-            // Alpha threshold depth prepass
-            if (MaterialTypeUsesSlotMask(SlotMask.AlphaThresholdDepthPrepass) && surfaceType == SurfaceType.Transparent && alphaTest.isOn && alphaTestDepthPrepass.isOn)
-            {
-                AddSlot(new Vector1MaterialSlot(AlphaThresholdDepthPrepassSlotId, AlphaClipThresholdDepthPrepassSlotName, AlphaClipThresholdDepthPrepassSlotName, SlotType.Input, 0.0f, ShaderStageCapability.Fragment));
-                validSlots.Add(AlphaThresholdDepthPrepassSlotId);
-            }
-
-            // Alpha threshold depth postpass
-            if (MaterialTypeUsesSlotMask(SlotMask.AlphaThresholdDepthPostpass) && surfaceType == SurfaceType.Transparent && alphaTest.isOn && alphaTestDepthPostpass.isOn)
-            {
-                AddSlot(new Vector1MaterialSlot(AlphaThresholdDepthPostpassSlotId, AlphaClipThresholdDepthPostpassSlotName, AlphaClipThresholdDepthPostpassSlotName, SlotType.Input, 0.0f, ShaderStageCapability.Fragment));
-                validSlots.Add(AlphaThresholdDepthPostpassSlotId);
+                AddSlot(new Vector1MaterialSlot(AlphaClipThresholdSlotId, AlphaClipThresholdSlotName, AlphaClipThresholdSlotName, SlotType.Input, 0.0f, ShaderStageCapability.Fragment));
+                validSlots.Add(AlphaClipThresholdSlotId);
             }
 
             RemoveSlotsNameNotMatching(validSlots, true);
@@ -614,8 +603,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         public bool RequiresSplitLighting()
         {
-            // TODO: Check this with SEB
-            return true;
+            return subsurfaceScattering.isOn;
         }
 
         public override void CollectShaderProperties(PropertyCollector collector, GenerationMode generationMode)
@@ -633,29 +621,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             });
 
             base.CollectShaderProperties(collector, generationMode);
-        }
-
-        public int GetStencilWriteMask()
-        {
-            int stencilWriteMask = (int)HDRenderPipeline.StencilBitMask.LightingMask;
-            if (!m_ReceivesSSR)
-            {
-                stencilWriteMask |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
-            }
-            return stencilWriteMask;
-        }
-        public int GetStencilRef()
-        {
-            int stencilRef = (int)StencilLightingUsage.RegularLighting;
-            if (RequiresSplitLighting())
-            {
-                stencilRef = (int)StencilLightingUsage.SplitLighting;
-            }
-            if (!m_ReceivesSSR)
-            {
-                stencilRef |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
-            }
-            return stencilRef;
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
@@ -7,49 +7,48 @@ Pass
     //-------------------------------------------------------------------------------------
     // Render Modes (Blend, Cull, ZTest, Stencil, etc)
     //-------------------------------------------------------------------------------------
-        $splice(Blending)
-        $splice(Culling)
-        $splice(ZTest)
-        $splice(ZWrite)
-        $splice(ZClip)
-        $splice(Stencil)
-        $splice(ColorMask)
+    $splice(Blending)
+    $splice(Culling)
+    $splice(ZTest)
+    $splice(ZWrite)
+    $splice(ZClip)
+    $splice(Stencil)
+    $splice(ColorMask)
     //-------------------------------------------------------------------------------------
     // End Render Modes
     //-------------------------------------------------------------------------------------
 
     HLSLPROGRAM
 
-        #pragma target 4.5
-        #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
-        //#pragma enable_d3d11_debug_symbols
+    #pragma target 4.5
+    #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+    //#pragma enable_d3d11_debug_symbols
 
-        #pragma multi_compile_instancing
-        #pragma instancing_options renderinglayer
+    #pragma multi_compile_instancing
+    #pragma instancing_options renderinglayer
 
-        #pragma multi_compile _ LOD_FADE_CROSSFADE
+    #pragma multi_compile _ LOD_FADE_CROSSFADE
 
     //-------------------------------------------------------------------------------------
     // Variant Definitions (active field translations to HDRP defines)
     //-------------------------------------------------------------------------------------
-        $Material.CottonWool:               #define _MATERIAL_FEATURE_COTTON_WOOL 1
-        $SurfaceDescription.Transmission:             #define _MATERIAL_FEATURE_TRANSMISSION 1
-        $SurfaceDescription.SubsurfaceScattering:     #define _MATERIAL_FEATURE_SUBSURFACE_SCATTERING 1
-        $SurfaceDescription.Emission:       #define _EMISSION 1
-        $SurfaceType.Transparent:           #define _SURFACE_TYPE_TRANSPARENT 1
-        $BlendMode.Alpha:                   #define _BLENDMODE_ALPHA 1
-        $BlendMode.Add:                     #define _BLENDMODE_ADD 1
-        $BlendMode.Premultiply:             #define _BLENDMODE_PRE_MULTIPLY 1
-        $BlendMode.PreserveSpecular:        #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1
-        $AlphaFog:                          #define _ENABLE_FOG_ON_TRANSPARENT 1
-        $Occlusion:                         #define _OCCLUSION 1
-        $SpecularOcclusionFromAO:           #define _SPECULAR_OCCLUSION_FROM_AO 1
-        $SpecularOcclusionFromAOBentNormal: #define _SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL 1
-        $SpecularOcclusionCustom:           #define _SPECULAR_OCCLUSION_CUSTOM 1
-        $Specular.EnergyConserving:         #define _ENERGY_CONSERVING_SPECULAR 1
-        $Specular.AA:                       #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
-        $Decals:                            #define _DECALS 1
-        $DisableSSR:                        #define _DISABLE_SSR 1
+    $Material.CottonWool:               #define _MATERIAL_FEATURE_COTTON_WOOL 1
+    $SurfaceDescription.Transmission:             #define _MATERIAL_FEATURE_TRANSMISSION 1
+    $SurfaceDescription.SubsurfaceScattering:     #define _MATERIAL_FEATURE_SUBSURFACE_SCATTERING 1
+    $SurfaceType.Transparent:           #define _SURFACE_TYPE_TRANSPARENT 1
+    $BlendMode.Alpha:                   #define _BLENDMODE_ALPHA 1
+    $BlendMode.Add:                     #define _BLENDMODE_ADD 1
+    $BlendMode.Premultiply:             #define _BLENDMODE_PRE_MULTIPLY 1
+    $BlendMode.PreserveSpecular:        #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1
+    $AlphaFog:                          #define _ENABLE_FOG_ON_TRANSPARENT 1
+    $Occlusion:                         #define _OCCLUSION 1
+    $SpecularOcclusionFromAO:           #define _SPECULAR_OCCLUSION_FROM_AO 1
+    $SpecularOcclusionFromAOBentNormal: #define _SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL 1
+    $SpecularOcclusionCustom:           #define _SPECULAR_OCCLUSION_CUSTOM 1
+    $Specular.EnergyConserving:         #define _ENERGY_CONSERVING_SPECULAR 1
+    $Specular.AA:                       #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
+    $DisableDecals:                     #define _DISABLE_DECALS 1
+    $DisableSSR:                        #define _DISABLE_SSR 1
     //-------------------------------------------------------------------------------------
     // End Variant Definitions
     //-------------------------------------------------------------------------------------
@@ -77,46 +76,39 @@ Pass
     //-------------------------------------------------------------------------------------
     // Defines
     //-------------------------------------------------------------------------------------
-$splice(Defines)
+    $splice(Defines)
 
-        // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
-        $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
-        $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
-        $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
-        $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
-        $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
-        $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
-        $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
-        $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
-        $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
-        $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
-        $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
-        $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
-        $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
-        $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
-        $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
-        $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
+    // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
+    $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
+    $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
+    $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
+    $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
+    $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
+    $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
+    $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
+    $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
+    $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
+    $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
+    $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
+    $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
+    $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
+    $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
+    $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
+    $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
 
     //-------------------------------------------------------------------------------------
     // End Defines
     //-------------------------------------------------------------------------------------
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #endif
+#ifdef DEBUG_DISPLAY
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
+#endif
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
 
 #if (SHADERPASS == SHADERPASS_FORWARD)
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
-
-    // The light loop (or lighting architecture) is in charge to:
-    // - Define light list
-    // - Define the light loop
-    // - Setup the constant/data
-    // - Do the reflection hierarchy
-    // - Provide sampling function for shadowmap, ies, cookie and reflection (depends on the specific use with the light loops like index array or atlas or single and texture format (cubemap/latlong))
 
     #define HAS_LIGHTLOOP
 
@@ -136,34 +128,12 @@ $splice(Defines)
     int _ObjectId;
     int _PassValue;
 
-    // this function assumes the bitangent flip is encoded in tangentWS.w
-    // TODO: move this function to HDRP shared file, once we merge with HDRP repo
-    float3x3 BuildWorldToTangent(float4 tangentWS, float3 normalWS)
-    {
-        // tangentWS must not be normalized (mikkts requirement)
-
-        // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
-	    float3 unnormalizedNormalWS = normalWS;
-        float renormFactor = 1.0 / length(unnormalizedNormalWS);
-
-        // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-	    // this is the mikktspace transformation (must use unnormalized attributes)
-        float3x3 worldToTangent = CreateWorldToTangent(unnormalizedNormalWS, tangentWS.xyz, tangentWS.w > 0.0 ? 1.0 : -1.0);
-
-	    // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-	    // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-        worldToTangent[0] = worldToTangent[0] * renormFactor;
-        worldToTangent[1] = worldToTangent[1] * renormFactor;
-        worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
-        return worldToTangent;
-    }
-
     //-------------------------------------------------------------------------------------
     // Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
-        $buildType(AttributesMesh)
-        $buildType(VaryingsMeshToPS)
-        $buildType(VaryingsMeshToDS)
+    $buildType(AttributesMesh)
+    $buildType(VaryingsMeshToPS)
+    $buildType(VaryingsMeshToDS)
     //-------------------------------------------------------------------------------------
     // End Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
@@ -171,7 +141,7 @@ $splice(Defines)
     //-------------------------------------------------------------------------------------
     // Graph generated code
     //-------------------------------------------------------------------------------------
-$splice(Graph)
+    $splice(Graph)
     //-------------------------------------------------------------------------------------
     // End graph generated code
     //-------------------------------------------------------------------------------------
@@ -204,47 +174,38 @@ $include("SharedCode.template.hlsl")
         }
     }
 
-    void BuildSurfaceData(FragInputs fragInputs, inout SurfaceDescription surfaceDescription, float3 V, out SurfaceData surfaceData)
+    void BuildSurfaceData(FragInputs fragInputs, inout SurfaceDescription surfaceDescription, float3 V, PositionInputs posInput, out SurfaceData surfaceData, out float3 bentNormalWS)
     {
         // setup defaults -- these are used if the graph doesn't output a value
         ZERO_INITIALIZE(SurfaceData, surfaceData);
 
         // copy across graph values, if defined
         $SurfaceDescription.Albedo:                     surfaceData.baseColor =                 surfaceDescription.Albedo;
-
         $SurfaceDescription.SpecularOcclusion:          surfaceData.specularOcclusion =         surfaceDescription.SpecularOcclusion;
-
         $SurfaceDescription.Smoothness:                 surfaceData.perceptualSmoothness =      surfaceDescription.Smoothness;
-
         $SurfaceDescription.Occlusion:                  surfaceData.ambientOcclusion =          surfaceDescription.Occlusion;
-
         $SurfaceDescription.Specular:                   surfaceData.specularColor =             surfaceDescription.Specular;
-
         $SurfaceDescription.DiffusionProfile:           surfaceData.diffusionProfile =          surfaceDescription.DiffusionProfile;
-
         $SurfaceDescription.SubsurfaceMask:             surfaceData.subsurfaceMask =            surfaceDescription.SubsurfaceMask;
-
         $SurfaceDescription.Thickness:                  surfaceData.thickness =                 surfaceDescription.Thickness;
-
         $SurfaceDescription.DiffusionProfile:           surfaceData.diffusionProfile =          surfaceDescription.DiffusionProfile;
-
         $SurfaceDescription.Anisotropy:                 surfaceData.anisotropy =                surfaceDescription.Anisotropy;
         
         // These static material feature allow compile time optimization
         surfaceData.materialFeatures = 0;
 
-        // Transform the preprocess macro into a material feature (note that silk flag is deduced from the abscence of this one)
-        #ifdef _MATERIAL_FEATURE_COTTON_WOOL
-            surfaceData.materialFeatures |= MATERIALFEATUREFLAGS_FABRIC_COTTON_WOOL;
-        #endif
+// Transform the preprocess macro into a material feature (note that silk flag is deduced from the abscence of this one)
+#ifdef _MATERIAL_FEATURE_COTTON_WOOL
+        surfaceData.materialFeatures |= MATERIALFEATUREFLAGS_FABRIC_COTTON_WOOL;
+#endif
 
-        #ifdef _MATERIAL_FEATURE_SUBSURFACE_SCATTERING
-            surfaceData.materialFeatures |= MATERIALFEATUREFLAGS_FABRIC_SUBSURFACE_SCATTERING;
-        #endif
+#ifdef _MATERIAL_FEATURE_SUBSURFACE_SCATTERING
+        surfaceData.materialFeatures |= MATERIALFEATUREFLAGS_FABRIC_SUBSURFACE_SCATTERING;
+#endif
 
-        #ifdef _MATERIAL_FEATURE_TRANSMISSION
-            surfaceData.materialFeatures |= MATERIALFEATUREFLAGS_FABRIC_TRANSMISSION;
-        #endif
+#ifdef _MATERIAL_FEATURE_TRANSMISSION
+        surfaceData.materialFeatures |= MATERIALFEATUREFLAGS_FABRIC_TRANSMISSION;
+#endif
 
 
 #if defined (_ENERGY_CONSERVING_SPECULAR)
@@ -259,6 +220,9 @@ $include("SharedCode.template.hlsl")
 
         // compute world space normal
         GetNormalWS(fragInputs, normalTS, surfaceData.normalWS);
+
+        bentNormalWS = surfaceData.normalWS;
+        $BentNormal: GetNormalWS(fragInputs, surfaceDescription.BentNormal, bentNormalWS);
 
         surfaceData.geomNormalWS = fragInputs.worldToTangent[2];
 
@@ -279,10 +243,22 @@ $include("SharedCode.template.hlsl")
         surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 #else
         surfaceData.specularOcclusion = 1.0;
-        surfaceData.specularOcclusion = 1.0;
+#endif
+
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
 #endif
 
 #ifdef DEBUG_DISPLAY
+        if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)
+        {
+            // TODO: need to update mip info
+        }
+
         // We need to call ApplyDebugToSurfaceData after filling the surfarcedata and before filling builtinData
         // as it can modify attribute use for static lighting
         ApplyDebugToSurfaceData(fragInputs.worldToTangent, surfaceData);
@@ -296,12 +272,14 @@ $include("SharedCode.template.hlsl")
         LODDitheringTransition(fadeMaskSeed, unity_LODFade.x);
 #endif
 
-        // this applies the double sided tangent space correction -- see 'ApplyDoubleSidedFlipOrMirror()'
-        $DoubleSided:           if (!fragInputs.isFrontFace) {
-        $DoubleSided.Flip:          fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
-        $DoubleSided.Flip:          fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided.Mirror:        fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided:           }
+        // This applies the double sided tangent space correction
+        // Must match /Runtime/Material/MaterialUtilities.hlsl:ApplyDoubleSidedFlipOrMirror()
+        $DoubleSided:            if (!fragInputs.isFrontFace)
+        $DoubleSided:            {
+        $DoubleSided.Flip:           fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
+        $DoubleSided.Flip:           fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
+        $DoubleSided.Mirror:         fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
+        $DoubleSided:            }
 
         SurfaceDescriptionInputs surfaceDescriptionInputs = FragInputsToSurfaceDescriptionInputs(fragInputs, V);
         SurfaceDescription surfaceDescription = SurfaceDescriptionFunction(surfaceDescriptionInputs);
@@ -309,23 +287,18 @@ $include("SharedCode.template.hlsl")
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
         $AlphaTest:         DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
-        $AlphaTestPrepass:  DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPrepass);
-        $AlphaTestPostpass: DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPostpass);
 
-        BuildSurfaceData(fragInputs, surfaceDescription, V, surfaceData);
-
-#if HAVE_DECALS && _DECALS
-        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-#endif
+        float3 bentNormalWS;
+        BuildSurfaceData(fragInputs, surfaceDescription, V, posInput, surfaceData, bentNormalWS);
 
         // Builtin Data
         // For back lighting we use the oposite vertex normal 
-        InitBuiltinData(surfaceDescription.Alpha, surfaceData.normalWS, -fragInputs.worldToTangent[2], fragInputs.positionRWS, fragInputs.texCoord1, fragInputs.texCoord2, builtinData);
+        InitBuiltinData(surfaceDescription.Alpha, bentNormalWS, -fragInputs.worldToTangent[2], fragInputs.positionRWS, fragInputs.texCoord1, fragInputs.texCoord2, builtinData);
 
         $SurfaceDescription.Emission: builtinData.emissiveColor = surfaceDescription.Emission;
 
-        builtinData.depthOffset = 0.0;                        // ApplyPerPixelDisplacement(input, V, layerTexCoord, blendMasks); #ifdef _DEPTHOFFSET_ON : ApplyDepthOffsetPositionInput(V, depthOffset, GetWorldToHClipMatrix(), posInput);
+        // TODO: Handle depth offset
+        //builtinData.depthOffset = 0.0;
 
         PostInitBuiltinData(V, posInput, surfaceData, builtinData);
     }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
@@ -44,41 +44,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 FabricMasterNode.AnisotropySlotId,
                 FabricMasterNode.EmissionSlotId,
                 FabricMasterNode.AlphaSlotId,
-                FabricMasterNode.AlphaThresholdSlotId,
+                FabricMasterNode.AlphaClipThresholdSlotId,
             },
             VertexShaderSlots = new List<int>()
             {
                 //FabricMasterNode.PositionSlotId
             },
             UseInPreview = false
-        };
-
-        Pass m_SceneSelectionPass = new Pass()
-        {
-            Name = "SceneSelectionPass",
-            LightMode = "SceneSelectionPass",
-            TemplateName = "FabricPass.template",
-            MaterialName = "Fabric",
-            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
-            ExtraDefines = new List<string>()
-            {
-                "#define SCENESELECTIONPASS",
-            },
-            ColorMaskOverride = "ColorMask 0",
-            Includes = new List<string>()
-            {
-                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
-            },
-            PixelShaderSlots = new List<int>()
-            {
-                FabricMasterNode.AlphaSlotId,
-                FabricMasterNode.AlphaThresholdSlotId
-            },
-            VertexShaderSlots = new List<int>()
-            {
-                FabricMasterNode.PositionSlotId
-            },
-            UseInPreview = true
         };
 
         Pass m_PassShadowCaster = new Pass()
@@ -102,54 +74,70 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             PixelShaderSlots = new List<int>()
             {
                 FabricMasterNode.AlphaSlotId,
-                FabricMasterNode.AlphaThresholdSlotId
+                FabricMasterNode.AlphaClipThresholdSlotId
             },
             VertexShaderSlots = new List<int>()
             {
                 FabricMasterNode.PositionSlotId
             },
-
             UseInPreview = false
         };
 
-        Pass m_PassDepthForwardOnly = new Pass()
+        Pass m_SceneSelectionPass = new Pass()
         {
+            Name = "SceneSelectionPass",
+            LightMode = "SceneSelectionPass",
             TemplateName = "FabricPass.template",
             MaterialName = "Fabric",
-
-            Name = "Depth prepass",
-            LightMode = "DepthForwardOnly",
-
-
-            ZWriteOverride = "ZWrite On",
-
-            StencilOverride = new List<string>()
-            {
-                "Stencil",
-                "{",
-                "   WriteMask 16",         // [DecalsForwardOutputNormalBuffer]
-                "   Ref 16",               // [_StencilDepthPrepassRef]
-                "   Comp Always",
-                "   Pass Replace",
-                "}"
-            },
-
+            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
+            ColorMaskOverride = "ColorMask 0",
             ExtraDefines = new List<string>()
             {
-                "#define WRITE_NORMAL_BUFFER",
-                "#pragma multi_compile _ WRITE_MSAA_DEPTH"
-            },
-            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
+                "#define SCENESELECTIONPASS",
+            },            
             Includes = new List<string>()
             {
                 "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
             },
             PixelShaderSlots = new List<int>()
             {
+                FabricMasterNode.AlphaSlotId,
+                FabricMasterNode.AlphaClipThresholdSlotId
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                FabricMasterNode.PositionSlotId
+            },
+            UseInPreview = true
+        };
+
+        Pass m_PassDepthForwardOnly = new Pass()
+        {
+            Name = "DepthOnly",
+            LightMode = "DepthForwardOnly",
+            TemplateName = "FabricPass.template",
+            MaterialName = "Fabric",
+            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
+            ZWriteOverride = "ZWrite On",
+
+            ExtraDefines = new List<string>()
+            {
+                "#define WRITE_NORMAL_BUFFER",
+                "#pragma multi_compile _ WRITE_MSAA_DEPTH"
+            },
+            
+            Includes = new List<string>()
+            {
+                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                FabricMasterNode.NormalSlotId,
                 FabricMasterNode.SmoothnessSlotId,
                 FabricMasterNode.AlphaSlotId,
-                FabricMasterNode.AlphaThresholdSlotId
+                FabricMasterNode.AlphaClipThresholdSlotId
             },
+
             RequiredFields = new List<string>()
             {
                 "AttributesMesh.normalOS",
@@ -173,8 +161,32 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 FabricMasterNode.PositionSlotId
             },
+            UseInPreview = false,
 
-            UseInPreview = false
+            OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
+            {
+                var masterNode = node as FabricMasterNode;
+
+                int stencilDepthPrepassWriteMask = masterNode.receiveDecals.isOn ? (int)HDRenderPipeline.StencilBitMask.DecalsForwardOutputNormalBuffer:0;
+                int stencilDepthPrepassRef = masterNode.receiveDecals.isOn ? (int)HDRenderPipeline.StencilBitMask.DecalsForwardOutputNormalBuffer:0;
+                stencilDepthPrepassWriteMask |= !masterNode.receiveSSR.isOn ? (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR : 0;
+                stencilDepthPrepassRef |= !masterNode.receiveSSR.isOn ? (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR : 0;
+
+                if (stencilDepthPrepassWriteMask != 0)
+                {
+                    pass.StencilOverride = new List<string>()
+                    {
+                        "// Stencil setup",
+                        "Stencil",
+                        "{",
+                        string.Format("   WriteMask {0}", stencilDepthPrepassWriteMask),
+                        string.Format("   Ref  {0}", stencilDepthPrepassRef),
+                        "   Comp Always",
+                        "   Pass Replace",
+                        "}"
+                    };
+                }
+            }           
         };
 
         Pass m_PassMotionVectors = new Pass()
@@ -193,17 +205,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassVelocity.hlsl\"",
             },
-            StencilOverride = new List<string>()
-            {
-                "// If velocity pass (motion vectors) is enabled we tag the stencil so it don't perform CameraMotionVelocity",
-                "Stencil",
-                "{",
-                "   WriteMask 128",         // [_StencilWriteMaskMV]        (int) HDRenderPipeline.StencilBitMask.ObjectVelocity   // this requires us to pull in the HD Pipeline assembly...
-                "   Ref 128",               // [_StencilRefMV]
-                "   Comp Always",
-                "   Pass Replace",
-                "}"
-            },
             RequiredFields = new List<string>()
             {
                 "AttributesMesh.normalOS",
@@ -224,15 +225,36 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             PixelShaderSlots = new List<int>()
             {
+                FabricMasterNode.NormalSlotId,
                 FabricMasterNode.SmoothnessSlotId,
                 FabricMasterNode.AlphaSlotId,
-                FabricMasterNode.AlphaThresholdSlotId
+                FabricMasterNode.AlphaClipThresholdSlotId
             },
             VertexShaderSlots = new List<int>()
             {
                 FabricMasterNode.PositionSlotId
             },
-            UseInPreview = false
+            UseInPreview = false,
+
+            OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
+            {
+                var masterNode = node as FabricMasterNode;
+
+                int stencilWriteMaskMV = (int)HDRenderPipeline.StencilBitMask.ObjectVelocity;
+                int stencilRefMV = (int)HDRenderPipeline.StencilBitMask.ObjectVelocity;
+
+                pass.StencilOverride = new List<string>()
+                {
+                    "// If velocity pass (motion vectors) is enabled we tag the stencil so it don't perform CameraMotionVelocity",
+                    "Stencil",
+                    "{",
+                    string.Format("   WriteMask {0}", stencilWriteMaskMV),
+                    string.Format("   Ref  {0}", stencilRefMV),
+                    "   Comp Always",
+                    "   Pass Replace",
+                    "}"
+                };
+            }
         };
 
         Pass m_PassForwardOnly = new Pass()
@@ -249,10 +271,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 "#pragma multi_compile _ DIRLIGHTMAP_COMBINED",
                 "#pragma multi_compile _ DYNAMICLIGHTMAP_ON",
                 "#pragma multi_compile _ SHADOWS_SHADOWMASK",
-
                 "#pragma multi_compile DECALS_OFF DECALS_3RT DECALS_4RT",
                 "#define LIGHTLOOP_TILE_PASS",
-
                 "#pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST",
                 "#pragma multi_compile SHADOW_LOW SHADOW_MEDIUM SHADOW_HIGH"
             },
@@ -283,6 +303,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 FabricMasterNode.AlbedoSlotId,
                 FabricMasterNode.SpecularOcclusionSlotId,
                 FabricMasterNode.NormalSlotId,
+                FabricMasterNode.BentNormalSlotId,
                 FabricMasterNode.SmoothnessSlotId,
                 FabricMasterNode.AmbientOcclusionSlotId,
                 FabricMasterNode.SpecularColorSlotId,
@@ -293,7 +314,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 FabricMasterNode.AnisotropySlotId,
                 FabricMasterNode.EmissionSlotId,
                 FabricMasterNode.AlphaSlotId,
-                FabricMasterNode.AlphaThresholdSlotId,
+                FabricMasterNode.AlphaClipThresholdSlotId,
             },
             VertexShaderSlots = new List<int>()
             {
@@ -309,8 +330,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     "// Stencil setup",
                     "Stencil",
                     "{",
-                    "   WriteMask " + masterNode.GetStencilWriteMask().ToString(),
-                    "   Ref  " + masterNode.GetStencilRef().ToString(),
+                    string.Format("   WriteMask {0}", (int) HDRenderPipeline.StencilBitMask.LightingMask),
+                    string.Format("   Ref  {0}", masterNode.RequiresSplitLighting() ? (int)StencilLightingUsage.SplitLighting : (int)StencilLightingUsage.RegularLighting),
                     "   Comp Always",
                     "   Pass Replace",
                     "}"
@@ -325,15 +346,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 else
                 {
                     pass.ZTestOverride = null;
-                }
-
-                if (masterNode.surfaceType == SurfaceType.Transparent && masterNode.backThenFrontRendering.isOn)
-                {
-                    pass.CullOverride = "Cull Back";
-                }
-                else
-                {
-                    pass.CullOverride = null;
                 }
             }
         };
@@ -362,8 +374,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     {
                         activeFields.Add("DoubleSided.Mirror");
                     }
-
-                    activeFields.Add("FragInputs.isFrontFace");     // will need this for determining normal flip mode
+                    // Important: the following is used in SharedCode.template.hlsl for determining the normal flip mode
+                    activeFields.Add("FragInputs.isFrontFace");
                 }
             }
 
@@ -382,23 +394,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             if (masterNode.alphaTest.isOn)
             {
-                int count = 0;
-                if (pass.PixelShaderUsesSlot(FabricMasterNode.AlphaThresholdSlotId))
+                if (pass.PixelShaderUsesSlot(FabricMasterNode.AlphaClipThresholdSlotId))
                 {
                     activeFields.Add("AlphaTest");
-                    ++count;
                 }
-                if (pass.PixelShaderUsesSlot(FabricMasterNode.AlphaThresholdDepthPrepassSlotId))
-                {
-                    activeFields.Add("AlphaTestPrepass");
-                    ++count;
-                }
-                if (pass.PixelShaderUsesSlot(FabricMasterNode.AlphaThresholdDepthPostpassSlotId))
-                {
-                    activeFields.Add("AlphaTestPostpass");
-                    ++count;
-                }
-                UnityEngine.Debug.Assert(count == 1, "Alpha test value not set correctly");
             }
 
             if (masterNode.surfaceType != SurfaceType.Opaque)
@@ -429,9 +428,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
 
-            if (masterNode.receiveDecals.isOn)
+            if (!masterNode.receiveDecals.isOn)
             {
-                activeFields.Add("Decals");
+                activeFields.Add("DisableDecals");
             }
 
             if (!masterNode.receiveSSR.isOn)
@@ -452,6 +451,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (masterNode.subsurfaceScattering.isOn)
             {
                 activeFields.Add("SurfaceDescription.SubsurfaceScattering");
+            }
+
+            if (masterNode.IsSlotConnected(FabricMasterNode.BentNormalSlotId) && pass.PixelShaderUsesSlot(FabricMasterNode.BentNormalSlotId))
+            {
+                activeFields.Add("BentNormal");
             }
 
             if (masterNode.IsSlotConnected(FabricMasterNode.TangentSlotId) && pass.PixelShaderUsesSlot(FabricMasterNode.TangentSlotId))
@@ -479,9 +483,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (pass.PixelShaderUsesSlot(FabricMasterNode.AmbientOcclusionSlotId))
             {
                 var occlusionSlot = masterNode.FindSlot<Vector1MaterialSlot>(FabricMasterNode.AmbientOcclusionSlotId);
-                if (occlusionSlot.value != occlusionSlot.defaultValue)
+
+                bool connected = masterNode.IsSlotConnected(FabricMasterNode.AmbientOcclusionSlotId);
+                if (connected || occlusionSlot.value != occlusionSlot.defaultValue)
                 {
-                    activeFields.Add("Occlusion");
+                    activeFields.Add("AmbientOcclusion");
                 }
             }
 
@@ -550,12 +556,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
                 GenerateShaderPassLit(masterNode, m_PassMotionVectors, mode, subShader, sourceAssetDependencyPaths);
 
-
                 GenerateShaderPassLit(masterNode, m_PassForwardOnly, mode, subShader, sourceAssetDependencyPaths);
             }
             subShader.Deindent();
             subShader.AddShaderChunk("}", true);
-            // subShader.AddShaderChunk(@"CustomEditor ""UnityEditor.Experimental.Rendering.HDPipeline.FabricGUI""");
+            subShader.AddShaderChunk(@"CustomEditor ""UnityEditor.Experimental.Rendering.HDPipeline.FabricGUI""");
 
             return subShader.GetShaderString(0);
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/CreateHDLitShaderGraph.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/CreateHDLitShaderGraph.cs
@@ -6,7 +6,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class CreateHDLitShaderGraph : EndNameEditAction
     {
-        [MenuItem("Assets/Create/Shader/HD Lit Graph", false, 208)]
+        [MenuItem("Assets/Create/Shader/Lit Graph", false, 208)]
         public static void CreateMaterialGraph()
         {
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, CreateInstance<CreateHDLitShaderGraph>(),

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -9,11 +9,10 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 
-
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     [Serializable]
-    [Title("Master", "HDLit")]
+    [Title("Master", "Lit")]
     [FormerName("UnityEditor.ShaderGraph.HDLitMasterNode")]
     class HDLitMasterNode : MasterNode<IHDLitSubShader>, IMayRequirePosition, IMayRequireNormal, IMayRequireTangent
     {
@@ -583,7 +582,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public sealed override void UpdateNodeAfterDeserialization()
         {
             base.UpdateNodeAfterDeserialization();
-            name = "HD Lit Master";
+            name = "Lit Master";
 
             List<int> validSlots = new List<int>();
             if (MaterialTypeUsesSlotMask(SlotMask.Position))
@@ -800,29 +799,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             });
 
             base.CollectShaderProperties(collector, generationMode);
-        }
-
-        public int GetStencilWriteMask()
-        {
-            int stencilWriteMask = (int)HDRenderPipeline.StencilBitMask.LightingMask;
-            if (!m_ReceivesSSR)
-            {
-                stencilWriteMask |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
-            }
-            return stencilWriteMask;
-        }
-        public int GetStencilRef()
-        {
-            int stencilRef = (int)StencilLightingUsage.RegularLighting;
-            if (RequiresSplitLighting())
-            {
-                stencilRef = (int)StencilLightingUsage.SplitLighting;
-            }
-            if (!m_ReceivesSSR)
-            {
-                stencilRef |= (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR;
-            }
-            return stencilRef;
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
@@ -7,54 +7,53 @@ Pass
     //-------------------------------------------------------------------------------------
     // Render Modes (Blend, Cull, ZTest, Stencil, etc)
     //-------------------------------------------------------------------------------------
-        $splice(Blending)
-        $splice(Culling)
-        $splice(ZTest)
-        $splice(ZWrite)
-        $splice(ZClip)
-        $splice(Stencil)
-        $splice(ColorMask)
+    $splice(Blending)
+    $splice(Culling)
+    $splice(ZTest)
+    $splice(ZWrite)
+    $splice(ZClip)
+    $splice(Stencil)
+    $splice(ColorMask)
     //-------------------------------------------------------------------------------------
     // End Render Modes
     //-------------------------------------------------------------------------------------
 
     HLSLPROGRAM
 
-        #pragma target 4.5
-        #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
-        //#pragma enable_d3d11_debug_symbols
+    #pragma target 4.5
+    #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+    //#pragma enable_d3d11_debug_symbols
 
-        #pragma multi_compile_instancing
-        #pragma instancing_options renderinglayer
+    #pragma multi_compile_instancing
+    #pragma instancing_options renderinglayer
 
-        #pragma multi_compile _ LOD_FADE_CROSSFADE
+    #pragma multi_compile _ LOD_FADE_CROSSFADE
 
     //-------------------------------------------------------------------------------------
     // Variant Definitions (active field translations to HDRP defines)
     //-------------------------------------------------------------------------------------
-        $Material.SubsurfaceScattering:      #define _MATERIAL_FEATURE_SUBSURFACE_SCATTERING 1
-        $Material.Transmission:              #define _MATERIAL_FEATURE_TRANSMISSION 1
-        $Material.Anisotropy:                #define _MATERIAL_FEATURE_ANISOTROPY 1
-        $Material.Iridescence:               #define _MATERIAL_FEATURE_IRIDESCENCE 1
-        $Material.SpecularColor:             #define _MATERIAL_FEATURE_SPECULAR_COLOR 1
-        $SurfaceDescription.Emission:        #define _EMISSION 1
-        $SurfaceType.Transparent:            #define _SURFACE_TYPE_TRANSPARENT 1
-        $BlendMode.Alpha:                    #define _BLENDMODE_ALPHA 1
-        $BlendMode.Add:                      #define _BLENDMODE_ADD 1
-        $BlendMode.Premultiply:              #define _BLENDMODE_PRE_MULTIPLY 1
-        $BlendMode.PreserveSpecular:         #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1
-        $AlphaFog:                           #define _ENABLE_FOG_ON_TRANSPARENT 1
-        $AmbientOcclusion:                   #define _AMBIENT_OCCLUSION 1
-        $SpecularOcclusionFromAO:            #define _SPECULAR_OCCLUSION_FROM_AO 1
-        $SpecularOcclusionFromAOBentNormal:  #define _SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL 1
-        $SpecularOcclusionCustom:            #define _SPECULAR_OCCLUSION_CUSTOM 1
-        $Specular.EnergyConserving:          #define _ENERGY_CONSERVING_SPECULAR 1
-        $Specular.AA:                        #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
-        $Refraction:                         #define _HAS_REFRACTION 1
-        $RefractionBox:                      #define _REFRACTION_PLANE 1
-        $RefractionSphere:                   #define _REFRACTION_SPHERE 1
-        $Decals:                             #define _DECALS 1
-        $DisableSSR:                         #define _DISABLE_SSR 1
+    $Material.SubsurfaceScattering:      #define _MATERIAL_FEATURE_SUBSURFACE_SCATTERING 1
+    $Material.Transmission:              #define _MATERIAL_FEATURE_TRANSMISSION 1
+    $Material.Anisotropy:                #define _MATERIAL_FEATURE_ANISOTROPY 1
+    $Material.Iridescence:               #define _MATERIAL_FEATURE_IRIDESCENCE 1
+    $Material.SpecularColor:             #define _MATERIAL_FEATURE_SPECULAR_COLOR 1
+    $SurfaceType.Transparent:            #define _SURFACE_TYPE_TRANSPARENT 1
+    $BlendMode.Alpha:                    #define _BLENDMODE_ALPHA 1
+    $BlendMode.Add:                      #define _BLENDMODE_ADD 1
+    $BlendMode.Premultiply:              #define _BLENDMODE_PRE_MULTIPLY 1
+    $BlendMode.PreserveSpecular:         #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1
+    $AlphaFog:                           #define _ENABLE_FOG_ON_TRANSPARENT 1
+    $AmbientOcclusion:                   #define _AMBIENT_OCCLUSION 1
+    $SpecularOcclusionFromAO:            #define _SPECULAR_OCCLUSION_FROM_AO 1
+    $SpecularOcclusionFromAOBentNormal:  #define _SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL 1
+    $SpecularOcclusionCustom:            #define _SPECULAR_OCCLUSION_CUSTOM 1
+    $Specular.EnergyConserving:          #define _ENERGY_CONSERVING_SPECULAR 1
+    $Specular.AA:                        #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
+    $Refraction:                         #define _HAS_REFRACTION 1
+    $RefractionBox:                      #define _REFRACTION_PLANE 1
+    $RefractionSphere:                   #define _REFRACTION_SPHERE 1
+    $DisableDecals:                      #define _DISABLE_DECALS 1
+    $DisableSSR:                         #define _DISABLE_SSR 1
 
     //-------------------------------------------------------------------------------------
     // End Variant Definitions
@@ -83,46 +82,39 @@ Pass
     //-------------------------------------------------------------------------------------
     // Defines
     //-------------------------------------------------------------------------------------
-$splice(Defines)
+    $splice(Defines)
 
-        // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
-        $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
-        $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
-        $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
-        $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
-        $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
-        $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
-        $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
-        $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
-        $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
-        $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
-        $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
-        $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
-        $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
-        $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
-        $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
-        $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
+    // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
+    $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
+    $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
+    $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
+    $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
+    $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
+    $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
+    $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
+    $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
+    $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
+    $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
+    $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
+    $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
+    $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
+    $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
+    $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
+    $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
 
     //-------------------------------------------------------------------------------------
     // End Defines
     //-------------------------------------------------------------------------------------
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #endif
+#ifdef DEBUG_DISPLAY
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
+#endif
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
 
 #if (SHADERPASS == SHADERPASS_FORWARD)
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
-
-    // The light loop (or lighting architecture) is in charge to:
-    // - Define light list
-    // - Define the light loop
-    // - Setup the constant/data
-    // - Do the reflection hierarchy
-    // - Provide sampling function for shadowmap, ies, cookie and reflection (depends on the specific use with the light loops like index array or atlas or single and texture format (cubemap/latlong))
 
     #define HAS_LIGHTLOOP
 
@@ -139,38 +131,16 @@ $splice(Defines)
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDecalData.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderGraphFunctions.hlsl"
 
-    //Used by SceneSelectionPass
+    // Used by SceneSelectionPass
     int _ObjectId;
     int _PassValue;
-
-    // this function assumes the bitangent flip is encoded in tangentWS.w
-    // TODO: move this function to HDRP shared file, once we merge with HDRP repo
-    float3x3 BuildWorldToTangent(float4 tangentWS, float3 normalWS)
-    {
-        // tangentWS must not be normalized (mikkts requirement)
-
-        // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
-	    float3 unnormalizedNormalWS = normalWS;
-        float renormFactor = 1.0 / length(unnormalizedNormalWS);
-
-        // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-	    // this is the mikktspace transformation (must use unnormalized attributes)
-        float3x3 worldToTangent = CreateWorldToTangent(unnormalizedNormalWS, tangentWS.xyz, tangentWS.w > 0.0 ? 1.0 : -1.0);
-
-	    // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-	    // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-        worldToTangent[0] = worldToTangent[0] * renormFactor;
-        worldToTangent[1] = worldToTangent[1] * renormFactor;
-        worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
-        return worldToTangent;
-    }
 
     //-------------------------------------------------------------------------------------
     // Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
-        $buildType(AttributesMesh)
-        $buildType(VaryingsMeshToPS)
-        $buildType(VaryingsMeshToDS)
+    $buildType(AttributesMesh)
+    $buildType(VaryingsMeshToPS)
+    $buildType(VaryingsMeshToDS)
     //-------------------------------------------------------------------------------------
     // End Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
@@ -178,7 +148,7 @@ $splice(Defines)
     //-------------------------------------------------------------------------------------
     // Graph generated code
     //-------------------------------------------------------------------------------------
-$splice(Graph)
+    $splice(Graph)
     //-------------------------------------------------------------------------------------
     // End graph generated code
     //-------------------------------------------------------------------------------------
@@ -187,7 +157,7 @@ $features.modifyMesh:   $include("VertexAnimation.template.hlsl")
 
 $include("SharedCode.template.hlsl")
 
-    void BuildSurfaceData(FragInputs fragInputs, inout SurfaceDescription surfaceDescription, float3 V, out SurfaceData surfaceData, out float3 bentNormalWS)
+    void BuildSurfaceData(FragInputs fragInputs, inout SurfaceDescription surfaceDescription, float3 V, PositionInputs posInput, out SurfaceData surfaceData, out float3 bentNormalWS)
     {
         // setup defaults -- these are used if the graph doesn't output a value
         ZERO_INITIALIZE(SurfaceData, surfaceData);
@@ -284,6 +254,15 @@ $include("SharedCode.template.hlsl")
 #else
         surfaceData.specularOcclusion = 1.0;
 #endif
+
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
+#endif
+
 #ifdef _ENABLE_GEOMETRIC_SPECULAR_AA
         surfaceData.perceptualSmoothness = GeometricNormalFiltering(surfaceData.perceptualSmoothness, fragInputs.worldToTangent[2], surfaceDescription.SpecularAAScreenSpaceVariance, surfaceDescription.SpecularAAThreshold);
 #endif
@@ -308,12 +287,14 @@ $include("SharedCode.template.hlsl")
         LODDitheringTransition(fadeMaskSeed, unity_LODFade.x);
 #endif
 
-        // this applies the double sided tangent space correction -- see 'ApplyDoubleSidedFlipOrMirror()'
-        $DoubleSided:           if (!fragInputs.isFrontFace) {
-        $DoubleSided.Flip:          fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
-        $DoubleSided.Flip:          fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided.Mirror:        fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided:           }
+        // This applies the double sided tangent space correction
+        // Must match /Runtime/Material/MaterialUtilities.hlsl:ApplyDoubleSidedFlipOrMirror()
+        $DoubleSided:            if (!fragInputs.isFrontFace)
+        $DoubleSided:            {
+        $DoubleSided.Flip:           fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
+        $DoubleSided.Flip:           fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
+        $DoubleSided.Mirror:         fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
+        $DoubleSided:            }
 
         SurfaceDescriptionInputs surfaceDescriptionInputs = FragInputsToSurfaceDescriptionInputs(fragInputs, V);
         SurfaceDescription surfaceDescription = SurfaceDescriptionFunction(surfaceDescriptionInputs);
@@ -325,12 +306,7 @@ $include("SharedCode.template.hlsl")
         $AlphaTestPostpass: DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPostpass);
 
         float3 bentNormalWS;
-        BuildSurfaceData(fragInputs, surfaceDescription, V, surfaceData, bentNormalWS);
-
-#if HAVE_DECALS && _DECALS
-        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-#endif
+        BuildSurfaceData(fragInputs, surfaceDescription, V, posInput, surfaceData, bentNormalWS);
 
         // Builtin Data
         // For back lighting we use the oposite vertex normal 
@@ -338,7 +314,8 @@ $include("SharedCode.template.hlsl")
 
         $SurfaceDescription.Emission: builtinData.emissiveColor = surfaceDescription.Emission;
 
-        builtinData.depthOffset = 0.0;                        // ApplyPerPixelDisplacement(input, V, layerTexCoord, blendMasks); #ifdef _DEPTHOFFSET_ON : ApplyDepthOffsetPositionInput(V, depthOffset, GetWorldToHClipMatrix(), posInput);
+        // TODO: Handle depth offset
+        //builtinData.depthOffset = 0.0;
 
 #if (SHADERPASS == SHADERPASS_DISTORTION)
         builtinData.distortion = surfaceDescription.Distortion;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRPass.template
@@ -7,35 +7,36 @@ Pass
     //-------------------------------------------------------------------------------------
     // Render Modes (Blend, Cull, ZTest, Stencil, etc)
     //-------------------------------------------------------------------------------------
-        $splice(Blending)
-        $splice(Culling)
-        $splice(ZTest)
-        $splice(ZWrite)
-        $splice(ZClip)
-        $splice(Stencil)
-        $splice(ColorMask)
+    $splice(Blending)
+    $splice(Culling)
+    $splice(ZTest)
+    $splice(ZWrite)
+    $splice(ZClip)
+    $splice(Stencil)
+    $splice(ColorMask)
     //-------------------------------------------------------------------------------------
     // End Render Modes
     //-------------------------------------------------------------------------------------
 
     HLSLPROGRAM
 
-        #pragma target 4.5
-        #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
-        //#pragma enable_d3d11_debug_symbols
+    #pragma target 4.5
+    #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+    //#pragma enable_d3d11_debug_symbols
 
-        #pragma multi_compile_instancing
-        #pragma instancing_options renderinglayer
-        #pragma multi_compile _ LOD_FADE_CROSSFADE
+    #pragma multi_compile_instancing
+    #pragma instancing_options renderinglayer
+    #pragma multi_compile _ LOD_FADE_CROSSFADE
 
     //-------------------------------------------------------------------------------------
     // Variant Definitions (active field translations to HDRP defines)
     //-------------------------------------------------------------------------------------
-        $AlphaTest:                      #define _ALPHATEST_ON 1
-        $Material.SpecularColor:         #define _MATERIAL_FEATURE_SPECULAR_COLOR 1
-        $SurfaceType.Transparent:        #define _SURFACE_TYPE_TRANSPARENT 1
-        $BlendMode.Alpha:                #define _BLENDMODE_ALPHA 1
-        $BlendMode.Add:                  #define _BLENDMODE_ADD 1
+    $Material.SpecularColor:             #define _MATERIAL_FEATURE_SPECULAR_COLOR 1
+    $SurfaceType.Transparent:            #define _SURFACE_TYPE_TRANSPARENT 1
+    $BlendMode.Alpha:                    #define _BLENDMODE_ALPHA 1
+    $BlendMode.Add:                      #define _BLENDMODE_ADD 1
+    $BlendMode.Premultiply:              #define _BLENDMODE_PRE_MULTIPLY 1
+
     //-------------------------------------------------------------------------------------
     // End Variant Definitions
     //-------------------------------------------------------------------------------------
@@ -59,25 +60,25 @@ Pass
     //-------------------------------------------------------------------------------------
     // Defines
     //-------------------------------------------------------------------------------------
-$splice(Defines)
+    $splice(Defines)
 
-        // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
-        $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
-        $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
-        $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
-        $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
-        $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
-        $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
-        $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
-        $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
-        $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
-        $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
-        $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
-        $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
-        $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
-        $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
-        $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
-        $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
+    // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
+    $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
+    $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
+    $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
+    $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
+    $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
+    $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
+    $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
+    $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
+    $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
+    $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
+    $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
+    $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
+    $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
+    $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
+    $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
+    $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
 
     //-------------------------------------------------------------------------------------
     // End Defines
@@ -93,13 +94,6 @@ $splice(Defines)
 #if (SHADERPASS == SHADERPASS_FORWARD)
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
 
-    // The light loop (or lighting architecture) is in charge to:
-    // - Define light list
-    // - Define the light loop
-    // - Setup the constant/data
-    // - Do the reflection hierarchy
-    // - Provide sampling function for shadowmap, ies, cookie and reflection (depends on the specific use with the light loops like index array or atlas or single and texture format (cubemap/latlong))
-
     #define HAS_LIGHTLOOP
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl"
@@ -111,41 +105,20 @@ $splice(Defines)
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl"
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl"
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDecalData.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderGraphFunctions.hlsl"
 
     //Used by SceneSelectionPass
     int _ObjectId;
     int _PassValue;
 
-
-    // this function assumes the bitangent flip is encoded in tangentWS.w
-    // TODO: move this function to HDRP shared file, once we merge with HDRP repo
-    float3x3 BuildWorldToTangent(float4 tangentWS, float3 normalWS)
-    {
-        // tangentWS must not be normalized (mikkts requirement)
-
-        // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
-	    float3 unnormalizedNormalWS = normalWS;
-        float renormFactor = 1.0 / length(unnormalizedNormalWS);
-
-        // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-	    // this is the mikktspace transformation (must use unnormalized attributes)
-        float3x3 worldToTangent = CreateWorldToTangent(unnormalizedNormalWS, tangentWS.xyz, tangentWS.w > 0.0 ? 1.0 : -1.0);
-
-	    // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-	    // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-        worldToTangent[0] = worldToTangent[0] * renormFactor;
-        worldToTangent[1] = worldToTangent[1] * renormFactor;
-        worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
-        return worldToTangent;
-    }
-
     //-------------------------------------------------------------------------------------
     // Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
-        $buildType(AttributesMesh)
-        $buildType(VaryingsMeshToPS)
-        $buildType(VaryingsMeshToDS)
+    $buildType(AttributesMesh)
+    $buildType(VaryingsMeshToPS)
+    $buildType(VaryingsMeshToDS)
     //-------------------------------------------------------------------------------------
     // End Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
@@ -153,7 +126,7 @@ $splice(Defines)
     //-------------------------------------------------------------------------------------
     // Graph generated code
     //-------------------------------------------------------------------------------------
-$splice(Graph)
+    $splice(Graph)
     //-------------------------------------------------------------------------------------
     // End graph generated code
     //-------------------------------------------------------------------------------------
@@ -163,21 +136,17 @@ $features.modifyMesh:   $include("VertexAnimation.template.hlsl")
 $include("SharedCode.template.hlsl")
 
 
-    void BuildSurfaceData(FragInputs fragInputs, SurfaceDescription surfaceDescription, float3 V, out SurfaceData surfaceData)
+    void BuildSurfaceData(FragInputs fragInputs, inout SurfaceDescription surfaceDescription, float3 V, PositionInputs posInput, out SurfaceData surfaceData)
     {
         // setup defaults -- these are used if the graph doesn't output a value
         ZERO_INITIALIZE(SurfaceData, surfaceData);
         surfaceData.ambientOcclusion =      1.0f;
-        surfaceData.subsurfaceMask =        1.0f;
 
         // copy across graph values, if defined
         $SurfaceDescription.Albedo:               surfaceData.baseColor =             surfaceDescription.Albedo;
         $SurfaceDescription.Smoothness:           surfaceData.perceptualSmoothness =  surfaceDescription.Smoothness;
         $SurfaceDescription.Occlusion:            surfaceData.ambientOcclusion =      surfaceDescription.Occlusion;
         $SurfaceDescription.Metallic:             surfaceData.metallic =              surfaceDescription.Metallic;
-        //                                  surfaceData.thickness =             surfaceDescription.Thickness;
-        //                                  surfaceData.diffusionProfile =      surfaceDescription.DiffusionProfile;
-        //                                  surfaceData.subsurfaceMask =        surfaceDescription.SubsurfaceMask;
         $SurfaceDescription.Specular:             surfaceData.specularColor =         surfaceDescription.Specular;
 
         // These static material feature allow compile time optimization
@@ -187,37 +156,25 @@ $include("SharedCode.template.hlsl")
 #endif
 
         // tangent-space normal
-        float3 normalTS =                   float3(0.0f, 0.0f, 1.0f);
-        $SurfaceDescription.Normal:       normalTS =                   surfaceDescription.Normal;
+        float3 normalTS = float3(0.0f, 0.0f, 1.0f);
+        $SurfaceDescription.Normal: normalTS = surfaceDescription.Normal;
 
         // compute world space normal
         GetNormalWS(fragInputs, normalTS, surfaceData.normalWS);
 
-        // TODO: use surfaceDescription tangent definition for anisotropy
         surfaceData.tangentWS = normalize(fragInputs.worldToTangent[0].xyz);    // The tangent is not normalize in worldToTangent for mikkt. TODO: Check if it expected that we normalize with Morten. Tag: SURFACE_GRADIENT
         surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
 
-        // Init other parameters
-        surfaceData.anisotropy = 0;
-        surfaceData.coatMask = 0.0f;
-        surfaceData.iridescenceThickness = 0.0;
-        surfaceData.iridescenceMask = 1.0;
-
-        // Transparency parameters
-        // Use thickness from SSS
-        surfaceData.ior = 1.0;
-        surfaceData.transmittanceColor = float3(1.0, 1.0, 1.0);
-        surfaceData.atDistance = 1000000.0;
-        surfaceData.transmittanceMask = 0.0;
-
         // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
         // If user provide bent normal then we process a better term
-        surfaceData.specularOcclusion = 1.0;
-#if defined(_BENTNORMALMAP) && defined(_ENABLESPECULAROCCLUSION)
-        // If we have bent normal and ambient occlusion, process a specular occlusion
-        surfaceData.specularOcclusion = GetSpecularOcclusionFromBentAO(V, bentNormalWS, surfaceData);
-#elif defined(_MASKMAP)
-        surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(NdotV, surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
+        surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
+
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
 #endif
 
 #ifdef DEBUG_DISPLAY
@@ -235,12 +192,19 @@ $include("SharedCode.template.hlsl")
 
     void GetSurfaceAndBuiltinData(FragInputs fragInputs, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
     {
-        // this applies the double sided tangent space correction -- see 'ApplyDoubleSidedFlipOrMirror()'
-        $DoubleSided:           if (!fragInputs.isFrontFace) {
-        $DoubleSided.Flip:          fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
-        $DoubleSided.Flip:          fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided.Mirror:        fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided:           }
+#ifdef LOD_FADE_CROSSFADE // enable dithering LOD transition if user select CrossFade transition in LOD group
+        uint3 fadeMaskSeed = asuint((int3)(V * _ScreenSize.xyx)); // Quantize V to _ScreenSize values
+        LODDitheringTransition(fadeMaskSeed, unity_LODFade.x);
+#endif
+
+        // This applies the double sided tangent space correction
+        // Must match /Runtime/Material/MaterialUtilities.hlsl:ApplyDoubleSidedFlipOrMirror()
+        $DoubleSided:            if (!fragInputs.isFrontFace)
+        $DoubleSided:            {
+        $DoubleSided.Flip:           fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
+        $DoubleSided.Flip:           fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
+        $DoubleSided.Mirror:         fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
+        $DoubleSided:            }
 
         SurfaceDescriptionInputs surfaceDescriptionInputs = FragInputsToSurfaceDescriptionInputs(fragInputs, V);
         SurfaceDescription surfaceDescription = SurfaceDescriptionFunction(surfaceDescriptionInputs);
@@ -249,18 +213,13 @@ $include("SharedCode.template.hlsl")
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
         $AlphaTest:     DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
 
-        BuildSurfaceData(fragInputs, surfaceDescription, V, surfaceData);
+        BuildSurfaceData(fragInputs, surfaceDescription, V, posInput, surfaceData);
 
         // Builtin Data
         // For back lighting we use the oposite vertex normal 
         InitBuiltinData(surfaceDescription.Alpha, surfaceData.normalWS, -fragInputs.worldToTangent[2], fragInputs.positionRWS, fragInputs.texCoord1, fragInputs.texCoord2, builtinData);
 
-$SurfaceDescription.Emission:     builtinData.emissiveColor =             surfaceDescription.Emission;
-
-        builtinData.distortion =                float2(0.0, 0.0);           // surfaceDescription.Distortion -- if distortion pass
-        builtinData.distortionBlur =            0.0;                        // surfaceDescription.DistortionBlur -- if distortion pass
-
-        builtinData.depthOffset =               0.0;                        // ApplyPerPixelDisplacement(input, V, layerTexCoord, blendMasks); #ifdef _DEPTHOFFSET_ON : ApplyDepthOffsetPositionInput(V, depthOffset, GetWorldToHClipMatrix(), posInput);
+        $SurfaceDescription.Emission: builtinData.emissiveColor = surfaceDescription.Emission;
 
         PostInitBuiltinData(V, posInput, surfaceData, builtinData);
     }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRSubShader.cs
@@ -17,17 +17,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             TemplateName = "HDPBRPass.template",
             MaterialName = "PBR",
             ShaderPassName = "SHADERPASS_GBUFFER",
-            StencilOverride = new List<string>()
-            {
-                "// Stencil setup for gbuffer",
-                "Stencil",
-                "{",
-                "   WriteMask " +  ((int)HDRenderPipeline.StencilBitMask.LightingMask).ToString(),       // [_StencilWriteMask]    // default: StencilMask.Lighting
-                "   Ref  "      + ((int)StencilLightingUsage.RegularLighting).ToString(),                // [_StencilRef]          // default: StencilLightingUsage.RegularLighting 
-                "   Comp Always",
-                "   Pass Replace",
-                "}"
-            },
+
             ExtraDefines = new List<string>()
             {
                 "#pragma multi_compile _ DEBUG_DISPLAY",
@@ -35,6 +25,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 "#pragma multi_compile _ DIRLIGHTMAP_COMBINED",
                 "#pragma multi_compile _ DYNAMICLIGHTMAP_ON",
                 "#pragma multi_compile _ SHADOWS_SHADOWMASK",
+                "#pragma multi_compile DECALS_OFF DECALS_3RT DECALS_4RT",
+                "#pragma multi_compile _ LIGHT_LAYERS",
             },
             Includes = new List<string>()
             {
@@ -62,6 +54,37 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             VertexShaderSlots = new List<int>()
             {
                 PBRMasterNode.PositionSlotId
+            },
+            UseInPreview = true,
+
+            OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
+            {
+                var masterNode = node as PBRMasterNode;
+                pass.StencilOverride = new List<string>()
+                {
+                    "// Stencil setup",
+                    "Stencil",
+                    "{",
+                    "   WriteMask " + ((int)HDRenderPipeline.StencilBitMask.LightingMask).ToString(),
+                    "   Ref  " + ((int)StencilLightingUsage.RegularLighting).ToString(),
+                    "   Comp Always",
+                    "   Pass Replace",
+                    "}"
+                };
+
+                pass.ExtraDefines.Remove("#define SHADERPASS_GBUFFER_BYPASS_ALPHA_TEST");
+
+                if (masterNode.surfaceType == SurfaceType.Opaque &&
+                    (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId) ||
+                     masterNode.GetInputSlots<Vector1MaterialSlot>().First(x => x.id == PBRMasterNode.AlphaThresholdSlotId).value > 0.0f))
+                {
+                    pass.ExtraDefines.Add("#define SHADERPASS_GBUFFER_BYPASS_ALPHA_TEST");
+                    pass.ZTestOverride = "ZTest Equal";
+                }
+                else
+                {
+                    pass.ZTestOverride = null;
+                }
             }
         };
 
@@ -101,7 +124,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             VertexShaderSlots = new List<int>()
             {
                 //PBRMasterNode.PositionSlotId
-            }
+            },
+            UseInPreview = false
         };
 
         Pass m_PassShadowCaster = new Pass()
@@ -122,11 +146,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
             },
-            RequiredFields = new List<string>()
-            {
-//                "FragInputs.worldToTangent",
-//                "FragInputs.positionRWS",
-            },
             PixelShaderSlots = new List<int>()
             {
                 PBRMasterNode.AlphaSlotId,
@@ -135,7 +154,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             VertexShaderSlots = new List<int>()
             {
                 PBRMasterNode.PositionSlotId
-            }
+            },
+            UseInPreview = false
         };
 
         Pass m_SceneSelectionPass = new Pass()
@@ -154,11 +174,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
             },
-            RequiredFields = new List<string>()
-            {
-//                "FragInputs.worldToTangent",
-//                "FragInputs.positionRWS",
-            },
             PixelShaderSlots = new List<int>()
             {
                 PBRMasterNode.AlphaSlotId,
@@ -167,7 +182,62 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             VertexShaderSlots = new List<int>()
             {
                 PBRMasterNode.PositionSlotId
-            }
+            },
+            UseInPreview = true
+        };
+
+        Pass m_PassDepthOnly = new Pass()
+        {
+            Name = "DepthOnly",
+            LightMode = "DepthOnly",
+            TemplateName = "HDPBRPass.template",
+            MaterialName = "PBR",
+
+            ZWriteOverride = "ZWrite On",
+
+            ExtraDefines = new List<string>()
+            {
+                "#pragma multi_compile _ WRITE_NORMAL_BUFFER",
+                "#pragma multi_compile _ WRITE_MSAA_DEPTH"
+            },
+
+            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
+
+            Includes = new List<string>()
+            {
+                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                PBRMasterNode.NormalSlotId,
+                PBRMasterNode.SmoothnessSlotId,
+                PBRMasterNode.AlphaSlotId,
+                PBRMasterNode.AlphaThresholdSlotId
+            },
+
+            RequiredFields = new List<string>()
+            {
+                "AttributesMesh.normalOS",
+                "AttributesMesh.tangentOS",     // Always present as we require it also in case of Variants lighting
+                "AttributesMesh.uv0",
+                "AttributesMesh.uv1",
+                "AttributesMesh.color",
+                "AttributesMesh.uv2",           // SHADERPASS_LIGHT_TRANSPORT always uses uv2
+                "AttributesMesh.uv3",           // DEBUG_DISPLAY
+
+                "FragInputs.worldToTangent",
+                "FragInputs.positionRWS",
+                "FragInputs.texCoord0",
+                "FragInputs.texCoord1",
+                "FragInputs.texCoord2",
+                "FragInputs.texCoord3",
+                "FragInputs.color",
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                PBRMasterNode.PositionSlotId
+            },
+            UseInPreview = false
         };
 
         Pass m_PassMotionVectors = new Pass()
@@ -203,6 +273,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             PixelShaderSlots = new List<int>()
             {
+                PBRMasterNode.NormalSlotId,
+                PBRMasterNode.SmoothnessSlotId,
                 PBRMasterNode.AlphaSlotId,
                 PBRMasterNode.AlphaThresholdSlotId
             },
@@ -210,65 +282,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 PBRMasterNode.PositionSlotId
             },
-        };
-
-        Pass m_PassDistortion = new Pass()
-        {
-            Name = "Distortion",
-            LightMode = "DistortionVectors",
-            TemplateName = "HDPBRPass.template",
-            MaterialName = "PBR",
-            ShaderPassName = "SHADERPASS_DISTORTION",
-            BlendOverride = "Blend One One, One One",   // [_DistortionSrcBlend] [_DistortionDstBlend], [_DistortionBlurSrcBlend] [_DistortionBlurDstBlend]
-            BlendOpOverride = "BlendOp Add, Add",       // Add, [_DistortionBlurBlendOp]
-            ZTestOverride = "ZTest LEqual",             // [_ZTestModeDistortion]
-            ZWriteOverride = "ZWrite Off",
-            Includes = new List<string>()
-            {
-                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDistortion.hlsl\"",
-            },
-            RequiredFields = new List<string>()
-            {
-//                "FragInputs.worldToTangent",
-//                "FragInputs.positionRWS",
-            },
-            PixelShaderSlots = new List<int>()
-            {
-                PBRMasterNode.AlphaSlotId,
-                PBRMasterNode.AlphaThresholdSlotId
-            },
-            VertexShaderSlots = new List<int>()
-            {
-                PBRMasterNode.PositionSlotId
-            },
-        };
-
-        Pass m_PassDepthOnly = new Pass()
-        {
-            Name = "DepthOnly",
-            LightMode = "DepthOnly",
-            TemplateName = "HDPBRPass.template",
-            MaterialName = "PBR",
-            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
-            ColorMaskOverride = "ColorMask 0",
-            Includes = new List<string>()
-            {
-                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
-            },
-            RequiredFields = new List<string>()
-            {
-//                "FragInputs.worldToTangent",
-//                "FragInputs.positionRWS",
-            },
-            PixelShaderSlots = new List<int>()
-            {
-                PBRMasterNode.AlphaSlotId,
-                PBRMasterNode.AlphaThresholdSlotId
-            },
-            VertexShaderSlots = new List<int>()
-            {
-                PBRMasterNode.PositionSlotId
-            }
+            UseInPreview = false
         };
 
         Pass m_PassForward = new Pass()
@@ -285,20 +299,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 "#pragma multi_compile _ DIRLIGHTMAP_COMBINED",
                 "#pragma multi_compile _ DYNAMICLIGHTMAP_ON",
                 "#pragma multi_compile _ SHADOWS_SHADOWMASK",
+                "#pragma multi_compile DECALS_OFF DECALS_3RT DECALS_4RT",
                 "#define LIGHTLOOP_TILE_PASS",
                 "#pragma multi_compile USE_FPTL_LIGHTLIST USE_CLUSTERED_LIGHTLIST",
                 "#pragma multi_compile SHADOW_LOW SHADOW_MEDIUM SHADOW_HIGH"
-            },
-            StencilOverride = new List<string>()
-            {
-                "// Stencil setup for forward",
-                "Stencil",
-                "{",
-                "   WriteMask " +  ((int)HDRenderPipeline.StencilBitMask.LightingMask).ToString(),       // [_StencilWriteMask]    // default: StencilMask.Lighting
-                "   Ref  "      + ((int)StencilLightingUsage.RegularLighting).ToString(),                // [_StencilRef]          // default: StencilLightingUsage.RegularLighting 
-                "   Comp Always",
-                "   Pass Replace",
-                "}"
             },
             Includes = new List<string>()
             {
@@ -327,6 +331,35 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 PBRMasterNode.PositionSlotId
             },
+
+            OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
+            {
+                var masterNode = node as PBRMasterNode;
+                pass.StencilOverride = new List<string>()
+                {
+                    "// Stencil setup",
+                    "Stencil",
+                    "{",
+                    "   WriteMask " + ((int)HDRenderPipeline.StencilBitMask.LightingMask).ToString(),
+                    "   Ref  " + ((int)StencilLightingUsage.RegularLighting).ToString(),
+                    "   Comp Always",
+                    "   Pass Replace",
+                    "}"
+                };
+
+                pass.ExtraDefines.Remove("#define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST");
+                if (masterNode.surfaceType == SurfaceType.Opaque &&
+                    (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId) ||
+                     masterNode.GetInputSlots<Vector1MaterialSlot>().First(x => x.id == PBRMasterNode.AlphaThresholdSlotId).value > 0.0f))
+                {
+                    pass.ExtraDefines.Add("#define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST");
+                    pass.ZTestOverride = "ZTest Equal";
+                }
+                else
+                {
+                    pass.ZTestOverride = null;
+                }
+            }
         };
 
         private static HashSet<string> GetActiveFieldsFromMasterNode(INode iMasterNode, Pass pass)
@@ -368,14 +401,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 activeFields.Add("AlphaTest");
             }
 
-            // Keywords for transparent
-            // #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
             if (masterNode.surfaceType != SurfaceType.Opaque)
             {
-                // transparent-only defines
                 activeFields.Add("SurfaceType.Transparent");
 
-                // #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
                 if (masterNode.alphaMode == AlphaMode.Alpha)
                 {
                     activeFields.Add("BlendMode.Alpha");
@@ -384,32 +413,35 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 {
                     activeFields.Add("BlendMode.Add");
                 }
-//                else if (masterNode.alphaMode == PBRMasterNode.AlphaMode.PremultiplyAlpha)            // TODO
-//                {
-//                    defines.AddShaderChunk("#define _BLENDMODE_PRE_MULTIPLY 1", true);
-//                }
+
+                // By default PBR node will take the fog
+                activeFields.Add("AlphaFog");
             }
             else
             {
                 // opaque-only defines
             }
 
-            // enable dithering LOD crossfade
-            // #pragma multi_compile _ LOD_FADE_CROSSFADE
-            // TODO: We should have this keyword only if VelocityInGBuffer is enable, how to do that ?
-            //#pragma multi_compile VELOCITYOUTPUT_OFF VELOCITYOUTPUT_ON
-
             return activeFields;
         }
 
         private static bool GenerateShaderPassLit(AbstractMaterialNode masterNode, Pass pass, GenerationMode mode, SurfaceMaterialOptions materialOptions, ShaderGenerator result, List<string> sourceAssetDependencyPaths)
         {
-            // apply master node options to active fields
-            HashSet<string> activeFields = GetActiveFieldsFromMasterNode(masterNode, pass);
+            if (mode == GenerationMode.ForReals || pass.UseInPreview)
+            {
+                pass.OnGeneratePass(masterNode as PBRMasterNode);
 
-            // use standard shader pass generation
-            bool vertexActive = masterNode.IsSlotConnected(PBRMasterNode.PositionSlotId);
-            return HDSubShaderUtilities.GenerateShaderPass(masterNode, pass, mode, materialOptions, activeFields, result, sourceAssetDependencyPaths, vertexActive);
+                // apply master node options to active fields
+                HashSet<string> activeFields = GetActiveFieldsFromMasterNode(masterNode, pass);                
+
+                // use standard shader pass generation
+                bool vertexActive = masterNode.IsSlotConnected(PBRMasterNode.PositionSlotId);
+                return HDSubShaderUtilities.GenerateShaderPass(masterNode, pass, mode, materialOptions, activeFields, result, sourceAssetDependencyPaths, vertexActive);
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public string GetSubshader(IMasterNode iMasterNode, GenerationMode mode, List<string> sourceAssetDependencyPaths = null)
@@ -442,11 +474,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 // generate the necessary shader passes
                 bool opaque = (masterNode.surfaceType == SurfaceType.Opaque);
 
-                if (opaque)
-                {
-                    GenerateShaderPassLit(masterNode, m_PassGBuffer, mode, materialOptions, subShader, sourceAssetDependencyPaths);
-                }
-
                 GenerateShaderPassLit(masterNode, m_PassMETA, mode, materialOptions, subShader, sourceAssetDependencyPaths);
                 GenerateShaderPassLit(masterNode, m_PassShadowCaster, mode, materialOptions, subShader, sourceAssetDependencyPaths);
                 GenerateShaderPassLit(masterNode, m_SceneSelectionPass, mode, materialOptions, subShader, sourceAssetDependencyPaths);
@@ -454,14 +481,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 if (opaque)
                 {
                     GenerateShaderPassLit(masterNode, m_PassDepthOnly, mode, materialOptions, subShader, sourceAssetDependencyPaths);
-                    GenerateShaderPassLit(masterNode, m_PassMotionVectors, mode, materialOptions, subShader, sourceAssetDependencyPaths);
+                    GenerateShaderPassLit(masterNode, m_PassGBuffer, mode, materialOptions, subShader, sourceAssetDependencyPaths);
                 }
+
+                GenerateShaderPassLit(masterNode, m_PassMotionVectors, mode, materialOptions, subShader, sourceAssetDependencyPaths);
 
                 GenerateShaderPassLit(masterNode, m_PassForward, mode, materialOptions, subShader, sourceAssetDependencyPaths);
             }
             subShader.Deindent();
             subShader.AddShaderChunk("}", true);
-            subShader.AddShaderChunk("CustomEditor \"UnityEditor.ShaderGraph.PBRMasterGUI\"", true);
+            subShader.AddShaderChunk("CustomEditor \"UnityEditor.Experimental.Rendering.HDPipeline.PBRMasterGUI\"", true);
 
             return subShader.GetShaderString(0);
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
@@ -7,27 +7,27 @@ Pass
     //-------------------------------------------------------------------------------------
     // Render Modes (Blend, Cull, ZTest, Stencil, etc)
     //-------------------------------------------------------------------------------------
-        $splice(Blending)
-        $splice(Culling)
-        $splice(ZTest)
-        $splice(ZWrite)
-        $splice(ZClip)
-        $splice(Stencil)
-        $splice(ColorMask)
+    $splice(Blending)
+    $splice(Culling)
+    $splice(ZTest)
+    $splice(ZWrite)
+    $splice(ZClip)
+    $splice(Stencil)
+    $splice(ColorMask)
     //-------------------------------------------------------------------------------------
     // End Render Modes
     //-------------------------------------------------------------------------------------
 
     HLSLPROGRAM
 
-        #pragma target 4.5
-        #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
-        //#pragma enable_d3d11_debug_symbols
+    #pragma target 4.5
+    #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+    //#pragma enable_d3d11_debug_symbols
 
-        #pragma multi_compile_instancing
-        #pragma instancing_options renderinglayer
+    #pragma multi_compile_instancing
+    #pragma instancing_options renderinglayer
 
-        #pragma multi_compile _ LOD_FADE_CROSSFADE
+    #pragma multi_compile _ LOD_FADE_CROSSFADE
 
     //-------------------------------------------------------------------------------------
     // Variant Definitions
@@ -37,144 +37,138 @@ Pass
     // StackLitData.hlsl)
     //-------------------------------------------------------------------------------------
 
-        //
-        // Predicate reference:
-        // Specific predicates
-        // (ie generated from StackLitSubShader.GetActiveFieldsFromMasterNode)
-        // --------------------
+    //
+    // Predicate reference:
+    // Specific predicates
+    // (ie generated from StackLitSubShader.GetActiveFieldsFromMasterNode)
+    // --------------------
 
-        // General surface and geometry semantics:
+    // General surface and geometry semantics:
 
-        // $DoubleSided:
-        // $DoubleSided.Flip:
-        // $DoubleSided.Mirror:
-        // $FragInputs.isFrontFace:     // will need this for determining normal flip mode
-        // $AlphaTest:
-        // $SurfaceType.Transparent:
-        // $BlendMode.Alpha:
-        // $BlendMode.Premultiply:
-        // $BlendMode.Add:
-        // $BlendMode.PreserveSpecular:
-        // $AlphaFog:
+    // $DoubleSided:
+    // $DoubleSided.Flip:
+    // $DoubleSided.Mirror:
+    // $FragInputs.isFrontFace:     // will need this for determining normal flip mode
+    // $AlphaTest:
+    // $SurfaceType.Transparent:
+    // $BlendMode.Alpha:
+    // $BlendMode.Premultiply:
+    // $BlendMode.Add:
+    // $BlendMode.PreserveSpecular:
+    // $AlphaFog:
 
-        // Combined (one predicate implicitly implying a combination of others):
-        // input slot presence + slot connection:
+    // Combined (one predicate implicitly implying a combination of others):
+    // input slot presence + slot connection:
 
-        // $BentNormal:
-        // $Tangent:
-        // $CoatNormal:
+    // $BentNormal:
+    // $Tangent:
+    // $CoatNormal:
 
-        // Combined predicates: other special cases.
-        // (eg property enabled + one or even multiple (and all of them) slots present,
-        // connection or unconnected but non default value):
+    // Combined predicates: other special cases.
+    // (eg property enabled + one or even multiple (and all of them) slots present,
+    // connection or unconnected but non default value):
 
-        // 
-        // $SpecularAA:             // this one is set whether we have GeometricSpecularAA or NormalMapFiltering (TODOTODO)
-        // $GeometricSpecularAA:
-        // $AmbientOcclusion: // not used, bugbug todotodo in Lit
+    // 
+    // $SpecularAA:             // this one is set whether we have GeometricSpecularAA or NormalMapFiltering (TODOTODO)
+    // $GeometricSpecularAA:
+    // $AmbientOcclusion: // not used, bugbug todotodo in Lit
 
-        // Features and config toggles:
+    // Features and config toggles:
 
-        // $BaseParametrization.SpecularColor:
-        // $EnergyConservingSpecular:
-        // $Material.Anisotropy:
-        // $Material.Coat:
-        // $Material.CoatNormal:
-        // $Material.DualSpecularLobe:
-        // $DualSpecularLobeParametrization.HazyGloss:
-        // $CapHazinessIfNotMetallic:
-        // $Material.Iridescence:
-        // $Material.SubsurfaceScattering:
-        // $Material.Transmission:
-        // $AnisotropyForAreaLights:
-        // $RecomputeStackPerLight:
-        // $ShadeBaseUsingRefractedAngles:
-        // $StackLitDebug:
-        // $ReceiveDecals:
-        // $ReceiveSSR:
-        // $DontReceiveDecals:
-        // $DontReceiveSSR:
-        // $SpecularOcclusion:
+    // $BaseParametrization.SpecularColor:
+    // $EnergyConservingSpecular:
+    // $Material.Anisotropy:
+    // $Material.Coat:
+    // $Material.CoatNormal:
+    // $Material.DualSpecularLobe:
+    // $DualSpecularLobeParametrization.HazyGloss:
+    // $CapHazinessIfNotMetallic:
+    // $Material.Iridescence:
+    // $Material.SubsurfaceScattering:
+    // $Material.Transmission:
+    // $AnisotropyForAreaLights:
+    // $RecomputeStackPerLight:
+    // $ShadeBaseUsingRefractedAngles:
+    // $StackLitDebug:
+    // Decals:
+    // DisableSSR:
+    // $SpecularOcclusion:
 
-        //
-        // Original shader keywords reference:
-        // 
+    //
+    // Original shader keywords reference:
+    // 
         
-        // _ALPHATEST_ON
-        // _DOUBLESIDED_ON
+    // _ALPHATEST_ON
+    // _DOUBLESIDED_ON
 
-        // _DETAILMAP
-        // _BENTNORMALMAP
-        // _TANGENTMAP
-        // _ENABLESPECULAROCCLUSION // This will control SO whether bent normals are there or not (cf Lit where only bent normals have effect with this keyword)
-
-
-        // // Keyword for transparent
-        // 
-        // _SURFACE_TYPE_TRANSPARENT
-        // _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
-        // _BLENDMODE_PRESERVE_SPECULAR_LIGHTING // handled in material.hlsl
-        // _ENABLE_FOG_ON_TRANSPARENT
-
-        // // MaterialFeature used as shader feature
-        // 
-        // _MATERIAL_FEATURE_DUAL_SPECULAR_LOBE
-        // _MATERIAL_FEATURE_ANISOTROPY
-        // _MATERIAL_FEATURE_COAT
-        // _MATERIAL_FEATURE_COAT_NORMALMAP
-        // _MATERIAL_FEATURE_IRIDESCENCE
-        // _MATERIAL_FEATURE_SUBSURFACE_SCATTERING
-        // _MATERIAL_FEATURE_TRANSMISSION
-        // _MATERIAL_FEATURE_SPECULAR_COLOR
-        // _MATERIAL_FEATURE_HAZY_GLOSS
-
-        // // Performance vs appearance options
-        //
-        // // Handling of anisotropy for area lights:
-        // _ANISOTROPY_FOR_AREA_LIGHTS
-        // 
-        // // Vertically layered BSDF test/tweak
-        // _VLAYERED_RECOMPUTE_PERLIGHT
-        // _VLAYERED_USE_REFRACTED_ANGLES_FOR_BASE
+    // _DETAILMAP
+    // _BENTNORMALMAP
+    // _TANGENTMAP
+    // _ENABLESPECULAROCCLUSION // This will control SO whether bent normals are there or not (cf Lit where only bent normals have effect with this keyword)
 
 
-        // Common shader_features:
+    // // Keyword for transparent
+    // 
+    // _SURFACE_TYPE_TRANSPARENT
+    // _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
+    // _BLENDMODE_PRESERVE_SPECULAR_LIGHTING // handled in material.hlsl
+    // _ENABLE_FOG_ON_TRANSPARENT
 
-        $SurfaceType.Transparent:                            #define _SURFACE_TYPE_TRANSPARENT
-        $BlendMode.Alpha:                                    #define _BLENDMODE_ALPHA
-        $BlendMode.Add:                                      #define _BLENDMODE_ADD
-        $BlendMode.Premultiply:                              #define _BLENDMODE_PRE_MULTIPLY
-        $BlendMode.PreserveSpecular:                         #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING
-        $AlphaFog:                                           #define _ENABLE_FOG_ON_TRANSPARENT
+    // // MaterialFeature used as shader feature
+    // 
+    // _MATERIAL_FEATURE_DUAL_SPECULAR_LOBE
+    // _MATERIAL_FEATURE_ANISOTROPY
+    // _MATERIAL_FEATURE_COAT
+    // _MATERIAL_FEATURE_COAT_NORMALMAP
+    // _MATERIAL_FEATURE_IRIDESCENCE
+    // _MATERIAL_FEATURE_SUBSURFACE_SCATTERING
+    // _MATERIAL_FEATURE_TRANSMISSION
+    // _MATERIAL_FEATURE_SPECULAR_COLOR
+    // _MATERIAL_FEATURE_HAZY_GLOSS
 
-        $DontReceiveDecals:                                  #define _DISABLE_DECALS
-        $DontReceiveSSR:                                     #define _DISABLE_SSR
+    // // Performance vs appearance options
+    //
+    // // Handling of anisotropy for area lights:
+    // _ANISOTROPY_FOR_AREA_LIGHTS
+    // 
+    // // Vertically layered BSDF test/tweak
+    // _VLAYERED_RECOMPUTE_PERLIGHT
+    // _VLAYERED_USE_REFRACTED_ANGLES_FOR_BASE
 
-        // StackLit shader_features:
 
-        $SpecularOcclusion:                                  #define _ENABLESPECULAROCCLUSION // directly for StackLit.hlsl
+    // Common shader_features:
 
-        $BaseParametrization.SpecularColor:                  #define _MATERIAL_FEATURE_SPECULAR_COLOR
-        $Material.Anisotropy:                                #define _MATERIAL_FEATURE_ANISOTROPY
-        $Material.Coat:                                      #define _MATERIAL_FEATURE_COAT
-        $Material.CoatNormal:                                #define _MATERIAL_FEATURE_COAT_NORMALMAP
-        $Material.DualSpecularLobe:                          #define _MATERIAL_FEATURE_DUAL_SPECULAR_LOBE
-        $DualSpecularLobeParametrization.HazyGloss:          #define _MATERIAL_FEATURE_HAZY_GLOSS
-        $Material.Iridescence:                               #define _MATERIAL_FEATURE_IRIDESCENCE
-        $Material.SubsurfaceScattering:                      #define _MATERIAL_FEATURE_SUBSURFACE_SCATTERING
-        $Material.Transmission:                              #define _MATERIAL_FEATURE_TRANSMISSION
-        $AnisotropyForAreaLights:                            #define _ANISOTROPY_FOR_AREA_LIGHTS
-        $RecomputeStackPerLight:                             #define _VLAYERED_RECOMPUTE_PERLIGHT
-        $ShadeBaseUsingRefractedAngles:                      #define _VLAYERED_USE_REFRACTED_ANGLES_FOR_BASE
-        $StackLitDebug:                                      #define _STACKLIT_DEBUG
+    $SurfaceType.Transparent:                            #define _SURFACE_TYPE_TRANSPARENT
+    $BlendMode.Alpha:                                    #define _BLENDMODE_ALPHA
+    $BlendMode.Add:                                      #define _BLENDMODE_ADD
+    $BlendMode.Premultiply:                              #define _BLENDMODE_PRE_MULTIPLY
+    $BlendMode.PreserveSpecular:                         #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING
+    $AlphaFog:                                           #define _ENABLE_FOG_ON_TRANSPARENT
 
-        // The other predicates that don't directly map to inputs (the more abstract, called "specific" above)
-        // are used in the surfaceData and builtinData functions.
-        // (eg EnergyConservingSpecular:, CapHazinessIfNotMetallic:, GeometricSpecularAA:, SpecularAA:)
+    $DisableDecals:                                      #define _DISABLE_DECALS
+    $DisableSSR:                                         #define _DISABLE_SSR
 
-        // local defines:
+    // StackLit shader_features:
 
-        //$SurfaceDescription.Emission:    #define _EMISSION 1 //old keyword in legacy unity, not used in HDRP
+    $SpecularOcclusion:                                  #define _ENABLESPECULAROCCLUSION // directly for StackLit.hlsl
+
+    $BaseParametrization.SpecularColor:                  #define _MATERIAL_FEATURE_SPECULAR_COLOR
+    $Material.Anisotropy:                                #define _MATERIAL_FEATURE_ANISOTROPY
+    $Material.Coat:                                      #define _MATERIAL_FEATURE_COAT
+    $Material.CoatNormal:                                #define _MATERIAL_FEATURE_COAT_NORMALMAP
+    $Material.DualSpecularLobe:                          #define _MATERIAL_FEATURE_DUAL_SPECULAR_LOBE
+    $DualSpecularLobeParametrization.HazyGloss:          #define _MATERIAL_FEATURE_HAZY_GLOSS
+    $Material.Iridescence:                               #define _MATERIAL_FEATURE_IRIDESCENCE
+    $Material.SubsurfaceScattering:                      #define _MATERIAL_FEATURE_SUBSURFACE_SCATTERING
+    $Material.Transmission:                              #define _MATERIAL_FEATURE_TRANSMISSION
+    $AnisotropyForAreaLights:                            #define _ANISOTROPY_FOR_AREA_LIGHTS
+    $RecomputeStackPerLight:                             #define _VLAYERED_RECOMPUTE_PERLIGHT
+    $ShadeBaseUsingRefractedAngles:                      #define _VLAYERED_USE_REFRACTED_ANGLES_FOR_BASE
+    $StackLitDebug:                                      #define _STACKLIT_DEBUG
+
+    // The other predicates that don't directly map to inputs (the more abstract, called "specific" above)
+    // are used in the surfaceData and builtinData functions.
+    // (eg EnergyConservingSpecular:, CapHazinessIfNotMetallic:, GeometricSpecularAA:, SpecularAA:)
 
     //-------------------------------------------------------------------------------------
     // End Variant Definitions
@@ -206,55 +200,48 @@ Pass
     //-------------------------------------------------------------------------------------
     // Defines
     //-------------------------------------------------------------------------------------
-        $splice(Defines)
+    $splice(Defines)
 
-        // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
-        $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
-        $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
-        $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
-        $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
-        $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
-        $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
-        $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
-        $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
-        $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
-        $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
-        $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
-        $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
-        $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
-        $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
-        $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
-        $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
+    // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
+    $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
+    $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
+    $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
+    $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
+    $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
+    $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
+    $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
+    $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
+    $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
+    $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
+    $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
+    $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
+    $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
+    $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
+    $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
+    $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
 
     //-------------------------------------------------------------------------------------
     // End Defines
     //-------------------------------------------------------------------------------------
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #endif
+#ifdef DEBUG_DISPLAY
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
+#endif
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
 
-    #if (SHADERPASS == SHADERPASS_FORWARD)
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
+#if (SHADERPASS == SHADERPASS_FORWARD)
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
 
-        // The light loop (or lighting architecture) is in charge to:
-        // - Define light list
-        // - Define the light loop
-        // - Setup the constant/data
-        // - Do the reflection hierarchy
-        // - Provide sampling function for shadowmap, ies, cookie and reflection (depends on the specific use with the light loops like index array or atlas or single and texture format (cubemap/latlong))
+    #define HAS_LIGHTLOOP
 
-        #define HAS_LIGHTLOOP
-
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl"
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLit.hlsl"
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl"
-    #else
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLit.hlsl"
-    #endif
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl"
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLit.hlsl"
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl"
+#else
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/StackLit/StackLit.hlsl"
+#endif
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl"
@@ -266,35 +253,12 @@ Pass
     int _ObjectId;
     int _PassValue;
 
-    // BuildWorldToTangent is required by SharedCode.template.hlsl:BuildFragInputs()
-    // This function assumes the bitangent flip is encoded in tangentWS.w
-    // TODO: move this function to HDRP shared file, once we merge with HDRP repo
-    float3x3 BuildWorldToTangent(float4 tangentWS, float3 normalWS)
-    {
-        // tangentWS must not be normalized (mikkts requirement)
-
-        // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
-        float3 unnormalizedNormalWS = normalWS;
-        float renormFactor = 1.0 / length(unnormalizedNormalWS);
-
-        // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-        // this is the mikktspace transformation (must use unnormalized attributes)
-        float3x3 worldToTangent = CreateWorldToTangent(unnormalizedNormalWS, tangentWS.xyz, tangentWS.w > 0.0 ? 1.0 : -1.0);
-
-        // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-        // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-        worldToTangent[0] = worldToTangent[0] * renormFactor;
-        worldToTangent[1] = worldToTangent[1] * renormFactor;
-        worldToTangent[2] = worldToTangent[2] * renormFactor; // normalizes the interpolated vertex normal
-        return worldToTangent;
-    }
-
     //-------------------------------------------------------------------------------------
     // Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
-        $buildType(AttributesMesh)
-        $buildType(VaryingsMeshToPS)
-        $buildType(VaryingsMeshToDS)
+    $buildType(AttributesMesh)
+    $buildType(VaryingsMeshToPS)
+    $buildType(VaryingsMeshToDS)
     //-------------------------------------------------------------------------------------
     // End Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
@@ -422,11 +386,12 @@ $include("SharedCode.template.hlsl")
         $Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.worldToTangent);
         surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
 
-        // TODOTODO: bugbug in Lit? Must be placed before specularAA, you don't want the decal to scale the roughness
-        // boost induced by the geometric specular AA
-#if defined(HAVE_DECALS) && !defined(_DISABLE_DECALS)
-        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
 #endif
 
         // 
@@ -452,7 +417,7 @@ $include("SharedCode.template.hlsl")
         // Note SpecularAA: or GeometricSpecularAA: guarantees surfaceDescription has SpecularAAScreenSpaceVariance and SpecularAAThreshold.
         $GeometricSpecularAA: geometricVariance = GeometricNormalVariance(input.worldToTangent[2], surfaceDescription.SpecularAAScreenSpaceVariance);
 
-        // TODOTODO:
+        // TODO: Handle normal map filtering
         // Also handle texture normal filtering when we have the proper operator nodes and can thus have the variance port
         // in our master node:
         float textureFilteringVariance = 0.0;
@@ -467,19 +432,7 @@ $include("SharedCode.template.hlsl")
 #if defined(DEBUG_DISPLAY)
         if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)
         {
-            // TODO: need for ShaderGraph to output equivalent info, but only in case of DEBUG_DISPLAY,
-            // see comments below for SHADERPASS_DISTORTION.
-            //
-            //
-            //if (_BaseColorMapUV != TEXCOORD_INDEX_TRIPLANAR)
-            //{
-            //    surfaceData.baseColor = GetTextureDataDebug(_DebugMipMapMode, uvMapping.texcoords[_BaseColorMapUV][_BaseColorMapUVLocal], _BaseColorMap, _BaseColorMap_TexelSize, _BaseColorMap_MipInfo, surfaceData.baseColor);
-            //}
-            //else
-            //{
-            //    surfaceData.baseColor = float3(0.0, 0.0, 0.0);
-            //}
-            //surfaceData.metallic = 0.0;
+            // TODO: need to update mip info
         }
 
         // We need to call ApplyDebugToSurfaceData after filling the surfarcedata and before filling builtinData
@@ -490,20 +443,18 @@ $include("SharedCode.template.hlsl")
 
     void GetSurfaceAndBuiltinData(FragInputs fragInputs, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
     {
-
-        // TODOTOCHECK:
 #ifdef LOD_FADE_CROSSFADE // enable dithering LOD transition if user select CrossFade transition in LOD group
         uint3 fadeMaskSeed = asuint((int3)(V * _ScreenSize.xyx)); // Quantize V to _ScreenSize values
         LODDitheringTransition(fadeMaskSeed, unity_LODFade.x);
 #endif
 
-        // this applies the double sided tangent space correction
+        // This applies the double sided tangent space correction
         // Must match /Runtime/Material/MaterialUtilities.hlsl:ApplyDoubleSidedFlipOrMirror()
         $DoubleSided:            if (!fragInputs.isFrontFace)
         $DoubleSided:            {
         $DoubleSided.Flip:           fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
         $DoubleSided.Flip:           fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided.Mirror:          fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
+        $DoubleSided.Mirror:         fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
         $DoubleSided:            }
 
         SurfaceDescriptionInputs surfaceDescriptionInputs = FragInputsToSurfaceDescriptionInputs(fragInputs, V);
@@ -521,17 +472,10 @@ $include("SharedCode.template.hlsl")
 
         $SurfaceDescription.Emission: builtinData.emissiveColor = surfaceDescription.Emission;
 
+        // TODO: Handle depth offset
         //builtinData.depthOffset = 0.0;
-        // ApplyPerPixelDisplacement(input, V, layerTexCoord, blendMasks); #ifdef _DEPTHOFFSET_ON : ApplyDepthOffsetPositionInput(V, depthOffset, GetWorldToHClipMatrix(), posInput);
 
 #if (SHADERPASS == SHADERPASS_DISTORTION)
-        // TODO
-        // For debug, maybe add an option in StackLitSettingsView like Advanced/Pass Extra Slots For Debug,
-        // check for the property in StackLitSubShader's ForwardOnly pass and add the distortion in PixelShaderSlots
-        // and finally here, do something like
-        // #if (SHADERPASS == SHADERPASS_DISTORTION) || (defined(DEBUG_DISPLAY) && defined(ALLOCATED_EXTRA_SLOTS_FOR_DEBUG))
-        // Until ShaderGraph can support multi-pathed (from defined keywords) in both the dependency management and
-        // graph evaluation and generation, that would do.
         builtinData.distortion = surfaceDescription.Distortion;
         builtinData.distortionBlur = surfaceDescription.DistortionBlur;
 #else

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
@@ -107,11 +107,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             TemplateName = "StackLitPass.template",
             MaterialName = "StackLit",
             ShaderPassName = "SHADERPASS_DEPTH_ONLY",
+            ColorMaskOverride = "ColorMask 0",
             ExtraDefines = new List<string>()
             {
                 "#define SCENESELECTIONPASS",
-            },
-            ColorMaskOverride = "ColorMask 0",
+            },            
             Includes = new List<string>()
             {
                 "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
@@ -173,6 +173,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             PixelShaderSlots = new List<int>()
             {
+                // see AddPixelShaderSlotsForWriteNormalBufferPasses
                 StackLitMasterNode.AlphaSlotId,
                 StackLitMasterNode.AlphaClipThresholdSlotId
             },
@@ -180,15 +181,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 StackLitMasterNode.PositionSlotId
             },
-            UseInPreview = true,
+            UseInPreview = false,
 
             OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
             {
                 var masterNode = node as StackLitMasterNode;
 
-                // TODOTODO or-in the DoesntReceiveSSR bit but would require tweak in RenderPipeline.cs, but this would save work in the compute shader.
-                int stencilDepthPrepassWriteMask = masterNode.receiveDecals.isOn ? (int)HDRenderPipeline.StencilBitMask.DecalsForwardOutputNormalBuffer:0;
-                int stencilDepthPrepassRef = masterNode.receiveDecals.isOn ? (int)HDRenderPipeline.StencilBitMask.DecalsForwardOutputNormalBuffer:0;
+                int stencilDepthPrepassWriteMask = masterNode.receiveDecals.isOn ? (int)HDRenderPipeline.StencilBitMask.DecalsForwardOutputNormalBuffer : 0;
+                int stencilDepthPrepassRef = masterNode.receiveDecals.isOn ? (int)HDRenderPipeline.StencilBitMask.DecalsForwardOutputNormalBuffer : 0;
+                stencilDepthPrepassWriteMask |= !masterNode.receiveSSR.isOn ? (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR : 0;
+                stencilDepthPrepassRef |= !masterNode.receiveSSR.isOn ? (int)HDRenderPipeline.StencilBitMask.DoesntReceiveSSR : 0;
 
                 if (stencilDepthPrepassWriteMask != 0)
                 {
@@ -227,14 +229,26 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             RequiredFields = new List<string>()
             {
+                "AttributesMesh.normalOS",
+                "AttributesMesh.tangentOS",     // Always present as we require it also in case of Variants lighting
+                "AttributesMesh.uv0",
+                "AttributesMesh.uv1",
+                "AttributesMesh.color",
+                "AttributesMesh.uv2",           // SHADERPASS_LIGHT_TRANSPORT always uses uv2
+                "AttributesMesh.uv3",           // DEBUG_DISPLAY
+
                 "FragInputs.worldToTangent",
                 "FragInputs.positionRWS",
+                "FragInputs.texCoord0",
                 "FragInputs.texCoord1",
-                "FragInputs.texCoord2"
+                "FragInputs.texCoord2",
+                "FragInputs.texCoord3",
+                "FragInputs.color",
             },
 
             PixelShaderSlots = new List<int>()
             {
+                // see AddPixelShaderSlotsForWriteNormalBufferPasses
                 StackLitMasterNode.AlphaSlotId,
                 StackLitMasterNode.AlphaClipThresholdSlotId
             },
@@ -275,9 +289,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             TemplateName = "StackLitPass.template",
             MaterialName = "StackLit",
             ShaderPassName = "SHADERPASS_DISTORTION",
-            BlendOverride = "Blend One One, One One",   // [_DistortionSrcBlend] [_DistortionDstBlend], [_DistortionBlurSrcBlend] [_DistortionBlurDstBlend]
-            BlendOpOverride = "BlendOp Add, Add",       // Add, [_DistortionBlurBlendOp]
-            ZTestOverride = "ZTest LEqual",             // [_ZTestModeDistortion]
             ZWriteOverride = "ZWrite Off",
             Includes = new List<string>()
             {
@@ -310,9 +321,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 if (masterNode.distortionMode == DistortionMode.Add)
                 {
                     pass.BlendOverride = "Blend One One, One One";
-                    pass.BlendOpOverride = "BlendOp Add, Max";
+                    pass.BlendOpOverride = "BlendOp Add, Add";
                 }
-                else if (masterNode.distortionMode == DistortionMode.Multiply)
+                else // if (masterNode.distortionMode == DistortionMode.Multiply)
                 {
                     pass.BlendOverride = "Blend DstColor Zero, DstAlpha Zero";
                     pass.BlendOpOverride = "BlendOp Add, Add";
@@ -345,10 +356,21 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             RequiredFields = new List<string>()
             {
+                "AttributesMesh.normalOS",
+                "AttributesMesh.tangentOS",     // Always present as we require it also in case of Variants lighting
+                "AttributesMesh.uv0",
+                "AttributesMesh.uv1",
+                "AttributesMesh.color",
+                "AttributesMesh.uv2",           // SHADERPASS_LIGHT_TRANSPORT always uses uv2
+                "AttributesMesh.uv3",           // DEBUG_DISPLAY
+
                 "FragInputs.worldToTangent",
                 "FragInputs.positionRWS",
+                "FragInputs.texCoord0",
                 "FragInputs.texCoord1",
-                "FragInputs.texCoord2"
+                "FragInputs.texCoord2",
+                "FragInputs.texCoord3",
+                "FragInputs.color",
             },
             PixelShaderSlots = new List<int>()
             {
@@ -398,7 +420,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     "// Stencil setup",
                     "Stencil",
                     "{",
-                    //"   WriteMask 7",
                     string.Format("   WriteMask {0}", (int) HDRenderPipeline.StencilBitMask.LightingMask),
                     string.Format("   Ref  {0}", masterNode.RequiresSplitLighting() ? (int)StencilLightingUsage.SplitLighting : (int)StencilLightingUsage.RegularLighting),
                     "   Comp Always",
@@ -407,7 +428,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 };
 
                 pass.ExtraDefines.Remove("#define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST");
-                if (masterNode.surfaceType == SurfaceType.Opaque)
+                if (masterNode.surfaceType == SurfaceType.Opaque && masterNode.alphaTest.isOn)
                 {
                     pass.ExtraDefines.Add("#define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST");
                     pass.ZTestOverride = "ZTest Equal";
@@ -416,15 +437,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 {
                     pass.ZTestOverride = null;
                 }
-                // We dont have a TransparentBackface pass in StackLit for now.
-                //if (masterNode.surfaceType == SurfaceType.Transparent && masterNode.backThenFrontRendering.isOn)
-                //{
-                //    pass.CullOverride = "Cull Back";
-                //}
-                //else
-                //{
-                //    pass.CullOverride = null;
-                //}
             }
         };
 
@@ -724,22 +736,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // Other property predicates:
             //
 
-            if (masterNode.receiveDecals.isOn)
+            if (!masterNode.receiveDecals.isOn)
             {
-                activeFields.Add("ReceiveDecals");
-            }
-            else
-            {
-                activeFields.Add("DontReceiveDecals");
+                activeFields.Add("DisableDecals");
             }
 
-            if (masterNode.receiveSSR.isOn)
+            if (!masterNode.receiveSSR.isOn)
             {
-                activeFields.Add("ReceiveSSR");
-            }
-            else
-            {
-                activeFields.Add("DontReceiveSSR");
+                activeFields.Add("DisableSSR");
             }
 
             // Note here we combine an "enable"-like predicate and the $SurfaceDescription.(slotname) predicate
@@ -872,18 +876,22 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
                 bool distortionActive = transparent && masterNode.distortion.isOn;
 
+                GenerateShaderPassLit(masterNode, m_PassMETA, mode, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPassLit(masterNode, m_PassShadowCaster, mode, subShader, sourceAssetDependencyPaths);
                 GenerateShaderPassLit(masterNode, m_SceneSelectionPass, mode, subShader, sourceAssetDependencyPaths);
+
                 if (opaque)
                 {
                     GenerateShaderPassLit(masterNode, m_PassDepthForwardOnly, mode, subShader, sourceAssetDependencyPaths);
                 }
+
                 GenerateShaderPassLit(masterNode, m_PassMotionVectors, mode, subShader, sourceAssetDependencyPaths);
-                GenerateShaderPassLit(masterNode, m_PassMETA, mode, subShader, sourceAssetDependencyPaths);
-                GenerateShaderPassLit(masterNode, m_PassShadowCaster, mode, subShader, sourceAssetDependencyPaths);
+
                 if (distortionActive)
                 {
                     GenerateShaderPassLit(masterNode, m_PassDistortion, mode, subShader, sourceAssetDependencyPaths);
                 }
+
                 GenerateShaderPassLit(masterNode, m_PassForwardOnly, mode, subShader, sourceAssetDependencyPaths);
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPassForward.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPassForward.template
@@ -7,38 +7,32 @@ Pass
     //-------------------------------------------------------------------------------------
     // Render Modes (Blend, Cull, ZTest, Stencil, etc)
     //-------------------------------------------------------------------------------------
-        $splice(Blending)
-        $splice(Culling)
-        $splice(ZTest)
-        $splice(ZWrite)
-        $splice(Stencil)
-        $splice(ColorMask)
+    $splice(Blending)
+    $splice(Culling)
+    $splice(ZTest)
+    $splice(ZWrite)
+    $splice(Stencil)
+    $splice(ColorMask)
     //-------------------------------------------------------------------------------------
     // End Render Modes
     //-------------------------------------------------------------------------------------
 
     HLSLPROGRAM
 
-        #pragma target 4.5
-        #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
-        //#pragma enable_d3d11_debug_symbols
+    #pragma target 4.5
+    #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+    //#pragma enable_d3d11_debug_symbols
 
-        //enable GPU instancing support
-        #pragma multi_compile_instancing
+    //enable GPU instancing support
+    #pragma multi_compile_instancing
 
     //-------------------------------------------------------------------------------------
     // Variant Definitions (active field translations to HDRP defines)
     //-------------------------------------------------------------------------------------
-        $AlphaTest:                      #define _ALPHATEST_ON 1
-        $Material.SubsurfaceScattering:  #define _MATERIAL_FEATURE_SUBSURFACE_SCATTERING 1
-        $Material.Transmission:          #define _MATERIAL_FEATURE_TRANSMISSION 1
-        $Material.Anisotropy:            #define _MATERIAL_FEATURE_ANISOTROPY 1
-        $Material.ClearCoat:             #define _MATERIAL_FEATURE_CLEAR_COAT 1
-        $Material.Iridescence:           #define _MATERIAL_FEATURE_IRIDESCENCE 1
-        $Material.SpecularColor:         #define _MATERIAL_FEATURE_SPECULAR_COLOR 1
-        $SurfaceType.Transparent:        #define _SURFACE_TYPE_TRANSPARENT 1
-        $BlendMode.Alpha:                #define _BLENDMODE_ALPHA 1
-        $BlendMode.Add:                  #define _BLENDMODE_ADD 1
+    $SurfaceType.Transparent:            #define _SURFACE_TYPE_TRANSPARENT 1
+    $BlendMode.Alpha:                    #define _BLENDMODE_ALPHA 1
+    $BlendMode.Add:                      #define _BLENDMODE_ADD 1
+    $BlendMode.Premultiply:              #define _BLENDMODE_PRE_MULTIPLY 1
     //-------------------------------------------------------------------------------------
     // End Variant Definitions
     //-------------------------------------------------------------------------------------
@@ -56,34 +50,34 @@ Pass
     //-------------------------------------------------------------------------------------
     // Defines
     //-------------------------------------------------------------------------------------
-$splice(Defines)
+    $splice(Defines)
 
-        // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
-        $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
-        $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
-        $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
-        $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
-        $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
-        $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
-        $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
-        $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
-        $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
-        $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
-        $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
-        $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
-        $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
-        $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
-        $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
-        $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
+    // this translates the new dependency tracker into the old preprocessor definitions for the existing HDRP shader code
+    $AttributesMesh.normalOS:               #define ATTRIBUTES_NEED_NORMAL
+    $AttributesMesh.tangentOS:              #define ATTRIBUTES_NEED_TANGENT
+    $AttributesMesh.uv0:                    #define ATTRIBUTES_NEED_TEXCOORD0
+    $AttributesMesh.uv1:                    #define ATTRIBUTES_NEED_TEXCOORD1
+    $AttributesMesh.uv2:                    #define ATTRIBUTES_NEED_TEXCOORD2
+    $AttributesMesh.uv3:                    #define ATTRIBUTES_NEED_TEXCOORD3
+    $AttributesMesh.color:                  #define ATTRIBUTES_NEED_COLOR
+    $VaryingsMeshToPS.positionRWS:          #define VARYINGS_NEED_POSITION_WS
+    $VaryingsMeshToPS.normalWS:             #define VARYINGS_NEED_TANGENT_TO_WORLD
+    $VaryingsMeshToPS.texCoord0:            #define VARYINGS_NEED_TEXCOORD0
+    $VaryingsMeshToPS.texCoord1:            #define VARYINGS_NEED_TEXCOORD1
+    $VaryingsMeshToPS.texCoord2:            #define VARYINGS_NEED_TEXCOORD2
+    $VaryingsMeshToPS.texCoord3:            #define VARYINGS_NEED_TEXCOORD3
+    $VaryingsMeshToPS.color:                #define VARYINGS_NEED_COLOR
+    $VaryingsMeshToPS.cullFace:             #define VARYINGS_NEED_CULLFACE
+    $features.modifyMesh:                   #define HAVE_MESH_MODIFICATION
 
     //-------------------------------------------------------------------------------------
     // End Defines
     //-------------------------------------------------------------------------------------
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #endif
+#ifdef DEBUG_DISPLAY
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
+#endif
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.hlsl"
@@ -92,34 +86,12 @@ $splice(Defines)
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderGraphFunctions.hlsl"
 
-    // this function assumes the bitangent flip is encoded in tangentWS.w
-    // TODO: move this function to HDRP shared file, once we merge with HDRP repo
-    float3x3 BuildWorldToTangent(float4 tangentWS, float3 normalWS)
-    {
-        // tangentWS must not be normalized (mikkts requirement)
-
-        // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
-	    float3 unnormalizedNormalWS = normalWS;
-        float renormFactor = 1.0 / length(unnormalizedNormalWS);
-
-        // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-	    // this is the mikktspace transformation (must use unnormalized attributes)
-        float3x3 worldToTangent = CreateWorldToTangent(unnormalizedNormalWS, tangentWS.xyz, tangentWS.w > 0.0 ? 1.0 : -1.0);
-
-	    // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-	    // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-        worldToTangent[0] = worldToTangent[0] * renormFactor;
-        worldToTangent[1] = worldToTangent[1] * renormFactor;
-        worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
-        return worldToTangent;
-    }
-
     //-------------------------------------------------------------------------------------
     // Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
-        $buildType(AttributesMesh)
-        $buildType(VaryingsMeshToPS)
-        $buildType(VaryingsMeshToDS)
+    $buildType(AttributesMesh)
+    $buildType(VaryingsMeshToPS)
+    $buildType(VaryingsMeshToDS)
     //-------------------------------------------------------------------------------------
     // End Interpolator Packing And Struct Declarations
     //-------------------------------------------------------------------------------------
@@ -127,7 +99,7 @@ $splice(Defines)
     //-------------------------------------------------------------------------------------
     // Graph generated code
     //-------------------------------------------------------------------------------------
-$splice(Graph)
+    $splice(Graph)
     //-------------------------------------------------------------------------------------
     // End graph generated code
     //-------------------------------------------------------------------------------------
@@ -137,24 +109,24 @@ $features.modifyMesh:   $include("VertexAnimation.template.hlsl")
 $include("SharedCode.template.hlsl")
 
 
-    void BuildSurfaceData(FragInputs fragInputs, SurfaceDescription surfaceDescription, float3 V, out SurfaceData surfaceData)
+    void BuildSurfaceData(FragInputs fragInputs, inout SurfaceDescription surfaceDescription, float3 V, PositionInputs posInput, out SurfaceData surfaceData)
     {
         // setup defaults -- these are used if the graph doesn't output a value
         ZERO_INITIALIZE(SurfaceData, surfaceData);
 
         // copy across graph values, if defined
-        $SurfaceDescription.Color:               surfaceData.color = surfaceDescription.Color;
+        $SurfaceDescription.Color: surfaceData.color = surfaceDescription.Color;
+
+#if defined(DEBUG_DISPLAY)
+        if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)
+        {
+            // TODO
+        }
+#endif
     }
 
     void GetSurfaceAndBuiltinData(FragInputs fragInputs, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
     {
-        // this applies the double sided tangent space correction -- see 'ApplyDoubleSidedFlipOrMirror()'
-        $DoubleSided:           if (!fragInputs.isFrontFace) {
-        $DoubleSided.Flip:          fragInputs.worldToTangent[1] = -fragInputs.worldToTangent[1];     // bitangent
-        $DoubleSided.Flip:          fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided.Mirror:        fragInputs.worldToTangent[2] = -fragInputs.worldToTangent[2];     // normal
-        $DoubleSided:           }
-
         SurfaceDescriptionInputs surfaceDescriptionInputs = FragInputsToSurfaceDescriptionInputs(fragInputs, V);
         SurfaceDescription surfaceDescription = SurfaceDescriptionFunction(surfaceDescriptionInputs);
 
@@ -162,17 +134,22 @@ $include("SharedCode.template.hlsl")
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
         $AlphaTest:     DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
 
-        BuildSurfaceData(fragInputs, surfaceDescription, V, surfaceData);
+        BuildSurfaceData(fragInputs, surfaceDescription, V, posInput, surfaceData);
 
         // Builtin Data
         ZERO_INITIALIZE(BuiltinData, builtinData); // No call to InitBuiltinData as we don't have any lighting
 
-        builtinData.opacity =                   surfaceDescription.Alpha;
+        builtinData.opacity = surfaceDescription.Alpha;
 
-$SurfaceDescription.Emission:     builtinData.emissiveColor =             surfaceDescription.Emission;
+        $SurfaceDescription.Emission: builtinData.emissiveColor = surfaceDescription.Emission;
 
-        builtinData.distortion =                float2(0.0, 0.0);           // surfaceDescription.Distortion -- if distortion pass
-        builtinData.distortionBlur =            0.0;                        // surfaceDescription.DistortionBlur -- if distortion pass
+#if (SHADERPASS == SHADERPASS_DISTORTION)
+        builtinData.distortion = surfaceDescription.Distortion;
+        builtinData.distortionBlur = surfaceDescription.DistortionBlur;
+#else
+        builtinData.distortion = float2(0.0, 0.0);
+        builtinData.distortionBlur = 0.0;
+#endif
     }
 
     //-------------------------------------------------------------------------------------

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
@@ -9,59 +9,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     class HDUnlitSubShader : IUnlitSubShader
     {
-        Pass m_PassDepthOnly = new Pass()
-        {
-            Name = "Depth prepass",
-            LightMode = "DepthForwardOnly",
-            TemplateName = "HDUnlitPassForward.template",
-            MaterialName = "Unlit",
-            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
-            ZWriteOverride = "ZWrite On",
-            Includes = new List<string>()
-            {
-                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
-            },
-            PixelShaderSlots = new List<int>()
-            {
-                UnlitMasterNode.AlphaSlotId,
-                UnlitMasterNode.AlphaThresholdSlotId
-            },
-            VertexShaderSlots = new List<int>()
-            {
-                PBRMasterNode.PositionSlotId
-            }
-        };
-
-        Pass m_PassForward = new Pass()
-        {
-            Name = "Forward Unlit",
-            LightMode = "ForwardOnly",
-            TemplateName = "HDUnlitPassForward.template",
-            MaterialName = "Unlit",
-            ShaderPassName = "SHADERPASS_FORWARD_UNLIT",
-            ExtraDefines = new List<string>()
-            {
-                "#pragma multi_compile _ DEBUG_DISPLAY",
-                "#pragma multi_compile _ LIGHTMAP_ON",
-                "#pragma multi_compile _ DIRLIGHTMAP_COMBINED",
-                "#pragma multi_compile _ DYNAMICLIGHTMAP_ON",
-            },
-            Includes = new List<string>()
-            {
-                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForwardUnlit.hlsl\"",
-            },
-            PixelShaderSlots = new List<int>()
-            {
-                UnlitMasterNode.ColorSlotId,
-                UnlitMasterNode.AlphaSlotId,
-                UnlitMasterNode.AlphaThresholdSlotId
-            },
-            VertexShaderSlots = new List<int>()
-            {
-                PBRMasterNode.PositionSlotId
-            }
-        };
-
         Pass m_PassMETA = new Pass()
         {
             Name = "META",
@@ -91,16 +38,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             VertexShaderSlots = new List<int>()
             {
-                //PBRMasterNode.PositionSlotId
-            }
+                //UnlitMasterNode.PositionSlotId
+            },
+            UseInPreview = false
         };
 
         Pass m_PassShadowCaster = new Pass()
         {
             Name = "ShadowCaster",
             LightMode = "ShadowCaster",
-            TemplateName = "HDPBRPass.template",
-            MaterialName = "PBR",
+            TemplateName = "HDUnlitPassForward.template",
+            MaterialName = "Unlit",
             ShaderPassName = "SHADERPASS_SHADOWS",
             ColorMaskOverride = "ColorMask 0",
             ExtraDefines = new List<string>()
@@ -116,12 +64,112 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             PixelShaderSlots = new List<int>()
             {
-                PBRMasterNode.AlphaSlotId,
-                PBRMasterNode.AlphaThresholdSlotId
+                UnlitMasterNode.AlphaSlotId,
+                UnlitMasterNode.AlphaThresholdSlotId
             },
             VertexShaderSlots = new List<int>()
             {
-                PBRMasterNode.PositionSlotId
+                UnlitMasterNode.PositionSlotId
+            },
+            UseInPreview = false
+        };
+
+        Pass m_SceneSelectionPass = new Pass()
+        {
+            Name = "SceneSelectionPass",
+            LightMode = "SceneSelectionPass",
+            TemplateName = "HDUnlitPassForward.template",
+            MaterialName = "Unlit",
+            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
+            ColorMaskOverride = "ColorMask 0",
+            ExtraDefines = new List<string>()
+            {
+                "#define SCENESELECTIONPASS",
+            },
+            Includes = new List<string>()
+            {
+                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.AlphaSlotId,
+                UnlitMasterNode.AlphaThresholdSlotId
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.PositionSlotId
+            },
+            UseInPreview = true
+        };
+
+        Pass m_PassDepthForwardOnly = new Pass()
+        {
+            Name = "DepthOnly",
+            LightMode = "DepthForwardOnly",
+            TemplateName = "HDUnlitPassForward.template",
+            MaterialName = "Unlit",
+            ShaderPassName = "SHADERPASS_DEPTH_ONLY",
+            ZWriteOverride = "ZWrite On",
+            Includes = new List<string>()
+            {
+                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.AlphaSlotId,
+                UnlitMasterNode.AlphaThresholdSlotId
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.PositionSlotId
+            },
+            UseInPreview = false
+        };
+
+        Pass m_PassMotionVectors = new Pass()
+        {
+            Name = "Motion Vectors",
+            LightMode = "MotionVectors",
+            TemplateName = "HDUnlitPassForward.template",
+            MaterialName = "Unlit",
+            ShaderPassName = "SHADERPASS_VELOCITY",
+            ExtraDefines = new List<string>()
+            {
+                "#pragma multi_compile _ WRITE_MSAA_DEPTH"
+            },
+            Includes = new List<string>()
+            {
+                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassVelocity.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.AlphaSlotId,
+                UnlitMasterNode.AlphaThresholdSlotId
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.PositionSlotId
+            },
+            UseInPreview = false,
+
+            OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
+            {
+                var masterNode = node as UnlitMasterNode;
+
+                int stencilWriteMaskMV = (int)HDRenderPipeline.StencilBitMask.ObjectVelocity;
+                int stencilRefMV = (int)HDRenderPipeline.StencilBitMask.ObjectVelocity;
+
+                pass.StencilOverride = new List<string>()
+                {
+                    "// If velocity pass (motion vectors) is enabled we tag the stencil so it don't perform CameraMotionVelocity",
+                    "Stencil",
+                    "{",
+                    string.Format("   WriteMask {0}", stencilWriteMaskMV),
+                    string.Format("   Ref  {0}", stencilRefMV),
+                    "   Comp Always",
+                    "   Pass Replace",
+                    "}"
+                };
             }
         };
 
@@ -132,9 +180,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             TemplateName = "HDUnlitPassForward.template",
             MaterialName = "Unlit",
             ShaderPassName = "SHADERPASS_DISTORTION",
-            BlendOverride = "Blend One One, One One",   // [_DistortionSrcBlend] [_DistortionDstBlend], [_DistortionBlurSrcBlend] [_DistortionBlurDstBlend]
-            BlendOpOverride = "BlendOp Add, Add",       // Add, [_DistortionBlurBlendOp]
-            ZTestOverride = "ZTest LEqual",             // [_ZTestModeDistortion]
             ZWriteOverride = "ZWrite Off",
             Includes = new List<string>()
             {
@@ -142,13 +187,72 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             },
             PixelShaderSlots = new List<int>()
             {
-                PBRMasterNode.AlphaSlotId,
-                PBRMasterNode.AlphaThresholdSlotId
+                UnlitMasterNode.AlphaSlotId,
+                UnlitMasterNode.AlphaThresholdSlotId,
+                UnlitMasterNode.DistortionSlotId,
+                UnlitMasterNode.DistortionBlurSlotId
             },
             VertexShaderSlots = new List<int>()
             {
-                PBRMasterNode.PositionSlotId
+                UnlitMasterNode.PositionSlotId
             },
+            UseInPreview = true,
+
+            OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
+            {
+                // TODO: Support distortion on unlit shader
+                /*
+                var masterNode = node as UnlitMasterNode;
+                if (masterNode.distortionDepthTest.isOn)
+                {
+                    pass.ZTestOverride = "ZTest LEqual";
+                }
+                else
+                {
+                    pass.ZTestOverride = "ZTest Always";
+                }
+                if (masterNode.distortionMode == DistortionMode.Add)
+                {
+                    pass.BlendOverride = "Blend One One, One One";
+                    pass.BlendOpOverride = "BlendOp Add, Add";
+                }
+                else // if (masterNode.distortionMode == DistortionMode.Multiply)
+                {
+                    pass.BlendOverride = "Blend DstColor Zero, DstAlpha Zero";
+                    pass.BlendOpOverride = "BlendOp Add, Add";
+                }
+                */
+            }
+        };
+
+        Pass m_PassForwardOnly = new Pass()
+        {
+            Name = "Forward Unlit",
+            LightMode = "ForwardOnly",
+            TemplateName = "HDUnlitPassForward.template",
+            MaterialName = "Unlit",
+            ShaderPassName = "SHADERPASS_FORWARD_UNLIT",
+            ExtraDefines = new List<string>()
+            {
+                "#pragma multi_compile _ DEBUG_DISPLAY",
+                "#pragma multi_compile _ LIGHTMAP_ON",
+                "#pragma multi_compile _ DIRLIGHTMAP_COMBINED",
+                "#pragma multi_compile _ DYNAMICLIGHTMAP_ON",
+            },
+            Includes = new List<string>()
+            {
+                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForwardUnlit.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.ColorSlotId,
+                UnlitMasterNode.AlphaSlotId,
+                UnlitMasterNode.AlphaThresholdSlotId
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                UnlitMasterNode.PositionSlotId
+            }
         };
 
         private static HashSet<string> GetActiveFieldsFromMasterNode(INode iMasterNode, Pass pass)
@@ -161,19 +265,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 return activeFields;
             }
 
-            if (masterNode.twoSided.isOn)
-            {
-                activeFields.Add("DoubleSided");
-                if (pass.ShaderPassName != "SHADERPASS_VELOCITY")   // HACK to get around lack of a good interpolator dependency system
-                {                                                   // we need to be able to build interpolators using multiple input structs
-                                                                    // also: should only require isFrontFace if Normals are required...
-                    activeFields.Add("DoubleSided.Mirror");         // TODO: change this depending on what kind of normal flip you want..
-                    activeFields.Add("FragInputs.isFrontFace");     // will need this for determining normal flip mode
-                }
-            }
-
-            if (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId) ||
-                masterNode.GetInputSlots<Vector1MaterialSlot>().First(x => x.id == PBRMasterNode.AlphaThresholdSlotId).value > 0.0f)
+            if (masterNode.IsSlotConnected(UnlitMasterNode.AlphaThresholdSlotId) ||
+                masterNode.GetInputSlots<Vector1MaterialSlot>().First(x => x.id == UnlitMasterNode.AlphaThresholdSlotId).value > 0.0f)
             {
                 activeFields.Add("AlphaTest");
             }
@@ -194,7 +287,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 {
                     activeFields.Add("BlendMode.Add");
                 }
-//                else if (masterNode.alphaMode == PBRMasterNode.AlphaMode.PremultiplyAlpha)            // TODO
+//                else if (masterNode.alphaMode == UnlitMasterNode.AlphaMode.PremultiplyAlpha)            // TODO
 //                {
 //                    defines.AddShaderChunk("#define _BLENDMODE_PRE_MULTIPLY 1", true);
 //                }
@@ -218,7 +311,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             HashSet<string> activeFields = GetActiveFieldsFromMasterNode(masterNode, pass);
 
             // use standard shader pass generation
-            bool vertexActive = masterNode.IsSlotConnected(PBRMasterNode.PositionSlotId);
+            bool vertexActive = masterNode.IsSlotConnected(UnlitMasterNode.PositionSlotId);
             return HDSubShaderUtilities.GenerateShaderPass(masterNode, pass, mode, materialOptions, activeFields, result, sourceAssetDependencyPaths, vertexActive);
         }
 
@@ -250,14 +343,20 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 SurfaceMaterialOptions materialOptions = HDSubShaderUtilities.BuildMaterialOptions(masterNode.surfaceType, masterNode.alphaMode, masterNode.twoSided.isOn, false);
 
                 // generate the necessary shader passes
-//                bool opaque = (masterNode.surfaceType == SurfaceType.Opaque);
-//                bool transparent = (masterNode.surfaceType != SurfaceType.Opaque);
-                bool distortionActive = false;
+                bool opaque = (masterNode.surfaceType == SurfaceType.Opaque);
+                bool distortionActive = false; // TODO: enable distortion on unlit node
 
-                GenerateShaderPassUnlit(masterNode, m_PassDepthOnly, mode, materialOptions, subShader, sourceAssetDependencyPaths);
-                GenerateShaderPassUnlit(masterNode, m_PassForward, mode, materialOptions, subShader, sourceAssetDependencyPaths);
                 GenerateShaderPassUnlit(masterNode, m_PassShadowCaster, mode, materialOptions, subShader, sourceAssetDependencyPaths);
                 GenerateShaderPassUnlit(masterNode, m_PassMETA, mode, materialOptions, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPassUnlit(masterNode, m_SceneSelectionPass, mode, materialOptions, subShader, sourceAssetDependencyPaths);
+
+                if (opaque)
+                {
+                    GenerateShaderPassUnlit(masterNode, m_PassDepthForwardOnly, mode, materialOptions, subShader, sourceAssetDependencyPaths);
+                }
+
+                GenerateShaderPassUnlit(masterNode, m_PassForwardOnly, mode, materialOptions, subShader, sourceAssetDependencyPaths);                
+                
                 if (distortionActive)
                 {
                     GenerateShaderPassUnlit(masterNode, m_PassDistortion, mode, materialOptions, subShader, sourceAssetDependencyPaths);

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
@@ -13,6 +13,7 @@
 #define SSR_TRACE_BEHIND_OBJECTS
 #define SSR_TRACE_TOWARDS_EYE
 #define SSR_TRACE_EPS            0.00024414 // 2^-12, should be good up to 4K
+#define SSR_USE_STENCIL // enable to take into account the disable reflection flags
 
 //--------------------------------------------------------------------------------------------------
 // Included headers
@@ -81,20 +82,17 @@ void WriteDebugInfo(uint2 positionSS, float4 value)
 [numthreads(8, 8, 1)]
 void ScreenSpaceReflectionsTracing(uint2 positionSS : SV_DispatchThreadID)
 {
-    // If we are in forward only, the exclusion happens at a later stage. This is detected with _SsrStencilExclusionValue < 0
-    // TODO: It would be good to find a way to skip some work here even in forward.
-    UNITY_BRANCH if (_SsrStencilExclusionValue > 0)
+#ifdef SSR_USE_STENCIL
+    uint stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
+    bool doesntReceiveSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
+    // Skip SSR for unlit/sky materials as well (check with stencilVal == 0). 
+    doesntReceiveSSR = doesntReceiveSSR || (stencilVal == 0);
+    if (doesntReceiveSSR)
     {
-        uint stencilVal = UnpackByte(LOAD_TEXTURE2D(_StencilTexture, positionSS).r);
-        bool doesntReceiveSSR = (stencilVal & _SsrStencilExclusionValue) != 0;
-        // Skip SSR for unlit materials as well. 
-        doesntReceiveSSR = doesntReceiveSSR || (stencilVal == 0);
-        if (doesntReceiveSSR)
-        {
-            WriteDebugInfo(positionSS, -1);
-            return;
-        }
+        WriteDebugInfo(positionSS, -1);
+        return;
     }
+#endif
 
     float2 positionNDC = positionSS * _ScreenSize.zw + (0.5 * _ScreenSize.zw); // Should we precompute the half-texel bias? We seem to use it a lot.
     float  deviceDepth = LOAD_TEXTURE2D(_DepthPyramidTexture, positionSS).r;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -670,6 +670,15 @@ Shader "HDRenderPipeline/LayeredLit"
 
             Cull[_CullMode]
 
+            // To be able to tag stencil with disableSSR information for forward
+            Stencil
+            {
+                WriteMask [_StencilWriteMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
+
             ZWrite On
 
             HLSLPROGRAM

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -702,6 +702,15 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
 
             Cull[_CullMode]
 
+            // To be able to tag stencil with disableSSR information for forward
+            Stencil
+            {
+                WriteMask [_StencilWriteMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
+
             ZWrite On
 
             HLSLPROGRAM

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -455,6 +455,15 @@ Shader "HDRenderPipeline/Lit"
 
             Cull[_CullMode]
 
+            // To be able to tag stencil with disableSSR information for forward
+            Stencil
+            {
+                WriteMask [_StencilWriteMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
+
             ZWrite On
 
             HLSLPROGRAM

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -480,6 +480,15 @@ Shader "HDRenderPipeline/LitTessellation"
 
             Cull[_CullMode]
 
+            // To be able to tag stencil with disableSSR information for forward
+            Stencil
+            {
+                WriteMask [_StencilWriteMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
+
             ZWrite On
 
             HLSLPROGRAM

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
@@ -208,6 +208,15 @@ Shader "HDRenderPipeline/TerrainLit"
 
             Cull[_CullMode]
 
+            // To be able to tag stencil with disableSSR information for forward
+            Stencil
+            {
+                WriteMask [_StencilWriteMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
+
             ZWrite On
 
             HLSLPROGRAM

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
@@ -32,17 +32,8 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
         float4 tangentWS;
         tangentWS.xyz = cross(normalWS, GetObjectToWorldMatrix()._13_23_33);
         tangentWS.w = -1;
-        float renormFactor = 1.0 / length(normalWS);
 
-        // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-        // this is the mikktspace transformation (must use unnormalized attributes)
-        float3x3 worldToTangent = CreateWorldToTangent(normalWS, tangentWS.xyz, tangentWS.w);
-
-        // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-        // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-        input.worldToTangent[0] = worldToTangent[0] * renormFactor;
-        input.worldToTangent[1] = worldToTangent[1] * renormFactor;
-        input.worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
+        input.worldToTangent = BuildWorldToTangent(tangentWS, normalWS);
 
         input.texCoord0.xy *= _TerrainHeightmapRecipSize.zw;
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData_Basemap.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData_Basemap.hlsl
@@ -33,17 +33,8 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
         float3 normalOS = SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_MainTex, (input.texCoord0.xy + 0.5f) * _TerrainHeightmapRecipSize.xy).rgb * 2 - 1;
         float3 normalWS = mul((float3x3)GetObjectToWorldMatrix(), normalOS);
         float3 tangentWS = cross(GetObjectToWorldMatrix()._13_23_33, normalWS);
-        float renormFactor = 1.0 / length(normalWS);
 
-        // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-        // this is the mikktspace transformation (must use unnormalized attributes)
-        float3x3 worldToTangent = CreateWorldToTangent(normalWS, tangentWS.xyz, 1);
-
-        // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-        // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-        input.worldToTangent[0] = worldToTangent[0] * renormFactor;
-        input.worldToTangent[1] = worldToTangent[1] * renormFactor;
-        input.worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
+        input.worldToTangent = BuildWorldToTangent(float4(tangentWS, 1.0), normalWS);
 
         input.texCoord0.xy *= _TerrainHeightmapRecipSize.zw;
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Basemap.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Basemap.shader
@@ -182,6 +182,15 @@ Shader "Hidden/HDRenderPipeline/TerrainLit_Basemap"
 
             Cull[_CullMode]
 
+            // To be able to tag stencil with disableSSR information for forward
+            Stencil
+            {
+                WriteMask [_StencilWriteMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
+
             ZWrite On
 
             HLSLPROGRAM

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
@@ -156,6 +156,7 @@ Shader "HDRenderPipeline/Unlit"
             ColorMask 0 // We don't have WRITE_NORMAL_BUFFER for unlit, but as we bind a buffer we shouldn't write into it.
 
             HLSLPROGRAM
+            #pragma multi_compile _ WRITE_MSAA_DEPTH
 
             #define SHADERPASS SHADERPASS_DEPTH_ONLY
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -2219,7 +2219,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrDepthPyramidMaxMip,             info.mipLevelCount);
                 cmd.SetComputeFloatParam(cs, HDShaderIDs._SsrEdgeFadeRcpLength,              edgeFadeRcpLength);
                 cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrReflectsSky,                    volumeSettings.reflectSky ? 1 : 0);
-                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrStencilExclusionValue,          hdCamera.frameSettings.shaderLitMode == LitShaderMode.Forward ? -1 : (int)StencilBitMask.DoesntReceiveSSR);
+                cmd.SetComputeIntParam(  cs, HDShaderIDs._SsrStencilExclusionValue,          (int)StencilBitMask.DoesntReceiveSSR);
                 cmd.SetComputeVectorParam(cs, HDShaderIDs._ColorPyramidUvScaleAndLimitPrevFrame, HDUtils.ComputeUvScaleAndLimit(hdCamera.viewportSizePrevFrame, previousColorPyramidSize));
 
                 // cmd.SetComputeTextureParam(cs, kernel, "_SsrDebugTexture",    m_SsrDebugTexture);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/VaryingMesh.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/VaryingMesh.hlsl
@@ -151,20 +151,7 @@ FragInputs UnpackVaryingsMeshToFragInputs(PackedVaryingsMeshToPS input)
 
 #ifdef VARYINGS_NEED_TANGENT_TO_WORLD
     float4 tangentWS = float4(input.interpolators2.xyz, input.interpolators2.w > 0.0 ? 1.0 : -1.0); // must not be normalized (mikkts requirement)
-
-    // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
-    float3 unnormalizedNormalWS = input.interpolators1.xyz;
-    float renormFactor = 1.0 / length(unnormalizedNormalWS);
-
-    // bitangent on the fly option in xnormal to reduce vertex shader outputs.
-    // this is the mikktspace transformation (must use unnormalized attributes)
-    float3x3 worldToTangent = CreateWorldToTangent(unnormalizedNormalWS, tangentWS.xyz, tangentWS.w);
-
-    // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
-    // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
-    output.worldToTangent[0] = worldToTangent[0] * renormFactor;
-    output.worldToTangent[1] = worldToTangent[1] * renormFactor;
-    output.worldToTangent[2] = worldToTangent[2] * renormFactor;        // normalizes the interpolated vertex normal
+    output.worldToTangent = BuildWorldToTangent(tangentWS, input.interpolators1.xyz);
 #endif // VARYINGS_NEED_TANGENT_TO_WORLD
 
 #ifdef VARYINGS_NEED_TEXCOORD0

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariablesFunctions.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariablesFunctions.hlsl
@@ -147,4 +147,27 @@ float2 TexCoordStereoOffset(float2 texCoord)
 #endif
     return texCoord;
 }
+
+// This function assumes the bitangent flip is encoded in tangentWS.w
+float3x3 BuildWorldToTangent(float4 tangentWS, float3 normalWS)
+{
+    // tangentWS must not be normalized (mikkts requirement)
+
+    // Normalize normalWS vector but keep the renormFactor to apply it to bitangent and tangent
+    float3 unnormalizedNormalWS = normalWS;
+    float renormFactor = 1.0 / length(unnormalizedNormalWS);
+
+    // bitangent on the fly option in xnormal to reduce vertex shader outputs.
+    // this is the mikktspace transformation (must use unnormalized attributes)
+    float3x3 worldToTangent = CreateWorldToTangent(unnormalizedNormalWS, tangentWS.xyz, tangentWS.w > 0.0 ? 1.0 : -1.0);
+
+    // surface gradient based formulation requires a unit length initial normal. We can maintain compliance with mikkts
+    // by uniformly scaling all 3 vectors since normalization of the perturbed normal will cancel it.
+    worldToTangent[0] = worldToTangent[0] * renormFactor;
+    worldToTangent[1] = worldToTangent[1] * renormFactor;
+    worldToTangent[2] = worldToTangent[2] * renormFactor;		// normalizes the interpolated vertex normal
+
+    return worldToTangent;
+}
+
 #endif // UNITY_SHADER_VARIABLES_FUNCTIONS_INCLUDED

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
@@ -16,12 +16,16 @@ namespace UnityEditor.ShaderGraph
         public const string ColorSlotName = "Color";
         public const string AlphaSlotName = "Alpha";
         public const string AlphaClipThresholdSlotName = "AlphaClipThreshold";
+        public const string DistortionSlotName = "Distortion";
+        public const string DistortionBlurSlotName = "DistortionBlur";
         public const string PositionName = "Position";
 
         public const int ColorSlotId = 0;
         public const int AlphaSlotId = 7;
         public const int AlphaThresholdSlotId = 8;
         public const int PositionSlotId = 9;
+        public const int DistortionSlotId = 10;
+        public const int DistortionBlurSlotId = 11;
 
         [SerializeField]
         SurfaceType m_SurfaceType;


### PR DESCRIPTION
### Purpose of this PR
There is a lot of inconsistency between all shader graph in HD: Unlit, Fabric, lit, stacklit, PBR. Goal of this PR is to fix various reported bug and clean the code.

What is not the goal: We don't factor the code in the PR. This is a pity as many many code is duplicated but we have been agree that we don't touch anything and just copy/paste until the refactor of the API

What this PR do:

clean:
- Share BuildWorldToTangent functions
- Clean unused keyword / define
- Fix indentation
- clean PBR subshader code
- clean unused code in fabric

Decal:
- Replace _DECALS by _DISABLE_DECALS as for regular shader
- Move decal before specular AA
- add if (_EnableDecals) for decal test in all shader
- PBR master node: add decal support
- factor naming of disable SSR and decal in stacklit
- Use DisableDecals instead of Decals

SSR:
- update SSRdisable stencil test (not working in forward)
- Fix disable SSR in forward for shader graph and regular shader

General:
- update BuildSurfaceData prototype
- Rename HD Lit master to Lit Master
- fixed distortion blend mode in HD Lit
- fix distortion blend mode in stacklit
- Add everything to prepare distortion support on Unlit
- optimize a bit generated pass
- fix PBR sub shader stencil test
- fix PBR shader multicompile (Light layers and decals)
- Fix RequiresSplitLighting in Fabric master node
- update stencil state in Fabric
- remove two sided from unlit code (useless)
- add selection pass to unlit
- Fix bent normal for Fabric shader

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrp-clean-hd-master-node&automation-tools_branch=add-platform-filter&unity_branch=trunk

Katana is green.

**Manual Tests**:  Launch test locally

**Automated Tests**: What did you setup?

I prepare an automated test in a separate PR as I want to backport this PR to 2018.3 but not the associated test.


For QA  here is a checklist that is valid in general for shader graph (and will add in separate test).

- check if distortion working correctly with the correct blend mode for lit and unlit ?
- check that normal buffer correctly write smoothness and normal in forward + with depth prepass and motion vector pass
- check that SSR work with all material and SSR disable flags work in deferred and forward
- check that SSS work with all shader graph in deferred and forward
- check that decal work with all material and decal disable flags work in deferred and forward
- check how we output normalbuffer in case of coat normal etc.. in all shader (stacklit, fabric..)

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
There still work to do to fully update PBR and unlit to API used in HDLitMaster node
