### PR TITLE
Various Fixes for Visual Effect Graph UI for 2019.1

### DIFF
--- a/TestProjects/VisualEffectGraph/Packages/manifest.json
+++ b/TestProjects/VisualEffectGraph/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.render-pipelines.high-definition": "file:../../../com.unity.render-pipelines.high-definition",
     "com.unity.shadergraph": "file:../../../com.unity.shadergraph",
     "com.unity.testframework.graphics": "file:../../../com.unity.testframework.graphics",
-    "com.unity.timeline": "0.0.0-builtin",
+    "com.unity.timeline": "1.0.0",
     "com.unity.visualeffectgraph": "file:../../../com.unity.visualeffectgraph",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
@@ -102,8 +102,8 @@ namespace  UnityEditor.VFX.UI
 
             resizer.RemoveFromHierarchy();
 
-
-            s_LayoutManual.SetValue(this, false);
+            if(s_LayoutManual != null)
+                s_LayoutManual.SetValue(this, false);
         }
 
         static System.Reflection.PropertyInfo s_LayoutManual = typeof(VisualElement).GetProperty("isLayoutManual",System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
@@ -754,9 +754,10 @@ namespace UnityEditor.VFX.UI
 
                 if (subSlot != null)
                 {
-                    if (m_Controller.viewController.CanGetEvaluatedContent(subSlot))
+                    object result = null ;
+                    if (m_Controller.viewController.CanGetEvaluatedContent(subSlot) && ( result = m_Controller.viewController.GetEvaluatedContent(subSlot)) != null)
                     {
-                        m_ValueBuilder.Add(o => o.Add(m_Controller.viewController.GetEvaluatedContent(subSlot)));
+                        m_ValueBuilder.Add(o => o.Add(result));
                     }
                     else if (subSlot.HasLink(false) && VFXTypeUtility.GetComponentCount(subSlot) != 0) // replace by is VFXType
                     {

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
@@ -757,7 +757,7 @@ namespace UnityEditor.VFX.UI
                     object result = null ;
                     if (m_Controller.viewController.CanGetEvaluatedContent(subSlot) && ( result = m_Controller.viewController.GetEvaluatedContent(subSlot)) != null)
                     {
-                        m_ValueBuilder.Add(o => o.Add(result));
+                        m_ValueBuilder.Add(o => o.Add(subSlot.value));
                     }
                     else if (subSlot.HasLink(false) && VFXTypeUtility.GetComponentCount(subSlot) != 0) // replace by is VFXType
                     {

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXContextUI.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXContextUI.cs
@@ -791,7 +791,11 @@ namespace UnityEditor.VFX.UI
             m_TextField.visible = true;
             UpdateTitleFieldRect();
 
-            m_TextField.Focus();
+
+            m_TextField.Q(TextField.textInputUssName).visible = false;
+            m_TextField.Q(TextField.textInputUssName).visible = true;
+            m_TextField.Q(TextField.textInputUssName).Focus();
+
             m_TextField.SelectAll();
 
         }

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXEditableDataAnchor.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXEditableDataAnchor.cs
@@ -38,6 +38,20 @@ namespace UnityEditor.VFX.UI
         void OnAttachToPanel(AttachToPanelEvent e)
         {
             m_View = GetFirstAncestorOfType<VFXView>();
+            if( m_View == null)
+            {
+                VisualElement current = this;
+                System.Text.StringBuilder sb = new System.Text.StringBuilder();
+                sb.AppendLine("Send tristan this error");
+                while( current != null)
+                {
+                    sb.AppendLine(current.GetType().Name + " " + current.name);
+                    current = current.parent;
+                }
+
+                Debug.LogError(sb.ToString());
+                return;
+            }
             m_View.allDataAnchors.Add(this);
         }
 

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/Controller/VFXViewController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/Controller/VFXViewController.cs
@@ -881,7 +881,7 @@ namespace UnityEditor.VFX.UI
 
             for (int i = index; i < m_StickyNoteControllers.Count; ++i)
             {
-                m_StickyNoteControllers[i].index = index;
+                m_StickyNoteControllers[i].index = i;
             }
 
             //Patch group nodes, removing this sticky note and fixing ids that are bigger than index

--- a/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
+++ b/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
@@ -163,6 +163,7 @@ VFXContextUI > #node-border > #inside > #contents
     background-color: rgba(63,63,63,0.8);
     margin-left:1;
     margin-right:1;
+    font-size:11;
 }
 VFXContextUI > #node-border > #inside > #contents > #settings
 {

--- a/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
+++ b/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
@@ -189,11 +189,6 @@ VFXContextUI #footer #icon
     --unity-image:resource("VFX/Execution");
 }
 
-VFXContextUI *
-{
-    font-size:11;
-}
-
 VFXContextUI #block-container {
     -unity-text-align:upper-center;
 

--- a/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
+++ b/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
@@ -310,3 +310,8 @@ VFXContextUI.inputTypeparticle #user-label
     height : 4;
     min-height:0;
 }
+
+VFXContextUI > #node-border > #inside > #contents
+{
+    background-color: rgba(45,45,45,0.8);
+}

--- a/com.unity.visualeffectgraph/Editor/Resources/VFXParameter.uss
+++ b/com.unity.visualeffectgraph/Editor/Resources/VFXParameter.uss
@@ -158,8 +158,7 @@ VFXParameterUI.node.exposed > #node-border > #title > #pill > #exposed-icon
     padding-left:4;
 }
 
-#super-collapse-button >#icon {
-    background-size: 2;
+#super-collapse-button >  #icon {
     width:12;
     height:12;
     align-self:center;

--- a/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
+++ b/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
@@ -110,7 +110,9 @@ namespace UnityEditor.VFX.UI
             m_TitleField.visible = true;
             UpdateTitleFieldRect();
 
-            m_TitleField.Q("unity-text-input").Focus();
+            m_TitleField.Q(TextField.textInputUssName).visible = false;
+            m_TitleField.Q(TextField.textInputUssName).visible = true;
+            m_TitleField.Q(TextField.textInputUssName).Focus();
             m_TitleField.SelectAll();
         }
 

--- a/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
+++ b/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
@@ -433,6 +433,8 @@ namespace UnityEditor.VFX.UI
             if (view == null || m_Controller == null)
                 return;
             contexts = controller.contexts.Select(t => view.GetGroupNodeElement(t) as VFXContextUI).ToArray();
+
+            title = controller.title;
         }
         public void OnControllerChanged(ref ControllerChangedEvent e)
         {


### PR DESCRIPTION
### Purpose of this PR
A few small bug in visual effect graph ui:
-fix for renaming systems and context in 2019.1
- fix for systems title not restored when opening asset.
- Add some log when weird peekweek bug happens. ( that julien saw also recently)
- added test in case isLayoutManual no longer exists.
- Fix exception when first opening vfxwindow aboute ScaleMode enum.
- Fix invalid code when deleting stickynote.
- Proofing gizmo code to prevent cases where gizmos don't move.

Everything but the first must be backported and willbe in an upcomming PR.
---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=vfx%2Ffix%2Fnot-to-backport&unity_branch=trunk&automation-tools_branch=add-platform-filter
running
**Manual Tests**: What did you do?
Tested with the lastest trunk and the latest SRP master at the time of creation
**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low
**Halo Effect**: None, Low, Medium, High?
Low
---
### Comments to reviewers
Notes for the reviewers you have assigned.
