### PR TITLE
Hdrp stacklit fix warnings and metapass

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
@@ -220,6 +220,16 @@ Pass
     //-------------------------------------------------------------------------------------
     // End Defines
     //-------------------------------------------------------------------------------------
+#if !( (SHADERPASS == SHADERPASS_FORWARD) || (SHADERPASS == SHADERPASS_LIGHT_TRANSPORT))
+    // StackLit.hlsl hooks the callback from PostInitBuiltinData() via #define MODIFY_BAKED_DIFFUSE_LIGHTING
+    // but in ShaderGraph, we don't evaluate/set all input ports when the values are not used by the pass.
+    // (In the material with the inspector UI, unused values were still normally set for all passes, here we
+    // don't, this saves compilation time, but these should always be pruned by compilation anyways).
+    // To prevent warnings, we disable our ModifyBakedDiffuseLighting() callback, while still leaving the
+    // call to PostInitBuiltinData() here along with avoiding putting SHADERPASS dependencies directly in
+    // StackLit.hlsl.
+    #define DISABLE_MODIFY_BAKED_DIFFUSE_LIGHTING
+#endif
 
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
 #ifdef DEBUG_DISPLAY


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
StackLit: Fix some warnings for shader passes outside the main (forward) one, that occur on shader graph because of non opened ports on the master node (code path was non existant - surfacedata values, even those eventually pruned by the compiler, would always be normally set in StackLitData)
Also make the meta pass (GetLightTransportData) code more robust

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
(just did windows editor tests)

https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders/proj57-Test%20Editor%20-%20Windows/builds/2393?ScriptableRenderLoop_branch=hdrp-stacklit-fix-warnings-and-metapass&unity_branch=trunk&automation-tools_branch=add-platform-filter

**Manual Tests**: What did you do?

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low
**Halo Effect**: None, Low, Medium, High?
None
---
### Comments to reviewers
Notes for the reviewers you have assigned.
