### PR TITLE
Hdrp/fix shadergraph hdrenderqueue migration

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -202,10 +202,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 Dirty(ModificationScope.Graph);
             }
         }
-
-        //could be either BaseUnlitGUI.OpaqueRenderQueue or BaseUnlitGUI.TransparentRenderQueue
+        
         [SerializeField]
-        HDRenderQueue.RenderQueueType m_RenderingPass = HDRenderQueue.RenderQueueType.Opaque;
+        HDRenderQueue.RenderQueueType m_RenderingPass = HDRenderQueue.RenderQueueType.Unknown;
 
         public HDRenderQueue.RenderQueueType renderingPass
         {
@@ -249,22 +248,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 Dirty(ModificationScope.Graph);
             }
         }
-
-        [SerializeField]
-        bool m_DrawBeforeRefraction;
-
-        public ToggleData drawBeforeRefraction
-        {
-            get { return new ToggleData(m_DrawBeforeRefraction); }
-            set
-            {
-                if (m_DrawBeforeRefraction == value.isOn)
-                    return;
-                m_DrawBeforeRefraction = value.isOn;
-                UpdateNodeAfterDeserialization();
-                Dirty(ModificationScope.Topological);
-            }
-        }
+        
+        [SerializeField, UnityEngine.Serialization.FormerlySerializedAs("m_DrawBeforeRefraction"), Obsolete("Kept for data migration")]
+        internal bool drawBeforeRefraction;
 
         [SerializeField]
         ScreenSpaceRefraction.RefractionModel m_RefractionModel;
@@ -607,7 +593,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         public bool HasRefraction()
         {
-            return (surfaceType == SurfaceType.Transparent && !drawBeforeRefraction.isOn && refractionModel != ScreenSpaceRefraction.RefractionModel.None);
+            return (surfaceType == SurfaceType.Transparent && renderingPass != HDRenderQueue.RenderQueueType.PreRefraction && refractionModel != ScreenSpaceRefraction.RefractionModel.None);
         }
 
         public bool HasDistortion()

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
@@ -43,42 +43,42 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             });
 
             ++indentLevel;
-            ps.Add(new PropertyRow(CreateLabel("Rendering Pass", indentLevel)), (row) =>
+            switch (m_Node.surfaceType)
             {
-                Enum defaultValue;
-                switch (m_Node.surfaceType)
-                {
-                    case SurfaceType.Opaque:
-                        defaultValue = HDRenderQueue.OpaqueRenderQueue.Default;
-                        break;
-                    case SurfaceType.Transparent:
-                        defaultValue = HDRenderQueue.TransparentRenderQueue.Default;
-                        break;
-                    default:
-                        throw new ArgumentException("Unknown SurfaceType");
-                }
-                row.Add(new EnumField(defaultValue), (field) =>
-                {
-                    switch (m_Node.surfaceType)
+                case SurfaceType.Opaque:
+                    ps.Add(new PropertyRow(CreateLabel("Rendering Pass", indentLevel)), (row) =>
                     {
-                        case SurfaceType.Opaque:
-                            //GetOpaqueEquivalent: prevent issue when switching surface type
+                        row.Add(new EnumField(HDRenderQueue.OpaqueRenderQueue.Default), (field) =>
+                        {
                             field.value = HDRenderQueue.ConvertToOpaqueRenderQueue(HDRenderQueue.GetOpaqueEquivalent(m_Node.renderingPass));
-                            break;
-                        case SurfaceType.Transparent:
-                            //GetTransparentEquivalent: prevent issue when switching surface type
+                            field.RegisterValueChangedCallback(ChangeRenderingPass);
+                        });
+                    });
+                    break;
+                case SurfaceType.Transparent:
+                    ps.Add(new PropertyRow(CreateLabel("Rendering Pass", indentLevel)), (row) =>
+                    {
+                        Enum defaultValue;
+                        switch (m_Node.renderingPass)
+                        {
+                            default: //when deserializing without issue, we still need to init the default to something even if not used.
+                            case HDRenderQueue.RenderQueueType.Transparent:
+                                defaultValue = HDRenderQueue.TransparentRenderQueue.Default;
+                                break;
+                            case HDRenderQueue.RenderQueueType.PreRefraction:
+                                defaultValue = HDRenderQueue.TransparentRenderQueue.BeforeRefraction;
+                                break;
+                        }
+                        row.Add(new EnumField(defaultValue), (field) =>
+                        {
                             field.value = HDRenderQueue.ConvertToTransparentRenderQueue(HDRenderQueue.GetTransparentEquivalent(m_Node.renderingPass));
-
-                            // Render queue BeforeRefraction is not supported with objects that has refraction
-                            if ((HDRenderQueue.TransparentRenderQueue)field.value == HDRenderQueue.TransparentRenderQueue.BeforeRefraction && node.HasRefraction())
-                                Debug.LogError("BeforeRefraction render pass is not supported for object that have refraction");
-                            break;
-                        default:
-                            throw new ArgumentException("Unknown SurfaceType");
-                    }
-                    field.RegisterValueChangedCallback(ChangeRenderingPass);
-                });
-            });
+                            field.RegisterValueChangedCallback(ChangeRenderingPass);
+                        });
+                    });
+                    break;
+                default:
+                    throw new ArgumentException("Unknown SurfaceType");
+            }
             --indentLevel;
 
             if (m_Node.surfaceType == SurfaceType.Transparent)
