### PR TITLE
Migrate HDAdditionalLightData.lightLayer to Light.renderingLayerMask

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
@@ -218,7 +218,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             using (new EditorGUI.DisabledScope(!HDUtils.hdrpSettings.supportLightLayers))
             {
-                serialized.serializedLightData.lightLayers.intValue = Convert.ToInt32(EditorGUILayout.EnumFlagsField(s_Styles.lightLayer, (LightLayerEnum)serialized.serializedLightData.lightLayers.intValue));
+                var renderingLayerMask = serialized.serializedLightData.lightLayers.intValue;
+                var lightLayer = HDAdditionalLightData.RenderingLayerMaskToLightLayer(renderingLayerMask);
+                EditorGUI.BeginChangeCheck();
+                lightLayer = Convert.ToInt32(EditorGUILayout.EnumFlagsField(s_Styles.lightLayer, (LightLayerEnum)lightLayer));
+                if (EditorGUI.EndChangeCheck())
+                {
+                    // Overwrite only first byte
+                    lightLayer = HDAdditionalLightData.LightLayerToRenderingLayerMask(lightLayer, renderingLayerMask);
+                    serialized.serializedLightData.lightLayers.intValue = lightLayer;
+                }
             }
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
@@ -218,7 +218,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             using (new EditorGUI.DisabledScope(!HDUtils.hdrpSettings.supportLightLayers))
             {
-                var renderingLayerMask = serialized.serializedLightData.lightLayers.intValue;
+                var renderingLayerMask = serialized.serializedLightData.renderingLayerMask.intValue;
                 var lightLayer = HDAdditionalLightData.RenderingLayerMaskToLightLayer(renderingLayerMask);
                 EditorGUI.BeginChangeCheck();
                 lightLayer = Convert.ToInt32(EditorGUILayout.EnumFlagsField(s_Styles.lightLayer, (LightLayerEnum)lightLayer));
@@ -226,7 +226,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 {
                     // Overwrite only first byte
                     lightLayer = HDAdditionalLightData.LightLayerToRenderingLayerMask(lightLayer, renderingLayerMask);
-                    serialized.serializedLightData.lightLayers.intValue = lightLayer;
+                    serialized.serializedLightData.renderingLayerMask.intValue = lightLayer;
                 }
             }
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
@@ -30,7 +30,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public SerializedProperty volumetricDimmer;
             public SerializedProperty lightUnit;
             public SerializedProperty displayAreaLightEmissiveMesh;
-            public SerializedProperty lightLayers;
+            public SerializedProperty renderingLayerMask;
             public SerializedProperty shadowNearPlane;
             public SerializedProperty shadowSoftness;
             public SerializedProperty blockerSampleCount;
@@ -135,7 +135,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     showFeatures = o.Find(x => x.featuresFoldout),
                     showAdditionalSettings = o.Find(x => x.showAdditionalSettings),
                     useVolumetric = o.Find(x => x.useVolumetric),
-                    lightLayers = settings.renderingLayerMask
+                    renderingLayerMask = settings.renderingLayerMask
                 };
 
             // TODO: Review this once AdditionalShadowData is refactored

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
@@ -104,7 +104,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     volumetricDimmer = o.Find(x => x.volumetricDimmer),
                     lightUnit = o.Find(x => x.lightUnit),
                     displayAreaLightEmissiveMesh = o.Find(x => x.displayAreaLightEmissiveMesh),
-                    lightLayers = o.Find(x => x.lightLayers),
                     fadeDistance = o.Find(x => x.fadeDistance),
                     affectDiffuse = o.Find(x => x.affectDiffuse),
                     affectSpecular = o.Find(x => x.affectSpecular),
@@ -135,7 +134,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     useOldInspector = o.Find(x => x.useOldInspector),
                     showFeatures = o.Find(x => x.featuresFoldout),
                     showAdditionalSettings = o.Find(x => x.showAdditionalSettings),
-                    useVolumetric = o.Find(x => x.useVolumetric)
+                    useVolumetric = o.Find(x => x.useVolumetric),
+                    lightLayers = settings.renderingLayerMask
                 };
 
             // TODO: Review this once AdditionalShadowData is refactored

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -68,8 +68,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     [ExecuteAlways]
     public class HDAdditionalLightData : MonoBehaviour, ISerializationCallbackReceiver
     {
+        // TODO: Use proper migration toolkit
         // 3. Added ShadowNearPlane to HDRP additional light data, we don't use Light.shadowNearPlane anymore
-        private const int currentVersion = 3;
+        // 4. Migrate HDAdditionalLightData.lightLayer to Light.renderingLayerMask
+        private const int currentVersion = 4;
 
         [HideInInspector, SerializeField]
         [FormerlySerializedAs("m_Version")]
@@ -179,12 +181,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // Duplication of HDLightEditor.k_MinAreaWidth, maybe do something about that
         const float k_MinAreaWidth = 0.01f; // Provide a small size of 1cm for line light
 
+        [Obsolete("Use Light.renderingLayerMask instead")]
         public LightLayerEnum lightLayers = LightLayerEnum.LightLayerDefault;
 
         // This function return a mask of light layers as uint and handle the case of Everything as being 0xFF and not -1
         public uint GetLightLayers()
         {
-            int value = (int)(lightLayers);
+            int value = m_Light.renderingLayerMask;
             return value < 0 ? (uint)LightLayerEnum.Everything : (uint)value;
         }
 
@@ -843,11 +846,42 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // ShadowNearPlane have been move to HDRP as default legacy unity clamp it to 0.1 and we need to be able to go below that
                 shadowNearPlane = m_Light.shadowNearPlane;
             }
+            if (m_Version <= 3)
+            {
+                m_Light.renderingLayerMask = LightLayerToRenderingLayerMask((int)lightLayers, m_Light.renderingLayerMask);
+            }
 
             m_Version = currentVersion;
             version = currentVersion;
 
 #pragma warning restore 0618
         }
+
+        /// <summary>
+        /// Converts a light layer into a rendering layer mask.
+        ///
+        /// Light layer is stored in the first 8 bit of the rendering layer mask.
+        ///
+        /// NOTE: light layers are obsolete, use directly renderingLayerMask.
+        /// </summary>
+        /// <param name="lightLayer">The light layer, only the first 8 bits will be used.</param>
+        /// <param name="renderingLayerMask">Current renderingLayerMask, only the last 24 bits will be used.</param>
+        /// <returns></returns>
+        internal static int LightLayerToRenderingLayerMask(int lightLayer, int renderingLayerMask)
+        {
+            var renderingLayerMask_u32 = (uint)renderingLayerMask;
+            var lightLayer_u8 = (byte)lightLayer;
+            return (int)((renderingLayerMask_u32 & 0xFFFFFF00) | lightLayer_u8);
+        }
+
+        /// <summary>
+        /// Converts a renderingLayerMask into a lightLayer.
+        ///
+        /// NOTE: light layers are obsolete, use directly renderingLayerMask.
+        /// </summary>
+        /// <param name="renderingLayerMask"></param>
+        /// <returns></returns>
+        internal static int RenderingLayerMaskToLightLayer(int renderingLayerMask)
+            => (byte)renderingLayerMask;
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Migrate HDAdditionalLightData.lightLayer to Light.renderingLayerMask

---
### Release Notes


---
### Testing status
**Katana Tests**: [ABV Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixLightLayer&automation-tools_branch=master&unity_branch=trunk#)

**Manual Tests**: Local manual testing
 - Testing that an object with a different light layer is not lit and does not cast shadows
 - Testing that migrating a light with specific light layer gets properly migrated.

**Automated Tests**: -

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
