### PR TITLE
Hdrp/hair tangents fixes

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
@@ -33,8 +33,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public const string BentNormalSlotName = "BentNormal";
         public const int BentNormalSlotId = 4;
 
-        public const string TangentSlotName = "Tangent";
-        public const int TangentSlotId = 5;
+        public const string BitangentSlotName = "Bitangent";
+        public const int BitangentSlotId = 5;
 
         public const string SubsurfaceMaskSlotName = "SubsurfaceMask";
         public const int SubsurfaceMaskSlotId = 6;
@@ -115,7 +115,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             Normal = 1 << NormalSlotId,
             SpecularOcclusion = 1 << SpecularOcclusionSlotId,
             BentNormal = 1 << BentNormalSlotId,
-            Tangent = 1 << TangentSlotId,
+            Bitangent = 1 << BitangentSlotId,
             SubsurfaceMask = 1 << SubsurfaceMaskSlotId,
             Thickness = 1 << ThicknessSlotId,
             DiffusionProfile = 1 << DiffusionProfileSlotId,
@@ -134,7 +134,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             AlphaClipThresholdShadow = 1 << AlphaClipThresholdShadowSlotId
         }
 
-        const SlotMask KajiyaKaySlotMask = SlotMask.Position | SlotMask.Albedo | SlotMask.Normal | SlotMask.SpecularOcclusion | SlotMask.BentNormal | SlotMask.Tangent | SlotMask.SubsurfaceMask 
+        const SlotMask KajiyaKaySlotMask = SlotMask.Position | SlotMask.Albedo | SlotMask.Normal | SlotMask.SpecularOcclusion | SlotMask.BentNormal | SlotMask.Bitangent | SlotMask.SubsurfaceMask 
                                             | SlotMask.Thickness | SlotMask.DiffusionProfile | SlotMask.Smoothness | SlotMask.Occlusion | SlotMask.Alpha | SlotMask.AlphaClipThreshold | SlotMask.AlphaClipThresholdDepthPrepass 
                                                 | SlotMask.AlphaClipThresholdDepthPostpass | SlotMask.SpecularTint | SlotMask.SpecularShift | SlotMask.SecondarySpecularTint | SlotMask.SecondarySmoothness | SlotMask.SecondarySpecularShift | SlotMask.AlphaClipThresholdShadow;
 
@@ -554,10 +554,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 AddSlot(new Vector1MaterialSlot(ThicknessSlotId, ThicknessSlotName, ThicknessSlotName, SlotType.Input, 1.0f, ShaderStageCapability.Fragment));
                 validSlots.Add(ThicknessSlotId);
             }
-            if (MaterialTypeUsesSlotMask(SlotMask.Tangent))
+            if (MaterialTypeUsesSlotMask(SlotMask.Bitangent))
             {
-                AddSlot(new TangentMaterialSlot(TangentSlotId, TangentSlotName, TangentSlotName, CoordinateSpace.Tangent, ShaderStageCapability.Fragment));
-                validSlots.Add(TangentSlotId);
+                AddSlot(new TangentMaterialSlot(BitangentSlotId, BitangentSlotName, BitangentSlotName, CoordinateSpace.Tangent, ShaderStageCapability.Fragment));
+                validSlots.Add(BitangentSlotId);
             }
             if (MaterialTypeUsesSlotMask(SlotMask.Emission))
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
@@ -33,7 +33,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public const string BentNormalSlotName = "BentNormal";
         public const int BentNormalSlotId = 4;
 
-        public const string BitangentSlotName = "Bitangent";
+        public const string BitangentSlotName = "HairStrandDirection";
         public const int BitangentSlotId = 5;
 
         public const string SubsurfaceMaskSlotName = "SubsurfaceMask";

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -223,8 +223,7 @@ $include("SharedCode.template.hlsl")
         //$Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.worldToTangent);
         //surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.geomNormalWS);
         surfaceData.bitangentWS = fragInputs.worldToTangent[1];
