### PR TITLE
Backport: LWRP enable postprocessing for XR (case 1110904)

### DIFF
--- a/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/DefaultRendererSetup.cs
@@ -194,7 +194,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             foreach (var pass in camera.GetComponents<IAfterTransparentPass>())
                 renderer.EnqueuePass(pass.GetPassToEnqueue(baseDescriptor, colorHandle, depthHandle));
 
-            if (!renderingData.cameraData.isStereoEnabled && renderingData.cameraData.postProcessEnabled)
+            if (renderingData.cameraData.postProcessEnabled)
             {
                 m_TransparentPostProcessPass.Setup(baseDescriptor, colorHandle, BuiltinRenderTextureType.CameraTarget);
                 renderer.EnqueuePass(m_TransparentPostProcessPass);


### PR DESCRIPTION
### Purpose of this PR
Backport of PR to re-enable postprocessing with XR in LWRP. Single-pass instancing and postprocessing v2 works with XR and LWRP for 2018.3.

See original PR: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2361
and postprocessing PR: Unity-Technologies/PostProcessing#685

---
### Release Notes

Fix for postprocessing is not applied when using LWRP with XR:
https://fogbugz.unity3d.com/f/cases/1110904/

---
### Testing status
**Katana Tests**:  [Katana](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=2018.3%2Flwrp-xr-enable-postfx&automation-tools_branch=add-platform-filter&unity_branch=2018.3%2Fstaging)

**Manual Tests**: 

Tested on Oculus Rift with LWRP and postprocessing v2 in Standalone Player and Editor, with single-pass instancing and double-wide.
QA @benjaminsunity 

---
### Overall Product Risks

**Technical Risk**: Low

**Halo Effect**: None

