### PR TITLE
Ambient occlusion raytracing hit distance

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/HDRaytracingEnvironmentInspector.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/HDRaytracingEnvironmentInspector.cs
@@ -63,7 +63,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             /////////////////////////////////////////////////////////////////////////////////////////////////
             // Primary visibility
             public static readonly GUIContent primaryRaytracingSectionText = EditorGUIUtility.TrTextContent("Primary Visiblity Raytracing");
-            public static readonly GUIContent rayrtacingEnableText = new GUIContent("Enable");
+            public static readonly GUIContent raytracingEnableText = new GUIContent("Enable");
             public static readonly GUIContent rayMaxDepth = new GUIContent("Raytracing Maximal Depth");
             public static readonly GUIContent raytracingRayLength = new GUIContent("Raytracing Ray Length");
         }
@@ -165,9 +165,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         static void RaytracingSubMenu(SerializedHDRaytracingEnvironment rtEnv, Editor owner)
         {
             // Primary Visibility Specific fields
-            EditorGUILayout.PropertyField(rtEnv.rayrtacedObjects, Styles.rayrtacingEnableText);
+            EditorGUILayout.PropertyField(rtEnv.raytracedObjects, Styles.raytracingEnableText);
 
-            if (rtEnv.rayrtacedObjects.boolValue)
+            if (rtEnv.raytracedObjects.boolValue)
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(rtEnv.rayMaxDepth, Styles.rayMaxDepth);

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/SerializedHDRaytracingEnvironment.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/SerializedHDRaytracingEnvironment.cs
@@ -38,7 +38,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedProperty reflBilateralSigma;
 
         // Primary visiblity raytracing
-        public SerializedProperty rayrtacedObjects;
+        public SerializedProperty raytracedObjects;
         public SerializedProperty rayMaxDepth;
         public SerializedProperty raytracingRayLength;
 
@@ -87,7 +87,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             cameraClusterRange = o.Find(x => x.cameraClusterRange);
 
             // Raytracing Attributes
-            rayrtacedObjects = o.Find(x => x.rayrtacedObjects);
+            raytracedObjects = o.Find(x => x.raytracedObjects);
             rayMaxDepth = o.Find(x => x.rayMaxDepth);
             raytracingRayLength = o.Find(x => x.raytracingRayLength);
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -2340,7 +2340,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // If there is a ray-tracing environment and the feature is enabled we want to push these objects to the prepass
             HDRaytracingEnvironment currentEnv = m_RayTracingManager.CurrentEnvironment();
             // We want the opaque objects to be in the prepass so that we avoid rendering uselessly the pixels before raytracing them
-            if (currentEnv != null && currentEnv.rayrtacedObjects)
+            if (currentEnv != null && currentEnv.raytracedObjects)
                 RenderOpaqueRenderList(cull, hdCamera, renderContext, cmd, m_DepthOnlyAndDepthForwardOnlyPassNames, 0, HDRenderQueue.k_RenderQueue_AllOpaqueRaytracing);
 #endif
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingEnvironment.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingEnvironment.cs
@@ -86,7 +86,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         /////////////////////////////////////////////////////////////////////////////////////////////////
         // Primary Visibility
         // Flag that defines if raytraced objects should be rendered
-        public bool rayrtacedObjects = false;
+        public bool raytracedObjects = false;
 
         // This is the maximal depth that a ray can have for the primary visibility pass
         const int maxRayDepth = 10;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingRenderer.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingRenderer.cs
@@ -136,7 +136,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             bool missingResources = rtEnvironement == null || noiseTexture == null || forwardShader == null || raytracingMask == null || accelerationStructure == null || lightData == null;
 
             // If any resource or game-object is missing We stop right away
-            if (missingResources || !rtEnvironement.rayrtacedObjects)
+            if (missingResources || !rtEnvironement.raytracedObjects)
                 return;
 
             if (m_RaytracingFlagMaterial == null)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
@@ -73,7 +73,7 @@ void RayGenAmbientOcclusion()
 	float3 completeColor = float3(0.0, 0.0, 0.0);
 
 	// Minimal distance of the intersection
-	float minDistance = 0.0f;
+	float minDistance = _RaytracingRayMaxLength;
 
 	// Let's loop through th e samples
 	for(int i = 0; i < numSamples; ++i)


### PR DESCRIPTION
Correcting a typo in the rayrtacedObjects attribute name
Correcting the min hit distance using the max ray distance 