### PR TITLE
Added guards so that MATERIAL_INCLUDE_SUBSURFACESCATTERING and MATERI…

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Deferred.shader
@@ -140,12 +140,14 @@ Shader "Hidden/HDRP/Deferred"
                 Outputs outputs;
 
             #ifdef OUTPUT_SPLIT_LIGHTING
+                #ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
                 if (_EnableSubsurfaceScattering != 0 && ShouldOutputSplitLighting(bsdfData))
                 {
                     outputs.specularLighting = float4(specularLighting, 1.0);
                     outputs.diffuseLighting  = TagLightingForSSS(diffuseLighting);
                 }
                 else
+                #endif
                 {
                     outputs.specularLighting = float4(diffuseLighting + specularLighting, 1.0);
                     outputs.diffuseLighting  = 0;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
@@ -181,12 +181,14 @@ void SHADE_OPAQUE_ENTRY(uint2 dispatchThreadId : SV_DispatchThreadID, uint2 grou
     diffuseLighting *= GetCurrentExposureMultiplier();
     specularLighting *= GetCurrentExposureMultiplier();
 
+    #ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
     if (_EnableSubsurfaceScattering != 0 && ShouldOutputSplitLighting(bsdfData))
     {
         specularLightingUAV[pixelCoord] = float4(specularLighting, 1.0);
         diffuseLightingUAV[pixelCoord]  = TagLightingForSSS(diffuseLighting);
     }
     else
+    #endif
     {
         specularLightingUAV[pixelCoord] = float4(diffuseLighting + specularLighting, 1.0);
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/DeferredTile.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/DeferredTile.shader
@@ -248,12 +248,14 @@ Shader "Hidden/HDRP/DeferredTile"
                 Outputs outputs;
 
             #ifdef OUTPUT_SPLIT_LIGHTING
+                #ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
                 if (_EnableSubsurfaceScattering != 0 && ShouldOutputSplitLighting(bsdfData))
                 {
                     outputs.specularLighting = float4(specularLighting, 1.0);
                     outputs.diffuseLighting  = TagLightingForSSS(diffuseLighting);
                 }
                 else
+                #endif
                 {
                     outputs.specularLighting = float4(diffuseLighting + specularLighting, 1.0);
                     outputs.diffuseLighting  = 0;
@@ -406,12 +408,14 @@ Shader "Hidden/HDRP/DeferredTile"
                 Outputs outputs;
 
             #ifdef OUTPUT_SPLIT_LIGHTING
+                #ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
                 if (_EnableSubsurfaceScattering != 0 && ShouldOutputSplitLighting(bsdfData))
                 {
                     outputs.specularLighting = float4(specularLighting, 1.0);
                     outputs.diffuseLighting  = TagLightingForSSS(diffuseLighting);
                 }
                 else
+                #endif
                 {
                     outputs.specularLighting = float4(diffuseLighting + specularLighting, 1.0);
                     outputs.diffuseLighting  = 0;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Hair/Hair.hlsl
@@ -152,17 +152,21 @@ BSDFData ConvertSurfaceDataToBSDFData(uint2 positionSS, SurfaceData surfaceData)
     // Note: we have ZERO_INITIALIZE the struct so bsdfData.anisotropy == 0.0
     // Note: DIFFUSION_PROFILE_NEUTRAL_ID is 0
 
+#ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
     if (HasFlag(surfaceData.materialFeatures, MATERIALFEATUREFLAGS_HAIR_SUBSURFACE_SCATTERING))
     {
         // Assign profile id and overwrite fresnel0
         FillMaterialSSS(surfaceData.diffusionProfile, surfaceData.subsurfaceMask, bsdfData);
     }
+#endif
 
+#ifdef MATERIAL_INCLUDE_TRANSMISSION
     if (HasFlag(surfaceData.materialFeatures, MATERIALFEATUREFLAGS_HAIR_TRANSMISSION))
     {
         // Assign profile id and overwrite fresnel0
         FillMaterialTransmission(surfaceData.diffusionProfile, surfaceData.thickness, bsdfData);
     }
+#endif
 
     // This is the hair tangent (which represents the hair strand direction, root to tip).
     bsdfData.hairStrandDirectionWS = surfaceData.hairStrandDirectionWS;
@@ -312,11 +316,13 @@ void ModifyBakedDiffuseLighting(float3 V, PositionInputs posInput, SurfaceData s
         builtinData.bakeDiffuseLighting += builtinData.backBakeDiffuseLighting * bsdfData.transmittance;
     }
 
+#ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
     // For SSS we need to take into account the state of diffuseColor 
     if (HasFlag(bsdfData.materialFeatures, MATERIALFEATUREFLAGS_HAIR_SUBSURFACE_SCATTERING))
     {
         bsdfData.diffuseColor = GetModifiedDiffuseColorForSSS(bsdfData);
     }
+#endif
 
     // Premultiply (back) bake diffuse lighting information with diffuse pre-integration
     builtinData.bakeDiffuseLighting *= preLightData.diffuseFGD * bsdfData.diffuseColor;
@@ -587,8 +593,12 @@ void PostEvaluateBSDF(  LightLoopContext lightLoopContext,
     GetScreenSpaceAmbientOcclusionMultibounce(posInput.positionSS, preLightData.NdotV, bsdfData.perceptualRoughness, bsdfData.ambientOcclusion, bsdfData.specularOcclusion, bsdfData.diffuseColor, bsdfData.fresnel0, aoFactor);
     ApplyAmbientOcclusionFactor(aoFactor, builtinData, lighting);
 
+#ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
     // Subsurface scattering mode
     float3 modifiedDiffuseColor = GetModifiedDiffuseColorForSSS(bsdfData);
+#else
+    float3 modifiedDiffuseColor = bsdfData.diffuseColor;
+#endif
 
     // Apply the albedo to the direct diffuse lighting (only once). The indirect (baked)
     // diffuse lighting has already multiply the albedo in ModifyBakedDiffuseLighting().

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/SimpleLit.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/SimpleLit.hlsl
@@ -103,17 +103,21 @@ BSDFData ConvertSurfaceDataToBSDFData(uint2 positionSS, SurfaceData surfaceData)
     // However in practice we keep parity between deferred and forward, so we should constrain the various features.
     // The UI is in charge of setuping the constrain, not the code. So if users is forward only and want unleash power, it is easy to unleash by some UI change
 
+#ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
     if (HasFlag(surfaceData.materialFeatures, MATERIALFEATUREFLAGS_LIT_SUBSURFACE_SCATTERING))
     {
         // Assign profile id and overwrite fresnel0
         FillMaterialSSS(surfaceData.diffusionProfile, surfaceData.subsurfaceMask, bsdfData);
     }
+#endif
 
+#ifdef MATERIAL_INCLUDE_TRANSMISSION
     if (HasFlag(surfaceData.materialFeatures, MATERIALFEATUREFLAGS_LIT_TRANSMISSION))
     {
         // Assign profile id and overwrite fresnel0
         FillMaterialTransmission(surfaceData.diffusionProfile, surfaceData.thickness, bsdfData);
     }
+#endif
 
     // roughnessT and roughnessB are clamped, and are meant to be used with punctual and directional lights.
     // perceptualRoughness is not clamped, and is meant to be used for IBL.
@@ -696,8 +700,12 @@ void PostEvaluateBSDF(  LightLoopContext lightLoopContext,
     GetScreenSpaceAmbientOcclusion(posInput.positionSS, preLightData.NdotV, bsdfData.perceptualRoughness, bsdfData.ambientOcclusion, bsdfData.specularOcclusion, aoFactor);
     ApplyAmbientOcclusionFactor(aoFactor, builtinData, lighting);
 
+#ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
     // Subsurface scattering mode
     float3 modifiedDiffuseColor = GetModifiedDiffuseColorForSSS(bsdfData);
+#else
+    float3 modifiedDiffuseColor = bsdfData.diffuseColor;
+#endif
 
     // Apply the albedo to the direct diffuse lighting (only once). The indirect (baked)
     // diffuse lighting has already multiply the albedo in ModifyBakedDiffuseLighting().

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForward.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForward.hlsl
@@ -118,12 +118,14 @@ void Frag(PackedVaryingsToPS packedInput,
         specularLighting *= GetCurrentExposureMultiplier();
 
 #ifdef OUTPUT_SPLIT_LIGHTING
+    #ifdef MATERIAL_INCLUDE_SUBSURFACESCATTERING
         if (_EnableSubsurfaceScattering != 0 && ShouldOutputSplitLighting(bsdfData))
         {
             outColor = float4(specularLighting, 1.0);
             outDiffuseLighting = float4(TagLightingForSSS(diffuseLighting), 1.0);
         }
         else
+    #endif
         {
             outColor = float4(diffuseLighting + specularLighting, 1.0);
             outDiffuseLighting = 0;


### PR DESCRIPTION
…AL_INCLUDE_TRANSMISSION can be commented out.

### Purpose of this PR
This PR fixes the shader code so that MATERIAL_INCLUDE_SUBSURFACESCATTERING and MATERIAL_INCLUDE_TRANSMISSION can be commented out and still compile.

---
### Release Notes
-

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
Didn't run Katana tests.

**Manual Tests**: What did you do?
This is running in the editor and for Switch target.

**Automated Tests**: What did you setup?
-

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
None.

**Halo Effect**: None, Low, Medium, High?
None

---
### Comments to reviewers
This will allow some platforms to easily comment out effects they do not want in their shader code.
At the moment, some instructions are still added to the shader code (deferred.compute, deferredTile.shader) even when subSurfaceScattering or transmission shader variants are not enabled. Completely removing these instruction saves a fraction of a ms on Switch (decreased register pressure).
