### PR TITLE
Added debug display for rays/frame

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.cs
@@ -81,7 +81,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             public FalseColorDebugSettings falseColorDebugSettings = new FalseColorDebugSettings();
             public DecalsDebugSettings decalsDebugSettings = new DecalsDebugSettings();
             public MSAASamples msaaSamples = MSAASamples.None;
-            
+
+            // Raytracing
+#if ENABLE_RAYTRACING
+            public bool countRays = false;
+            public Color rayCountFontColor = Color.white;
+            public bool showRayCountTex = false;
+            public int countRayPassIndex;
+#endif
+
             public int debugCameraToFreeze = 0;
 
             //saved enum fields for when repainting
@@ -312,6 +320,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 new DebugUI.Value { displayName = "Frame Rate (fps)", getter = () => 1f / Time.smoothDeltaTime, refreshRate = 1f / 30f },
                 new DebugUI.Value { displayName = "Frame Time (ms)", getter = () => Time.smoothDeltaTime * 1000f, refreshRate = 1f / 30f }
+#if ENABLE_RAYTRACING
+                ,
+                new DebugUI.BoolField { displayName = "Display Ray Count", getter = () => data.countRays, setter = value => data.countRays = value, onValueChanged = RefreshDisplayStatsDebug },
+                new DebugUI.ColorField { displayName = "Ray Count Font Color", getter = () => data.rayCountFontColor, setter = value => data.rayCountFontColor = value }
+#endif
             };
 
             var panel = DebugManager.instance.GetPanel(k_PanelDisplayStats, true);
@@ -347,6 +360,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_DebugMaterialItems = list.ToArray();
             var panel = DebugManager.instance.GetPanel(k_PanelMaterials, true);
             panel.children.Add(m_DebugMaterialItems);
