### PR TITLE
Deprecate Linux Universal support in 2019.2+

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
@@ -542,7 +542,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             return (buildTarget == UnityEditor.BuildTarget.StandaloneWindows ||
                     buildTarget == UnityEditor.BuildTarget.StandaloneWindows64 ||
                     buildTarget == UnityEditor.BuildTarget.StandaloneLinux64 ||
+#if !UNITY_2019_2_OR_NEWER
                     buildTarget == UnityEditor.BuildTarget.StandaloneLinuxUniversal ||
+#endif
                     buildTarget == UnityEditor.BuildTarget.StandaloneOSX ||
                     buildTarget == UnityEditor.BuildTarget.WSAPlayer ||
                     buildTarget == UnityEditor.BuildTarget.XboxOne ||

--- a/com.unity.testframework.graphics/Runtime/Utils.cs
+++ b/com.unity.testframework.graphics/Runtime/Utils.cs
@@ -15,9 +15,11 @@ namespace UnityEditor.TestTools.Graphics
                     return RuntimePlatform.Android;
                 case BuildTarget.iOS:
                     return RuntimePlatform.IPhonePlayer;
+#if !UNITY_2019_2_OR_NEWER
                 case BuildTarget.StandaloneLinux:
-                case BuildTarget.StandaloneLinux64:
                 case BuildTarget.StandaloneLinuxUniversal:
+#endif
+                case BuildTarget.StandaloneLinux64:
                     return RuntimePlatform.LinuxPlayer;
                 case BuildTarget.StandaloneOSX:
                     return RuntimePlatform.OSXPlayer;
@@ -55,7 +57,11 @@ namespace UnityEditor.TestTools.Graphics
                     return BuildTarget.iOS;
                 case RuntimePlatform.LinuxEditor:
                 case RuntimePlatform.LinuxPlayer:
+#if UNITY_2019_2_OR_NEWER
+                    return BuildTarget.StandaloneLinux64;
+#else
                     return BuildTarget.StandaloneLinuxUniversal;
+#endif
                 case RuntimePlatform.OSXEditor:
                 case RuntimePlatform.OSXPlayer:
                     return BuildTarget.StandaloneOSX;


### PR DESCRIPTION
Deprecate Linux Universal support in 2019.2+

There is no Katana run here as there is no test related to linux for now or for a player.

Editor test: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=deprecate_linux32&automation-tools_branch=add-platform-filter&unity_branch=trunk#
