### PR TITLE
blackboard in SG remember expanded states

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Shader Graph now has __Group Node__, where you can group together several nodes. You can use this to keep your Graphs organized and nice.
 
+### Fixed
+- The expanded state of blackboard properties are now remembered during  a Unity session.
+
 ## [5.1.0] - 2018-11-19
 ### Added
 - You can now show and hide the Main Preview and the Blackboard from the toolbar.

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Shader Graph now has __Group Node__, where you can group together several nodes. You can use this to keep your Graphs organized and nice.
 
 ### Fixed
-- The expanded state of blackboard properties are now remembered during  a Unity session.
+- The expanded state of blackboard properties are now remembered during a Unity session.
 
 ## [5.1.0] - 2018-11-19
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractMaterialGraph.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractMaterialGraph.cs
@@ -51,6 +51,14 @@ namespace UnityEditor.ShaderGraph
             get { return m_MovedProperties; }
         }
 
+        [NonSerialized]
+        Dictionary<IShaderProperty, bool> m_ExpandedProperties = new Dictionary<IShaderProperty, bool>();
+
+        public Dictionary<IShaderProperty, bool> expandedProperties
+        {
+            get { return m_ExpandedProperties; }
+        }
+
         [SerializeField]
         SerializableGuid m_GUID = new SerializableGuid();
 
@@ -241,6 +249,7 @@ namespace UnityEditor.ShaderGraph
             m_AddedProperties.Clear();
             m_RemovedProperties.Clear();
             m_MovedProperties.Clear();
+            m_ExpandedProperties.Clear();
         }
 
         public virtual void AddNode(INode node)
@@ -600,6 +609,11 @@ namespace UnityEditor.ShaderGraph
                 m_Properties.Insert(newIndex, property);
             if (!m_MovedProperties.Contains(property))
                 m_MovedProperties.Add(property);
+        }
+
+        public void ShaderPropertyExpandedState(IShaderProperty property, bool expanded)
+        {
+            m_ExpandedProperties[property] = expanded;
         }
 
         public int GetShaderPropertyIndex(IShaderProperty property)

--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractMaterialGraph.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractMaterialGraph.cs
@@ -51,14 +51,6 @@ namespace UnityEditor.ShaderGraph
             get { return m_MovedProperties; }
         }
 
-        [NonSerialized]
-        Dictionary<IShaderProperty, bool> m_ExpandedProperties = new Dictionary<IShaderProperty, bool>();
-
-        public Dictionary<IShaderProperty, bool> expandedProperties
-        {
-            get { return m_ExpandedProperties; }
-        }
-
         [SerializeField]
         SerializableGuid m_GUID = new SerializableGuid();
 
@@ -249,7 +241,6 @@ namespace UnityEditor.ShaderGraph
             m_AddedProperties.Clear();
             m_RemovedProperties.Clear();
             m_MovedProperties.Clear();
-            m_ExpandedProperties.Clear();
         }
 
         public virtual void AddNode(INode node)
@@ -609,11 +600,6 @@ namespace UnityEditor.ShaderGraph
                 m_Properties.Insert(newIndex, property);
             if (!m_MovedProperties.Contains(property))
                 m_MovedProperties.Add(property);
-        }
-
-        public void ShaderPropertyExpandedState(IShaderProperty property, bool expanded)
-        {
-            m_ExpandedProperties[property] = expanded;
         }
 
         public int GetShaderPropertyIndex(IShaderProperty property)

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -221,6 +221,12 @@ namespace UnityEditor.ShaderGraph.Drawing
             foreach (var property in m_Graph.addedProperties)
                 AddProperty(property, index: m_Graph.GetShaderPropertyIndex(property));
 
