### PR TITLE
Fixing a missing include in the raytracing lit graph template

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitRaytracingPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitRaytracingPass.template
@@ -85,11 +85,7 @@ Pass
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/BuiltinUtilities.hlsl"
     #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingBuiltinData.hlsl"
-
-    bool IsGammaSpace()
-    {
-        return false;
-    }
+    #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderGraphFunctions.hlsl"
 
     //-------------------------------------------------------------------------------------
     // Graph generated code


### PR DESCRIPTION
All in the title