### PR TITLE
Add support of rectangle and disc shadow mask

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Handles.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Handles.cs
@@ -152,6 +152,59 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                         // Handles.color reseted at end of scope
                     }
                     break;
+
+                //case LightTypeExtent.Sphere:
+                case LightTypeExtent.Disc:
+                    Matrix4x4 transform = Matrix4x4.TRS(light.transform.position, light.transform.rotation, Vector3.one);
+                    //if (src.lightTypeExtent == LightTypeExtent.Sphere)
+                    //{   // Make the rendering facing camera
+                    //    transform = Camera.current.cameraToWorldMatrix;
+                    //    transform.SetColumn(3, new Vector4(light.transform.position.x, light.transform.position.y, light.transform.position.z, 1));
+                    //}
+                    using (new Handles.DrawingScope(transform))
+                    {
+                        EditorGUI.BeginChangeCheck();
+                        Vector2 widthHeight = new Vector4(src.shapeWidth, src.lightTypeExtent == LightTypeExtent.Disc ? src.shapeHeight : src.shapeWidth);
+                        float range = light.range;
+                        // Draw a subdivided ellipse
+                        const int N = 40;
+                        Vector3[] vertices = new Vector3[2 * N];
+                        float Rx = 0.5f * src.shapeWidth;
+                        float Ry = src.lightTypeExtent == LightTypeExtent.Disc ? 0.5f * src.shapeHeight : Rx;
+                        for (int i = 0; i < N; i++)
+                        {
+                            float a0 = 2 * Mathf.PI * i / N;
+                            float a1 = 2 * Mathf.PI * (i + 1) / N;
+                            vertices[2 * i] = new Vector3(Rx * Mathf.Cos(a0), Ry * Mathf.Sin(a0), 0);
+                            vertices[2 * i + 1] = new Vector3(Rx * Mathf.Cos(a1), Ry * Mathf.Sin(a1), 0);
+                        }
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.Greater;
+                        Handles.color = wireframeColorBehind;
+                        Handles.DrawLines(vertices);
+                        range = Handles.RadiusHandle(Quaternion.identity, Vector3.zero, range); //also draw handles
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.LessEqual;
+                        Handles.color = wireframeColorAbove;
+                        Handles.DrawLines(vertices);
+                        range = Handles.RadiusHandle(Quaternion.identity, Vector3.zero, range); //also draw handles
+                                                                                                // Draw handles
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.Greater;
+                        Handles.color = handleColorBehind;
+                        widthHeight = CoreLightEditorUtilities.DrawAreaLightHandle(widthHeight, src.lightTypeExtent == LightTypeExtent.Disc);
+                        Handles.zTest = UnityEngine.Rendering.CompareFunction.LessEqual;
+                        Handles.color = handleColorAbove;
+                        widthHeight = CoreLightEditorUtilities.DrawAreaLightHandle(widthHeight, src.lightTypeExtent == LightTypeExtent.Disc);
+                        if (EditorGUI.EndChangeCheck())
+                        {
+                            Undo.RecordObjects(new UnityEngine.Object[] { light, src }, src.lightTypeExtent == LightTypeExtent.Disc ? "Adjust Area Disk Light" : "Adjust Area Sphere Light");
+                            src.shapeWidth = widthHeight.x;
+                            if (src.lightTypeExtent == LightTypeExtent.Disc)
+                            {
+                                src.shapeHeight = widthHeight.y;
+                            }
+                            light.range = range;
+                        }
+                    }
+                    break;
             }
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Skin.cs
@@ -53,6 +53,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public readonly GUIContent spotInnerPercent = new GUIContent("Inner Angle (%)", "Controls size of the angular attenuation in percent of the base angle of the Spot light's cone.");
             public readonly GUIContent spotLightShape = new GUIContent("Shape", "The shape use for the spotlight. Has an impact on the cookie transformation and light angular attenuation.");
             public readonly GUIContent shapeWidthTube = new GUIContent("Length", "Length of the tube light");
+            public readonly GUIContent shapeDiscRadius = new GUIContent("Radius", "Radius of the disc light");            
             public readonly GUIContent shapeWidthRect = new GUIContent("Size X", "SizeX of the rectangle light");
             public readonly GUIContent shapeHeightRect = new GUIContent("Size Y", "SizeY of the rectangle light");
             public readonly GUIContent aspectRatioPyramid = new GUIContent("Aspect ratio", "");

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Skin.cs
@@ -47,7 +47,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public readonly GUIContent lightRadius = new GUIContent("Emission Radius", "Can be used to soften the core of the punctual light to create fill lighting.");
             public readonly GUIContent affectDiffuse = new GUIContent("Affect Diffuse", "This will disable diffuse lighting for this light. Doesn't save performance, diffuse lighting is still computed.");
             public readonly GUIContent affectSpecular = new GUIContent("Affect Specular", "This will disable specular lighting for this light. Doesn't save performance, specular lighting is still computed.");
