### PR TITLE
Rendering layer support for raytracing

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/CommonLighting.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/CommonLighting.hlsl
@@ -414,4 +414,10 @@ real3x3 GetOrthoBasisViewNormal(real3 V, real3 N, real unclampedNdotV, bool test
     return orthoBasisViewNormal;
 }
 
+// Move this here since it's used by both LightLoop.hlsl and RaytracingLightLoop.hlsl
+bool IsMatchingLightLayer(uint lightLayers, uint renderingLayers)
+{
+    return (lightLayers & renderingLayers) != 0;
+}
+
 #endif // UNITY_COMMON_LIGHTING_INCLUDED

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -61,12 +61,6 @@ void ApplyDebug(LightLoopContext lightLoopContext, float3 positionWS, inout floa
 #endif
 }
 
-// Factor all test so we can disable it easily
-bool IsMatchingLightLayer(uint lightLayers, uint renderingLayers)
-{
-    return (lightLayers & renderingLayers) != 0;
-}
-
 void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BSDFData bsdfData, BuiltinData builtinData, uint featureFlags,
                 out float3 diffuseLighting,
                 out float3 specularLighting)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingLightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingLightLoop.hlsl
@@ -95,8 +95,11 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
     int i = 0;
     for (i = 0; i < _DirectionalLightCount; ++i)
     {
-        DirectLighting lighting = EvaluateBSDF_Directional(context, V, posInput, preLightData, _DirectionalLightDatas[i], bsdfData, builtinData);
-        AccumulateDirectLighting(lighting, aggregateLighting);
+		if (IsMatchingLightLayer(_DirectionalLightDatas[i].lightLayers, builtinData.renderingLayers))
+		{
+			DirectLighting lighting = EvaluateBSDF_Directional(context, V, posInput, preLightData, _DirectionalLightDatas[i], bsdfData, builtinData);
+			AccumulateDirectLighting(lighting, aggregateLighting);
+		}
     }
 
     // Indices of the subranges to process
@@ -124,9 +127,11 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         #else
         LightData lightData = _LightDatasRT[i];
         #endif
-
-        DirectLighting lighting = EvaluateBSDF_Punctual(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
-        AccumulateDirectLighting(lighting, aggregateLighting);
+		if (IsMatchingLightLayer(lightData.lightLayers, builtinData.renderingLayers))
+		{
+			DirectLighting lighting = EvaluateBSDF_Punctual(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
+			AccumulateDirectLighting(lighting, aggregateLighting);
+		}
     }
 
     #ifdef USE_LIGHT_CLUSTER
@@ -153,6 +158,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         {
             lightData.lightType = GPULIGHTTYPE_TUBE; // Enforce constant propagation
 
+			if (IsMatchingLightLayer(lightData.lightLayers, builtinData.renderingLayers))
             {
                 DirectLighting lighting = EvaluateBSDF_Area(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
                 AccumulateDirectLighting(lighting, aggregateLighting);
@@ -169,6 +175,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         {
             lightData.lightType = GPULIGHTTYPE_RECTANGLE; // Enforce constant propagation
 
+			if (IsMatchingLightLayer(lightData.lightLayers, builtinData.renderingLayers))
             {
                 DirectLighting lighting = EvaluateBSDF_Area(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
                 AccumulateDirectLighting(lighting, aggregateLighting);


### PR DESCRIPTION
### Purpose of this PR
![image](https://user-images.githubusercontent.com/3450690/52587020-d117ae80-2ded-11e9-94e3-7e42dd14c460.png)

---
### Release Notes
Editor changeset c7e4dc25183b has been merged into the graphics/raytracing/dxr branch. 

TODO:
- When sky env lighting is added, it needs to be bracketed by IsMatchingLightLayer also

---
### Testing status
The image above shows 3 spheres and 3 lights on 3 different rendering layer masks, plus one sphere with rendering layer mask set to "everything". The reflection indicates that the layer masks are correctly applied to raytracing as well. 

Since this is to be merged into master, and it modifies LightLoop.hlsl, I kicked off katana for this branch after rebasing to master:
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrtr_crashingbranch_lightlayers&unity_branch=trunk&automation-tools_branch=add-platform-filter

---
### Overall Product Risks
**Technical Risk**:  None
**Halo Effect**: Low- brackets most EvaluateBSDF calls in RaytracingLightLoop.

---
### Comments to reviewers

