### PR TITLE
Added quality mode for GameWorks reflection filtering

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/HDRaytracingEnvironmentInspector.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/HDRaytracingEnvironmentInspector.cs
@@ -45,6 +45,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // Reflections Quarter Res
             public static GUIContent reflTemporalAccumulationWeight = new GUIContent("Reflections Temporal Accumulation Weight");
 
+            // Reflections NVidia Filter Data
+            public static GUIContent reflLowerRoughnessTransitionPt = new GUIContent("Lower Roughness Transition Point");
+            public static GUIContent reflUpperRoughnessTransitionPt = new GUIContent("Upper Roughness Transition Point");
+            public static GUIContent reflMinSamplingBias = new GUIContent("Min Sampling Bias");
+            public static GUIContent reflMaxSamplingBias = new GUIContent("Max Sampling Bias");
+            public static GUIContent reflUseLogSpace = new GUIContent("Filter in log space");
+            public static GUIContent reflLogSpaceParam = new GUIContent("Logspace Param");
+            public static GUIContent reflNormalWeightMode = new GUIContent("Normal Weight Mode");
+
             // Relections Integration
             public static GUIContent reflNumMaxSamplesText = new GUIContent("Reflections Num Samples");
             /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -161,6 +170,25 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                         {
                             EditorGUILayout.PropertyField(rtEnv.reflTemporalAccumulationWeight, Styles.reflTemporalAccumulationWeight);
                             
+                        }
+                    break;
+                    case HDRaytracingEnvironment.ReflectionsQuality.Nvidia:
+                        {
+                            EditorGUILayout.PropertyField(rtEnv.reflLowerRoughnessTransitionPt, Styles.reflLowerRoughnessTransitionPt);
+                            EditorGUILayout.PropertyField(rtEnv.reflUpperRoughnessTransitionPt, Styles.reflUpperRoughnessTransitionPt);
+                            EditorGUILayout.PropertyField(rtEnv.reflMinSamplingBias, Styles.reflMinSamplingBias);
+                            EditorGUILayout.PropertyField(rtEnv.reflMaxSamplingBias, Styles.reflMaxSamplingBias);
+                            if (rtEnv.reflLowerRoughnessTransitionPt.floatValue > rtEnv.reflUpperRoughnessTransitionPt.floatValue
+                                || rtEnv.reflMinSamplingBias.floatValue > rtEnv.reflMaxSamplingBias.floatValue)
+                                EditorGUILayout.HelpBox("Lower roughness transition point must be less than upper roughness transition point. Minimum sampling bias must be less than maximum sampling bias.", MessageType.Error);
+                            EditorGUILayout.PropertyField(rtEnv.reflNormalWeightMode, Styles.reflNormalWeightMode);
+                            EditorGUILayout.PropertyField(rtEnv.reflUseLogSpace, Styles.reflUseLogSpace);
+                            if (rtEnv.reflUseLogSpace.boolValue)
+                            {
+                                EditorGUI.indentLevel++;
+                                EditorGUILayout.PropertyField(rtEnv.reflLogSpaceParam, Styles.reflLogSpaceParam);
+                                EditorGUI.indentLevel--;
+                            }
                         }
                     break;
                     case HDRaytracingEnvironment.ReflectionsQuality.Integration:

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/SerializedHDRaytracingEnvironment.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/SerializedHDRaytracingEnvironment.cs
@@ -38,6 +38,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public SerializedProperty reflQualityMode;
         public SerializedProperty reflTemporalAccumulationWeight;
         public SerializedProperty reflNumMaxSamples;
+        public SerializedProperty reflNormalWeightMode;
+        public SerializedProperty reflUseLogSpace;
+        public SerializedProperty reflLogSpaceParam;
+        public SerializedProperty reflLowerRoughnessTransitionPt;
+        public SerializedProperty reflUpperRoughnessTransitionPt;
+        public SerializedProperty reflMinSamplingBias;
+        public SerializedProperty reflMaxSamplingBias;
 
         // Primary visiblity raytracing
         public SerializedProperty raytracedObjects;
