### PR TITLE
Add missing PLATFORM_NEEDS_UNORM_UAV_SPECIFIER to Vulkan.hlsl

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/API/Vulkan.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/Vulkan.hlsl
@@ -16,6 +16,7 @@
 #define CBUFFER_END };
 
 #define PLATFORM_SUPPORTS_EXPLICIT_BINDING 1
+#define PLATFORM_NEEDS_UNORM_UAV_SPECIFIER 1
 #define PLATFORM_THREAD_GROUP_OPTIMAL_SIZE 0		// cannot infer the optimal compute shader group size (GPU vendor not known).
 
 // flow control attributes


### PR DESCRIPTION
### Purpose of this PR

Vulkan.hlsl was not updated to contain the PLATFORM_NEEDS_UNORM_UAV_SPECIFIER define, causing error spew in HDRP scenes.

---
### Release Notes

Fixed "Attempting to draw with missing UAV bindings" errors on Vulkan.

---
### Testing status
Trivial fix, local testing only.

**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