@@ -154,7 +154,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                     });
                 });
 
-                if (!m_Node.drawBeforeRefraction.isOn)
+                if (m_Node.renderingPass != HDRenderQueue.RenderQueueType.PreRefraction)
                 {
                     ps.Add(new PropertyRow(CreateLabel("Refraction Model", indentLevel)), (row) =>
                     {
@@ -314,7 +314,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             m_Node.owner.owner.RegisterCompleteObjectUndo("Surface Type Change");
             m_Node.surfaceType = (SurfaceType)evt.newValue;
 
-            UpdateRenderingPassValue((int)m_Node.renderingPass);
+            UpdateRenderingPassValue(m_Node.renderingPass);
         }
 
         void ChangeDoubleSidedMode(ChangeEvent<Enum> evt)
@@ -358,19 +358,26 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
         
         void ChangeRenderingPass(ChangeEvent<Enum> evt)
         {
-            UpdateRenderingPassValue(Convert.ToInt32(evt.newValue));
+            HDRenderQueue.RenderQueueType renderQueueType = HDRenderQueue.RenderQueueType.Unknown;
+            if (evt.newValue is HDRenderQueue.OpaqueRenderQueue)
+                renderQueueType = HDRenderQueue.ConvertFromOpaqueRenderQueue((HDRenderQueue.OpaqueRenderQueue)evt.newValue);
+            else if (evt.newValue is HDRenderQueue.TransparentRenderQueue)
+                renderQueueType = HDRenderQueue.ConvertFromTransparentRenderQueue((HDRenderQueue.TransparentRenderQueue)evt.newValue);
+            else
+                throw new ArgumentException("Unknown kind of RenderQueue, was " + evt.newValue);
+            UpdateRenderingPassValue(renderQueueType);
         }
 
-        void UpdateRenderingPassValue(int newValue)
+        void UpdateRenderingPassValue(HDRenderQueue.RenderQueueType newValue)
         {
             HDRenderQueue.RenderQueueType renderingPass;
             switch (m_Node.surfaceType)
             {
                 case SurfaceType.Opaque:
-                    renderingPass = HDRenderQueue.ConvertFromOpaqueRenderQueue((HDRenderQueue.OpaqueRenderQueue)newValue);
+                    renderingPass = HDRenderQueue.GetOpaqueEquivalent(newValue);
                     break;
                 case SurfaceType.Transparent:
-                    renderingPass = HDRenderQueue.ConvertFromTransparentRenderQueue((HDRenderQueue.TransparentRenderQueue)newValue);
+                    renderingPass = HDRenderQueue.GetTransparentEquivalent(newValue);
                     break;
                 default:
                     throw new ArgumentException("Unknown SurfaceType");

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
@@ -958,6 +958,33 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             subShader.AddShaderChunk("{", false);
             subShader.Indent();
             {
+                //Handle data migration here as we need to have a renderingPass already set with accurate data at this point.
+                if (masterNode.renderingPass == HDRenderQueue.RenderQueueType.Unknown)
+                {
+                    switch (masterNode.surfaceType)
+                    {
+                        case SurfaceType.Opaque:
+                            masterNode.renderingPass = HDRenderQueue.RenderQueueType.Opaque;
+                            break;
+                        case SurfaceType.Transparent:
+#pragma warning disable CS0618 // Type or member is obsolete
+                            if (masterNode.drawBeforeRefraction)
+                            {
+                                masterNode.drawBeforeRefraction = false;
+#pragma warning restore CS0618 // Type or member is obsolete
+                                masterNode.renderingPass = HDRenderQueue.RenderQueueType.PreRefraction;
+                            }
+                            else
+                            {
+                                masterNode.renderingPass = HDRenderQueue.RenderQueueType.Transparent;
+                            }
+                            break;
+                        default:
+                            throw new System.ArgumentException("Unknown SurfaceType");
+                    }
+                }
+
+
                 HDMaterialTags materialTags = HDSubShaderUtilities.BuildMaterialTags(masterNode.renderingPass, masterNode.sortPriority, masterNode.alphaTest.isOn);
 
                 // Add tags at the SubShader level

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
@@ -72,9 +72,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
-        //could be either BaseUnlitGUI.OpaqueRenderQueue or BaseUnlitGUI.TransparentRenderQueue
         [SerializeField]
-        HDRenderQueue.RenderQueueType m_RenderingPass = HDRenderQueue.RenderQueueType.Opaque;
+        HDRenderQueue.RenderQueueType m_RenderingPass = HDRenderQueue.RenderQueueType.Unknown;
 
         public HDRenderQueue.RenderQueueType renderingPass
         {
@@ -104,21 +103,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
-        [SerializeField]
-        bool m_DrawBeforeRefraction;
-
-        public ToggleData drawBeforeRefraction
-        {
-            get { return new ToggleData(m_DrawBeforeRefraction); }
-            set
-            {
-                if (m_DrawBeforeRefraction == value.isOn)
-                    return;
-                m_DrawBeforeRefraction = value.isOn;
-                UpdateNodeAfterDeserialization();
-                Dirty(ModificationScope.Topological);
-            }
-        }
+        [SerializeField, UnityEngine.Serialization.FormerlySerializedAs("m_DrawBeforeRefraction"), Obsolete("Kept for data migration")]
+        internal bool drawBeforeRefraction;
 
         [SerializeField]
         bool m_Distortion;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
@@ -43,38 +43,42 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             });
 
             ++indentLevel;
-            ps.Add(new PropertyRow(CreateLabel("Rendering Pass", indentLevel)), (row) =>
+            switch (m_Node.surfaceType)
             {
-                Enum defaultValue;
-                switch (m_Node.surfaceType)
-                {
-                    case SurfaceType.Opaque:
-                        defaultValue = HDRenderQueue.OpaqueRenderQueue.Default;
-                        break;
-                    case SurfaceType.Transparent:
-                        defaultValue = HDRenderQueue.TransparentRenderQueue.Default;
-                        break;
-                    default:
-                        throw new ArgumentException("Unknown SurfaceType");
-                }
-                row.Add(new EnumField(defaultValue), (field) =>
-                {
-                    switch (m_Node.surfaceType)
+                case SurfaceType.Opaque:
+                    ps.Add(new PropertyRow(CreateLabel("Rendering Pass", indentLevel)), (row) =>
                     {
-                        case SurfaceType.Opaque:
-                            //GetOpaqueEquivalent: prevent issue when switching surface type
+                        row.Add(new EnumField(HDRenderQueue.OpaqueRenderQueue.Default), (field) =>
+                        {
                             field.value = HDRenderQueue.ConvertToOpaqueRenderQueue(HDRenderQueue.GetOpaqueEquivalent(m_Node.renderingPass));
-                            break;
-                        case SurfaceType.Transparent:
-                            //GetTransparentEquivalent: prevent issue when switching surface type
+                            field.RegisterValueChangedCallback(ChangeRenderingPass);
+                        });
+                    });
+                    break;
+                case SurfaceType.Transparent:
+                    ps.Add(new PropertyRow(CreateLabel("Rendering Pass", indentLevel)), (row) =>
+                    {
+                        Enum defaultValue;
+                        switch (m_Node.renderingPass)
+                        {
+                            default: //when deserializing without issue, we still need to init the default to something even if not used.
+                            case HDRenderQueue.RenderQueueType.Transparent:
+                                defaultValue = HDRenderQueue.TransparentRenderQueue.Default;
+                                break;
+                            case HDRenderQueue.RenderQueueType.PreRefraction:
+                                defaultValue = HDRenderQueue.TransparentRenderQueue.BeforeRefraction;
+                                break;
+                        }
+                        row.Add(new EnumField(defaultValue), (field) =>
+                        {
                             field.value = HDRenderQueue.ConvertToTransparentRenderQueue(HDRenderQueue.GetTransparentEquivalent(m_Node.renderingPass));
-                            break;
-                        default:
-                            throw new ArgumentException("Unknown SurfaceType");
-                    }
-                    field.RegisterValueChangedCallback(ChangeRenderingPass);
-                });
-            });
+                            field.RegisterValueChangedCallback(ChangeRenderingPass);
+                        });
+                    });
+                    break;
+                default:
+                    throw new ArgumentException("Unknown SurfaceType");
+            }
             --indentLevel;
 
             if (m_Node.surfaceType == SurfaceType.Transparent)
@@ -105,15 +109,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                     {
                         toggle.value = m_Node.transparencyFog.isOn;
                         toggle.OnToggleChanged(ChangeTransparencyFog);
-                    });
-                });
-
-                ps.Add(new PropertyRow(CreateLabel("Appear in Refraction", indentLevel)), (row) =>
-                {
-                    row.Add(new Toggle(), (toggle) =>
-                    {
-                        toggle.value = m_Node.drawBeforeRefraction.isOn;
-                        toggle.OnToggleChanged(ChangeDrawBeforeRefraction);
                     });
                 });
 
