### PR TITLE
Prevent non-RTed cameras from loading from stale RT textures

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
@@ -79,17 +79,6 @@ Shader "Hidden/HDRP/Deferred"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl"
 
-            //-------------------------------------------------------------------------------------
-            // variable declaration
-            //-------------------------------------------------------------------------------------
-
-            //#define ENABLE_RAYTRACING
-            #ifdef ENABLE_RAYTRACING
-            CBUFFER_START(UnityDeferred)
-                // Uniform variables that defines if we shall be using the shadow area texture or not
-                int _RaytracedAreaShadow;
-            CBUFFER_END
-            #endif
 
             struct Attributes
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
@@ -90,10 +90,6 @@
 
 CBUFFER_START(UnityDeferredCompute)
     uint g_TileListOffset;
-    #ifdef ENABLE_RAYTRACING
-    // Uniform variables that defines if we shall be using the shadow area texture or not
-    int _RaytracedAreaShadow;
-    #endif
 CBUFFER_END
 
 #ifdef DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -2606,11 +2606,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void RenderDeferredLighting(HDCamera hdCamera, CommandBuffer cmd, DebugDisplaySettings debugDisplaySettings,
             RenderTargetIdentifier[] colorBuffers, RenderTargetIdentifier depthStencilBuffer, RenderTargetIdentifier depthTexture,
-            LightingPassOptions options
-#if ENABLE_RAYTRACING
-            , bool areaShadowsRendered
-#endif
-            )
+            LightingPassOptions options)
         {
             cmd.SetGlobalBuffer(HDShaderIDs.g_vLightListGlobal, s_LightList);
 
@@ -2641,13 +2637,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     int numTilesX = hdCamera.camera.stereoEnabled ? ((w / 2) + 15) / 16 : (w + 15) / 16;
                     int numTilesY = (h + 15) / 16;
                     int numTiles = numTilesX * numTilesY;
-
-#if ENABLE_RAYTRACING
-                    if (areaShadowsRendered)
-                        cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._RaytracedAreaShadow, 1);
-                    else
-                        cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._RaytracedAreaShadow, 0);
-#endif
 
                     bool enableFeatureVariants = GetFeatureVariantsEnabled() && !debugDisplaySettings.IsDebugDisplayEnabled() && !hdCamera.camera.stereoEnabled; // TODO VR: Reenable later
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -2606,7 +2606,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void RenderDeferredLighting(HDCamera hdCamera, CommandBuffer cmd, DebugDisplaySettings debugDisplaySettings,
             RenderTargetIdentifier[] colorBuffers, RenderTargetIdentifier depthStencilBuffer, RenderTargetIdentifier depthTexture,
-            LightingPassOptions options, bool areaShadowsRendered = false)
+            LightingPassOptions options
+#if ENABLE_RAYTRACING
+            , bool areaShadowsRendered
+#endif
+            )
         {
             cmd.SetGlobalBuffer(HDShaderIDs.g_vLightListGlobal, s_LightList);
 
@@ -2638,11 +2642,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     int numTilesY = (h + 15) / 16;
                     int numTiles = numTilesX * numTilesY;
 
+#if ENABLE_RAYTRACING
                     if (areaShadowsRendered)
                         cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._RaytracedAreaShadow, 1);
                     else
                         cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._RaytracedAreaShadow, 0);