+            foreach (var propertyDict in m_Graph.expandedProperties)
+            {
+                SessionState.SetBool(propertyDict.Key.guid.ToString(), propertyDict.Value);
+                //SessionState.SetBool(property.guid.ToString(), m_PropertyRows[property.guid].expanded);
+            }
+
             if (m_Graph.movedProperties.Any())
             {
                 foreach (var row in m_PropertyRows.Values)
@@ -246,7 +252,8 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             var expandButton = row.Q<Button>("expandButton");
             //expandButton.RegisterCallback<MouseDownEvent>(evt => OnExpanded(evt, property));
-            expandButton.RegisterCallback<MouseDownEvent>(OnExpanded);
+            //expandButton.RegisterCallback<MouseOverEvent>(evt => OnExpanded(evt, property));
+            expandButton.RegisterCallback<MouseDownEvent>(evt => OnExpanded(evt, property), TrickleDown.TrickleDown);
 
             row.userData = property;
             if (index < 0)
@@ -259,7 +266,9 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             try
             {
-                Debug.Log(SessionState.GetBool(property.guid.ToString(), false));
+                //Debug.Log(SessionState.GetBool(property.guid.ToString(), false));
+                m_PropertyRows[property.guid].expanded = SessionState.GetBool(property.guid.ToString(), false);
+                //Debug.Log("found: " + property.displayName);
             }
             catch (Exception e)
             {
@@ -276,20 +285,10 @@ namespace UnityEditor.ShaderGraph.Drawing
         }
 
         //void OnExpanded(MouseDownEvent evt, IShaderProperty property)
-        void OnExpanded(MouseDownEvent evt)
+        void OnExpanded(MouseDownEvent evt, IShaderProperty property)
         {
-            Debug.Log("Muppets");
-            //SessionState.SetBool(property.guid.ToString(), true);
-//            foreach (Guid unFoldedProperty in GetUnFoldedProperties())
-//            {
-//                SessionState.SetBool(unFoldedProperty.ToString(), false);
-//            }
-
-            //if (evt.button == (int)MouseButton.LeftMouse)
-            //{
-            //    Debug.Log("Muppets");
-            //}
-
+            m_Graph.ShaderPropertyExpandedState(property, !m_PropertyRows[property.guid].expanded);
+            //Debug.Log(property.displayName +" is " + !m_PropertyRows[property.guid].expanded);
         }
 
         void DirtyNodes()
@@ -301,20 +300,20 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        public List<Guid> GetUnFoldedProperties()
-        {
-            List<Guid> unFoldedProperties = new List<Guid>();
-            foreach (var propertyRow in m_PropertyRows)
-            {
-                if (propertyRow.Value.expanded)
-                {
-                    unFoldedProperties.Add(propertyRow.Key);
-                }
-
-                //Debug.Log($"{propertyRow.Value.name} " + $"{propertyRow.Value.expanded}");
-            }
-
-            return unFoldedProperties;
-        }
+//        public List<Guid> GetUnFoldedProperties()
+//        {
+//            List<Guid> unFoldedProperties = new List<Guid>();
+//            foreach (var propertyRow in m_PropertyRows)
+//            {
+//                if (propertyRow.Value.expanded)
+//                {
+//                    unFoldedProperties.Add(propertyRow.Key);
+//                }
+//
+//                //Debug.Log($"{propertyRow.Value.name} " + $"{propertyRow.Value.expanded}");
+//            }
+//
+//            return unFoldedProperties;
+//        }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -276,7 +276,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             List<Guid> unFoldedProperties = new List<Guid>();
             foreach (var propertyRow in m_PropertyRows)
             {
-                unFoldedProperties.Add(propertyRow.Key);
+                if (propertyRow.Value.expanded)
+                {
+                    unFoldedProperties.Add(propertyRow.Key);
+                }
+
                 //Debug.Log($"{propertyRow.Value.name} " + $"{propertyRow.Value.expanded}");
             }
 

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -263,7 +263,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Debug.LogException(e);
             }
 
             if (create)

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -244,6 +244,10 @@ namespace UnityEditor.ShaderGraph.Drawing
             var field = new BlackboardField(icon, property.displayName, property.propertyType.ToString()) { userData = property };
             var row = new BlackboardRow(field, new BlackboardFieldPropertyView(field, m_Graph, property));
 
