### PR TITLE
Added custom SH volume texture (from LPPV) support.

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/EntityLighting.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/EntityLighting.hlsl
@@ -115,13 +115,42 @@ float3 SampleProbeVolumeSH4(TEXTURE3D_ARGS(SHVolumeTexture, SHVolumeSampler), fl
     // This avoid leaking
     texCoord.x = clamp(texCoord.x * 0.25, 0.5 * texelSizeX, 0.25 - 0.5 * texelSizeX);
 
-    float4 shAr = SAMPLE_TEXTURE3D(SHVolumeTexture, SHVolumeSampler, texCoord);
+    float4 shAr = SAMPLE_TEXTURE3D_LOD(SHVolumeTexture, SHVolumeSampler, texCoord, 0);
     texCoord.x += 0.25;
-    float4 shAg = SAMPLE_TEXTURE3D(SHVolumeTexture, SHVolumeSampler, texCoord);
+    float4 shAg = SAMPLE_TEXTURE3D_LOD(SHVolumeTexture, SHVolumeSampler, texCoord, 0);
     texCoord.x += 0.25;
-    float4 shAb = SAMPLE_TEXTURE3D(SHVolumeTexture, SHVolumeSampler, texCoord);
+    float4 shAb = SAMPLE_TEXTURE3D_LOD(SHVolumeTexture, SHVolumeSampler, texCoord, 0);
 
     return SHEvalLinearL0L1(normalWS, shAr, shAg, shAb);
+}
+
+// The SphericalHarmonicsL2 coefficients are packed into 7 coefficients per color channel instead of 9.
+// The packing from 9 to 7 is done from engine code and will use the alpha component of the pixel to store an additional SH coefficient.
+// The 3D atlas texture will contain 7 SH coefficient parts.
+float3 SampleProbeVolumeSH9(TEXTURE3D_ARGS(SHVolumeTexture, SHVolumeSampler), float3 positionWS, float3 normalWS, float4x4 WorldToTexture,
+                                           float transformToLocal, float texelSizeX, float3 probeVolumeMin, float3 probeVolumeSizeInv)
+{
+    float3 position = (transformToLocal == 1.0f) ? mul(WorldToTexture, float4(positionWS, 1.0)).xyz : positionWS;
+    float3 texCoord = (position - probeVolumeMin) * probeVolumeSizeInv;
+
+    const uint shCoeffCount = 7;
+    const float invShCoeffCount = 1.0f / float(shCoeffCount);
+
+    // We need to compute proper X coordinate to sample into the atlas.
+    texCoord.x = texCoord.x / shCoeffCount;
+
+    // Clamp the x coordinate otherwise we'll have leaking between RGB coefficients.
+    float texCoordX = clamp(texCoord.x, 0.5f * texelSizeX, invShCoeffCount - 0.5f * texelSizeX);
+
+    float4 SHCoefficients[7];
+
+    for (uint i = 0; i < shCoeffCount; i++)
+    {
+        texCoord.x = texCoordX + i * invShCoeffCount;
+        SHCoefficients[i] = SAMPLE_TEXTURE3D_LOD(SHVolumeTexture, SHVolumeSampler, texCoord, 0);
+    }
+
+    return SampleSH9(SHCoefficients, normalize(normalWS));
 }
 
 float4 SampleProbeOcclusion(TEXTURE3D_ARGS(SHVolumeTexture, SHVolumeSampler), float3 positionWS, float4x4 WorldToTexture,

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl
@@ -28,8 +28,12 @@ float3 SampleBakedGI(float3 positionRWS, float3 normalWS, float2 uvStaticLightma
     }
     else
     {
-        return SampleProbeVolumeSH4(TEXTURE3D_PARAM(unity_ProbeVolumeSH, samplerunity_ProbeVolumeSH), positionRWS, normalWS, GetProbeVolumeWorldToObject(),
-                                    unity_ProbeVolumeParams.y, unity_ProbeVolumeParams.z, unity_ProbeVolumeMin.xyz, unity_ProbeVolumeSizeInv.xyz);
+        if (unity_ProbeVolumeParams.w == 0.0)
+            return SampleProbeVolumeSH4(TEXTURE3D_PARAM(unity_ProbeVolumeSH, samplerunity_ProbeVolumeSH), positionRWS, normalWS, GetProbeVolumeWorldToObject(),
+                unity_ProbeVolumeParams.y, unity_ProbeVolumeParams.z, unity_ProbeVolumeMin.xyz, unity_ProbeVolumeSizeInv.xyz);
+        else
+            return SampleProbeVolumeSH9(TEXTURE3D_PARAM(unity_ProbeVolumeSH, samplerunity_ProbeVolumeSH), positionRWS, normalWS, GetProbeVolumeWorldToObject(),
+                unity_ProbeVolumeParams.y, unity_ProbeVolumeParams.z, unity_ProbeVolumeMin.xyz, unity_ProbeVolumeSizeInv.xyz);
     }
 
 #else

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -867,6 +867,39 @@ Shader "HDRP/Lit"
 
             ENDHLSL
         }