-
+#endif
 
                     bool enableFeatureVariants = GetFeatureVariantsEnabled() && !debugDisplaySettings.IsDebugDisplayEnabled() && !hdCamera.camera.stereoEnabled; // TODO VR: Reenable later
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -2606,7 +2606,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void RenderDeferredLighting(HDCamera hdCamera, CommandBuffer cmd, DebugDisplaySettings debugDisplaySettings,
             RenderTargetIdentifier[] colorBuffers, RenderTargetIdentifier depthStencilBuffer, RenderTargetIdentifier depthTexture,
-            LightingPassOptions options)
+            LightingPassOptions options, bool areaShadowsRendered = false)
         {
             cmd.SetGlobalBuffer(HDShaderIDs.g_vLightListGlobal, s_LightList);
 
@@ -2637,6 +2637,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     int numTilesX = hdCamera.camera.stereoEnabled ? ((w / 2) + 15) / 16 : (w + 15) / 16;
                     int numTilesY = (h + 15) / 16;
                     int numTiles = numTilesX * numTilesY;
+
+                    if (areaShadowsRendered)
+                        cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._RaytracedAreaShadow, 1);
+                    else
+                        cmd.SetComputeIntParam(deferredComputeShader, HDShaderIDs._RaytracedAreaShadow, 0);
+
 
                     bool enableFeatureVariants = GetFeatureVariantsEnabled() && !debugDisplaySettings.IsDebugDisplayEnabled() && !hdCamera.camera.stereoEnabled; // TODO VR: Reenable later
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/AmbientOcclusion.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/AmbientOcclusion.cs
@@ -213,30 +213,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void Render(CommandBuffer cmd, HDCamera camera, SharedRTManager sharedRTManager, ScriptableRenderContext renderContext)
         {
-            var settings = VolumeManager.instance.stack.GetComponent<AmbientOcclusion>();
 
 #if ENABLE_RAYTRACING
             HDRaytracingEnvironment rtEnvironement = m_RayTracingManager.CurrentEnvironment();
+
             if (m_Settings.supportRayTracing && rtEnvironement != null && rtEnvironement.raytracedAO)
-            {
-
-                if (!camera.frameSettings.enableSSAO) // Use filler texture if SRP settings have disabled SSAO
-                {
-                    // No AO applied - neutral is black, see the comment in the shaders
-                    cmd.SetGlobalTexture(HDShaderIDs._AmbientOcclusionTexture, Texture2D.blackTexture);
-                    cmd.SetGlobalVector(HDShaderIDs._AmbientOcclusionParam, Vector4.zero);
-                    return;
-                }
-                else
-                {
-                    m_RaytracingAmbientOcclusion.RenderAO(camera, cmd, m_AmbientOcclusionTex, renderContext);
-                    cmd.SetGlobalTexture(HDShaderIDs._AmbientOcclusionTexture, m_AmbientOcclusionTex);
-                    cmd.SetGlobalVector(HDShaderIDs._AmbientOcclusionParam, new Vector4(0f, 0f, 0f, settings.directLightingStrength.value));
-
-                    // TODO: All the push-debug stuff should be centralized somewhere
-                    (RenderPipelineManager.currentPipeline as HDRenderPipeline).PushFullScreenDebugTexture(camera, cmd, m_AmbientOcclusionTex, FullScreenDebugMode.SSAO);
-                }
-            }
+                m_RaytracingAmbientOcclusion.RenderAO(camera, cmd, m_AmbientOcclusionTex, renderContext);
             else
 #endif
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1271,9 +1271,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             var cullingResults = renderRequest.cullingResults.cullingResults;
             var hdProbeCullingResults = renderRequest.cullingResults.hdProbeCullingResults;
             var target = renderRequest.target;
-#if ENABLE_RAYTRACING
-            m_AreaShadowsRendered = false;
-#endif
 
             m_DbufferManager.enableDecals = false;
             if (hdCamera.frameSettings.enableDecals)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -205,11 +205,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         bool                            m_IsDepthBufferCopyValid;
         RenderTexture                   m_TemporaryTargetForCubemaps;
         Stack<Camera>                   m_ProbeCameraPool = new Stack<Camera>();
-
-#if ENABLE_RAYTRACING
-        bool                            m_AreaShadowsRendered;
-#endif
-
+        
         RenderTargetIdentifier[] m_MRTWithSSS;
         string m_ForwardPassProfileName;
 
@@ -1486,8 +1482,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
 #if ENABLE_RAYTRACING
                     // Let's render the screen space area light shadows
-                    m_AreaShadowsRendered = m_RaytracingShadows.RenderAreaShadows(hdCamera, cmd, renderContext);
-                    if (m_AreaShadowsRendered)
+                    bool areaShadowsRendered = m_RaytracingShadows.RenderAreaShadows(hdCamera, cmd, renderContext);
+                    if (areaShadowsRendered)
                     {
                         cmd.SetGlobalInt(HDShaderIDs._RaytracedAreaShadow, 1);
                     }
@@ -2429,21 +2425,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Output split lighting for materials asking for it (masked in the stencil buffer)
                 options.outputSplitLighting = true;
 
-                m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options
-#if ENABLE_RAYTRACING
-                    , m_AreaShadowsRendered
-#endif
-                    );
+                m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options);
             }
 
             // Output combined lighting for all the other materials.
             options.outputSplitLighting = false;
 
