### PR TITLE
Disable some motion blur improvements until HLSLcc bug is fixed

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
@@ -1234,6 +1234,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // -----------------------------------------------------------------------------
 
             bool scattering = SystemInfo.IsFormatSupported(GraphicsFormat.R32_UInt, FormatUsage.LoadStore) && SystemInfo.IsFormatSupported(GraphicsFormat.R16_UInt, FormatUsage.LoadStore);
+            scattering = scattering && (SystemInfo.graphicsDeviceType != GraphicsDeviceType.Vulkan);
             int tileSize = 32;
 
             if (scattering)

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/MotionBlurCommon.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/MotionBlurCommon.hlsl
@@ -2,7 +2,7 @@
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Builtin/BuiltinData.hlsl"
 
-#if defined(SHADER_API_PSSL) && (UNITY_VERSION < 20192)
+#if ((defined(SHADER_API_PSSL) && (UNITY_VERSION < 20192)) || defined(SHADER_API_VULKAN)) 
 #define SCATTERING 0
 #else
 #define SCATTERING 1


### PR DESCRIPTION
### Purpose of this PR
Bypass compilation error on Vulkan caused by a bug in HLSLcc. 
