### PR TITLE
enable LIGHT_LAYERS keyword on deferred lighting and add it to forwar…

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
@@ -43,6 +43,7 @@ Shader "Hidden/HDRP/Deferred"
             #pragma multi_compile _ OUTPUT_SPLIT_LIGHTING
             #pragma multi_compile _ SHADOWS_SHADOWMASK
             #pragma multi_compile _ DEBUG_DISPLAY
+            #pragma multi_compile _ LIGHT_LAYERS
 
             #define USE_FPTL_LIGHTLIST // deferred opaque always use FPTL
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
@@ -1,9 +1,13 @@
-#pragma kernel Deferred_Direct_Fptl                                SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl
-#pragma kernel Deferred_Direct_Fptl_DebugDisplay                   SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl_DebugDisplay             DEBUG_DISPLAY
-#pragma kernel Deferred_Direct_ShadowMask_Fptl                     SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl               SHADOWS_SHADOWMASK
-#pragma kernel Deferred_Direct_ShadowMask_Fptl_DebugDisplay        SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl_DebugDisplay  SHADOWS_SHADOWMASK  DEBUG_DISPLAY
+#pragma kernel Deferred_Direct_Fptl                                      SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl
+#pragma kernel Deferred_Direct_Fptl_DebugDisplay                         SHADE_OPAQUE_ENTRY=Deferred_Direct_Fptl_DebugDisplay                         DEBUG_DISPLAY
+#pragma kernel Deferred_Direct_ShadowMask_Fptl                           SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl                           SHADOWS_SHADOWMASK
+#pragma kernel Deferred_Direct_ShadowMask_Fptl_DebugDisplay              SHADE_OPAQUE_ENTRY=Deferred_Direct_ShadowMask_Fptl_DebugDisplay              SHADOWS_SHADOWMASK  DEBUG_DISPLAY
+#pragma kernel Deferred_Direct_LightLayers_Fptl                          SHADE_OPAQUE_ENTRY=Deferred_Direct_LightLayers_Fptl                          LIGHT_LAYERS
+#pragma kernel Deferred_Direct_LightLayers_Fptl_DebugDisplay             SHADE_OPAQUE_ENTRY=Deferred_Direct_LightLayers_Fptl_DebugDisplay             LIGHT_LAYERS DEBUG_DISPLAY
+#pragma kernel Deferred_Direct_LightLayers_ShadowMask_Fptl               SHADE_OPAQUE_ENTRY=Deferred_Direct_LightLayers_ShadowMask_Fptl               LIGHT_LAYERS SHADOWS_SHADOWMASK
+#pragma kernel Deferred_Direct_LightLayers_ShadowMask_Fptl_DebugDisplay  SHADE_OPAQUE_ENTRY=Deferred_Direct_LightLayers_ShadowMask_Fptl_DebugDisplay  LIGHT_LAYERS SHADOWS_SHADOWMASK DEBUG_DISPLAY
 
-// Variant with and without shadowmask
+// Variant with and without shadowmask, with and without light layers
 #pragma kernel Deferred_Indirect_Fptl_Variant0      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant0      USE_INDIRECT    VARIANT=0
 #pragma kernel Deferred_Indirect_Fptl_Variant1      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant1      USE_INDIRECT    VARIANT=1
 #pragma kernel Deferred_Indirect_Fptl_Variant2      SHADE_OPAQUE_ENTRY=Deferred_Indirect_Fptl_Variant2      USE_INDIRECT    VARIANT=2
@@ -59,6 +63,63 @@
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant24      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant24      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=24
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant25      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant25      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=25
 #pragma kernel Deferred_Indirect_ShadowMask_Fptl_Variant26      SHADE_OPAQUE_ENTRY=Deferred_Indirect_ShadowMask_Fptl_Variant26      USE_INDIRECT    SHADOWS_SHADOWMASK  VARIANT=26