+            var expandButton = row.Q<Button>("expandButton");
+            //expandButton.RegisterCallback<MouseDownEvent>(evt => OnExpanded(evt, property));
+            expandButton.RegisterCallback<MouseDownEvent>(OnExpanded);
+
             row.userData = property;
             if (index < 0)
                 index = m_PropertyRows.Count;
@@ -253,6 +257,15 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_Section.Insert(index, row);
             m_PropertyRows[property.guid] = row;
 
+            try
+            {
+                Debug.Log(SessionState.GetBool(property.guid.ToString(), false));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+
             if (create)
             {
                 row.expanded = true;
@@ -260,6 +273,23 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_Graph.AddShaderProperty(property);
                 field.OpenTextEditor();
             }
+        }
+
+        //void OnExpanded(MouseDownEvent evt, IShaderProperty property)
+        void OnExpanded(MouseDownEvent evt)
+        {
+            Debug.Log("Muppets");
+            //SessionState.SetBool(property.guid.ToString(), true);
+//            foreach (Guid unFoldedProperty in GetUnFoldedProperties())
+//            {
+//                SessionState.SetBool(unFoldedProperty.ToString(), false);
+//            }
+
+            //if (evt.button == (int)MouseButton.LeftMouse)
+            //{
+            //    Debug.Log("Muppets");
+            //}
+
         }
 
         void DirtyNodes()
@@ -271,7 +301,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        List<Guid> GetUnFoldedProperties()
+        public List<Guid> GetUnFoldedProperties()
         {
             List<Guid> unFoldedProperties = new List<Guid>();
             foreach (var propertyRow in m_PropertyRows)

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -270,5 +270,17 @@ namespace UnityEditor.ShaderGraph.Drawing
                 node.Dirty(ModificationScope.Node);
             }
         }
+
+        List<Guid> GetUnFoldedProperties()
+        {
+            List<Guid> unFoldedProperties = new List<Guid>();
+            foreach (var propertyRow in m_PropertyRows)
+            {
+                unFoldedProperties.Add(propertyRow.Key);
+                //Debug.Log($"{propertyRow.Value.name} " + $"{propertyRow.Value.expanded}");
+            }
+
+            return unFoldedProperties;
+        }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -3,12 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor.Graphing;
 using UnityEngine;
-
-
-
 using UnityEditor.Experimental.GraphView;
 using UnityEngine.UIElements;
-using UnityEngine.UIElements.StyleSheets;
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -224,7 +220,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             foreach (var propertyDict in m_Graph.expandedProperties)
             {
                 SessionState.SetBool(propertyDict.Key.guid.ToString(), propertyDict.Value);
-                //SessionState.SetBool(property.guid.ToString(), m_PropertyRows[property.guid].expanded);
             }
 
             if (m_Graph.movedProperties.Any())
@@ -251,8 +246,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             var row = new BlackboardRow(field, new BlackboardFieldPropertyView(field, m_Graph, property));
 
             var expandButton = row.Q<Button>("expandButton");
-            //expandButton.RegisterCallback<MouseDownEvent>(evt => OnExpanded(evt, property));
-            //expandButton.RegisterCallback<MouseOverEvent>(evt => OnExpanded(evt, property));
             expandButton.RegisterCallback<MouseDownEvent>(evt => OnExpanded(evt, property), TrickleDown.TrickleDown);
 
             row.userData = property;
@@ -266,9 +259,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             try
             {
-                //Debug.Log(SessionState.GetBool(property.guid.ToString(), false));
                 m_PropertyRows[property.guid].expanded = SessionState.GetBool(property.guid.ToString(), false);
-                //Debug.Log("found: " + property.displayName);
             }
             catch (Exception e)
             {
@@ -284,11 +275,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        //void OnExpanded(MouseDownEvent evt, IShaderProperty property)
         void OnExpanded(MouseDownEvent evt, IShaderProperty property)
         {
             m_Graph.ShaderPropertyExpandedState(property, !m_PropertyRows[property.guid].expanded);
-            //Debug.Log(property.displayName +" is " + !m_PropertyRows[property.guid].expanded);
         }
 
         void DirtyNodes()
@@ -299,21 +288,5 @@ namespace UnityEditor.ShaderGraph.Drawing
                 node.Dirty(ModificationScope.Node);
             }
         }