@@ -188,7 +183,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             m_Node.owner.owner.RegisterCompleteObjectUndo("Surface Type Change");
             m_Node.surfaceType = (SurfaceType)evt.newValue;
 
-            UpdateRenderingPassValue((int)m_Node.renderingPass);
+            UpdateRenderingPassValue(m_Node.renderingPass);
         }
 
         void ChangeDoubleSided(ChangeEvent<bool> evt)
@@ -222,19 +217,26 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             
         void ChangeRenderingPass(ChangeEvent<Enum> evt)
         {
-            UpdateRenderingPassValue(Convert.ToInt32(evt.newValue));
+            HDRenderQueue.RenderQueueType renderQueueType = HDRenderQueue.RenderQueueType.Unknown;
+            if (evt.newValue is HDRenderQueue.OpaqueRenderQueue)
+                renderQueueType = HDRenderQueue.ConvertFromOpaqueRenderQueue((HDRenderQueue.OpaqueRenderQueue)evt.newValue);
+            else if (evt.newValue is HDRenderQueue.TransparentRenderQueue)
+                renderQueueType = HDRenderQueue.ConvertFromTransparentRenderQueue((HDRenderQueue.TransparentRenderQueue)evt.newValue);
+            else
+                throw new ArgumentException("Unknown kind of RenderQueue, was " + evt.newValue);
+            UpdateRenderingPassValue(renderQueueType);
         }
 