+        }
+
+        void RefreshDisplayStatsDebug<T>(DebugUI.Field<T> field, T value)
+        {
+            UnregisterDebugItems(k_PanelDisplayStats, m_DebugDisplayStatsItems);
+            RegisterDisplayStatsDebug();
         }
 
         // For now we just rebuild the lighting panel if needed, but ultimately it could be done in a better way

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/RayCountManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/RayCountManager.cs
@@ -1,0 +1,109 @@
+using UnityEngine.Rendering;
+
+namespace UnityEngine.Experimental.Rendering.HDPipeline
+{
+#if ENABLE_RAYTRACING
+    public class RayCountManager
+    {
+        // Ray count UAV
+        RTHandleSystem.RTHandle m_RayCountTex = null;
+        static Texture2D s_DebugFontTex = null;
+        static ComputeBuffer s_TotalRayCountBuffer = null;
+
+        // Material used to blit the output texture into the camera render target
+        Material m_Blit;
+        Material m_DrawRayCount;
+        MaterialPropertyBlock m_DrawRayCountProperties = new MaterialPropertyBlock();
+        // Raycount shader
+        ComputeShader m_RayCountCompute;
+        bool m_RayCountEnabled;
+
+        int _TotalRayCountBuffer = Shader.PropertyToID("_TotalRayCountBuffer");
+        int _FontColor = Shader.PropertyToID("_FontColor");
+        
+        public void Init(RenderPipelineResources renderPipelineResources)
+        {
+            m_Blit = CoreUtils.CreateEngineMaterial(renderPipelineResources.shaders.blitPS);
+            m_DrawRayCount = CoreUtils.CreateEngineMaterial(renderPipelineResources.shaders.debugViewRayCountPS);
+            m_RayCountCompute = renderPipelineResources.shaders.countTracedRays;
+            s_DebugFontTex = renderPipelineResources.textures.debugFontTex;
+            // UINT textures must use UINT32, since groupshared uint used to synchronize counts is allocated as a UINT32
+            m_RayCountTex = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R32G32B32A32_UInt, enableRandomWrite: true, useMipMap: false, name: "RayCountTex");
+            s_TotalRayCountBuffer = new ComputeBuffer(3, sizeof(uint));
+        }
+
+        public void Release()
+        {
+            CoreUtils.Destroy(m_Blit);
+            CoreUtils.Destroy(m_DrawRayCount);
+
+            RTHandles.Release(m_RayCountTex);
+            CoreUtils.SafeRelease(s_TotalRayCountBuffer);
+        }
+
+        public RTHandleSystem.RTHandle rayCountTex
+        {
+            get
+            {
+                return m_RayCountTex;
+            }
+        }
+
+        public int rayCountEnabled
+        {
+            get
+            {
+                return m_RayCountEnabled ? 1 : 0;
+            }
+        }
+
+        public void ClearRayCount(CommandBuffer cmd, HDCamera camera)
+        {
+            if (m_RayCountEnabled)
+            {
+                int clearBufferKernelIdx = m_RayCountCompute.FindKernel("CS_Clear");
+                cmd.SetComputeBufferParam(m_RayCountCompute, clearBufferKernelIdx, _TotalRayCountBuffer, s_TotalRayCountBuffer);
+                cmd.DispatchCompute(m_RayCountCompute, clearBufferKernelIdx, 1, 1, 1);
+
+                HDUtils.SetRenderTarget(cmd, camera, m_RayCountTex, ClearFlag.Color);
+            }
+        }
+
+        public void Update(CommandBuffer cmd, HDCamera camera, bool rayCountEnabled)
+        {
+            m_RayCountEnabled = rayCountEnabled;
+            ClearRayCount(cmd, camera);
+        }
+
+        public void RenderRayCount(CommandBuffer cmd, HDCamera camera, RTHandleSystem.RTHandle colorTex, Color fontColor)
+        {
+            if (m_RayCountEnabled)
+            {
+                using (new ProfilingSample(cmd, "Raytracing Debug Overlay", CustomSamplerId.RaytracingDebug.GetSampler()))
+                {
+                    int width = camera.actualWidth;
+                    int height = camera.actualHeight;
+
+                    // Sum across all rays per pixel
+                    int countKernelIdx = m_RayCountCompute.FindKernel("CS_CountRays");
+                    uint groupSizeX = 0, groupSizeY = 0, groupSizeZ = 0;
+                    m_RayCountCompute.GetKernelThreadGroupSizes(countKernelIdx, out groupSizeX, out groupSizeY, out groupSizeZ);
+                    int dispatchWidth = 0, dispatchHeight = 0;
+                    dispatchWidth = (int)((width + groupSizeX - 1) / groupSizeX);
+                    dispatchHeight = (int)((height + groupSizeY - 1) / groupSizeY);
+                    cmd.SetComputeTextureParam(m_RayCountCompute, countKernelIdx, HDShaderIDs._RayCountTexture, m_RayCountTex);
+                    cmd.SetComputeBufferParam(m_RayCountCompute, countKernelIdx, _TotalRayCountBuffer, s_TotalRayCountBuffer);
+                    cmd.DispatchCompute(m_RayCountCompute, countKernelIdx, dispatchWidth, dispatchHeight, 1);
+
+                    // Draw overlay
+                    m_DrawRayCountProperties.SetTexture(HDShaderIDs._CameraColorTexture, colorTex);
+                    m_DrawRayCountProperties.SetTexture(HDShaderIDs._DebugFont, s_DebugFontTex);
+                    m_DrawRayCountProperties.SetColor(_FontColor, fontColor);
+                    m_DrawRayCount.SetBuffer(_TotalRayCountBuffer, s_TotalRayCountBuffer);
+                    CoreUtils.DrawFullScreen(cmd, m_DrawRayCount, m_DrawRayCountProperties);
+                }
+            }
+        }
+    }
+#endif
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/RayCountManager.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/RayCountManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f01d095bc3d9e54f91f0506b1c63cb1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDCustomSamplerId.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDCustomSamplerId.cs
@@ -62,8 +62,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         RaytracingIntegrateReflection,
         RaytracingFilterReflection,
         RaytracingAmbientOcclusion,
+        RaytracingFilterAO,
         RaytracingShadowIntegration,
         RaytracingShadowCombination,
+        RaytracingDebug,
 
         // Profile sampler for tile pass
         TPPrepareLightsForGPU,

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1398,6 +1398,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_CurrentDebugDisplaySettings = m_DebugDisplaySettings;
             }
 
