### PR TITLE
Various Fixes for Visual Effect Graph UI for 2018.3

### DIFF
--- a/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
@@ -101,9 +101,6 @@ namespace  UnityEditor.VFX.UI
             subTitle = "Parameters";
 
             resizer.RemoveFromHierarchy();
-
-
-            s_LayoutManual.SetValue(this, false);
         }
 
         void OnKeyDown(KeyDownEvent e)

--- a/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Blackboard/VFXBlackboard.cs
@@ -101,6 +101,9 @@ namespace  UnityEditor.VFX.UI
             subTitle = "Parameters";
 
             resizer.RemoveFromHierarchy();
+
+
+            s_LayoutManual.SetValue(this, false);
         }
 
         void OnKeyDown(KeyDownEvent e)

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
@@ -754,9 +754,10 @@ namespace UnityEditor.VFX.UI
 
                 if (subSlot != null)
                 {
-                    if (m_Controller.viewController.CanGetEvaluatedContent(subSlot))
+                    object result = null ;
+                    if (m_Controller.viewController.CanGetEvaluatedContent(subSlot) && ( result = m_Controller.viewController.GetEvaluatedContent(subSlot)) != null)
                     {
-                        m_ValueBuilder.Add(o => o.Add(m_Controller.viewController.GetEvaluatedContent(subSlot)));
+                        m_ValueBuilder.Add(o => o.Add(result));
                     }
                     else if (subSlot.HasLink(false) && VFXTypeUtility.GetComponentCount(subSlot) != 0) // replace by is VFXType
                     {

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
@@ -757,7 +757,7 @@ namespace UnityEditor.VFX.UI
                     object result = null ;
                     if (m_Controller.viewController.CanGetEvaluatedContent(subSlot) && ( result = m_Controller.viewController.GetEvaluatedContent(subSlot)) != null)
                     {
-                        m_ValueBuilder.Add(o => o.Add(result));
+                        m_ValueBuilder.Add(o => o.Add(subSlot.value));
                     }
                     else if (subSlot.HasLink(false) && VFXTypeUtility.GetComponentCount(subSlot) != 0) // replace by is VFXType
                     {

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXEditableDataAnchor.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXEditableDataAnchor.cs
@@ -123,6 +123,20 @@ namespace UnityEditor.VFX.UI
         void OnAttachToPanel(AttachToPanelEvent e)
         {
             m_View = GetFirstAncestorOfType<VFXView>();
+            if( m_View == null)
+            {
+                VisualElement current = this;
+                System.Text.StringBuilder sb = new System.Text.StringBuilder();
+                sb.AppendLine("Send tristan this error");
+                while( current != null)
+                {
+                    sb.AppendLine(current.GetType().Name + " " + current.name);
+                    current = current.parent;
+                }
+
+                Debug.LogError(sb.ToString());
+                return;
+            }
             m_View.allDataAnchors.Add(this);
         }
 

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/Controller/VFXViewController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/Controller/VFXViewController.cs
@@ -887,7 +887,7 @@ namespace UnityEditor.VFX.UI
 
             for (int i = index; i < m_StickyNoteControllers.Count; ++i)
             {
-                m_StickyNoteControllers[i].index = index;
+                m_StickyNoteControllers[i].index = i;
             }
 
             //Patch group nodes, removing this sticky note and fixing ids that are bigger than index

--- a/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
+++ b/com.unity.visualeffectgraph/Editor/Resources/VFXContext.uss
@@ -311,3 +311,8 @@ VFXContextUI.inputTypeparticle #user-label
     height : 4;
     min-height:0;
 }
+
+VFXContextUI > #node-border > #inside > #contents
+{
+    background-color: rgba(45,45,45,0.8);
+}

--- a/com.unity.visualeffectgraph/Editor/Resources/VFXParameter.uss
+++ b/com.unity.visualeffectgraph/Editor/Resources/VFXParameter.uss
@@ -155,8 +155,7 @@ VFXParameterUI.node.exposed > #node-border > #title > #pill > #exposed-icon
     padding-left:4;
 }
 
-#super-collapse-button >#icon {
-    background-size: 2;
+#super-collapse-button >  #icon {
     width:12;
     height:12;
     align-self:center;

--- a/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
+++ b/com.unity.visualeffectgraph/Editor/Utils/VFXSystemBorder.cs
@@ -411,6 +411,8 @@ namespace UnityEditor.VFX.UI
             if (view == null || m_Controller == null)
                 return;
             contexts = controller.contexts.Select(t => view.GetGroupNodeElement(t) as VFXContextUI).ToArray();
+
+            title = controller.title;
         }
         public void OnControllerChanged(ref ControllerChangedEvent e)
         {


### PR DESCRIPTION
### Purpose of this PR

back port of https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2611 except for things that should not be backported :
- fix for systems title not restored when opening asset.
- Add some log when weird peekweek bug happens (exception in VFXEditableDataAnchor). ( that julien saw also recently)
- Fix exception when first opening vfxwindow about ScaleMode enum.
- Fix invalid code when deleting stickynote.
- Proofing gizmo code to prevent cases where gizmos don't move.
---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=vfx%2Ffix%2F2018%2Fbackported&unity_branch=2018.3%2Frelease&automation-tools_branch=add-platform-filter
passed.

**Manual Tests**: What did you do?
Tested the regression and some manipulations close to them.

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low

**Halo Effect**: None, Low, Medium, High?
Low
---
### Comments to reviewers
Notes for the reviewers you have assigned.