-        $Bitangent: surfaceData.bitangentWS = TransformTangentToWorld(-surfaceDescription.Bitangent, fragInputs.worldToTangent);
-
+        $Bitangent: surfaceData.bitangentWS = TransformTangentToWorld(-normalize(surfaceDescription.Bitangent), fragInputs.worldToTangent);
 
         // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
         // If user provide bent normal then we process a better term

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -220,8 +220,11 @@ $include("SharedCode.template.hlsl")
         surfaceData.geomNormalWS = fragInputs.worldToTangent[2];
 
         surfaceData.tangentWS = normalize(fragInputs.worldToTangent[0].xyz);    // The tangent is not normalize in worldToTangent for mikkt. TODO: Check if it expected that we normalize with Morten. Tag: SURFACE_GRADIENT
-        $Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.worldToTangent);
-        surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
+        //$Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.worldToTangent);
+        //surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.geomNormalWS);
+        surfaceData.bitangentWS = fragInputs.worldToTangent[1];
+        $Bitangent: surfaceData.bitangentWS = TransformTangentToWorld(-surfaceDescription.Bitangent, fragInputs.worldToTangent);
+
 
         // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
         // If user provide bent normal then we process a better term

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -223,7 +223,7 @@ $include("SharedCode.template.hlsl")
         //$Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.worldToTangent);
         //surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.geomNormalWS);
         surfaceData.bitangentWS = fragInputs.worldToTangent[1];
-        $Bitangent: surfaceData.bitangentWS = TransformTangentToWorld(-normalize(surfaceDescription.Bitangent), fragInputs.worldToTangent);
+        $Bitangent: surfaceData.bitangentWS = TransformTangentToWorld(-normalize(surfaceDescription.HairStrandDirection), fragInputs.worldToTangent);
 
         // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
         // If user provide bent normal then we process a better term

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -223,7 +223,7 @@ $include("SharedCode.template.hlsl")
         //$Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.worldToTangent);
         //surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.geomNormalWS);
         surfaceData.bitangentWS = fragInputs.worldToTangent[1];
