### PR TITLE
Make the light delegate function in LightweightRenderPipeline private

### DIFF
--- a/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
@@ -454,7 +454,7 @@ namespace UnityEngine.Rendering.LWRP
             Shader.SetGlobalMatrix(PerCameraBuffer._InvCameraViewProj, invViewProjMatrix);
         }
 
-        public static Lightmapping.RequestLightsDelegate lightsDelegate = (Light[] requests, NativeArray<LightDataGI> lightsOutput) =>
+        static Lightmapping.RequestLightsDelegate lightsDelegate = (Light[] requests, NativeArray<LightDataGI> lightsOutput) =>
         {
             LightDataGI lightData = new LightDataGI();
 


### PR DESCRIPTION
### Purpose of this PR

Makes the light delegate function in LWRP private. Having the function public is not necessary.

---
### Release Notes

The lightmap delegate is no longer public in LWRP.

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=add-platform-filter&ScriptableRenderLoop_branch=lw%2Flights-delegate-private&unity_branch=trunk

**Manual Tests**: I have run a test scene that uses baked lights without issues.

---
### Overall Product Risks
**Technical Risk**: Very low

**Halo Effect**: Low. If someone already depends on delegate being public, this might cause issues.