@@ -78,6 +85,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             reflQualityMode = o.Find(x => x.reflQualityMode);
             reflTemporalAccumulationWeight = o.Find(x => x.reflTemporalAccumulationWeight);
             reflNumMaxSamples = o.Find(x => x.reflNumMaxSamples);
+            reflNormalWeightMode = o.Find(x => x.normalWeightMode);
+            reflUseLogSpace = o.Find(x => x.useLogSpace);
+            reflLogSpaceParam = o.Find(x => x.logSpaceParam);
+            reflLowerRoughnessTransitionPt = o.Find(x => x.lowerRoughnessTransitionPoint);
+            reflUpperRoughnessTransitionPt = o.Find(x => x.upperRoughnessTransitionPoint);
+            reflMinSamplingBias = o.Find(x => x.minSamplingBias);
+            reflMaxSamplingBias = o.Find(x => x.maxSamplingBias);
 
             // Shadows Attributes
             raytracedShadows = o.Find(x => x.raytracedShadows);

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GBufferManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GBufferManager.cs
@@ -147,5 +147,22 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             return null;
         }
+        public RTHandleSystem.RTHandle GetLightLayersBuffer(int index)
+        {
+            int currentIndex = 0;
+            for (int gbufferIndex = 0; gbufferIndex < m_BufferCount; ++gbufferIndex)
+            {
+                if (m_GBufferUsage[gbufferIndex] == GBufferUsage.LightLayers)
+                {
+                    if (currentIndex == index)
+                        return m_RTs[gbufferIndex];
+
+                    // This is not the index we are looking for, find the next one
+                    currentIndex++;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
@@ -635,6 +635,7 @@ void EncodeIntoGBuffer( SurfaceData surfaceData
     outGBuffer3 *= GetCurrentExposureMultiplier();
 
 #ifdef LIGHT_LAYERS
+#ifdef ENABLE_RAYTRACING
     // fixme for some reason ifdef ENABLE_RAYTRACING was never being hit here. debug and add it later
     NormalData smoothNormalData;
     float4 outSmoothNormals;
@@ -642,6 +643,9 @@ void EncodeIntoGBuffer( SurfaceData surfaceData
     smoothNormalData.perceptualRoughness = 1.0; // Unused
     EncodeIntoNormalBuffer(smoothNormalData, positionSS, outSmoothNormals);
     OUT_GBUFFER_LIGHT_LAYERS = float4(outSmoothNormals.xyz, builtinData.renderingLayers / 255.0);
+#else
+    OUT_GBUFFER_LIGHT_LAYERS = float4(0.0, 0.0, 0.0, builtinData.renderingLayers / 255.0);
+#endif
 #endif
 
 #ifdef SHADOWS_SHADOWMASK

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
@@ -635,7 +635,13 @@ void EncodeIntoGBuffer( SurfaceData surfaceData
     outGBuffer3 *= GetCurrentExposureMultiplier();
 
 #ifdef LIGHT_LAYERS
-    OUT_GBUFFER_LIGHT_LAYERS = float4(0.0, 0.0, 0.0, builtinData.renderingLayers / 255.0);
+    // fixme for some reason ifdef ENABLE_RAYTRACING was never being hit here. debug and add it later
+    NormalData smoothNormalData;
+    float4 outSmoothNormals;
+    smoothNormalData.normalWS = surfaceData.geomNormalWS.xyz;
+    smoothNormalData.perceptualRoughness = 1.0; // Unused
+    EncodeIntoNormalBuffer(smoothNormalData, positionSS, outSmoothNormals);
+    OUT_GBUFFER_LIGHT_LAYERS = float4(outSmoothNormals.xyz, builtinData.renderingLayers / 255.0);
 #endif
 
 #ifdef SHADOWS_SHADOWMASK

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -379,7 +379,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_MRTWithSSS = new RenderTargetIdentifier[2 + m_SSSBufferManager.sssBufferCount];
 #if ENABLE_RAYTRACING
             m_RayTracingManager.Init(m_Asset.renderPipelineSettings, m_Asset.renderPipelineResources, m_BlueNoise);
-            m_RaytracingReflections.Init(m_Asset, m_SkyManager, m_RayTracingManager, m_SharedRTManager);
+            m_RaytracingReflections.Init(m_Asset, m_SkyManager, m_RayTracingManager, m_SharedRTManager, m_GbufferManager);
             m_RaytracingShadows.Init(m_Asset, m_RayTracingManager, m_SharedRTManager, m_LightLoop, m_GbufferManager);
             m_RaytracingRenderer.Init(m_Asset, m_SkyManager, m_RayTracingManager, m_SharedRTManager);
             m_LightLoop.InitRaytracing(m_RayTracingManager);
@@ -826,6 +826,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             CoreUtils.SetKeyword(cmd, "LIGHT_LAYERS", hdCamera.frameSettings.IsEnabled(FrameSettingsField.LightLayers));
             cmd.SetGlobalInt(HDShaderIDs._EnableLightLayers, hdCamera.frameSettings.IsEnabled(FrameSettingsField.LightLayers) ? 1 : 0);
+
+#if ENABLE_RAYTRACING
+            CoreUtils.SetKeyword(cmd, "ENABLE_RAYTRACING", true); // Propagate scripting define to shader define
+#endif
 
             // configure keyword for both decal.shader and material
             if (m_Asset.renderPipelineSettings.supportDecals)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -827,10 +827,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             CoreUtils.SetKeyword(cmd, "LIGHT_LAYERS", hdCamera.frameSettings.IsEnabled(FrameSettingsField.LightLayers));
             cmd.SetGlobalInt(HDShaderIDs._EnableLightLayers, hdCamera.frameSettings.IsEnabled(FrameSettingsField.LightLayers) ? 1 : 0);
 
-#if ENABLE_RAYTRACING
-            CoreUtils.SetKeyword(cmd, "ENABLE_RAYTRACING", true); // Propagate scripting define to shader define
-#endif
-
             // configure keyword for both decal.shader and material
             if (m_Asset.renderPipelineSettings.supportDecals)
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingEnvironment.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingEnvironment.cs
@@ -74,8 +74,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // 1 ray for every 4 pixels
             QuarterRes,
             // Full integration
-            Integration
+            Integration,
+			// 1 spp with Nvidia filtering
+            Nvidia
         };
+
         public ReflectionsQuality reflQualityMode = ReflectionsQuality.QuarterRes;
 
         // Reflection Quarter Res Data
@@ -86,6 +89,27 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // Number of Samples for the integration
         [Range(1, 64)]
         public int reflNumMaxSamples = 8;
+
+        // Reflection Nvidia Filter Data
+        [Range(0.0f, 1.0f)]
+        public float lowerRoughnessTransitionPoint = 0.22f;
+        [Range(0.0f, 1.0f)]
+        public float upperRoughnessTransitionPoint = 0.27f;
+        [Range(0.0f, 1.0f)]
+        public float minSamplingBias = 0.7f;
+        [Range(0.0f, 1.0f)]
+        public float maxSamplingBias = 1.0f;
+        public bool useLogSpace = false;
+        [Range(0.0f, 5.0f)]
+        public float logSpaceParam = 1.0f;
+
+        public enum NormalWeightMode
+        {
+            None = 0,           // Ignore differences in normal
+            WorldSpace = 1,     // Use worldspace normal; has risk of filtering curved geometries
+            TangentSpace = 2    // Use normal differences in surface tangent space; best quality but requires smooth normal buffer as input
+        };
+        public NormalWeightMode normalWeightMode;
 
         /////////////////////////////////////////////////////////////////////////////////////////////////
         // Light Cluster

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
@@ -12,6 +12,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         SkyManager m_SkyManager = null;
         HDRaytracingManager m_RaytracingManager = null;
         SharedRTManager m_SharedRTManager = null;
+        GBufferManager m_GBufferManager = null; 
+
+        static readonly int _BumpNormalTexture = Shader.PropertyToID("_BumpNormalTexture");
+        static readonly int _SmoothNormalTexture = Shader.PropertyToID("_SmoothNormalTexture");
+        static readonly int _PackedSmoothNormals = Shader.PropertyToID("_PackedSmoothNormals");
 
         // Intermediate buffer that stores the reflection pre-denoising
         RTHandleSystem.RTHandle m_LightingTexture = null;
@@ -20,12 +25,18 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         RTHandleSystem.RTHandle m_MinBoundBuffer = null;
         RTHandleSystem.RTHandle m_MaxBoundBuffer = null;
 
+        // Additional textures for NVFilter
+        RTHandleSystem.RTHandle m_HitDistanceTexture = null;
+        RTHandleSystem.RTHandle m_BumpNormalTexture = null;
+        RTHandleSystem.RTHandle m_SmoothNormalTexture = null;
+
         // Light cluster structure
         public HDRaytracingLightCluster m_LightCluster = null;
 
         // String values
         const string m_RayGenHalfResName = "RayGenHalfRes";
         const string m_RayGenIntegrationName = "RayGenIntegration";
+        const string m_RayGenNVFilterName = "RayGenNVFilter";
         const string m_MissShaderName = "MissShaderReflections";
         const string m_ClosestHitShaderName = "ClosestHitMain";
 
@@ -33,7 +44,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
         }
 
-        public void Init(HDRenderPipelineAsset asset, SkyManager skyManager, HDRaytracingManager raytracingManager, SharedRTManager sharedRTManager)
+        public void Init(HDRenderPipelineAsset asset, SkyManager skyManager, HDRaytracingManager raytracingManager, SharedRTManager sharedRTManager, GBufferManager gBufferManager)
         {
             // Keep track of the pipeline asset
             m_PipelineAsset = asset;
@@ -46,6 +57,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             // Keep track of the shared rt manager
             m_SharedRTManager = sharedRTManager;
+
+            // Keep track of the GBuffer manager
+            m_GBufferManager = gBufferManager;
+
+            // Additional textures needed for Nvidia filtering
+            // TODO standardize GW filter inputs and allocate shared textures in RaytracingManager
+            // TODO modify filter library to accommodate existing textures instead of allocating new ones
+            m_HitDistanceTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16_SFloat, enableRandomWrite: true, useMipMap: false, name: "HitDistanceTexture");
+            // Normal buffer stores octal bumpmapped normal + octal perceptual roughness. Filter expects unpacked geometric normals and octal roughness = perceptualRoughness^2. 
+            m_BumpNormalTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useMipMap: false, name: "BumpNormalTexture");
+            m_SmoothNormalTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useMipMap: false, name: "SmoothNormalsTexture");
 
             m_LightingTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "LightingBuffer");
             m_HitPdfTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "HitPdfBuffer");