+#if ENABLE_RAYTRACING
+            // Must update after getting DebugDisplaySettings
+            m_RayTracingManager.rayCountManager.Update(cmd, hdCamera, m_CurrentDebugDisplaySettings.data.countRays);
+#endif
+
             m_DbufferManager.enableDecals = false;
             if (hdCamera.frameSettings.IsEnabled(FrameSettingsField.Decals))
             {
@@ -3022,8 +3027,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     HDUtils.NextOverlayCoord(ref x, ref y, overlaySize, overlaySize, hdCamera);
                 }
 
+#if ENABLE_RAYTRACING
+                m_RayTracingManager.rayCountManager.RenderRayCount(cmd, hdCamera, m_CameraColorBuffer, m_CurrentDebugDisplaySettings.data.rayCountFontColor);
+#endif
+
                 m_LightLoop.RenderDebugOverlay(hdCamera, cmd, m_CurrentDebugDisplaySettings, ref x, ref y, overlaySize, hdCamera.actualWidth, cullResults, m_IntermediateAfterPostProcessBuffer);
 
+                
                 DecalSystem.instance.RenderDebugOverlay(hdCamera, cmd, m_CurrentDebugDisplaySettings, ref x, ref y, overlaySize, hdCamera.actualWidth);
 
                 if (m_CurrentDebugDisplaySettings.data.colorPickerDebugSettings.colorPickerMode != ColorPickerDebugMode.None || m_CurrentDebugDisplaySettings.data.falseColorDebugSettings.falseColor || m_CurrentDebugDisplaySettings.data.lightingDebugSettings.debugLightingMode == DebugLightingMode.LuminanceMeter)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -283,6 +283,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if(needUpdate)
             {
                 UnityEditor.PlayerSettings.SetScriptingDefineSymbolsForGroup(UnityEditor.BuildTargetGroup.Standalone, string.Join(";", defineArray.ToArray()));
+#if ENABLE_RAYTRACING
+                m_RenderPipelineResources.LoadRayTraceShaders();
+#endif
             }
 #endif
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -493,6 +493,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _AccumulatedFrameTexture         = Shader.PropertyToID("_AccumulatedFrameTexture");
         public static readonly int _TemporalAccumuationWeight       = Shader.PropertyToID("_TemporalAccumuationWeight");
 
+        public static readonly int _RayCountTexture                 = Shader.PropertyToID("_RayCountTexture");
+        public static readonly int _RayCountEnabled                 = Shader.PropertyToID("_RayCountEnabled");
 #else
         public static readonly int _RaytracedAreaShadow             = Shader.PropertyToID("_RaytracedAreaShadow");
 #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingAmbientOcclusion.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingAmbientOcclusion.cs
@@ -87,7 +87,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 SetDefaultAmbientOcclusionTexture(cmd);
                 return;
             }
-            
+
             // Define the shader pass to use for the reflection pass
             cmd.SetRaytracingShaderPass(aoShader, "VisibilityDXR");
 
@@ -113,6 +113,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetRaytracingTextureParam(aoShader, m_RayGenShaderName, HDShaderIDs._AmbientOcclusionTextureRW, m_IntermediateBuffer);
             cmd.SetRaytracingTextureParam(aoShader, m_RayGenShaderName, HDShaderIDs._DepthTexture, m_SharedRTManager.GetDepthStencilBuffer());
             cmd.SetRaytracingTextureParam(aoShader, m_RayGenShaderName, HDShaderIDs._NormalBufferTexture, m_SharedRTManager.GetNormalBuffer());
+
+            cmd.SetRaytracingIntParam(aoShader, HDShaderIDs._RayCountEnabled, m_RaytracingManager.rayCountManager.rayCountEnabled);
+            cmd.SetRaytracingTextureParam(aoShader, m_RayGenShaderName, HDShaderIDs._RayCountTexture, m_RaytracingManager.rayCountManager.rayCountTex);
 
             // Run the calculus
             cmd.DispatchRays(aoShader, m_RayGenShaderName, (uint)hdCamera.actualWidth, (uint)hdCamera.actualHeight, 1);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
@@ -12,6 +12,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     {
         // The list of raytracing environments that have been registered
         List<HDRaytracingEnvironment> m_Environments = null;
+        RayCountManager m_RayCountManager = new RayCountManager();
+        public RayCountManager rayCountManager
+        {
+            get
+            {
+                return m_RayCountManager;
+            }
+        }
 
         // Flag that defines if we should rebuild everything (when adding or removing an environment)
         bool m_DirtyEnvironment = false;
@@ -183,6 +191,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 RegisterFilter(filterArray[filterIdx]);
             }
 
