### PR TITLE
Group camera tabs in debug menu

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugManager.cs
@@ -25,13 +25,18 @@ namespace UnityEngine.Experimental.Rendering
         ReadOnlyCollection<DebugUI.Panel> m_ReadOnlyPanels;
         readonly List<DebugUI.Panel> m_Panels = new List<DebugUI.Panel>();
 
+        void UpdateReadOnlyCollection()
+        {
+            m_Panels.Sort();
+            m_ReadOnlyPanels = m_Panels.AsReadOnly();
+        }
+
         public ReadOnlyCollection<DebugUI.Panel> panels
         {
             get
             {
                 if (m_ReadOnlyPanels == null)
-                    m_ReadOnlyPanels = m_Panels.AsReadOnly();
-
+                    UpdateReadOnlyCollection();
                 return m_ReadOnlyPanels;
             }
         }
@@ -192,7 +197,7 @@ namespace UnityEngine.Experimental.Rendering
         }
 
         // TODO: Optimally we should use a query path here instead of a display name
-        public DebugUI.Panel GetPanel(string displayName, bool createIfNull = false)
+        public DebugUI.Panel GetPanel(string displayName, bool createIfNull = false, int groupIndex = 0)
         {
             foreach (var panel in m_Panels)
             {
@@ -204,10 +209,10 @@ namespace UnityEngine.Experimental.Rendering
 
             if (createIfNull)
             {
-                p = new DebugUI.Panel { displayName = displayName };
+                p = new DebugUI.Panel { displayName = displayName, groupIndex = groupIndex };
                 p.onSetDirty += OnPanelDirty;
                 m_Panels.Add(p);
-                m_ReadOnlyPanels = m_Panels.AsReadOnly();
+                UpdateReadOnlyCollection();
             }
 
             return p;
@@ -237,7 +242,7 @@ namespace UnityEngine.Experimental.Rendering
                 return;
 
             m_Panels.Remove(panel);
-            m_ReadOnlyPanels = m_Panels.AsReadOnly();
+            UpdateReadOnlyCollection();
         }
 
         public DebugUI.Widget GetItem(string queryPath)

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugUI.Panel.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Debugging/DebugUI.Panel.cs
@@ -6,10 +6,11 @@ namespace UnityEngine.Experimental.Rendering
     {
         // Root panel class - we don't want to extend Container here because we need a clear
         // separation between debug panels and actual widgets
-        public class Panel : IContainer
+        public class Panel : IContainer, IComparable<Panel>
         {
             public Flags flags { get; set; }
             public string displayName { get; set; }
+            public int groupIndex { get; set; }
             public string queryPath { get { return displayName; } }
 
             public bool isEditorOnly { get { return (flags & Flags.EditorOnly) != 0; } }
@@ -67,6 +68,8 @@ namespace UnityEngine.Experimental.Rendering
 
                 return hash;
             }
+
+            int IComparable<Panel>.CompareTo(Panel other) => other == null ? 1 : groupIndex.CompareTo(other.groupIndex);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettingsHistory.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettingsHistory.cs
@@ -224,7 +224,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             var camera = frameSettings.camera;
             List<DebugUI.Widget> widgets = new List<DebugUI.Widget>();
             widgets.AddRange(GenerateFrameSettingsPanelContent(hdrpAsset, ref frameSettings));
-            var panel = DebugManager.instance.GetPanel(menuName, true);
+            var panel = DebugManager.instance.GetPanel(menuName, true, 1);
             panel.children.Add(widgets.ToArray());
         }
 


### PR DESCRIPTION
### Purpose of this PR
Group all camera tabs at end in Debug Menu (Better in UX perspective)
Formerly, Main Camera where often above non camera tabs and Scene Camera at the bottom. And this order can evolve when changing scene content.

---
### Release Notes

---
### Testing status
**Katana Tests**: 

**Manual Tests**: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None

---
### Comments to reviewers