@@ -69,6 +91,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             m_LightCluster.ReleaseResources();
             m_LightCluster = null;
+
+            RTHandles.Release(m_HitDistanceTexture);
+            RTHandles.Release(m_BumpNormalTexture);
+            RTHandles.Release(m_SmoothNormalTexture);
 
             RTHandles.Release(m_MinBoundBuffer);
             RTHandles.Release(m_MaxBoundBuffer);
@@ -108,6 +134,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     targetRayGen = m_RayGenIntegrationName;
                 };
                 break;
+                case HDRaytracingEnvironment.ReflectionsQuality.Nvidia:
+                {
+                    targetRayGen = m_RayGenNVFilterName;
+                };
+                break;
             }
 
             // Evaluate the light cluster
@@ -143,6 +174,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._SsrHitPointTexture, m_HitPdfTexture);
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._DepthTexture, m_SharedRTManager.GetDepthStencilBuffer());
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._NormalBufferTexture, m_SharedRTManager.GetNormalBuffer());
+            cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, _PackedSmoothNormals, m_PipelineAsset.renderPipelineSettings.supportLightLayers ? m_GBufferManager.GetLightLayersBuffer(0) : m_SharedRTManager.GetNormalBuffer());
+
+            // Data required for nvidia filter
+            cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._RaytracingHitDistanceTexture, m_HitDistanceTexture);
+            cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, _BumpNormalTexture, m_BumpNormalTexture);
+            cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, _SmoothNormalTexture, m_SmoothNormalTexture);
 
             // Compute the pixel spread value
             float pixelSpreadAngle = Mathf.Atan(2.0f * Mathf.Tan(hdCamera.camera.fieldOfView * Mathf.PI / 360.0f) / Mathf.Min(hdCamera.actualWidth, hdCamera.actualHeight));
