### PR TITLE
Fix crash on Metal when Shader Graph is running and Unity is not in focus

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `Color` node control is now a consistent width.
 - Function declarations no longer contain double delimiters.
 - The `Slider` node control now functions correctly.
+- Unity no longer crashes on Metal when Shader Graph is open while the Unity Editor does not have focus.
 
 ## [5.2.0] - 2018-11-27
 ### Added

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -93,29 +93,37 @@ namespace UnityEditor.ShaderGraph.Drawing
                 graphEditorView.assetName = value;
             }
         }
-        
+
+        bool m_HandleNextUpdate;
+
         void OnGUI()
         {
-            if (Event.current.type != EventType.Repaint)
-                return;
-            
-            if (m_HasError)
-                return;
-
-            if (PlayerSettings.colorSpace != m_ColorSpace)
-            {
-                graphEditorView = null;
-                m_ColorSpace = PlayerSettings.colorSpace;
-            }
-
-            if (GraphicsSettings.renderPipelineAsset != m_RenderPipelineAsset)
-            {
-                graphEditorView = null;
-                m_RenderPipelineAsset = GraphicsSettings.renderPipelineAsset;
-            }
-
+            m_HandleNextUpdate = true;
+        }
+        
+        void Update()
+        {
             try
             {
+                if (!m_HandleNextUpdate)
+                    return;
+                m_HandleNextUpdate = false;
+            
+                if (m_HasError)
+                    return;
+
+                if (PlayerSettings.colorSpace != m_ColorSpace)
+                {
+                    graphEditorView = null;
+                    m_ColorSpace = PlayerSettings.colorSpace;
+                }
+
+                if (GraphicsSettings.renderPipelineAsset != m_RenderPipelineAsset)
+                {
+                    graphEditorView = null;
+                    m_RenderPipelineAsset = GraphicsSettings.renderPipelineAsset;
+                }
+                
                 if (graphObject == null && selectedGuid != null)
                 {
                     var guid = selectedGuid;

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -93,9 +93,12 @@ namespace UnityEditor.ShaderGraph.Drawing
                 graphEditorView.assetName = value;
             }
         }
-
-        void Update()
+        
+        void OnGUI()
         {
+            if (Event.current.type != EventType.Repaint)
+                return;
+            
             if (m_HasError)
                 return;
 


### PR DESCRIPTION
### Purpose of this PR
Fixes an issue where Unity would crash on Metal if Shader Graph was running and Unity wasn't in focus. I fixed it by using `OnGUI` to restrict when `Update` runs. Purely using `Update` turned out to cause window-wide blinking issues when e.g. deleting nodes.

---
### Testing status
**Katana Tests**: Currently running: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=add-platform-filter&ScriptableRenderLoop_branch=sg%2Ffix-metal-background-crash&unity_branch=trunk

**Manual Tests**: Open up time-based and non-time-based graphs, try deleting nodes and performing undo. I have only tested on macOS.

**Automated Tests**: Nothing

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None