-        void UpdateRenderingPassValue(int newValue)
+        void UpdateRenderingPassValue(HDRenderQueue.RenderQueueType newValue)
         {
             HDRenderQueue.RenderQueueType renderingPass;
             switch (m_Node.surfaceType)
             {
                 case SurfaceType.Opaque:
-                    renderingPass = HDRenderQueue.ConvertFromOpaqueRenderQueue((HDRenderQueue.OpaqueRenderQueue)newValue);
+                    renderingPass = HDRenderQueue.GetOpaqueEquivalent(newValue);
                     break;
                 case SurfaceType.Transparent:
-                    renderingPass = HDRenderQueue.ConvertFromTransparentRenderQueue((HDRenderQueue.TransparentRenderQueue)newValue);
+                    renderingPass = HDRenderQueue.GetTransparentEquivalent(newValue);
                     break;
                 default:
                     throw new ArgumentException("Unknown SurfaceType");
@@ -245,14 +247,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
 
             m_Node.owner.owner.RegisterCompleteObjectUndo("Rendering Pass Change");
             m_Node.renderingPass = renderingPass;
-        }
-
-        void ChangeDrawBeforeRefraction(ChangeEvent<bool> evt)
-        {
-            m_Node.owner.owner.RegisterCompleteObjectUndo("Draw Before Refraction Change");
-            ToggleData td = m_Node.drawBeforeRefraction;
-            td.isOn = evt.newValue;
-            m_Node.drawBeforeRefraction = td;
         }
 
         void ChangeDistortion(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
@@ -346,6 +346,32 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             subShader.AddShaderChunk("{", true);
             subShader.Indent();
             {
+                //Handle data migration here as we need to have a renderingPass already set with accurate data at this point.
+                if (masterNode.renderingPass == HDRenderQueue.RenderQueueType.Unknown)
+                {
+                    switch (masterNode.surfaceType)
+                    {
+                        case SurfaceType.Opaque:
+                            masterNode.renderingPass = HDRenderQueue.RenderQueueType.Opaque;
+                            break;
+                        case SurfaceType.Transparent:
+#pragma warning disable CS0618 // Type or member is obsolete
+                            if (masterNode.drawBeforeRefraction)
+                            {
+                                masterNode.drawBeforeRefraction = false;
+#pragma warning restore CS0618 // Type or member is obsolete
+                                masterNode.renderingPass = HDRenderQueue.RenderQueueType.PreRefraction;
+                            }
+                            else
+                            {
+                                masterNode.renderingPass = HDRenderQueue.RenderQueueType.Transparent;
+                            }
+                            break;
+                        default:
+                            throw new System.ArgumentException("Unknown SurfaceType");
+                    }
+                }
+
                 HDMaterialTags materialTags = HDSubShaderUtilities.BuildMaterialTags(masterNode.renderingPass, masterNode.sortPriority, masterNode.alphaTest.isOn, HDMaterialTags.RenderType.HDUnlitShader);
 
                 // Add tags at the SubShader level

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDMaterialTags.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDMaterialTags.cs
@@ -51,7 +51,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             // Special case for transparent (as we have transparent range from PreRefractionFirst to AfterPostprocessTransparentLast
             // that start before RenderQueue.Transparent value
-            if (HDRenderQueue.k_RenderQueue_AllTransparent.Contains(index))
+            if (HDRenderQueue.k_RenderQueue_AllTransparent.Contains(index)
+                || HDRenderQueue.k_RenderQueue_AfterPostProcessTransparent.Contains(index))
             {
                 int v = (index - (int)RenderQueue.Transparent);
                 return "Transparent" + ((v < 0) ? "" : "+") + v;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderQueue.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderQueue.cs
@@ -121,7 +121,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 case RenderQueueType.Overlay:
                     return (int)Priority.Overlay;
                 default:
-                    throw new ArgumentException("Unknown RenderQueueType");
+                    throw new ArgumentException("Unknown RenderQueueType, was " + targetType);
             }
         }
 
@@ -138,7 +138,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     return type;
                 case RenderQueueType.Overlay:
                 case RenderQueueType.Background:
-                    throw new ArgumentException("Unknow RenderQueueType conversion to transparent equivalent");
+                    throw new ArgumentException("Unknow RenderQueueType conversion to transparent equivalent, was " + type);
             }
         }
 
