### PR TITLE
Update HDRP VFXSampleDepth() to use LoadCameraDepth()

### DIFF
--- a/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXCommon.cginc
+++ b/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXCommon.cginc
@@ -57,7 +57,7 @@ float4x4 VFXGetViewToWorldMatrix()
 
 float VFXSampleDepth(float4 posSS)
 {
-    return LOAD_TEXTURE2D(_CameraDepthTexture, posSS.xy).r;
+    return LoadCameraDepth(posSS.xy);
 }
 
 float VFXLinearEyeDepth(float depth)


### PR DESCRIPTION
### Purpose of this PR
Update VFX code to be compatible with XR stereo instancing

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp-xr-vfxsampledepth&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Code from ShaderVariables.hlsl
~~~~
float LoadCameraDepth(uint2 pixelCoords)
{
    return LOAD_TEXTURE2D_X_LOD(_CameraDepthTexture, pixelCoords, 0).r;
}
~~~~