-            public readonly GUIContent nonLightmappedOnly = new GUIContent("Shadowmask Mode", "Sets the shadowmask behaviour when using Shadowmask Mixed Lighting mode. Distance Shadowmask: Realtime shadows are used up to Shadow Distance, baked shadows after. Shadowmask: Static shadow casters always use baked shadows. Refer to documentation for further details.");
+            public readonly GUIContent nonLightmappedOnly = new GUIContent("Shadowmask Mode", "Sets the shadowmask behavior when using Shadowmask Mixed Lighting mode. Distance Shadowmask: Realtime shadows are used up to Shadow Distance, baked shadows after. Shadowmask: Static shadow casters always use baked shadows. Refer to documentation for further details.");
             public readonly GUIContent lightDimmer = new GUIContent("Dimmer", "Aim to be used with script, timeline or animation. It allows dimming one or multiple lights of heterogeneous intensity easily (without needing to know the intensity of each light).");
             public readonly GUIContent fadeDistance = new GUIContent("Fade Distance", "The distance at which the light will smoothly fade before being culled to minimize popping.");
             public readonly GUIContent spotInnerPercent = new GUIContent("Inner Angle (%)", "Controls size of the angular attenuation in percent of the base angle of the Spot light's cone.");
@@ -66,7 +66,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public readonly GUIContent sunDiskSize = new GUIContent("Sun Highlight Disk Size", "Controls the size of the highlight of the sun disk. It's the angle of the sun cone in degrees.");
             public readonly GUIContent sunHaloSize = new GUIContent("Sun Highlight Halo Size", "Controls the size of the halo around the highlight of the sun disk.");
 
-            public readonly GUIContent shape = new GUIContent("Type", "Specifies the current type of light. Possible types are Directional, Spot, Point, Rectangle and Tube lights.");
+            public readonly GUIContent shape = new GUIContent("Type", "Specifies the current type of light. Possible types are Directional, Spot, Point, Rectangle, Tube and Disc lights.");
             public readonly GUIContent[] shapeNames;
             public readonly GUIContent enableSpotReflector = new GUIContent("Reflector", "When true it simulate a spot light with reflector (mean the intensity of the light will be more focus with narrower angle), otherwise light outside of the cone is simply absorbed (mean intensity is constent whatever the size of the cone).");
             public readonly GUIContent luxAtDistance = new GUIContent("At", "Distance in meter where a surface receive an amount of lighting equivalent to the provided number of lux");

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
@@ -697,7 +697,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     // TODO: Currently if we use Area type as it is offline light in legacy, the light will not exist at runtime
                     //m_BaseData.type.enumValueIndex = (int)LightType.Rectangle;
                     // In case of change, think to update InitDefaultHDAdditionalLightData()
-                    serialized.settings.lightType.enumValueIndex = (int)LightType.Point;
+                    serialized.settings.lightType.enumValueIndex = (int)LightType.Rectangle;
                     serialized.serializedLightData.lightTypeExtent.enumValueIndex = (int)LightTypeExtent.Rectangle;
                     if (serialized.settings.isRealtime)
                         serialized.settings.shadowsType.enumValueIndex = (int)LightShadows.None;
@@ -714,7 +714,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     // TODO: Currently if we use Area type as it is offline light in legacy, the light will not exist at runtime
                     //m_BaseData.type.enumValueIndex = (int)LightType.Rectangle;
                     // In case of change, think to update InitDefaultHDAdditionalLightData()
-                    serialized.settings.lightType.enumValueIndex = (int)LightType.Point;
+                    serialized.settings.lightType.enumValueIndex = (int)LightType.Disc;
                     serialized.serializedLightData.lightTypeExtent.enumValueIndex = (int)LightTypeExtent.Disc;
                     if (serialized.settings.isRealtime)
                         serialized.settings.shadowsType.enumValueIndex = (int)LightShadows.None;

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
@@ -288,9 +288,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     EditorGUILayout.PropertyField(serialized.serializedLightData.shapeWidth, s_Styles.shapeDiscRadius);
                     if (EditorGUI.EndChangeCheck())
                     {
+                        serialized.serializedLightData.shapeHeight.floatValue = serialized.serializedLightData.shapeWidth.floatValue;
                         // Fake line with a small rectangle in vanilla unity for GI
                         serialized.settings.areaSizeX.floatValue = serialized.serializedLightData.shapeRadius.floatValue;
-                        serialized.settings.areaSizeY.floatValue = 0.0f;
+                        serialized.settings.areaSizeY.floatValue = serialized.serializedLightData.shapeRadius.floatValue;
                     }
                     break;
 
