### PR TITLE
Do not add duplicate textures to the atlas

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/Texture3DAtlas.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/Texture3DAtlas.cs
@@ -34,6 +34,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void AddTexture(Texture3D tex)
         {
+            if (m_textures.Contains(tex))
+            {
+                return;
+            }
+            
             if (tex.width != m_atlasSize || tex.height != m_atlasSize || tex.depth != m_atlasSize)
             {
                 Debug.LogError(String.Format("3D Texture Atlas: Added texture {4} size {0}x{1}x{2} does not match size of atlas {3}x{3}x{3}", tex.width, tex.height, tex.depth, m_atlasSize, tex.name));


### PR DESCRIPTION
### Purpose of this PR
Do not add duplicate textures to the atlas

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Fatlas_no_duplicates&automation-tools_branch=add-platform-filter&unity_branch=trunk