-        $Bitangent: surfaceData.bitangentWS = TransformTangentToWorld(-normalize(surfaceDescription.HairStrandDirection), fragInputs.worldToTangent);
+        $Bitangent: surfaceData.bitangentWS = normalize(TransformTangentToWorld(-surfaceDescription.HairStrandDirection, fragInputs.worldToTangent);
 
         // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
         // If user provide bent normal then we process a better term

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -222,7 +222,7 @@ $include("SharedCode.template.hlsl")
         surfaceData.tangentWS = normalize(fragInputs.worldToTangent[0].xyz);    // The tangent is not normalize in worldToTangent for mikkt. TODO: Check if it expected that we normalize with Morten. Tag: SURFACE_GRADIENT
         //$Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.worldToTangent);
         //surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.geomNormalWS);
-        surfaceData.bitangentWS = fragInputs.worldToTangent[1];
+        surfaceData.bitangentWS = normalize(fragInputs.worldToTangent[1]);
         $Bitangent: surfaceData.bitangentWS = normalize(TransformTangentToWorld(-surfaceDescription.HairStrandDirection, fragInputs.worldToTangent);
 
         // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
@@ -35,7 +35,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 HairMasterNode.NormalSlotId,
                 HairMasterNode.SpecularOcclusionSlotId,
                 HairMasterNode.BentNormalSlotId,
-                HairMasterNode.TangentSlotId,
+                HairMasterNode.BitangentSlotId,
                 HairMasterNode.SubsurfaceMaskSlotId,
                 HairMasterNode.ThicknessSlotId,
                 HairMasterNode.DiffusionProfileSlotId,
@@ -312,7 +312,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 HairMasterNode.NormalSlotId,
                 HairMasterNode.SpecularOcclusionSlotId,
                 HairMasterNode.BentNormalSlotId,
-                HairMasterNode.TangentSlotId,
+                HairMasterNode.BitangentSlotId,
                 HairMasterNode.SubsurfaceMaskSlotId,
                 HairMasterNode.ThicknessSlotId,
                 HairMasterNode.DiffusionProfileSlotId,
@@ -372,7 +372,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 HairMasterNode.NormalSlotId,
                 HairMasterNode.SpecularOcclusionSlotId,
                 HairMasterNode.BentNormalSlotId,
-                HairMasterNode.TangentSlotId,
+                HairMasterNode.BitangentSlotId,
                 HairMasterNode.SubsurfaceMaskSlotId,
                 HairMasterNode.ThicknessSlotId,
                 HairMasterNode.DiffusionProfileSlotId,
@@ -579,9 +579,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 activeFields.Add("BentNormal");
             }
 
-            if (masterNode.IsSlotConnected(HairMasterNode.TangentSlotId) && pass.PixelShaderUsesSlot(HairMasterNode.TangentSlotId))
+            if (masterNode.IsSlotConnected(HairMasterNode.BitangentSlotId) && pass.PixelShaderUsesSlot(HairMasterNode.BitangentSlotId))
             {
-                activeFields.Add("Tangent");
+                activeFields.Add("Bitangent");
             }
 
             if (masterNode.transmission.isOn)

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.cs
@@ -54,8 +54,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             public float thickness;
 
             // Anisotropic
-            [SurfaceDataAttributes("Tangent", true)]
-            public Vector3 tangentWS;
+            //[SurfaceDataAttributes("Tangent", true)]
+            //public Vector3 tangentWS;
+            [SurfaceDataAttributes("Bitangent", true)]
+            public Vector3 bitangentWS;
 
             // Kajiya kay
             [SurfaceDataAttributes("Secondary Smoothness")]

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.cs.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.cs.hlsl
@@ -27,11 +27,12 @@
 #define DEBUGVIEW_HAIR_SURFACEDATA_SUBSURFACE_MASK (1410)
 #define DEBUGVIEW_HAIR_SURFACEDATA_THICKNESS (1411)
 #define DEBUGVIEW_HAIR_SURFACEDATA_TANGENT (1412)
-#define DEBUGVIEW_HAIR_SURFACEDATA_SECONDARY_SMOOTHNESS (1413)
-#define DEBUGVIEW_HAIR_SURFACEDATA_SPECULAR_TINT (1414)
-#define DEBUGVIEW_HAIR_SURFACEDATA_SECONDARY_SPECULAR_TINT (1415)
-#define DEBUGVIEW_HAIR_SURFACEDATA_SPECULAR_SHIFT (1416)
-#define DEBUGVIEW_HAIR_SURFACEDATA_SECONDARY_SPECULAR_SHIFT (1417)
+#define DEBUGVIEW_HAIR_SURFACEDATA_BITANGENT (1413)
+#define DEBUGVIEW_HAIR_SURFACEDATA_SECONDARY_SMOOTHNESS (1414)
+#define DEBUGVIEW_HAIR_SURFACEDATA_SPECULAR_TINT (1415)
+#define DEBUGVIEW_HAIR_SURFACEDATA_SECONDARY_SPECULAR_TINT (1416)
+#define DEBUGVIEW_HAIR_SURFACEDATA_SPECULAR_SHIFT (1417)
+#define DEBUGVIEW_HAIR_SURFACEDATA_SECONDARY_SPECULAR_SHIFT (1418)
 
 //
 // UnityEngine.Experimental.Rendering.HDPipeline.Hair+BSDFData:  static fields
@@ -79,6 +80,7 @@ struct SurfaceData
     float subsurfaceMask;
     float thickness;
     float3 tangentWS;
+    float3 bitangentWS;
     float secondaryPerceptualSmoothness;
     float3 specularTint;
     float3 secondarySpecularTint;
@@ -163,6 +165,9 @@ void GetGeneratedSurfaceDataDebug(uint paramId, SurfaceData surfacedata, inout f
             break;
         case DEBUGVIEW_HAIR_SURFACEDATA_TANGENT:
             result = surfacedata.tangentWS * 0.5 + 0.5;
+            break;
+        case DEBUGVIEW_HAIR_SURFACEDATA_BITANGENT:
+            result = surfacedata.bitangentWS * 0.5 + 0.5;
             break;
         case DEBUGVIEW_HAIR_SURFACEDATA_SECONDARY_SMOOTHNESS:
             result = surfacedata.secondaryPerceptualSmoothness.xxx;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
@@ -156,7 +156,7 @@ BSDFData ConvertSurfaceDataToBSDFData(uint2 positionSS, SurfaceData surfaceData)
     }
 
     bsdfData.bitangentWS = surfaceData.bitangentWS;
-    surfaceData.tangentWS = cross(surfaceData.bitangentWS, surfaceData.normalWS);
+    bsdfData.tangentWS = cross(surfaceData.bitangentWS, surfaceData.normalWS);
 
     // Kajiya kay
     if (HasFlag(surfaceData.materialFeatures, MATERIALFEATUREFLAGS_HAIR_KAJIYA_KAY))

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
@@ -155,8 +155,8 @@ BSDFData ConvertSurfaceDataToBSDFData(uint2 positionSS, SurfaceData surfaceData)
         FillMaterialTransmission(surfaceData.diffusionProfile, surfaceData.thickness, bsdfData);
     }
 