+            m_RayCountManager.Init(resources);
+
 #if UNITY_EDITOR
             // We need to invalidate the acceleration structures in case the hierarchy changed
             EditorApplication.hierarchyChanged += OnHierarchyChanged;
@@ -223,6 +233,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 HDRayTracingSubScene currentSubScene = m_SubScenes[m_LayerMasks[subSceneIndex]];
                 DestroySubSceneStructure(ref currentSubScene);
             }
+            m_RayCountManager.Release();
         }
 
         public void DestroySubSceneStructure(ref HDRayTracingSubScene subScene)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
@@ -144,6 +144,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._DepthTexture, m_SharedRTManager.GetDepthStencilBuffer());
             cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._NormalBufferTexture, m_SharedRTManager.GetNormalBuffer());
 
+            // Set ray count tex
+            cmd.SetRaytracingIntParam(reflectionShader, HDShaderIDs._RayCountEnabled, m_RaytracingManager.rayCountManager.rayCountEnabled);
+            cmd.SetRaytracingTextureParam(reflectionShader, targetRayGen, HDShaderIDs._RayCountTexture, m_RaytracingManager.rayCountManager.rayCountTex);
+
             // Compute the pixel spread value
             float pixelSpreadAngle = Mathf.Atan(2.0f * Mathf.Tan(hdCamera.camera.fieldOfView * Mathf.PI / 360.0f) / Mathf.Min(hdCamera.actualWidth, hdCamera.actualHeight));
             cmd.SetRaytracingFloatParam(reflectionShader, HDShaderIDs._RaytracingPixelSpreadAngle, pixelSpreadAngle);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingShadowManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingShadowManager.cs
@@ -166,6 +166,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     cmd.SetRaytracingTextureParam(shadowsShader, m_RayGenShaderName, HDShaderIDs._GBufferTexture[1], m_GbufferManager.GetBuffer(1));
                     cmd.SetRaytracingTextureParam(shadowsShader, m_RayGenShaderName, HDShaderIDs._GBufferTexture[2], m_GbufferManager.GetBuffer(2));
                     cmd.SetRaytracingTextureParam(shadowsShader, m_RayGenShaderName, HDShaderIDs._GBufferTexture[3], m_GbufferManager.GetBuffer(3));
+                    cmd.SetRaytracingIntParam(shadowsShader, HDShaderIDs._RayCountEnabled, m_RaytracingManager.rayCountManager.rayCountEnabled);
+                    cmd.SetRaytracingTextureParam(shadowsShader, m_RayGenShaderName, HDShaderIDs._RayCountTexture, m_RaytracingManager.rayCountManager.rayCountTex);
 
                     // Set the output textures
                     cmd.SetRaytracingTextureParam(shadowsShader, m_RayGenShaderName, _SNBuffer, m_SNBuffer);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/CountTracedRays.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/CountTracedRays.compute
