### PR TITLE
 Fixed wrong scissor value leaking from editor code.

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added emissive property for shader graph decals
 
+### Fixed
+- Fixed an issue where scissor render state leaking from the editor code caused partially black rendering
+
 ## [6.2.0-preview] - 2019-02-15
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1457,6 +1457,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // The NewFrame must be after the VolumeManager update and before Resize because it uses properties set in NewFrame
             m_LightLoop.NewFrame(hdCamera.frameSettings);
 
+            // Apparently scissor states can leak from editor code. As it is not used currently in HDRP (appart from VR). We disable scissor at the beginning of the frame.
+            cmd.DisableScissorRect();
+
             Resize(hdCamera);
             m_PostProcessSystem.BeginFrame(cmd, hdCamera);
 


### PR DESCRIPTION
### Purpose of this PR
Fixed an issue where scissor render state leaking from the editor code caused partially black rendering

### Testing status
Local manual testing
Katana : https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-wrong-scissor&automation-tools_branch=master&unity_branch=trunk