### PR TITLE
Fix shader compilation issue 

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -29,7 +29,6 @@
 #define INTRINSIC_WAVE_LOGICAL_OPS
 #define WaveActiveBitAnd CrossLaneAnd
 #define WaveActiveBitOr CrossLaneOr
-#define WaveGetLaneCount() (64)
 #define WaveGetID GetWaveID
 
 #define INTRINSIC_WAVE_ACTIVE_ALL_ANY

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/PSSL.hlsl
@@ -1,5 +1,8 @@
 // This file assume SHADER_API_D3D11 is defined
 
+#define PLATFORM_LANE_COUNT 64
+#define PLATFORM_THREAD_GROUP_OPTIMAL_SIZE PLATFORM_LANE_COUNT       // 64 threads in a wafefront
+
 #define SUPPORTS_WAVE_INTRINSICS
 
 #define INTRINSIC_BITFIELD_EXTRACT
@@ -50,6 +53,12 @@ bool WaveIsFirstLane()
     return MaskBitCnt(__s_read_exec()) == 0;
 }
 
+uint WaveGetLaneCount()
+{
+    return PLATFORM_LANE_COUNT;
+}
+
+
 #define UNITY_UV_STARTS_AT_TOP 1
 #define UNITY_REVERSED_Z 1
 #define UNITY_NEAR_CLIP_VALUE (1.0)
@@ -64,7 +73,6 @@ bool WaveIsFirstLane()
 #define CBUFFER_START(name) cbuffer name {
 #define CBUFFER_END };
 
-#define PLATFORM_THREAD_GROUP_OPTIMAL_SIZE 64		// 64 threads in a wafefront
 
 // flow control attributes
 #define UNITY_BRANCH        [branch]

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/XBoxOne.hlsl
@@ -31,7 +31,8 @@
 
 #define PLATFORM_SUPPORTS_EXPLICIT_BINDING 1
 #define PLATFORM_NEEDS_UNORM_UAV_SPECIFIER 1
-#define PLATFORM_THREAD_GROUP_OPTIMAL_SIZE 64       // 64 threads in a wafefront
+#define PLATFORM_LANE_COUNT 64
+#define PLATFORM_THREAD_GROUP_OPTIMAL_SIZE PLATFORM_LANE_COUNT       // 64 threads in a wafefront
 
 // Intrinsics
 #define SUPPORTS_WAVE_INTRINSICS
@@ -45,7 +46,6 @@
 #define INTRINSIC_WAVE_LOGICAL_OPS
 #define WaveActiveBitAnd __XB_WaveAND
 #define WaveActiveBitOr __XB_WaveOR
-#define WaveGetLaneCount() (64)
 #define WaveGetID __XB_GetWaveID
 
 #define INTRINSIC_BITFIELD_EXTRACT
@@ -80,6 +80,12 @@ bool WaveIsFirstLane()
 {
     return (__XB_MBCNT64(WaveActiveBallot(true))) == 0;
 }
+
+uint WaveGetLaneCount()
+{
+    return PLATFORM_LANE_COUNT;
+}
+
 
 #define INTRINSIC_MINMAX3
 GENERATE_INTRINSIC_VARIANTS_3_ARGS(Min3, __XB_Min3_, a, b, c);

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/AmbientProbeConvolution.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/AmbientProbeConvolution.compute
@@ -24,7 +24,7 @@ TEXTURECUBE(_AmbientProbeInputCubemap);
 
 #ifdef SUPPORTS_WAVE_INTRINSICS
     // Allocate space to accumulate all waves result. We need space for each single wavefront (because we can't atomic add floats)
-    groupshared float outputSHCoeffsLDS[SH_COEFF_COUNT * SAMPLE_COUNT / WaveGetLaneCount()];
+    groupshared float outputSHCoeffsLDS[SH_COEFF_COUNT * SAMPLE_COUNT / PLATFORM_LANE_COUNT];
 #else
     // Allocate space for parallel reduction (so half the number of samples.
     groupshared float outputSHCoeffsLDS[SH_COEFF_COUNT * SAMPLE_COUNT / 2];
@@ -81,7 +81,7 @@ void KERNEL_NAME(uint dispatchThreadId : SV_DispatchThreadID)
     }
 
     // First thread of each wave stores the result in LDS
-    uint laneCount = WaveGetLaneCount();
+    uint laneCount = PLATFORM_LANE_COUNT;
     if (dispatchThreadId % laneCount == 0)
     {
         for (int i = 0; i < SH_COEFF_COUNT; ++i)


### PR DESCRIPTION
Not sure when this went in, however I just merged hdrp-master to my branch and it didn't compile for consoles. 
The way WaveGetLaneCount() was defined doesn't seem to compile. Moreover, when we are going to support SM 6.0, this won't have compiled anyway since we cannot use functions to define groupshared 
 mem array size.  

I changed that to a constant, but I kept the function  there anyway, in case we want to use it in the future 🙂 