### PR TITLE
Hdrp tests asserts

### DIFF
--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/Scripts/DebugViewController.cs
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/Scripts/DebugViewController.cs
@@ -38,8 +38,10 @@ public class DebugViewController : MonoBehaviour
     void OnDestroy()
     {
         HDRenderPipeline hdPipeline = RenderPipelineManager.currentPipeline as HDRenderPipeline;
-
-        hdPipeline.debugDisplaySettings.SetDebugViewGBuffer(0);
-        hdPipeline.debugDisplaySettings.data.fullScreenDebugMode = FullScreenDebugMode.None;
+        if (hdPipeline != null)
+        {
+            hdPipeline.debugDisplaySettings.SetDebugViewGBuffer(0);
+            hdPipeline.debugDisplaySettings.data.fullScreenDebugMode = FullScreenDebugMode.None;
+        }
     }
 }

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed issue with ambient occlusion incorrectly applied to emissiveColor with light layers in deferred
 - Fixed issue with fabric convolution not using the correct convolved texture when fabric convolution is enabled
 - Fixed issue with Thick mode for Transmission that was disabling transmission with directional light
+- Fixed shutdown edge cases with HDRP tests
 - Fixed slowdow when enabling Fabric convolution in HDRP asset
 - Fixed specularAA not compiling in StackLit Master node
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/ReflectionProbeCache.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/ReflectionProbeCache.cs
@@ -89,10 +89,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             m_TextureCache.Release();
             CoreUtils.Destroy(m_TempRenderTexture);
-            for (int bsdfIdx = 0; bsdfIdx < m_IBLFilterBSDF.Length; ++bsdfIdx)
+
+            if (m_ConvolutionTargetTextureArray != null)
             {
-                CoreUtils.Destroy(m_ConvolutionTargetTextureArray[bsdfIdx]);
+                for (int bsdfIdx = 0; bsdfIdx < m_IBLFilterBSDF.Length; ++bsdfIdx)
+                {
+                    CoreUtils.Destroy(m_ConvolutionTargetTextureArray[bsdfIdx]);
+                }
             }
+            
             m_ProbeBakingState = null;
 
             CoreUtils.Destroy(m_ConvertTextureMaterial);


### PR DESCRIPTION
### Purpose of this PR
There were a few null access during tests tear down while testing in XR mode.

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=add-platform-filter&ScriptableRenderLoop_branch=hdrp-tests-asserts&unity_branch=trunk)

**Manual Tests**: run HDRP tests locally in various mode

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None
