### PR TITLE
Fix - Minimum influence extent for probes

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/Volume/InfluenceVolume.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Reflection/Volume/InfluenceVolume.cs
@@ -208,9 +208,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     default:
                     case InfluenceShape.Box:
-                    return boxSize * 0.5f;
+                        return Vector3.Max(Vector3.one * 0.0001f, boxSize * 0.5f);
                     case InfluenceShape.Sphere:
-                    return sphereRadius * Vector3.one;
+                        return Mathf.Max(0.0001f, sphereRadius) * Vector3.one;
             }
         }
     }


### PR DESCRIPTION
### Purpose of this PR
Some weird computation happens when the influence extent has a value below 0.0001f.
Now it can't go below an it stay in a range where the algorithm works.

[Katana](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixInfluenceSize&automation-tools_branch=add-platform-filter&unity_branch=trunk)
---
### Release Notes


---
### Testing status
**Katana Tests**: Run ABV

**Manual Tests**: Manual Local test

**Automated Tests**: -

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: Low
Only probes with near 0 influence size are impacted.

---
### Comments to reviewers