+
+        Pass
+        {
+            Name "RTLightProbesDXR"
+            Tags{ "LightMode" = "RTLightProbesDXR" }
+
+            HLSLPROGRAM
+
+            #pragma raytracing LightProbe
+
+            // We use the low shadow maps for raytracing
+            #define SHADOW_LOW
+
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingMacros.hlsl"
+
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracingLightLoop.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
+
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingIntersection.hlsl"
+
+            #include "Packages/com.unity.render-pipelines.high-definition\Runtime\Lighting\LightLoop\LightLoopDef.hlsl"
+            #define HAS_LIGHTLOOP
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitRaytracing.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingLightLoop.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitRaytracingData.hlsl"
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingLightProbe.hlsl"
+
+            ENDHLSL
+        }
     }
 
     CustomEditor "Experimental.Rendering.HDPipeline.LitGUI"

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1797,6 +1797,22 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Might float this higher if we enable stereo w/ deferred
                 StartStereoRendering(cmd, renderContext, camera);
 
+#if (ENABLE_RAYTRACING)
+                {
+                    HDRaytracingEnvironment rtEnvironement = m_RayTracingManager.CurrentEnvironment();
+                    HDRaytracingLightCluster lightCluster = m_RayTracingManager.RequestLightCluster(hdCamera);
+                    cmd.SetGlobalBuffer(HDShaderIDs._RaytracingLightCluster, lightCluster.GetCluster());
+                    cmd.SetGlobalBuffer(HDShaderIDs._LightDatasRT, lightCluster.GetLightDatas());
+                    cmd.SetGlobalVector(HDShaderIDs._MinClusterPos, lightCluster.GetMinClusterPos());
+                    cmd.SetGlobalVector(HDShaderIDs._MaxClusterPos, lightCluster.GetMaxClusterPos());
+                    cmd.SetGlobalInt(HDShaderIDs._LightPerCellCount, rtEnvironement.maxNumLightsPercell);
+                    cmd.SetGlobalInt(HDShaderIDs._PunctualLightCountRT, lightCluster.GetPunctualLightCount());
+                    cmd.SetGlobalInt(HDShaderIDs._AreaLightCountRT, lightCluster.GetAreaLightCount());
+
+                    HDRaytracingLightProbeBakeManager.Bake(hdCamera.camera, cmd);
+                }
+#endif
+
                 RenderDeferredLighting(hdCamera, cmd);
 
                 RenderForward(cullingResults, hdCamera, renderContext, cmd, ForwardPass.Opaque);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightProbeBakeManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightProbeBakeManager.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace UnityEngine.Experimental.Rendering.HDPipeline