-            m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options
-#if ENABLE_RAYTRACING
-                    , m_AreaShadowsRendered
-#endif
-                    );
+            m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options);
         }
 
         void UpdateSkyEnvironment(HDCamera hdCamera, CommandBuffer cmd)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -206,7 +206,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         RenderTexture                   m_TemporaryTargetForCubemaps;
         Stack<Camera>                   m_ProbeCameraPool = new Stack<Camera>();
 
+#if ENABLE_RAYTRACING
         bool                            m_AreaShadowsRendered;
+#endif
 
         RenderTargetIdentifier[] m_MRTWithSSS;
         string m_ForwardPassProfileName;
@@ -1273,7 +1275,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             var cullingResults = renderRequest.cullingResults.cullingResults;
             var hdProbeCullingResults = renderRequest.cullingResults.hdProbeCullingResults;
             var target = renderRequest.target;
+#if ENABLE_RAYTRACING
             m_AreaShadowsRendered = false;
+#endif
 
             m_DbufferManager.enableDecals = false;
             if (hdCamera.frameSettings.enableDecals)
@@ -1488,10 +1492,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         cmd.SetGlobalInt(HDShaderIDs._RaytracedAreaShadow, 1);
                     }
                     else
-#endif
                     {
                         cmd.SetGlobalInt(HDShaderIDs._RaytracedAreaShadow, 0);
                     }
+#endif
 
                     HDUtils.CheckRTCreated(m_ScreenSpaceShadowsBuffer);
 
@@ -2425,13 +2429,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Output split lighting for materials asking for it (masked in the stencil buffer)
                 options.outputSplitLighting = true;
 
-                m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options, m_AreaShadowsRendered);
+                m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options
+#if ENABLE_RAYTRACING
+                    , m_AreaShadowsRendered
+#endif
+                    );
             }
 
             // Output combined lighting for all the other materials.
             options.outputSplitLighting = false;
 
-            m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options, m_AreaShadowsRendered);
+            m_LightLoop.RenderDeferredLighting(hdCamera, cmd, m_CurrentDebugDisplaySettings, m_MRTCache2, m_SharedRTManager.GetDepthStencilBuffer(), depthTexture, options
+#if ENABLE_RAYTRACING
+                    , m_AreaShadowsRendered
+#endif
+                    );
         }
 
         void UpdateSkyEnvironment(HDCamera hdCamera, CommandBuffer cmd)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -334,6 +334,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if(needUpdate)
             {
                 UnityEditor.PlayerSettings.SetScriptingDefineSymbolsForGroup(UnityEditor.BuildTargetGroup.Standalone, string.Join(";", defineArray.ToArray()));
+#if ENABLE_RAYTRACING
+                m_RenderPipelineResources.LoadRayTraceShaders();
+#endif
             }
 #endif
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingAmbientOcclusion.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingAmbientOcclusion.cs
@@ -70,8 +70,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             Texture2DArray noiseTexture = m_RaytracingManager.m_RGNoiseTexture;
             ComputeShader bilateralFilter = m_PipelineResources.shaders.reflectionBilateralFilterCS;
             RaytracingShader aoShader = m_PipelineResources.shaders.aoRaytracing;