-
-//        public List<Guid> GetUnFoldedProperties()
-//        {
-//            List<Guid> unFoldedProperties = new List<Guid>();
-//            foreach (var propertyRow in m_PropertyRows)
-//            {
-//                if (propertyRow.Value.expanded)
-//                {
-//                    unFoldedProperties.Add(propertyRow.Key);
-//                }
-//
-//                //Debug.Log($"{propertyRow.Value.name} " + $"{propertyRow.Value.expanded}");
-//            }
-//
-//            return unFoldedProperties;
-//        }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -33,7 +33,6 @@ namespace UnityEditor.ShaderGraph.Drawing
         //    set { m_ResizeBorderFrame.OnResizeFinished = value; }
         //}
 
-        [NonSerialized]
         Dictionary<IShaderProperty, bool> m_ExpandedProperties = new Dictionary<IShaderProperty, bool>();
 
         public Dictionary<IShaderProperty, bool> expandedProperties
@@ -266,14 +265,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_Section.Insert(index, row);
             m_PropertyRows[property.guid] = row;
 
-            try
-            {
-                m_PropertyRows[property.guid].expanded = SessionState.GetBool(property.guid.ToString(), false);
-            }
-            catch (Exception e)
-            {
-                Debug.LogException(e);
-            }
+            m_PropertyRows[property.guid].expanded = SessionState.GetBool(property.guid.ToString(), false);
 
             if (create)
             {

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -265,7 +265,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_Section.Insert(index, row);
             m_PropertyRows[property.guid] = row;
 
-            m_PropertyRows[property.guid].expanded = SessionState.GetBool(property.guid.ToString(), false);
+            m_PropertyRows[property.guid].expanded = SessionState.GetBool(property.guid.ToString(), true);
 
             if (create)
             {

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -33,6 +33,14 @@ namespace UnityEditor.ShaderGraph.Drawing
         //    set { m_ResizeBorderFrame.OnResizeFinished = value; }
         //}
 
+        [NonSerialized]
+        Dictionary<IShaderProperty, bool> m_ExpandedProperties = new Dictionary<IShaderProperty, bool>();
+
+        public Dictionary<IShaderProperty, bool> expandedProperties
+        {
+            get { return m_ExpandedProperties; }
+        }
+
         public string assetName
         {
             get { return blackboard.title; }
@@ -217,7 +225,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             foreach (var property in m_Graph.addedProperties)
                 AddProperty(property, index: m_Graph.GetShaderPropertyIndex(property));
 
-            foreach (var propertyDict in m_Graph.expandedProperties)
+            foreach (var propertyDict in expandedProperties)
             {
                 SessionState.SetBool(propertyDict.Key.guid.ToString(), propertyDict.Value);
             }
@@ -230,6 +238,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 foreach (var property in m_Graph.properties)
                     m_Section.Add(m_PropertyRows[property.guid]);
             }
+            m_ExpandedProperties.Clear();
         }
 
         void AddProperty(IShaderProperty property, bool create = false, int index = -1)
@@ -277,7 +286,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void OnExpanded(MouseDownEvent evt, IShaderProperty property)
         {
-            m_Graph.ShaderPropertyExpandedState(property, !m_PropertyRows[property.guid].expanded);
+            m_ExpandedProperties[property] = !m_PropertyRows[property.guid].expanded;
         }
 
         void DirtyNodes()


### PR DESCRIPTION
### Purpose of this PR
Fixing case https://fogbugz.unity3d.com/f/cases/1102332/
Now the blackboard remembers the state it is in when undoing. This is per Unity session.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Fblackboard-remember-unfolds&automation-tools_branch=add-platform-filter&unity_branch=trunk

**Manual Tests**: What did you do?
Open up a shadergraph and add properties into the blackboard. unfold some of them and restart the graph and they should now be remembered. 
It will only remember during the session. SO if you close Unity it will no longer remember the state.

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
Low

**Halo Effect**: None, Low, Medium, High?
Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