+
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant0      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant0      USE_INDIRECT    LIGHT_LAYERS    VARIANT=0
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant1      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant1      USE_INDIRECT    LIGHT_LAYERS    VARIANT=1
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant2      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant2      USE_INDIRECT    LIGHT_LAYERS    VARIANT=2
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant3      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant3      USE_INDIRECT    LIGHT_LAYERS    VARIANT=3
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant4      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant4      USE_INDIRECT    LIGHT_LAYERS    VARIANT=4
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant5      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant5      USE_INDIRECT    LIGHT_LAYERS    VARIANT=5
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant6      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant6      USE_INDIRECT    LIGHT_LAYERS    VARIANT=6
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant7      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant7      USE_INDIRECT    LIGHT_LAYERS    VARIANT=7
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant8      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant8      USE_INDIRECT    LIGHT_LAYERS    VARIANT=8
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant9      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant9      USE_INDIRECT    LIGHT_LAYERS    VARIANT=9
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant10     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant10     USE_INDIRECT    LIGHT_LAYERS    VARIANT=10
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant11     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant11     USE_INDIRECT    LIGHT_LAYERS    VARIANT=11
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant12     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant12     USE_INDIRECT    LIGHT_LAYERS    VARIANT=12
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant13     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant13     USE_INDIRECT    LIGHT_LAYERS    VARIANT=13
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant14     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant14     USE_INDIRECT    LIGHT_LAYERS    VARIANT=14
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant15     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant15     USE_INDIRECT    LIGHT_LAYERS    VARIANT=15
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant16     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant16     USE_INDIRECT    LIGHT_LAYERS    VARIANT=16
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant17     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant17     USE_INDIRECT    LIGHT_LAYERS    VARIANT=17
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant18     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant18     USE_INDIRECT    LIGHT_LAYERS    VARIANT=18
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant19     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant19     USE_INDIRECT    LIGHT_LAYERS    VARIANT=19
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant20     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant20     USE_INDIRECT    LIGHT_LAYERS    VARIANT=20
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant21     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant21     USE_INDIRECT    LIGHT_LAYERS    VARIANT=21
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant22     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant22     USE_INDIRECT    LIGHT_LAYERS    VARIANT=22
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant23     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant23     USE_INDIRECT    LIGHT_LAYERS    VARIANT=23
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant24     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant24     USE_INDIRECT    LIGHT_LAYERS    VARIANT=24
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant25     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant25     USE_INDIRECT    LIGHT_LAYERS    VARIANT=25
+#pragma kernel Deferred_Indirect_LightLayers_Fptl_Variant26     SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_Fptl_Variant26     USE_INDIRECT    LIGHT_LAYERS    VARIANT=26
+
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant0       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant0       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=0
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant1       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant1       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=1
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant2       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant2       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=2
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant3       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant3       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=3
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant4       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant4       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=4
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant5       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant5       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=5
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant6       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant6       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=6
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant7       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant7       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=7
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant8       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant8       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=8
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant9       SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant9       USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=9
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant10      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant10      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=10
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant11      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant11      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=11
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant12      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant12      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=12
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant13      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant13      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=13
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant14      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant14      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=14
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant15      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant15      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=15
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant16      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant16      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=16
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant17      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant17      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=17
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant18      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant18      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=18
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant19      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant19      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=19
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant20      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant20      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=20
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant21      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant21      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=21
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant22      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant22      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=22
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant23      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant23      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=23
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant24      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant24      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=24
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant25      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant25      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=25
+#pragma kernel Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant26      SHADE_OPAQUE_ENTRY=Deferred_Indirect_LightLayers_ShadowMask_Fptl_Variant26      USE_INDIRECT    LIGHT_LAYERS    SHADOWS_SHADOWMASK  VARIANT=26
+
 
 #ifdef DEBUG_DISPLAY
     // Don't care about this warning in debug

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -661,6 +661,7 @@ Shader "HDRP/Lit"
             #pragma multi_compile _ SHADOWS_SHADOWMASK
             // Setup DECALS_OFF so the shader stripper can remove variants
             #pragma multi_compile DECALS_OFF DECALS_3RT DECALS_4RT
+            #pragma multi_compile _ LIGHT_LAYERS
             
             // Supported shadow modes per light type
             #pragma multi_compile SHADOW_LOW SHADOW_MEDIUM SHADOW_HIGH SHADOW_VERY_HIGH


### PR DESCRIPTION
### Purpose of this PR
Micro shadowing enabled with occlusion from bent normals, artifacts appeared. so I tried to enable light layers in asset, the specular occlusion was not transitioned to ambient occlusion. I found 'LIGHT_LAYERS' keyword was not enabled during LightLoop.

---
### Release Notes
Fix micro shadowing from ambient occlusion when 'LIGHT_LAYERS' is enabled.

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=fix_lightLayers&unity_branch=trunk&automation-tools_branch=master

**Manual Tests**:
1. Create any objects(in HDRP).
2. Set micro shadowing volume and enable it,
3. Replace codes with the below in Lit.hlsl
```
float ComputeMicroShadowing(BSDFData bsdfData, float NdotL)
{
#ifdef LIGHT_LAYERS
    return 1.0;
#else
    return 0.0;
#endif
}
```
4. check if the result is changed to white or black, when enable light layers in HDPipeline asset.

**Automated Tests**: None.

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None

---
### Comments to reviewers
I added keyword in forward pass and deferred shader and added kernels in compute shader.
It generates many shaders(in deferred.shader and deferred.compute).

Is it better to use ternary operation instead of using keyword? check please here.

for example
```
float ComputeMicroShadowing(BSDFData bsdfData, float NdotL)
{
#ifdef LIGHT_LAYERS
    return ComputeMicroShadowing(bsdfData.ambientOcclusion, NdotL, _MicroShadowOpacity);
#else
    // No extra G-Buffer for AO, so 'bsdfData.ambientOcclusion' does not hold a meaningful value.
    return ComputeMicroShadowing(bsdfData.specularOcclusion, NdotL, _MicroShadowOpacity);
#endif
}
```
to
```
float ComputeMicroShadowing(BSDFData bsdfData, float NdotL)
{
    float occlusion = _EnableLightLayers ? bsdfData.ambientOcclusion : bsdfData.specularOcclusion;
    return ComputeMicroShadowing(occlusion, NdotL, _MicroShadowOpacity);
}
```