-    bsdfData.tangentWS = surfaceData.tangentWS;
-    bsdfData.bitangentWS = cross(surfaceData.normalWS, surfaceData.tangentWS);
+    bsdfData.bitangentWS = surfaceData.bitangentWS;
+    surfaceData.tangentWS = cross(surfaceData.bitangentWS, surfaceData.normalWS);
 
     // Kajiya kay
     if (HasFlag(surfaceData.materialFeatures, MATERIALFEATUREFLAGS_HAIR_KAJIYA_KAY))
@@ -251,8 +251,6 @@ PreLightData GetPreLightData(float3 V, PositionInputs posInput, inout BSDFData b
     preLightData.NdotV = dot(N, V);
 
     float NdotV = ClampNdotV(preLightData.NdotV);
-    float TdotV = dot(bsdfData.tangentWS, V);
-    float BdotV = dot(bsdfData.bitangentWS, V);
 
     float unused;
     float3 iblN;
@@ -363,8 +361,9 @@ void BSDF(  float3 V, float3 L, float NdotL, float3 positionWS, PreLightData pre
     if (HasFlag(bsdfData.materialFeatures, MATERIALFEATUREFLAGS_HAIR_KAJIYA_KAY))
     {
         // Must shift with bitangent and not tangent? <= TODO: check this
-        float3 t1 = ShiftTangent(bsdfData.bitangentWS, bsdfData.normalWS, bsdfData.specularShift);
-        float3 t2 = ShiftTangent(bsdfData.bitangentWS, bsdfData.normalWS, bsdfData.secondarySpecularShift);
+        float3 hairStrandDirection = -Orthonormalize(bsdfData.bitangentWS, bsdfData.normalWS);
+        float3 t1 = ShiftTangent(hairStrandDirection, bsdfData.normalWS, bsdfData.specularShift);
+        float3 t2 = ShiftTangent(hairStrandDirection, bsdfData.normalWS, bsdfData.secondarySpecularShift);
 
         float3 H = (L + V) * invLenLV;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
@@ -358,10 +358,11 @@ void BSDF(  float3 V, float3 L, float NdotL, float3 positionWS, PreLightData pre
     float LdotV, NdotH, LdotH, NdotV, invLenLV;
     GetBSDFAngle(V, L, NdotL, preLightData.NdotV, LdotV, NdotH, LdotH, NdotV, invLenLV);
 
+    float3 hairStrandDirection = -Orthonormalize(bsdfData.bitangentWS, bsdfData.normalWS);
+
     if (HasFlag(bsdfData.materialFeatures, MATERIALFEATUREFLAGS_HAIR_KAJIYA_KAY))
     {
         // Must shift with bitangent and not tangent? <= TODO: check this
-        float3 hairStrandDirection = -Orthonormalize(bsdfData.bitangentWS, bsdfData.normalWS);
         float3 t1 = ShiftTangent(hairStrandDirection, bsdfData.normalWS, bsdfData.specularShift);
         float3 t2 = ShiftTangent(hairStrandDirection, bsdfData.normalWS, bsdfData.secondarySpecularShift);
 


### PR DESCRIPTION
### Purpose of this PR
Introduces fixes on the hair shader masternode.
Tangents are now derived from bitangents in order to avoid visible flips in the hair highlights.
The tangent input is now renamed HairStrandDirection for more straightforward artistic input.

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None