-            if (rtEnvironement == null || noiseTexture == null || bilateralFilter == null || aoShader == null)
+            if (rtEnvironement == null || noiseTexture == null || bilateralFilter == null || aoShader == null || !hdCamera.frameSettings.enableSSAO || (hdCamera.camera.GetComponent<HDRayTracingFilter>() == null))
             {
+                cmd.SetGlobalTexture(HDShaderIDs._AmbientOcclusionTexture, Texture2D.blackTexture);
+                cmd.SetGlobalVector(HDShaderIDs._AmbientOcclusionParam, Vector4.zero);
                 return;
             }
 
@@ -162,6 +164,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     break;
                 }
             }
+
+
+            cmd.SetGlobalTexture(HDShaderIDs._AmbientOcclusionTexture, outputTexture);
+            cmd.SetGlobalVector(HDShaderIDs._AmbientOcclusionParam, new Vector4(0f, 0f, 0f, VolumeManager.instance.stack.GetComponent<AmbientOcclusion>().directLightingStrength.value));
+            // TODO: All the push-debug stuff should be centralized somewhere
+            (RenderPipelineManager.currentPipeline as HDRenderPipeline).PushFullScreenDebugTexture(hdCamera, cmd, outputTexture, FullScreenDebugMode.SSAO);
         }
     }
 #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
@@ -301,6 +301,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 finalPassPS = Load<Shader>(HDRenderPipelinePath + "PostProcessing/Shaders/FinalPass.shader")
             };
 
+#if ENABLE_RAYTRACING
+            LoadRayTraceShaders();
+#endif
+
             // Materials
             materials = new MaterialResources
             {
@@ -351,6 +355,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 textures.coherentRGNoise128[i] = Load<Texture2D>(HDRenderPipelinePath + "RenderPipelineResources/Texture/CoherentNoise128/sample_" + i + "_xy.bmp");
             }
         }
+#if ENABLE_RAYTRACING
+        public void LoadRayTraceShaders()
+        {
+            string HDRenderPipelinePath = HDUtils.GetHDRenderPipelinePath() + "Runtime/";
+            shaders.aoRaytracing = Load<RaytracingShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace");
+            shaders.reflectionRaytracing = Load<RaytracingShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace");
+            shaders.shadowsRaytracing = Load<RaytracingShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingAreaShadows.raytrace");
+            shaders.areaBillateralFilterCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/AreaBilateralShadow.compute");
+            shaders.reflectionBilateralFilterCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/GaussianBilateral.compute");
+            shaders.lightClusterBuildCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingLightCluster.compute");
+            shaders.lightClusterDebugCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/DebugLightCluster.compute");
+        }
+#endif
 #endif
     }
+
+
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -5,6 +5,19 @@
 
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderConfig.cs.hlsl"
 
+
+//-------------------------------------------------------------------------------------
+// RT variables
+//-------------------------------------------------------------------------------------
+
+//#define ENABLE_RAYTRACING
+#ifdef ENABLE_RAYTRACING
+CBUFFER_START(UnityDeferred)
+// Uniform variables that defines if we shall be using the shadow area texture or not
+int _RaytracedAreaShadow;
+CBUFFER_END
+#endif
+
 // CAUTION:
 // Currently the shaders compiler always include regualr Unity shaderVariables, so I get a conflict here were UNITY_SHADER_VARIABLES_INCLUDED is already define, this need to be fixed.
 // As I haven't change the variables name yet, I simply don't define anything, and I put the transform function at the end of the file outside the guard header.


### PR DESCRIPTION
### Purpose of this PR
For a game camera that doesn't have a raytracing filter component, AO and area shadows that were rendered out during scene view rendering get used for rendering the game view. To avoid unnecessarily texture writes/loads, control flow was updated rather than clearing the textures every cycle. 

Minor refactor of RTAO control flow. 

---
### Testing status
Visual hand-testing only: 
![image](https://user-images.githubusercontent.com/3450690/51009358-ba3b1f00-1504-11e9-8201-cf063af0580a.png)

---
### Overall Product Risks
Low
