### PR TITLE
Remove HDRP from SG test project manifest for faster load times.

### DIFF
--- a/TestProjects/ShaderGraph/Packages/manifest.json
+++ b/TestProjects/ShaderGraph/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "com.unity.render-pipelines.core": "file:../../../com.unity.render-pipelines.core",
-    "com.unity.render-pipelines.high-definition": "file:../../../com.unity.render-pipelines.high-definition",
     "com.unity.render-pipelines.lightweight": "file:../../../com.unity.render-pipelines.lightweight",
     "com.unity.shadergraph": "file:../../../com.unity.shadergraph",
     "com.unity.testframework.graphics": "file:../../../com.unity.testframework.graphics",


### PR DESCRIPTION
### Purpose of this PR

SG tests are taking a long time. Loading HDRP is unnecessary. Stop doing that!
---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Fremove-hdrp-from-tests&unity_branch=trunk, you can see SG tests passed on both platforms, failures in VFX and LW were related to image compression changes that have their own PRs to fix.

**Manual Tests**: Ran test project locally, passed.
---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None
