### PR TITLE
Raytracing Forward for Shader Graph

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitRaytracingPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitRaytracingPass.template
@@ -66,20 +66,22 @@ Pass
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
 
-    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingIntersection.hlsl"
-#if (SHADERPASS == SHADERPASS_RAYTRACING_REFLECTION)
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracingLightLoop.hlsl"
+
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingIntersection.hlsl"
+
+#if (SHADERPASS == SHADERPASS_RAYTRACING_REFLECTION) || (SHADERPASS == SHADERPASS_RAYTRACING_FORWARD)
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
-
     #define HAS_LIGHTLOOP
-
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl"
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitRaytracing.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingLightLoop.hlsl"
 #else
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl"
 #endif
-
+    
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingBuiltinData.hlsl"
@@ -154,10 +156,19 @@ Pass
         $SurfaceDescription.IridescenceMask:            surfaceData.iridescenceMask =           surfaceDescription.IridescenceMask;
         $SurfaceDescription.IridescenceThickness:       surfaceData.iridescenceThickness =      surfaceDescription.IridescenceThickness;
 
+#ifdef _HAS_REFRACTION
+        $SurfaceDescription.RefractionIndex:            surfaceData.ior =                       surfaceDescription.RefractionIndex;
+        $SurfaceDescription.RefractionColor:            surfaceData.transmittanceColor =        surfaceDescription.RefractionColor;
+        $SurfaceDescription.RefractionDistance:         surfaceData.atDistance =                surfaceDescription.RefractionDistance;
+
+        surfaceData.transmittanceMask = (1.0 - surfaceDescription.Alpha);
+        surfaceDescription.Alpha = 1.0;
+#else
         surfaceData.ior = 1.0;
         surfaceData.transmittanceColor = float3(1.0, 1.0, 1.0);
         surfaceData.atDistance = 1.0;
         surfaceData.transmittanceMask = 0.0;
+#endif
         
         // These static material feature allow compile time optimization
         surfaceData.materialFeatures = MATERIALFEATUREFLAGS_LIT_STANDARD;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
@@ -718,6 +718,58 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             UseInPreview = false
         };
 
+        Pass m_PassRaytracingForward = new Pass()
+        {
+            Name = "ForwardDXR",
+            LightMode = "ForwardDXR",
+            TemplateName = "HDLitRaytracingPass.template",
+            MaterialName = "Lit",
+            ShaderPassName = "SHADERPASS_RAYTRACING_FORWARD",
+            ExtraDefines = new List<string>()
+            {
+                "#pragma multi_compile _ LIGHTMAP_ON",
+                "#pragma multi_compile _ DIRLIGHTMAP_COMBINED",
+                "#pragma multi_compile _ DYNAMICLIGHTMAP_ON",
+                "#define SHADOW_LOW",
+            },
+            Includes = new List<string>()
+            {
+                "#include \"Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderpassRaytracingForward.hlsl\"",
+            },
+            PixelShaderSlots = new List<int>()
+            {
+                HDLitMasterNode.AlbedoSlotId,
+                HDLitMasterNode.NormalSlotId,
+                HDLitMasterNode.BentNormalSlotId,
+                HDLitMasterNode.TangentSlotId,
+                HDLitMasterNode.SubsurfaceMaskSlotId,
+                HDLitMasterNode.ThicknessSlotId,
+                HDLitMasterNode.DiffusionProfileSlotId,
+                HDLitMasterNode.IridescenceMaskSlotId,
+                HDLitMasterNode.IridescenceThicknessSlotId,
+                HDLitMasterNode.SpecularColorSlotId,
+                HDLitMasterNode.CoatMaskSlotId,
+                HDLitMasterNode.MetallicSlotId,
+                HDLitMasterNode.EmissionSlotId,
+                HDLitMasterNode.SmoothnessSlotId,
+                HDLitMasterNode.AmbientOcclusionSlotId,
+                HDLitMasterNode.SpecularOcclusionSlotId,
+                HDLitMasterNode.AlphaSlotId,
+                HDLitMasterNode.AlphaThresholdSlotId,
+                HDLitMasterNode.AnisotropySlotId,
+                HDLitMasterNode.SpecularAAScreenSpaceVarianceSlotId,
+                HDLitMasterNode.SpecularAAThresholdSlotId,
+                HDLitMasterNode.RefractionIndexSlotId,
+                HDLitMasterNode.RefractionColorSlotId,
+                HDLitMasterNode.RefractionDistanceSlotId,
+            },
+            VertexShaderSlots = new List<int>()
+            {
+                HDLitMasterNode.PositionSlotId
+            },
+            UseInPreview = false
+        };
+
         private static HashSet<string> GetActiveFieldsFromMasterNode(AbstractMaterialNode iMasterNode, Pass pass)
         {
             HashSet<string> activeFields = new HashSet<string>();
@@ -1077,6 +1129,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 {
                     GenerateShaderPassLit(masterNode, m_PassRaytracingReflection, mode, subShader, sourceAssetDependencyPaths);
                     GenerateShaderPassLit(masterNode, m_PassRaytracingVisibility, mode, subShader, sourceAssetDependencyPaths);
+                    GenerateShaderPassLit(masterNode, m_PassRaytracingForward, mode, subShader, sourceAssetDependencyPaths);
                 }
                 subShader.Deindent();
                 subShader.AddShaderChunk("}", false);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -243,6 +243,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             Reset();
         }
 