@@ -179,6 +216,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     heightResolution = (uint)hdCamera.actualHeight;
                 };
                 break;
+                case HDRaytracingEnvironment.ReflectionsQuality.Nvidia:
+                {
+                    widthResolution = (uint)hdCamera.actualWidth;
+                    heightResolution = (uint)hdCamera.actualHeight;
+                };
+                break;
             }
 
             // Run the calculus
@@ -188,6 +231,26 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 switch (rtEnvironement.reflQualityMode)
                 {
+                    case HDRaytracingEnvironment.ReflectionsQuality.Nvidia:
+                    {
+                        cmd.FilterReflectionTexture(m_LightingTexture /*raw reflections*/, m_HitDistanceTexture /*hitT*/, m_SharedRTManager.GetDepthStencilBuffer() /*reverseZ depth*/, 
+                                                    m_BumpNormalTexture /*Bumpmapped normals*/, m_PipelineAsset.renderPipelineSettings.supportLightLayers ? m_SmoothNormalTexture : m_BumpNormalTexture /*Smooth normals*/, m_SharedRTManager.GetNormalBuffer() /*Octal roughness (in alpha channel)*/,
+                                                    outputTexture /*filtered reflections*/,
+                                                    hdCamera.viewMatrix, hdCamera.projMatrix, hdCamera.viewProjMatrix, hdCamera.viewProjMatrix.inverse,
+                                                    rtEnvironement.lowerRoughnessTransitionPoint, rtEnvironement.upperRoughnessTransitionPoint,
+                                                    rtEnvironement.minSamplingBias, rtEnvironement.maxSamplingBias,
+                                                    rtEnvironement.useLogSpace, rtEnvironement.logSpaceParam,
+                                                    (uint)rtEnvironement.normalWeightMode);
+
+                        ComputeShader postPassCS = m_PipelineAsset.renderPipelineResources.shaders.nvReflectionsPostPassCS;
+                        int mainKernel = postPassCS.FindKernel("CSMain");
+                        cmd.SetComputeTextureParam(postPassCS, mainKernel, "_Result", outputTexture);
+                        cmd.SetComputeFloatParam(postPassCS, "_RaytracingRayMaxLength", rtEnvironement.aoRayLength);
+                        uint thdX, thdY, thdZ;
+                        postPassCS.GetKernelThreadGroupSizes(mainKernel, out thdX, out thdY, out thdZ);
+                        cmd.DispatchCompute(postPassCS, mainKernel, hdCamera.actualWidth / (int)thdX, hdCamera.actualHeight / (int)thdY, 1);
+                    }
+                    break;
                     case HDRaytracingEnvironment.ReflectionsQuality.QuarterRes:
                     {
                         // Fetch the right filter to use

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
@@ -174,7 +174,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._SsrHitPointTexture, m_HitPdfTexture);
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._DepthTexture, m_SharedRTManager.GetDepthStencilBuffer());
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._NormalBufferTexture, m_SharedRTManager.GetNormalBuffer());
-            cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, _PackedSmoothNormals, m_PipelineAsset.renderPipelineSettings.supportLightLayers ? m_GBufferManager.GetLightLayersBuffer(0) : m_SharedRTManager.GetNormalBuffer());
+            bool geomNormalsAvailable = m_PipelineAsset.renderPipelineSettings.supportLightLayers && (hdCamera.frameSettings.litShaderMode == LitShaderMode.Deferred);
+            cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, _PackedSmoothNormals, (geomNormalsAvailable) ? m_GBufferManager.GetLightLayersBuffer(0) : m_SharedRTManager.GetNormalBuffer());
 
             // Data required for nvidia filter
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._RaytracingHitDistanceTexture, m_HitDistanceTexture);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/NVFilterPostPass.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/NVFilterPostPass.compute
@@ -1,0 +1,12 @@
+#pragma kernel CSMain
+
+RWTexture2D<float4> _Result;
+float               _RaytracingRayMaxLength;
+
+[numthreads(8,8,1)]
+void CSMain (uint3 id : SV_DispatchThreadID)
+{
+    // TODO: insert actual code here!
+    float convertHitTToAlpha = (_RaytracingRayMaxLength - _Result[id.xy].w) / _RaytracingRayMaxLength;
+    _Result[id.xy] = float4(_Result[id.xy].x, _Result[id.xy].y, _Result[id.xy].z, 1.0);
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/NVFilterPostPass.compute.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/NVFilterPostPass.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc7c13b30d1c9ab40872f5c3d66bc71b
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 262148
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace
@@ -25,6 +25,7 @@
 // The target acceleration structure that we will evaluate the reflexion in
 Texture2D<float>                        _StencilTexture;
 Texture2D<float>                        _DepthTexture;
+Texture2D<float4>                       _PackedSmoothNormals;
 
 // Flag value that defines if a given pixel recieves reflections or not
 // int                                       _SsrStencilExclusionValue;
@@ -33,11 +34,95 @@ Texture2D<float>                        _DepthTexture;
 RWTexture2D<float4>                     _SsrLightingTextureRW;
 RWTexture2D<float4>                     _SsrHitPointTexture;
 
+// Needed for NVReflectionFilter
+RWTexture2D<float4> _BumpNormalTexture;
+RWTexture2D<float4> _SmoothNormalTexture;
+RWTexture2D<float>  _RaytracingHitDistanceTexture;
+
 [shader("miss")]
 void MissShaderReflections(inout RayIntersection rayIntersection : SV_RayPayload)
 {
     rayIntersection.color = SAMPLE_TEXTURECUBE_ARRAY_LOD(_SkyTexture, s_trilinear_clamp_sampler, rayIntersection.incidentDirection, 0.0f, 0);
     rayIntersection.t = _RaytracingRayMaxLength;
+}
+
+[shader("raygeneration")]
+void RayGenNVFilter()
+{
+    // Grab the dimensions of the current dispatch
+    uint3 LaunchIndex = DispatchRaysIndex();
+    uint3 LaunchDim = DispatchRaysDimensions();
+    
+    // Compute the pixel coordinate to evaluate
+    uint2 currentCoord = uint2(LaunchIndex.x, LaunchDim.y - LaunchIndex.y - 1);
+    
+    // Read the depth value
+    float depthValue  = _DepthTexture[currentCoord];
+
+    // Clear the textures 
+    _SsrLightingTextureRW[currentCoord] = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    _BumpNormalTexture[currentCoord] = float4(0.0f, 0.0f, 0.0f, 1.0f);
+    _SmoothNormalTexture[currentCoord] = float4(0.0f, 0.0f, 0.0f, 1.0f);
+    _RaytracingHitDistanceTexture[currentCoord] = 0.0f; 
+
+    // This point is part of the background, we don't really care 
+    if(depthValue == 0.0f)
+        return;
+
+    // Convert this to a world space position
+    PositionInputs posInput = GetPositionInput(currentCoord, 1.0f/LaunchDim.xy, depthValue, _InvViewProjMatrix, _ViewMatrix, 0);
+    float distanceToCamera = length(posInput.positionWS);
+    float3 positionWS = GetAbsolutePositionWS(posInput.positionWS);
+
+    // Compute the incident vector on the surfaces
+    float3 viewWS = normalize(_WorldSpaceCameraPos - positionWS);
+    
+    // Decode the world space normal
+    NormalData normalData;    
+    DecodeFromNormalBuffer(currentCoord, normalData);
+    // If this value is beyond the smothness that we allow, no need to compute it
+    if(_RaytracingReflectionMinSmoothness > PerceptualSmoothnessToPerceptualRoughness(normalData.perceptualRoughness))
+        return;
+
+    // Create the local ortho basis
+    float3x3 localToWorld = GetLocalFrame(normalData.normalWS);
+    
+    // Store unpacked normals and roughness for filtering
+    _BumpNormalTexture[currentCoord].xyz = normalData.normalWS;
+    _BumpNormalTexture[currentCoord].w = 1.0;
+    NormalData unpackedSmoothNormals;
+    DecodeFromNormalBuffer(_PackedSmoothNormals[currentCoord], currentCoord, unpackedSmoothNormals);
+    _SmoothNormalTexture[currentCoord].xyz = unpackedSmoothNormals.normalWS;
+    _SmoothNormalTexture[currentCoord].w = 1.0;
+    
+    // Create the ray descriptor for this pixel
+    RayDesc rayDescriptor;
+    rayDescriptor.Origin = positionWS + normalData.normalWS * _RaytracingRayBias;
+    rayDescriptor.Direction = reflect(-viewWS, normalData.normalWS).xyz;
+    rayDescriptor.TMin = 0;
+    rayDescriptor.TMax = _RaytracingRayMaxLength;
+
+    // Create and init the RayIntersection structure for this
+    RayIntersection rayIntersection;
+    rayIntersection.color = float3(0.0, 0.0, 0.0);
+    rayIntersection.incidentDirection = rayDescriptor.Direction;
+    rayIntersection.origin = rayDescriptor.Origin;
+    rayIntersection.t = -1.0f;
+
+    // In order to achieve filtering for the textures, we need to compute the spread angle of the pixel
+    rayIntersection.cone.spreadAngle = _RaytracingPixelSpreadAngle;
+    rayIntersection.cone.width = distanceToCamera * _RaytracingPixelSpreadAngle;
+    
+    // Evaluate the ray intersection
+    TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, rayDescriptor, rayIntersection);
+    
+    _RaytracingHitDistanceTexture[currentCoord] = rayIntersection.t;
+
+    // Make sure we pre-expose and then we clamp
+    float3 exposedValue = clamp(rayIntersection.color * GetCurrentExposureMultiplier(), 0.0, _RaytracingIntensityClamp);
+
+    // We store the clamped, pre-exposed valuein the first texture
+    _SsrLightingTextureRW[currentCoord] = float4(exposedValue, 1.0f);
 }
 
 [shader("raygeneration")]

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
@@ -139,6 +139,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             public ComputeShader reflectionBilateralFilterCS;
             public ComputeShader lightClusterBuildCS;
             public ComputeShader lightClusterDebugCS;