@@ -157,7 +157,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     return type;
                 case RenderQueueType.Overlay:
                 case RenderQueueType.Background:
-                    throw new ArgumentException("Unknow RenderQueueType conversion to opaque equivalent");
+                    throw new ArgumentException("Unknow RenderQueueType conversion to opaque equivalent, was " + type);
             }
         }
 
@@ -186,7 +186,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 case RenderQueueType.AfterPostProcessOpaque:
                     return OpaqueRenderQueue.AfterPostProcessing;
                 default:
-                    throw new ArgumentException("Cannot map to OpaqueRenderQueue");
+                    throw new ArgumentException("Cannot map to OpaqueRenderQueue, was " + renderQueue);
             }
         }
 
@@ -199,7 +199,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 case OpaqueRenderQueue.AfterPostProcessing:
                     return RenderQueueType.AfterPostProcessOpaque;
                 default:
-                    throw new ArgumentException("Unknown OpaqueRenderQueue");
+                    throw new ArgumentException("Unknown OpaqueRenderQueue, was " + opaqueRenderQueue);
             }
         }
 
@@ -216,7 +216,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 case RenderQueueType.AfterPostprocessTransparent:
                     return TransparentRenderQueue.AfterPostProcessing;
                 default:
-                    throw new ArgumentException("Cannot map to TransparentRenderQueue");
+                    throw new ArgumentException("Cannot map to TransparentRenderQueue, was " + renderQueue);
             }
         }
 
@@ -233,7 +233,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 case TransparentRenderQueue.AfterPostProcessing:
                     return RenderQueueType.AfterPostprocessTransparent;
                 default:
-                    throw new ArgumentException("Unknown TransparentRenderQueue");
+                    throw new ArgumentException("Unknown TransparentRenderQueue, was " + transparentRenderqueue);
             }
         }
     }


### PR DESCRIPTION
### Purpose of this PR
Fix migration data issue on shadergraph when importing shadergraph prior to HDRenderQueue additional queue.

---
### Release Notes
Fix data migration issue when importing ShaderGraph prior to new Low Resolution transparent render queue.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: tested locally with shader in graphic test 8102 and new ones

**Automated Tests**: 


---
### Overall Product Risks
**Technical Risk**: Medium (several lines of code)

**Halo Effect**: Low-Medium (only affect Unlit and Lit ShaderGraph created before)

---
### Comments to reviewers

@anisunity This will help to finalize your work on DXR
