### PR TITLE
Fix HitT generation in AO

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
@@ -73,7 +73,7 @@ void RayGenAmbientOcclusion()
 	float3 completeColor = float3(0.0, 0.0, 0.0);
 
 	// Minimal distance of the intersection
-	float minDistance = 0.0f;
+	float minDistance = FLT_MAX;
 
 	// Let's loop through th e samples
 	for(int i = 0; i < numSamples; ++i)


### PR DESCRIPTION
### Purpose of this PR
Previously the HitT texture was always getting written to 0 since minDist was initialized to 0f.
Stencil still needs to be hooked up to raytrace shader but this at least puts meaningful data into HitT.