### PR TITLE
Fetch exposure from postprocess and forward to Gizmos.

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using UnityEngine.Experimental.GlobalIllumination;
+using UnityEngine;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
@@ -1827,7 +1828,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 #if UNITY_EDITOR
                 // Render gizmos that should be affected by post processes
                 if (showGizmos)
+                {
+                    Gizmos.exposure = m_PostProcessSystem.GetExposureTexture(hdCamera).rt;
                     RenderGizmos(cmd, camera, renderContext, GizmoSubset.PreImageEffects);
+                }
 #endif
 
                 // Render All forward error


### PR DESCRIPTION
### Purpose of this PR
Fix the currently broken exposure correction of Light Probe gizmos when using HDRP. HDRP changed exposure correction from postprocessing to a pre-exposure style system. This PR introduces a small change in the Gizmos API, the public Gizmos.exposure variable, to which the typical exposure GPU texture resource can be forwarded. The SH material shader that we use to display the SH coefficients on the Light Probe spheres will use this texture to correct the exposure. If this texture is null, the default builtin white texture will be used.

---
### Release Notes
Fixes exposure correction for Light Probe gizmos in HDRP.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: 
* Create a legacy project and set Gizmos.exposure to a given texture. The probes should be black if a a black texture is used.
* Use HDRP with a 20000 lumen light source, a global volume and exposure correction to check that it works there as well.

---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: Low

---
### Comments to reviewers
The corresponding branch is:
`lighting/lightprobes/fix-hdrp-gizmo-exposure`
https://ono.unity3d.com/unity/unity/pull-request/82953/_/lighting/lightprobes/fix-hdrp-gizmo-exposure