@@ -1,0 +1,53 @@
+#pragma kernel CS_CountRays
+#pragma kernel CS_Clear
+
+#pragma only_renderers d3d11
+
+RWTexture2D<uint4> _RayCountTexture;
+RWStructuredBuffer<uint> _TotalRayCountBuffer;
+
+groupshared uint aoRayCountPerThreadGroup;
+groupshared uint reflectionRayCountPerThreadGroup;
+groupshared uint areaShadowRayCountPerThreadGroup;
+
+[numthreads(1,1,1)]
+void CS_Clear(uint3 globalID : SV_DispatchThreadID)
+{
+    _TotalRayCountBuffer[0] = 0;
+    _TotalRayCountBuffer[1] = 0;
+    _TotalRayCountBuffer[2] = 0;
+}
+
+[numthreads(8,8,1)]
+void CS_CountRays(uint3 globalId : SV_DispatchThreadID, uint3 localId : SV_GroupThreadID)
+{
+    // CS_CountRays reads from a texture holding ray count per pixel
+    // and sums first across all pixels in a threadgroup,
+    // and then across all threadgroups. Barriers are used to prevent contention.
+
+    if (localId.x == 0 && localId.y == 0)
+    {
+        aoRayCountPerThreadGroup = 0;
+        reflectionRayCountPerThreadGroup = 0;
+        areaShadowRayCountPerThreadGroup = 0;
+    }
+		
+    GroupMemoryBarrierWithGroupSync();
+	
+    const uint aoRayCount           = (uint)_RayCountTexture[globalId.xy].x;
+    const uint reflectionRayCount   = (uint)_RayCountTexture[globalId.xy].y;
+    const uint areaShadowRayCount   = (uint)_RayCountTexture[globalId.xy].z;
+	
+    InterlockedAdd(aoRayCountPerThreadGroup,            aoRayCount);
+    InterlockedAdd(reflectionRayCountPerThreadGroup,    reflectionRayCount);
+    InterlockedAdd(areaShadowRayCountPerThreadGroup,    areaShadowRayCount);
+	
+    GroupMemoryBarrierWithGroupSync();
+		
+    if (localId.x == 0 && localId.y == 0)
+    {
+        InterlockedAdd(_TotalRayCountBuffer[0], aoRayCountPerThreadGroup);
+        InterlockedAdd(_TotalRayCountBuffer[1], reflectionRayCountPerThreadGroup);
+        InterlockedAdd(_TotalRayCountBuffer[2], areaShadowRayCountPerThreadGroup);
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/CountTracedRays.compute.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/CountTracedRays.compute.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 3ce144cff5783da45aa5d4fdc2da14b7
-NativeFormatImporter:
+guid: e1f3fa867f1dfbd4ab7dd4d39d2b96d8
+ComputeShaderImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
+  currentAPIMask: 262148
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/DebugViewRayCount.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/DebugViewRayCount.shader
@@ -1,0 +1,184 @@
+Shader "Hidden/HDRP/DebugViewRayCount"
+{
+    Properties
+    {
+        _CameraColorTexture("_CameraColorTexture", 2D) = "white" {}
+        _FontColor("_FontColor", Color) = (1,1,1,1)
+    }
+        SubShader
+        {
+            Tags{ "RenderPipeline" = "HDRenderPipeline" }
+            Pass
+            {
+                ZWrite Off
+                Cull Off
+                ZTest Always
+                Blend SrcAlpha OneMinusSrcAlpha
+
+                HLSLPROGRAM
+                #pragma target 4.5
+                #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+
+                #pragma vertex Vert
+                #pragma fragment Frag
+
+            //-------------------------------------------------------------------------------------
+            // Include
+            //-------------------------------------------------------------------------------------
+
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
+
+            //-------------------------------------------------------------------------------------
+            // variable declaration
+            //-------------------------------------------------------------------------------------
+
+            StructuredBuffer<uint> _TotalRayCountBuffer;
+            TEXTURE2D(_CameraColorTexture);
+            float4 _FontColor;
+
+            struct Attributes
+            {
+                uint vertexID : SV_VertexID;
+            };
+
+            struct Varyings
+            {
+                float4  positionCS  : SV_POSITION;
+                float2  texcoord    : TEXCOORD0;
+            };
+
+            Varyings Vert(Attributes input)
+            {
+                Varyings output;
+                output.positionCS = GetFullScreenTriangleVertexPosition(input.vertexID);
+                output.texcoord = GetFullScreenTriangleTexCoord(input.vertexID);
+                return output;
+            }
+
+            float4 AlphaBlend(float4 c0, float4 c1) // c1 over c0
+            {
+                return float4(lerp(c0.rgb, c1.rgb, c1.a), c0.a + c1.a - c0.a * c1.a);
+            }
+            
+            float4 Frag(Varyings input) : SV_Target
+            {
+                bool flipY = ShouldFlipDebugTexture();
+
+                // Display message offset:
+                int displayTextOffsetX = 1.5 * DEBUG_FONT_TEXT_WIDTH;
+                int displayTextOffsetY;
+                if (flipY)
+                {
+                    input.texcoord.y = 1.0 - input.texcoord.y;
+                    displayTextOffsetY = DEBUG_FONT_TEXT_HEIGHT;
+                }
+                else
+                {
+                    displayTextOffsetY = -DEBUG_FONT_TEXT_HEIGHT;
+                }
+                // Get MRays/frame
+                float aoMRays = (float)_TotalRayCountBuffer[0] / (1000.0f * 1000.0f);
+                float reflectionMRays = (float)_TotalRayCountBuffer[1] / (1000.0f * 1000.0f);
+                float areaShadowMRays = (float)_TotalRayCountBuffer[2] / (1000.0f * 1000.0f);
+				float totalMRays = aoMRays + reflectionMRays + areaShadowMRays;
+
+                uint2 displayUnormCoord = uint2(displayTextOffsetX, abs(displayTextOffsetY) * 4);
+                uint2 unormCoord = input.positionCS.xy;
+                float3 fontColor = _FontColor.rgb;
+                float4 result = LOAD_TEXTURE2D(_CameraColorTexture, input.texcoord.xy * _ScreenSize.xy); //float4(0.0, 0.0, 0.0, 1.0);
+
+                DrawCharacter('A', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('O', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter(':', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawFloat(aoMRays, fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('M', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('R', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('y', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('s', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('/', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('f', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('r', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('m', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('e', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+
+                displayUnormCoord = uint2(displayTextOffsetX, abs(displayTextOffsetY) * 3);
+                DrawCharacter('R', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('e', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('f', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('l', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('e', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('c', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('t', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('i', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('o', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('n', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter(':', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawFloat(reflectionMRays, fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('M', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('R', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('y', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('s', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('/', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('f', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('r', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('m', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('e', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+
+                displayUnormCoord = uint2(displayTextOffsetX, abs(displayTextOffsetY) * 2);
+                DrawCharacter('A', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('r', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('e', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('S', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('h', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('d', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('o', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('w', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter(':', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawFloat(areaShadowMRays, fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('M', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('R', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('y', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('s', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('/', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('f', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('r', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('m', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('e', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+
+                displayUnormCoord = uint2(displayTextOffsetX, abs(displayTextOffsetY));
+                DrawCharacter('T', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('o', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('t', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('l', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter(':', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawFloat(totalMRays, fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('M', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('R', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('y', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('s', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('/', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('f', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('r', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('a', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('m', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                DrawCharacter('e', fontColor, unormCoord, displayUnormCoord, flipY, result.rgb);
+                return result;
+            }
+
+            ENDHLSL
+        }
+    }
+    Fallback Off
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/DebugViewRayCount.shader.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/DebugViewRayCount.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ec2e19714a33f8c4a936a011626e4d20
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
@@ -71,6 +71,11 @@ void RayGenAmbientOcclusion()
 	// the number of samples based on the roughness
 	int numSamples = _RaytracingNumSamples;
 
+    if (_RayCountEnabled > 0)
+    {
+        _RayCountTexture[currentPixelCoord].x = _RayCountTexture[currentPixelCoord].x + (uint)numSamples;
+    }
+
 	// Variable that accumulate the radiance
 	float3 completeColor = float3(0.0, 0.0, 0.0);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAreaShadows.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAreaShadows.raytrace
@@ -298,6 +298,11 @@ void RayGenShadows()
     // Here we need to evaluate the diffuseProbablity and the unshadowed lighting
     EvaluateMISProbabilties(misInput, lightData, preLightData, posInput.positionWS, misInput.diffProb, misInput.brdfProb);
 
+    if (_RayCountEnabled > 0)
+    {
+        _RayCountTexture[currentPixelCoord].z = _RayCountTexture[currentPixelCoord].z + (uint)_RaytracingNumSamples;
+    }
+
     bool validity = false;
     for (int sampleIdx = 0; sampleIdx < _RaytracingNumSamples; ++sampleIdx)
     {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace
@@ -134,6 +134,10 @@ void RayGenHalfRes()
     // In order to achieve filtering for the textures, we need to compute the spread angle of the pixel
     rayIntersection.cone.spreadAngle = _RaytracingPixelSpreadAngle;
     rayIntersection.cone.width = distanceToCamera * _RaytracingPixelSpreadAngle;
+    if (_RayCountEnabled > 0)
+    {
+        _RayCountTexture[outputCoord].y = _RayCountTexture[outputCoord].y + 1;
+    }
 
     // Evaluate the ray intersection
     TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, rayDescriptor, rayIntersection);
@@ -210,6 +214,11 @@ void RayGenIntegration()
 
     // Variable that accumulate the radiance
     float3 finalColor = float3(0.0, 0.0, 0.0);
+    
+    if (_RayCountEnabled > 0)
+    {
+        _RayCountTexture[currentCoord].y = _RayCountTexture[currentCoord].y + (uint)_RaytracingNumSamples;
+    }
 
     // Loop through the samples and add their contribution
     for (int sampleIndex = 0; sampleIndex < _RaytracingNumSamples; ++sampleIndex)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl
@@ -9,3 +9,5 @@ float                                   _RaytracingReflectionMaxDistance;
 float                                   _RaytracingReflectionMinSmoothness;
 int                                     _RaytracingFrameIndex;
 float                                   _RaytracingPixelSpreadAngle;
+int                                     _RayCountEnabled;
+RWTexture2D<uint4>                      _RayCountTexture;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
@@ -139,6 +139,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             public ComputeShader reflectionBilateralFilterCS;
             public ComputeShader lightClusterBuildCS;
             public ComputeShader lightClusterDebugCS;
+            public ComputeShader countTracedRays;
+            public Shader debugViewRayCountPS;
 #endif
         }
 
@@ -312,7 +314,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 FXAACS = Load<ComputeShader>(HDRenderPipelinePath + "PostProcessing/Shaders/FXAA.compute"),
                 finalPassPS = Load<Shader>(HDRenderPipelinePath + "PostProcessing/Shaders/FinalPass.shader"),
 
-            
 #if ENABLE_RAYTRACING
                 aoRaytracing = Load<RaytracingShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace"),
                 reflectionRaytracing = Load<RaytracingShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace"),
@@ -321,7 +322,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 jointBilateralFilterCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/JointBilateralFilter.compute"),
                 reflectionBilateralFilterCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingReflectionFilter.compute"),
                 lightClusterBuildCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/RaytracingLightCluster.compute"),
-                lightClusterDebugCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/DebugLightCluster.compute")
+                lightClusterDebugCS = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/DebugLightCluster.compute"),
+				countTracedRays = Load<ComputeShader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/CountTracedRays.compute"),
+				debugViewRayCountPS = Load<Shader>(HDRenderPipelinePath + "RenderPipeline/Raytracing/Shaders/DebugViewRayCount.shader")
 #endif
         };
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineResources.asset
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineResources.asset
@@ -146,6 +146,29 @@ MonoBehaviour:
     bloomUpsampleCS: {fileID: 7200000, guid: 5dbb0ac12cb11f84084b7e5633481bd1, type: 3}
     FXAACS: {fileID: 7200000, guid: 1535d29f35ea86b4282b6ca652002e2a, type: 3}
     finalPassPS: {fileID: 4800000, guid: 5ac9ef0c50282754b93c7692488e7ee7, type: 3}
+    aoRaytracing: {fileID: 4807578003741378534, guid: 82dc8cd069971d2488c502b0f32b94fb,
+      type: 3}
+    reflectionRaytracing: {fileID: 4807578003741378534, guid: 1a500e5079fba734aa90fe92e70ea131,
+      type: 3}
+    shadowsRaytracing: {fileID: 4807578003741378534, guid: 562bbaa310be359439258321ea2e6b3b,
+      type: 3}
+    raytracingFlagMask: {fileID: 4800000, guid: 7822c8a69a1f21144a20cf6d84e5e706,
+      type: 3}
+    forwardRaytracing: {fileID: 4807578003741378534, guid: d3a89a2d3f73b3e4da6f191e844fe68c,
+      type: 3}
+    areaBillateralFilterCS: {fileID: 7200000, guid: 757ff50c499f3c44ba741a41c7ab8510,
+      type: 3}
+    jointBilateralFilterCS: {fileID: 7200000, guid: eaf971fd1c5d09b4d8736cf54f0ed768,
+      type: 3}
+    reflectionBilateralFilterCS: {fileID: 7200000, guid: 07c445e7aa373284a9cc1584ca9b3f84,
+      type: 3}
+    lightClusterBuildCS: {fileID: 7200000, guid: c0625ea908b52854bbf1d456e34026e4,
+      type: 3}
+    lightClusterDebugCS: {fileID: 7200000, guid: d48a3a5496d98a44c89f335934805d10,
+      type: 3}
+    countTracedRays: {fileID: 7200000, guid: e1f3fa867f1dfbd4ab7dd4d39d2b96d8, type: 3}
+    debugViewRayCountPS: {fileID: 4800000, guid: ec2e19714a33f8c4a936a011626e4d20,
+      type: 3}
   materials:
     defaultDiffuseMat: {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
     defaultMirrorMat: {fileID: 2100000, guid: 6b17274157b33bc45b6a40e7d4ff51fe, type: 2}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineResources.asset
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/HDRenderPipelineResources.asset
@@ -146,29 +146,6 @@ MonoBehaviour:
     bloomUpsampleCS: {fileID: 7200000, guid: 5dbb0ac12cb11f84084b7e5633481bd1, type: 3}
     FXAACS: {fileID: 7200000, guid: 1535d29f35ea86b4282b6ca652002e2a, type: 3}
     finalPassPS: {fileID: 4800000, guid: 5ac9ef0c50282754b93c7692488e7ee7, type: 3}
-    aoRaytracing: {fileID: 4807578003741378534, guid: 82dc8cd069971d2488c502b0f32b94fb,
-      type: 3}
-    reflectionRaytracing: {fileID: 4807578003741378534, guid: 1a500e5079fba734aa90fe92e70ea131,
-      type: 3}
-    shadowsRaytracing: {fileID: 4807578003741378534, guid: 562bbaa310be359439258321ea2e6b3b,
-      type: 3}
-    raytracingFlagMask: {fileID: 4800000, guid: 7822c8a69a1f21144a20cf6d84e5e706,
-      type: 3}
-    forwardRaytracing: {fileID: 4807578003741378534, guid: d3a89a2d3f73b3e4da6f191e844fe68c,
-      type: 3}
-    areaBillateralFilterCS: {fileID: 7200000, guid: 757ff50c499f3c44ba741a41c7ab8510,
-      type: 3}
-    jointBilateralFilterCS: {fileID: 7200000, guid: eaf971fd1c5d09b4d8736cf54f0ed768,
-      type: 3}
-    reflectionBilateralFilterCS: {fileID: 7200000, guid: 07c445e7aa373284a9cc1584ca9b3f84,
-      type: 3}
-    lightClusterBuildCS: {fileID: 7200000, guid: c0625ea908b52854bbf1d456e34026e4,
-      type: 3}
-    lightClusterDebugCS: {fileID: 7200000, guid: d48a3a5496d98a44c89f335934805d10,
-      type: 3}
-    countTracedRays: {fileID: 7200000, guid: e1f3fa867f1dfbd4ab7dd4d39d2b96d8, type: 3}
-    debugViewRayCountPS: {fileID: 4800000, guid: ec2e19714a33f8c4a936a011626e4d20,
-      type: 3}
   materials:
     defaultDiffuseMat: {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
     defaultMirrorMat: {fileID: 2100000, guid: 6b17274157b33bc45b6a40e7d4ff51fe, type: 2}


### PR DESCRIPTION
### Purpose of this PR
![image](https://user-images.githubusercontent.com/3450690/52094537-5db3a880-2574-11e9-94b3-6f44045d00d1.png)

This PR doesn't have rays/second support yet- this will be added in a separate branch on top of this changeset. 

---
### Release Notes
Sourced heavily from Ionut's hackweek project. Major point of deviation is using a shader to draw results to the screen, instead of doing an AsyncReadback to write to a text GameObject. 

Rebased https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/2811 on HDRP/ReflectionFilter.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrtr_reflectionfilter_countrays&unity_branch=graphics%2Fraytracing%2Fdxr&automation-tools_branch=add-platform-filter

**Manual Tests**: What did you do?
Verified overlay looked correct and updated as I panned around the screen in the scene view. 
Confirmed that issue with missing area shadows occurred on HDRP/ReflectionFilter without my changes.

**Automated Tests**: What did you setup?
Nothing

Any test projects to go with this to help reviewers?
None

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low- most of the trickiness was in getting texture formats to play nice. 

**Halo Effect**: None, Low, Medium, High?
Low- the shader code that was added does not change existing shader code, and the invocation of the raycount debug is very self-contained. 