+{
+#if ENABLE_RAYTRACING
+
+    public static class HDRaytracingLightProbeBakeManager
+    {
+        public static event System.Action<Camera, CommandBuffer> bakeLightProbes;
+        public static void Bake(Camera camera, CommandBuffer cmdBuffer)
+        {
+            bakeLightProbes?.Invoke(camera, cmdBuffer);
+        }
+    }
+#endif
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightProbeBakeManager.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightProbeBakeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62753968ef4f78440aff9fc34985ef9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingManager.cs
@@ -440,7 +440,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                     // Also, we need to contribute to the maximal number of submeshes
                     MeshFilter currentFilter = currentRenderer.GetComponent<MeshFilter>();
-                    maxNumSubMeshes = Mathf.Max(maxNumSubMeshes, currentFilter.sharedMesh.subMeshCount);
+                    if (currentFilter != null && currentFilter.sharedMesh != null)
+                    {
+                        maxNumSubMeshes = Mathf.Max(maxNumSubMeshes, currentFilter.sharedMesh.subMeshCount);
+                    }
                 }
 
                 bool[] subMeshFlagArray = new bool[maxNumSubMeshes];

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingLightProbe.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingLightProbe.hlsl
@@ -1,0 +1,53 @@
+#include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingFragInputs.hlsl"
+
+// Generic function that handles the reflection code
+[shader("closesthit")]
+void ClosestHitMain(inout RayIntersection rayIntersection : SV_RayPayload, AttributeData attributeData : SV_IntersectionAttributes)
+{
+    // The first thing that we should do is grab the intersection vertice
+    IntersectionVertice currentvertex;
+    GetCurrentIntersectionVertice(attributeData, currentvertex);
+
+    // Build the Frag inputs from the intersection vertice
+    FragInputs fragInput;
+    BuildFragInputsFromIntersection(currentvertex, rayIntersection, fragInput);
+
+    // Compute the view vector
+    float3 viewWS = -rayIntersection.incidentDirection;
+
+    // Make sure to add the additional travel distance
+    float travelDistance = length(GetAbsolutePositionWS(fragInput.positionRWS) - rayIntersection.origin);
+    rayIntersection.t = travelDistance;
+    rayIntersection.cone.width += travelDistance * rayIntersection.cone.spreadAngle;
+
+    PositionInputs posInput;
+    posInput.positionWS = fragInput.positionRWS;
+    posInput.positionSS = uint2(0, 0);
+
+    // Build the surfacedata and builtindata
+    SurfaceData surfaceData;
+    BuiltinData builtinData;
+    GetSurfaceDataFromIntersection(fragInput, viewWS, posInput, currentvertex, rayIntersection.cone, surfaceData, builtinData);
+
+    builtinData.bakeDiffuseLighting = float3(0, 0, 0);
+
+    // Compute the bsdf data
+    BSDFData bsdfData = ConvertSurfaceDataToBSDFData(posInput.positionSS, surfaceData);
+
+#ifdef HAS_LIGHTLOOP
+    // Compute the prelight data
+    PreLightData preLightData = GetPreLightData(viewWS, posInput, bsdfData);
+
+    // Run the lightloop
+    float3 diffuseLighting;
+    float3 specularLighting;
+    LightLoop(viewWS, posInput, preLightData, bsdfData, builtinData, float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0), diffuseLighting, specularLighting);
+
+    // Color display for the moment
+    rayIntersection.color = diffuseLighting + specularLighting;
+#else
+    // Given that we will be multiplying the final color by the current exposure multiplier outside of this function, we need to make sure that
+    // the unlit color is not impacted by that. Thus, we multiply it by the inverse of the current exposure multiplier.
+    rayIntersection.color = bsdfData.color * GetInverseCurrentExposureMultiplier() + builtinData.emissiveColor;
+#endif
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingLightProbe.hlsl.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingLightProbe.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e20f39a976edbd742bba4a6c90d364ec
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a pass in Lit.shader for baking light probes. The pass is a copy paste from the dxr reflection pass.
Bake light probes and update LPPV volume texture before deferred pass. This should be moved before GBuffer pass.

### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