@@ -341,7 +342,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 (serialized.editorLightShape == LightShape.Spot && ((SpotLightShape)serialized.serializedLightData.spotLightShape.enumValueIndex == SpotLightShape.Box)))
             {
                 serialized.serializedLightData.lightUnit.enumValueIndex = (int)DirectionalLightUnit.Lux;
-                // We need to reset luxAtDistance to neutral when changing to (local) directional light, otherwise first display value ins't correct
+                // We need to reset luxAtDistance to neutral when changing to (local) directional light, otherwise first display value isn't correct
                 serialized.serializedLightData.luxAtDistance.floatValue = 1.0f;
             }
             else

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
@@ -200,6 +200,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 case LightTypeExtent.Tube:
                     editorLightShape = LightShape.Tube;
                     break;
+                case LightTypeExtent.Disc:
+                    editorLightShape = LightShape.Disc;
+                    break;
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugLightVolumes.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugLightVolumes.cs
@@ -123,6 +123,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                 cmd.DrawMesh(DebugShapes.instance.RequestSphereMesh(), positionMat, m_DebugLightVolumeMaterial, 0, 0, m_MaterialProperty);
                             }
                             break;
+                        case LightTypeExtent.Disc:
+                            {
+                                m_MaterialProperty.SetColor(_ColorShaderID, new Color(1.0f, 0.5f, 0.0f, 1.0f));
+                                m_MaterialProperty.SetVector(_OffsetShaderID, new Vector3(0, 0, 0));
+                                cmd.DrawMesh(DebugShapes.instance.RequestSphereMesh(), positionMat, m_DebugLightVolumeMaterial, 0, 0, m_MaterialProperty);
+                            }
+                            break;
                         default:
                             break;
                     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/GlobalIlluminationUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/GlobalIlluminationUtils.cs
@@ -158,13 +158,29 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 ld.shape0 = 0.0f;
                 ld.shape1 = 0.0f;
 #endif
-                // TEMP: for now, if we bake a rectangle type this will disable the light for runtime, need to speak with GI team about it!
                 ld.type = UnityEngine.Experimental.GlobalIllumination.LightType.Rectangle;
                 ld.falloff = add.applyRangeAttenuation ? FalloffType.InverseSquared : FalloffType.InverseSquaredNoRangeAttenuation;
             }
             else if (add.lightTypeExtent == LightTypeExtent.Tube)
             {
                 ld.InitNoBake(ld.instanceID);
+            }
+            else if (add.lightTypeExtent == LightTypeExtent.Disc)
+            {
+                ld.orientation = l.transform.rotation;
+                ld.position = l.transform.position;
+                ld.range = l.range;
+                ld.coneAngle = 0.0f;
+                ld.innerConeAngle = 0.0f;
+#if UNITY_EDITOR
+                ld.shape0 = l.areaSize.x; // radius
+                ld.shape1 = 0.0f;
+#else
+                ld.shape0 = 0.0f;
+                ld.shape1 = 0.0f;
+#endif
+                ld.type = UnityEngine.Experimental.GlobalIllumination.LightType.Disc;
+                ld.falloff = add.applyRangeAttenuation ? FalloffType.InverseSquared : FalloffType.InverseSquaredNoRangeAttenuation;
             }
             else
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -15,8 +15,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         Punctual, // Fallback on LightShape type
         Rectangle,
         Tube,
+        Disc,
         // Sphere,
-        // Disc,
     };
 
     public enum SpotLightShape { Cone, Pyramid, Box };
@@ -737,10 +737,18 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     break;
             }
 