+        public bool IsTAAEnabled()
+        {
+            return antialiasing == AntialiasingMode.TemporalAntialiasing;
+        }
+
         // Pass all the systems that may want to update per-camera data here.
         // That way you will never update an HDCamera and forget to update the dependent system.
         public void Update(FrameSettings currentFrameSettings, VolumetricLightingSystem vlSys, MSAASamples msaaSamples)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
@@ -26,7 +26,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void RegisterEnvironment(HDRaytracingEnvironment targetEnvironment)
         {
-            if(!m_Environments.Contains(targetEnvironment))
+            if (!m_Environments.Contains(targetEnvironment))
             {
                 m_Environments.Add(targetEnvironment);
                 m_DirtyEnvironment = true;
@@ -97,7 +97,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void RegisterFilter(HDRayTracingFilter targetFilter)
         {
-            if(!m_Filters.Contains(targetFilter))
+            if (!m_Filters.Contains(targetFilter))
             {
                 // Add this graph
                 m_Filters.Add(targetFilter);
@@ -197,7 +197,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             // Grab all the ray-tracing graphs that have been created before
             HDRayTracingFilter[] filterArray = Object.FindObjectsOfType<HDRayTracingFilter>();
-            for(int filterIdx = 0; filterIdx < filterArray.Length; ++filterIdx)
+            for (int filterIdx = 0; filterIdx < filterArray.Length; ++filterIdx)
             {
                 RegisterFilter(filterArray[filterIdx]);
             }
@@ -224,13 +224,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public void SetDirty()
         {
             int numFilters = m_Filters.Count;
-            for(int filterIdx = 0; filterIdx < numFilters; ++filterIdx)
+            for (int filterIdx = 0; filterIdx < numFilters; ++filterIdx)
             {
                 // Grab the target graph component
                 HDRayTracingFilter filterComponent = m_Filters[filterIdx];
-                
+
                 // If this camera had a graph component had an obsolete flag
-                if(filterComponent != null)
+                if (filterComponent != null)
                 {
                     filterComponent.SetDirty();
                 }
@@ -262,17 +262,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public void CheckSubScenes()
         {
             // Here there is two options, either the full things needs to be rebuilded or we should only rebuild the ones that have been flagged obsolete
-            if(m_DirtyEnvironment)
+            if (m_DirtyEnvironment)
             {
                 // First of let's reset all the obsolescence flags
                 int numFilters = m_Filters.Count;
-                for(int filterIdx = 0; filterIdx < numFilters; ++filterIdx)
+                for (int filterIdx = 0; filterIdx < numFilters; ++filterIdx)
                 {
                     // Grab the target graph component
                     HDRayTracingFilter filterComponent = m_Filters[filterIdx];
-                    
+
                     // If this camera had a graph component had an obsolete flag
-                    if(filterComponent != null)
+                    if (filterComponent != null)
                     {
                         filterComponent.ResetDirty();
                     }
@@ -290,13 +290,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 // First of all propagate the obsolete flags to the sub scenes
                 int numGraphs = m_Filters.Count;
-                for(int filterIdx = 0; filterIdx < numGraphs; ++filterIdx)
+                for (int filterIdx = 0; filterIdx < numGraphs; ++filterIdx)
                 {
                     // Grab the target graph component
                     HDRayTracingFilter filterComponent = m_Filters[filterIdx];
-                    
+
                     // If this camera had a graph component had an obsolete flag
-                    if(filterComponent != null && filterComponent.IsDirty())
+                    if (filterComponent != null && filterComponent.IsDirty())
                     {
                         // Get the sub-scene  that matches
                         HDRayTracingSubScene currentSubScene = null;
@@ -308,7 +308,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     }
                 }
             }
- 
+
 
             // Rebuild all the obsolete scenes
             for (var subSceneIndex = 0; subSceneIndex < m_LayerMasks.Count; subSceneIndex++)
@@ -329,7 +329,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public void UpdateSubSceneData(CommandBuffer cmd, HDCamera hdCamera)
         {
             HDRayTracingSubScene subScene = RequestSubScene(hdCamera);
-            if(subScene != null)
+            if (subScene != null)
             {
                 // Update the acceleration structure
                 if (subScene.accelerationStructure != null)
@@ -352,7 +352,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public void BuildSubSceneStructure(ref HDRayTracingSubScene subScene)
         {
             // If there is no render environments, then we should not generate acceleration structure
-            if(m_Environments.Count > 0)
+            if (m_Environments.Count > 0)
             {
                 // This structure references all the renderers that are considered to be processed
                 Dictionary<int, int> rendererReference = new Dictionary<int, int>();
@@ -372,13 +372,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                     // Get the set of LODs
                     LOD[] lodArray = lodGroup.GetLODs();
-                    for(int lodIdx = 0; lodIdx < lodArray.Length; ++lodIdx)
+                    for (int lodIdx = 0; lodIdx < lodArray.Length; ++lodIdx)
                     {
                         LOD currentLOD = lodArray[lodIdx];
                         // We only want to push to the acceleration structure the first fella
                         if (lodIdx == 0)
                         {
-                            for(int rendererIdx = 0; rendererIdx < currentLOD.renderers.Length; ++rendererIdx)
+                            for (int rendererIdx = 0; rendererIdx < currentLOD.renderers.Length; ++rendererIdx)
                             {
                                 // Convert the object's layer to an int
                                 int objectLayerValue = 1 << currentLOD.renderers[rendererIdx].gameObject.layer;
@@ -399,7 +399,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             // Add this fella to the renderer list
                             rendererReference.Add(currentRenderer.GetInstanceID(), 1);
                         }
-                        
+
                     }
                 }
 
@@ -410,16 +410,16 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 for (var i = 0; i < rendererArray.Length; i++)
                 {
                     // Fetch the current renderer
-                    Renderer currentRenderer =  rendererArray[i];
+                    Renderer currentRenderer = rendererArray[i];
 
                     // If it is not active skip it
-                    if(currentRenderer.enabled ==  false) continue;
+                    if (currentRenderer.enabled == false) continue;
 
                     // Grab the current game object
                     GameObject gameObject = currentRenderer.gameObject;
 
                     // Has this object already been processed, jsut skip
-                    if(rendererReference.ContainsKey(currentRenderer.GetInstanceID()))
+                    if (rendererReference.ContainsKey(currentRenderer.GetInstanceID()))
                     {
                         continue;
                     }
@@ -460,26 +460,44 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             // For every sub-mesh/sub-material let's build the right flags
                             int numSubMeshes = currentRenderer.sharedMaterials.Length;
 
-                            for(int meshIdx = 0; meshIdx < numSubMeshes; ++meshIdx)
+                            uint instanceFlag = 0xff;
+                            for (int meshIdx = 0; meshIdx < numSubMeshes; ++meshIdx)
                             {
                                 Material currentMaterial = currentRenderer.sharedMaterials[meshIdx];
-                                bool materialIsTransparent = currentMaterial.IsKeywordEnabled("_SURFACE_TYPE_TRANSPARENT");
-                                if(currentMaterial != null)
+                                // The material is transparent if either it has the requested keyword or is in the transparent queue range
+                                if (currentMaterial != null)
                                 {
-                                    subMeshFlagArray[meshIdx] = true; // !currentMaterial.IsKeywordEnabled("_SURFACE_TYPE_TRANSPARENT");
-                                    subMeshCutoffArray[meshIdx] = currentMaterial.IsKeywordEnabled("_ALPHATEST_ON");
-                                    singleSided |= !currentMaterial.IsKeywordEnabled("_DOUBLESIDED_ON");
+                                    subMeshFlagArray[meshIdx] = true;
+
+                                    // Is the material transparent?
+                                    bool materialIsTransparent = currentMaterial.IsKeywordEnabled("_SURFACE_TYPE_TRANSPARENT")
+                                    || (HDRenderQueue.k_RenderQueue_Transparent.lowerBound <= currentMaterial.renderQueue
+                                    && HDRenderQueue.k_RenderQueue_Transparent.upperBound >= currentMaterial.renderQueue)
+                                    || (HDRenderQueue.k_RenderQueue_AllTransparentRaytracing.lowerBound <= currentMaterial.renderQueue
+                                    && HDRenderQueue.k_RenderQueue_AllTransparentRaytracing.upperBound >= currentMaterial.renderQueue);
+
+                                    // Propagate the right mask
+                                    instanceFlag = materialIsTransparent ? (uint)0xf0 : (uint)0x0f;
+
+                                    // Is the material alpha tested?
+                                    subMeshCutoffArray[meshIdx] = currentMaterial.IsKeywordEnabled("_ALPHATEST_ON")
+                                    || (HDRenderQueue.k_RenderQueue_OpaqueAlphaTest.lowerBound <= currentMaterial.renderQueue
+                                    && HDRenderQueue.k_RenderQueue_OpaqueAlphaTest.upperBound >= currentMaterial.renderQueue);
+
+                                    // Force it to be non single sided if it has the keyword if there is a reason
+                                    bool doubleSided = currentMaterial.doubleSidedGI || currentMaterial.IsKeywordEnabled("_DOUBLESIDED_ON");
+                                    singleSided |= !doubleSided;
                                 }
                                 else
                                 {
-                                    singleSided = true;
-                                    subMeshCutoffArray[meshIdx] = false;
                                     subMeshFlagArray[meshIdx] = false;
+                                    subMeshCutoffArray[meshIdx] = false;
+                                    singleSided = true;
                                 }
                             }
 
                             // Add it to the acceleration structure
-                            subScene.accelerationStructure.AddInstance(currentRenderer, subMeshMask: subMeshFlagArray, subMeshTransparencyFlags: subMeshCutoffArray, enableTriangleCulling: singleSided);
+                            subScene.accelerationStructure.AddInstance(currentRenderer, subMeshMask: subMeshFlagArray, subMeshTransparencyFlags: subMeshCutoffArray, enableTriangleCulling: singleSided, mask: instanceFlag);
                         }
                     }
                 }
@@ -502,19 +520,19 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 for (int lightIdx = 0; lightIdx < hdLightArray.Length; ++lightIdx)
                 {
                     HDAdditionalLightData hdLight = hdLightArray[lightIdx];
-                    if (hdLight.enabled )
+                    if (hdLight.enabled)
                     {
                         // Convert the object's layer to an int
                         int lightayerValue = 1 << hdLight.gameObject.layer;
                         if ((lightayerValue & subScene.mask.value) != 0)
                         {
-                            if(hdLight.GetComponent<Light>().type == LightType.Directional)
+                            if (hdLight.GetComponent<Light>().type == LightType.Directional)
                             {
                                 subScene.hdDirectionalLightArray.Add(hdLight);
                             }
                             else
                             {
-                                if(hdLight.lightTypeExtent == LightTypeExtent.Punctual)
+                                if (hdLight.lightTypeExtent == LightTypeExtent.Punctual)
                                 {
                                     pointLights.Add(hdLight);
                                 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
@@ -105,7 +105,7 @@ void RayGenAmbientOcclusion()
 		rayIntersection.t = 0.0f;
 
 		// Evaluate the ray intersection
-		TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_FORCE_NON_OPAQUE | RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, rayDescriptor, rayIntersection);
+		TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACING_OPAQUE_FLAG, 0, 1, 0, rayDescriptor, rayIntersection);
 		
 		// combine
 		if (rayIntersection.t > 0.0f)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAreaShadows.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAreaShadows.raytrace
@@ -383,7 +383,7 @@ void RayGenShadows()
         rayIntersection.incidentDirection = rayDescriptor.Direction;
         
         // Evaluate the ray visibility term and PDF
-        TraceRay(_RaytracingAccelerationStructure, rayFlag, 0xFF, 0, 1, 0, rayDescriptor, rayIntersection);
+        TraceRay(_RaytracingAccelerationStructure, rayFlag, RAYTRACING_OPAQUE_FLAG, 0, 1, 0, rayDescriptor, rayIntersection);
 
         // Evaluate the lighting
         float3 diffuseLighting = float3(0.0, 0.0, 0.0);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingIntersection.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingIntersection.hlsl
@@ -1,6 +1,9 @@
 // Engine includes
 #include "UnityRaytracingMeshUtils.cginc"
 
+#define RAYTRACING_OPAQUE_FLAG      0x0f
+#define RAYTRACING_TRANSPARENT_FLAG 0xf0
+
 // Raycone structure that defines the stateof the ray
 struct RayCone
 {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingMacros.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingMacros.hlsl
@@ -1,5 +1,6 @@
 #ifdef SAMPLE_TEXTURE2D
 #undef SAMPLE_TEXTURE2D
 #define SAMPLE_TEXTURE2D(textureName, samplerName, coord2)                          	textureName.SampleLevel(samplerName, coord2, 0)
+#undef SAMPLE_TEXTURE3D
 #define SAMPLE_TEXTURE3D(textureName, samplerName, coord3)                      		textureName.SampleLevel(samplerName, coord3, 0)
 #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflections.raytrace
@@ -148,7 +148,7 @@ void RayGenHalfRes()
     }
 
     // Evaluate the ray intersection
-    TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, rayDescriptor, rayIntersection);
+    TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACING_OPAQUE_FLAG, 0, 1, 0, rayDescriptor, rayIntersection);
 
     // Compute the PDF
     float samplePDF = 1.0f;
@@ -264,7 +264,7 @@ void RayGenIntegration()
         rayIntersection.cone.width = distanceToCamera * _RaytracingPixelSpreadAngle;
 
         // Evaluate the ray intersection
-        TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, rayDescriptor, rayIntersection);
+        TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACING_OPAQUE_FLAG, 0, 1, 0, rayDescriptor, rayIntersection);
 
         // Contribute to the pixel
         finalColor += rayIntersection.color;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingRenderer.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingRenderer.raytrace
@@ -76,10 +76,10 @@ void RayGenRenderer()
 	rayIntersection.cone.width = 0.0f;
 	
 	// Evaluate the ray intersection
-	TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, rayDescriptor, rayIntersection);
+	TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACING_OPAQUE_FLAG | RAYTRACING_TRANSPARENT_FLAG, 0, 1, 0, rayDescriptor, rayIntersection);
 
 	// Alright we are done :D
-    _CameraColorTextureRW[currentPixelCoord] = float4(rayIntersection.color, 1.0f);
+    _CameraColorTextureRW[currentPixelCoord] = float4(rayIntersection.color * GetCurrentExposureMultiplier(), 1.0f);
 }
 
 [shader("closesthit")]

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingForward.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingForward.hlsl
@@ -79,7 +79,7 @@ void ClosestHitMain(inout RayIntersection rayIntersection : SV_RayPayload, Attri
         transmittedIntersection.cone.width = rayIntersection.cone.width;
         
         // Evaluate the ray intersection
-        TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, transmittedRay, transmittedIntersection);
+        TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACING_OPAQUE_FLAG | RAYTRACING_TRANSPARENT_FLAG, 0, 1, 0, transmittedRay, transmittedIntersection);
             
         // Override the transmitted color
         transmitted = transmittedIntersection.color;
@@ -113,7 +113,7 @@ void ClosestHitMain(inout RayIntersection rayIntersection : SV_RayPayload, Attri
         reflectedIntersection.cone.width = rayIntersection.cone.width;
         
         // Evaluate the ray intersection
-        TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, 0xFF, 0, 1, 0, reflectedRay, reflectedIntersection);
+        TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACING_OPAQUE_FLAG | RAYTRACING_TRANSPARENT_FLAG, 0, 1, 0, reflectedRay, reflectedIntersection);
 
         // Override the transmitted color
         reflected = reflectedIntersection.color;
@@ -124,10 +124,12 @@ void ClosestHitMain(inout RayIntersection rayIntersection : SV_RayPayload, Attri
     float3 specularLighting;
     LightLoop(viewWS, posInput, preLightData, bsdfData, builtinData, reflected, transmitted, diffuseLighting, specularLighting);
 
-    // Compute the Color of the current intersection
-    rayIntersection.color = (diffuseLighting + specularLighting) * GetCurrentExposureMultiplier();;
+    // Color display for the moment
+    rayIntersection.color = diffuseLighting + specularLighting;
 #else
-    rayIntersection.color = bsdfData.color;
+    // Given that we will be multiplying the final color by the current exposure multiplier outside of this function, we need to make sure that
+    // the unlit color is not impacted by that. Thus, we multiply it by the inverse of the current exposure multiplier.
+    rayIntersection.color = bsdfData.color * GetInverseCurrentExposureMultiplier() + builtinData.emissiveColor;
 #endif
 }
 


### PR DESCRIPTION
Using instance flags for discarding/including transparent objects
Using renderqueues and doublesidedgi to identify properties of shader graph shaders
Correcting Exposure for forward rendered objects

Tests:
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FRaytracingPrimary2&automation-tools_branch=add-platform-filter&unity_branch=trunk