### PR TITLE
Modify GetPropertiesDeclaration to fix SRP batcher

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Util/PropertyCollector.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/PropertyCollector.cs
@@ -47,14 +47,14 @@ namespace UnityEditor.ShaderGraph
         public void GetPropertiesDeclaration(ShaderStringBuilder builder)
         {
             builder.AppendLine("CBUFFER_START(UnityPerMaterial)");
-            foreach (var prop in m_Properties.Where(n => n.isBatchable))
+            foreach (var prop in m_Properties.Where(n => n.isBatchable && n.generatePropertyBlock))
             {
                 builder.AppendLine(prop.GetPropertyDeclarationString());
             }
             builder.AppendLine("CBUFFER_END");
             builder.AppendNewLine();
 
-            foreach (var prop in m_Properties.Where(n => !n.isBatchable))
+            foreach (var prop in m_Properties.Where(n => !n.isBatchable || !n.generatePropertyBlock))
             {
                 builder.AppendLine(prop.GetPropertyDeclarationString());
             }


### PR DESCRIPTION
Move non exposed properties out of the CBUFFER "UnityPerMaterial" declaration.

### Purpose of this PR
This fixes SRP Batcher compatibility with global shader variables. Also non exposed properties are likely not to be per material.

---
### Testing status
**Katana Tests**: not tested on Katana

**Manual Tests**: Tested in a project that uses global shader variables for vertex position animation.
Before the fix the batcher would ignore vertex position animation (in play mode only), after the fix I can see the vertex position animation.

---
### Comments to reviewers
I don't know if this is how you want to do this. You could also test if the property is exposed and take that into account in order to determine if the property "isBatchable".