-            // Sanity check: lightData.lightTypeExtent is init to LightTypeExtent.Punctual (in case for unknow reasons we recreate additional data on an existing line)
+            // Sanity check: lightData.lightTypeExtent is init to LightTypeExtent.Punctual (in case for unknown reasons we recreate additional data on an existing light)
             if (light.type == LightType.Rectangle && lightData.lightTypeExtent == LightTypeExtent.Punctual)
             {
                 lightData.lightTypeExtent = LightTypeExtent.Rectangle;
+                light.type = LightType.Point; // Same as in HDLightEditor
+#if UNITY_EDITOR
+                light.lightmapBakeType = LightmapBakeType.Realtime;
+#endif
+            }
+            else if (light.type == LightType.Disc && lightData.lightTypeExtent == LightTypeExtent.Punctual)
+            {
+                lightData.lightTypeExtent = LightTypeExtent.Disc;
                 light.type = LightType.Point; // Same as in HDLightEditor
 #if UNITY_EDITOR
                 light.lightmapBakeType = LightmapBakeType.Realtime;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -805,6 +805,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                 break;
                         }
                         break;
+                    case LightTypeExtent.Disc:
                     case LightTypeExtent.Tube:
                     case LightTypeExtent.Rectangle:
                         lightUnit = LightUnit.Lumen;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightEvaluation.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightEvaluation.hlsl
@@ -262,7 +262,7 @@ void EvaluateLight_Punctual(LightLoopContext lightLoopContext, PositionInputs po
         // The second case for blend with distance is handled with ShadowDimmer. ShadowDimmer is define manually and by shadowDistance by light.
         // With distance, ShadowDimmer become one and only the ShadowMask appear, we get the blend with distance behavior.
         shadow = light.nonLightMappedOnly ? min(shadowMask, shadow) : shadow;
-    #endif
+#endif
 
         shadow = lerp(shadowMask, shadow, light.shadowDimmer);
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -1751,6 +1751,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                                     lightVolumeType = LightVolumeType.Box;
                                     break;
 
+                                case LightTypeExtent.Disc:
+                                    if (areaLightCount >= m_MaxAreaLightsOnScreen)
+                                        continue;
+                                    // TODO: Implement disc light
+                                    gpuLightType = GPULightType.Rectangle;
+                                    lightVolumeType = LightVolumeType.Box;
+                                    break;
+
                                 default:
                                     Debug.Assert(false, "Encountered an unknown LightType.");
                                     break;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightUtils.cs
@@ -209,6 +209,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     return LightUtils.CalculateLineLightLumenToLuminance(lumen, width);
                 case LightTypeExtent.Rectangle:
                     return LightUtils.ConvertRectLightLumenToLuminance(lumen, width, height);
+                case LightTypeExtent.Disc:
+                    return LightUtils.ConvertDiscLightLumenToLuminance(lumen, width); // width is use as radius in this context
             }
 
             return lumen;
@@ -222,6 +224,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     return LightUtils.CalculateLineLightLuminanceToLumen(luminance, width);
                 case LightTypeExtent.Rectangle:
                     return LightUtils.ConvertRectLightLuminanceToLumen(luminance, width, height);
+                case LightTypeExtent.Disc:
+                    return LightUtils.ConvertDiscLightLuminanceToLumen(luminance, width); // width is use as radius in this context
             }
 
             return luminance;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
@@ -1433,6 +1433,28 @@ DirectLighting EvaluateBSDF_Rect(   LightLoopContext lightLoopContext,
                                                 lightData.rangeAttenuationBias);
     #endif
 
+        float  shadow = 1.0;
+        float  shadowMask = 1.0;
+    #ifdef SHADOWS_SHADOWMASK
+        // shadowMaskSelector.x is -1 if there is no shadow mask
+        // Note that we override shadow value (in case we don't have any dynamic shadow)
+        shadow = shadowMask = (lightData.shadowMaskSelector.x >= 0.0) ? dot(BUILTIN_DATA_SHADOW_MASK, lightData.shadowMaskSelector) : 1.0;
+    #endif
+
+        if ((lightData.shadowIndex >= 0) && (lightData.shadowDimmer > 0))
+        {
+            // shadow = ; TODO: realtime shadow
+
+    #ifdef SHADOWS_SHADOWMASK
+            // See comment for punctual light shadow mask
+            shadow = lightData.nonLightMappedOnly ? min(shadowMask, shadow) : shadow;
+    #endif
+
+            shadow = lerp(shadowMask, shadow, lightData.shadowDimmer);
+        }
+
+        intensity *= shadow;
+
         // Terminate if the shaded point is too far away.
         if (intensity != 0.0)
         {


### PR DESCRIPTION
### Purpose of this PR
This PR add support for disc and rect shadow map.
Note that disc only work with fully bake currently as their isn't any real time version, which mean even if supported, shadow mask disk is useless.
Rectangle shadow mask area light is supported however.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