+            public ComputeShader nvReflectionsPostPassCS;
 #endif
         }
 
@@ -321,9 +322,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 jointBilateralFilterCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/JointBilateralFilter.compute"),
                 reflectionBilateralFilterCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingReflectionFilter.compute"),
                 lightClusterBuildCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingLightCluster.compute"),
-                lightClusterDebugCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/DebugLightCluster.compute")
+                lightClusterDebugCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/DebugLightCluster.compute"),
+                nvReflectionsPostPassCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/NVFilterPostPass.compute")
 #endif
-        };
+            };
 
             // Materials
             materials = new MaterialResources


### PR DESCRIPTION
### Purpose of this PR
![image](https://user-images.githubusercontent.com/3450690/52679307-8e3b0100-2ee9-11e9-88d2-fb3602ecd399.png)

---
### Release Notes
- Added smooth raygeneration for raytraced reflections
- Added nvidia filtering for smooth reflections
- Requires graphics/raytracing/dxr/reflectionfilter Editor branch
- Assumes that input roughness should be perceptual roughness, not roughness^2
- Reflections on surfaces that have normal textures don't get properly filtered, since smooth normals are used

---
### Testing status
Checked input textures in PIX to make sure they were generated correctly.
Adjusted roughness on surfaces to ensure that reflection was being filtered as needed.

---
### Overall Product Risks
**Technical Risk**: 
Low- Allocating new textures, but only affects RAYTRACING_ENABLED

**Halo Effect**: 
Low- changes are contained by case-statements and so shouldn't affect other reflection modes

---
### Comments to reviewers
Maybe we should give the quality mode a more descriptive name? 
Once this and my other PR are cleaned up I can handle merging between my two PRs- to make this compatible with CountRays I just need to add logic to my new raygeneration code. 

I've also been having issues with the GBuffer pass never dropping into #if ENABLE_RAYTRACING.
