### PR TITLE
Hdrp/add cascade shadow visualisation 

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added new API to perform a camera rendering
 - Add suport for hair master node (Double kajiya kay - Lambert)
 - Added Reset behaviour in DebugMenu (ingame mapping is right joystick + B)
+- Added cascade shadow visualisation toggle in HD shadow settings
 
 ### Fixed
 - Fixed logic to disable FPTL with stereo rendering

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Shadow/HDShadowSettingsEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Shadow/HDShadowSettingsEditor.cs
@@ -32,6 +32,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public override void OnInspectorGUI()
         {
             PropertyField(m_MaxShadowDistance, CoreEditorUtils.GetContent("Max Distance"));
+            Rect firstLine = GUILayoutUtility.GetLastRect();
 
             EditorGUILayout.Space();
             PropertyField(m_CascadeShadowSplitCount, CoreEditorUtils.GetContent("Cascade Count"));
@@ -56,6 +57,19 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
                 EditorGUI.indentLevel--;
             }
+
+            HDRenderPipeline hdrp = UnityEngine.Rendering.RenderPipelineManager.currentPipeline as HDRenderPipeline;
+            if (hdrp == null)
+                return;
+
+            firstLine.y -= EditorGUIUtility.singleLineHeight;
+            firstLine.height -= 2;
+            firstLine.x += EditorGUIUtility.labelWidth + 20;
+            firstLine.width -= EditorGUIUtility.labelWidth + 20;
+            bool currentCascadeValue = hdrp.showCascade;
+            bool newCascadeValue = GUI.Toggle(firstLine, currentCascadeValue, EditorGUIUtility.TrTextContent("Visualize Cascades"), EditorStyles.miniButton);
+            if (currentCascadeValue ^ newCascadeValue)
+                hdrp.showCascade = newCascadeValue;
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -220,6 +220,18 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         ScriptableCullingParameters frozenCullingParams;
         bool frozenCullingParamAvailable = false;
 
+        public bool showCascade
+        {
+            get => m_DebugDisplaySettings.GetDebugLightingMode() == DebugLightingMode.VisualizeCascade;
+            set
+            {
+                if (value)
+                    m_DebugDisplaySettings.SetDebugLightingMode(DebugLightingMode.VisualizeCascade);
+                else
+                    m_DebugDisplaySettings.SetDebugLightingMode(DebugLightingMode.None);
+            }
+        }
+
         public HDRenderPipeline(HDRenderPipelineAsset asset)
         {
             m_Asset = asset;


### PR DESCRIPTION
### Purpose of this PR
Adding visualisation debug menu in HD Shadow Settings of volume

---
### Release Notes
Added cascade shadow visualisation toggle in HD shadow settings

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Fadd-cascade-shadow-visualisation&automation-tools_branch=add-platform-filter&unity_branch=trunk#

**Manual Tests**: Tested locally

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
@Chman : Is there any possible conflict with the "Advanced" mode on the volume?
![image](https://user-images.githubusercontent.com/40034005/49818267-8ee0db00-fd72-11e8-92ec-9ae2ec925473.png)

