### PR TITLE
Vfx/fix/2018.3/ui backported

### DIFF
--- a/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
@@ -103,7 +103,12 @@ namespace  UnityEditor.VFX.UI
             subTitle = "Parameters";
 
             resizer.RemoveFromHierarchy();
+
+
+            s_LayoutManual.SetValue(this, false);
         }
+
+        static System.Reflection.PropertyInfo s_LayoutManual = typeof(VisualElement).GetProperty("isLayoutManual",System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
         void OnKeyDown(KeyDownEvent e)
         {

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXDataAnchor.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXDataAnchor.cs
@@ -296,7 +296,7 @@ namespace UnityEditor.VFX.UI
             }
             else if (!exists)
             {
-                VFXFilterWindow.Show(VFXViewWindow.currentWindow, Event.current.mousePosition, view.ViewToScreenPosition(Event.current.mousePosition), new VFXNodeProvider(viewController, AddLinkedNode, ProviderFilter, new Type[] { typeof(VFXOperator), typeof(VFXParameter) }));
+                VFXFilterWindow.Show(VFXViewWindow.currentWindow, Event.current.mousePosition, view.ViewToScreenPosition(Event.current.mousePosition), new VFXNodeProvider(viewController, AddLinkedNode, ProviderFilter, new Type[] { typeof(VFXOperator), typeof(VFXParameter), typeof(VFXContext) }));
             }
         }
 

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/Properties/StringPropertyRM.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/Properties/StringPropertyRM.cs
@@ -133,6 +133,11 @@ namespace UnityEditor.VFX.UI
             else if (pushButtonProvider.action != null)
             {
                 m_StringFieldPushButton = new VFXStringFieldPushButton(m_Label, pushButtonProvider.action, pushButtonProvider.buttonName);
+                if (isDelayed)
+                {
+                    m_StringFieldPushButton.textfield.Q("unity-text-input").RegisterCallback<BlurEvent>(OnFocusLost);
+                    m_StringFieldPushButton.textfield.Q("unity-text-input").RegisterCallback<KeyDownEvent>(OnKeyDown);
+                }
                 return m_StringFieldPushButton;
             }
             else

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
@@ -1594,8 +1594,8 @@ namespace UnityEditor.VFX.UI
             {
                 VFXSystemBorder border = new VFXSystemBorder();
                 m_Systems.Add(border);
-                border.controller = controller.systems[m_Systems.Count()-1];
                 AddElement(border);
+                border.controller = controller.systems[m_Systems.Count() - 1];
             }
         }
         

--- a/com.unity.visualeffectgraph/Editor/Models/Contexts/Implementations/VFXBasicEvent.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Contexts/Implementations/VFXBasicEvent.cs
@@ -20,7 +20,7 @@ namespace UnityEditor.VFX
     [VFXInfo]
     class VFXBasicEvent : VFXContext
     {
-        [VFXSetting, PushButton(typeof(LaunchEventBehavior), "Send")]
+        [VFXSetting, PushButton(typeof(LaunchEventBehavior), "Send"), Delayed]
         public string eventName = "OnPlay";
 
         public VFXBasicEvent() : base(VFXContextType.kEvent, VFXDataType.kNone, VFXDataType.kSpawnEvent) {}

--- a/com.unity.visualeffectgraph/Editor/Models/Contexts/Implementations/VFXBasicInitialize.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Contexts/Implementations/VFXBasicInitialize.cs
@@ -32,7 +32,29 @@ namespace UnityEditor.VFX
         {
             base.OnEnable();
             capacity = ((VFXDataParticle)GetData()).capacity;
+            GetData().onModified += DataModified;
         }
+
+        protected void OnDisable()
+        {
+            GetData().onModified -= DataModified;
+        }
+
+        void DataModified(VFXObject o)
+        {
+            capacity = ((VFXDataParticle)o).capacity;
+        }
+
+        public override void OnDataChanges(VFXData oldData, VFXData newData)
+        {
+            if(oldData != null)
+                oldData.onModified -= DataModified;
+            base.OnDataChanges(oldData, newData);
+            if( newData != null)
+                newData.onModified += DataModified;
+            DataModified(newData);
+        }
+
 
         protected override void OnInvalidate(VFXModel model, VFXModel.InvalidationCause cause)
         {

--- a/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
+++ b/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
@@ -32,6 +32,9 @@ VFXContextUI > #node-border > #inside > #contents
 VFXContextUI > #node-border.empty > #inside > #contents
 {
     margin-top : 0;
+    padding-top : 0;
+    margin-bottom : 0;
+    padding-bottom : 0;
 }
 
 /*  update */
@@ -155,14 +158,14 @@ VFXContextUI #header-space
     width:48;
     height:16;
 }
-VFXContextUI #node-border > #inside > #contents
+VFXContextUI > #node-border > #inside > #contents
 {
     border-radius:6;
     background-color: rgba(63,63,63,0.8);
     margin-left:4;
     margin-right:4;
 }
-VFXContextUI #node-border > #inside > #contents > #settings
+VFXContextUI > #node-border > #inside > #contents > #settings
 {
     background-color: rgba(0,0,0,0);
 }


### PR DESCRIPTION
### Purpose of this PR
A few ui fixes. Backported from https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2532
- Fix system borders not surounding their contexts on opening.
- make sure empty context content is invisible.
- make event name setting delayed.
- workaround for blackboard not resizable.
- Allow contexts in the list of proposals when dropping edge on graph.
- Also contains the fix for capacity not working with undo/redo.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
