### PR TITLE
Add depth-of-field support with stereo instancing

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [6.5.0-preview] - 2019-XX-XX
 
+### Added
+- Added depth-of-field support with stereo instancing
+
 ### Fixed
 - Fixed diffusion profile upgrade breaking package when upgrading to a new version
 - Fixed decals cropped by gizmo not updating correctly if prefab

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Components/DepthOfField.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Components/DepthOfField.cs
@@ -48,15 +48,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public bool IsActive()
         {
-            bool dofActive = focusMode.value != DepthOfFieldMode.Off && (IsNearLayerActive() || IsFarLayerActive());
-
-            if (dofActive && XRGraphics.enabled)
-            {
-                Debug.LogWarning("DepthOfField is not supported with VR.");
-                dofActive = false;
-            }
-
-            return dofActive;
+            return focusMode.value != DepthOfFieldMode.Off && (IsNearLayerActive() || IsFarLayerActive());
         }
 
         public bool IsNearLayerActive() => nearMaxBlur > 0f && nearFocusEnd > 0f;

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCoC.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCoC.compute
@@ -41,9 +41,11 @@ float GetFixedNearBlend(float linearEyeDepth)
 // Physical CoC
 // "A Lens and Aperture Camera Model for Synthetic Image Generation" [Potmesil81]
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void KMainPhysical(uint2 dispatchThreadId : SV_DispatchThreadID)
+void KMainPhysical(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
-    float depth = LoadCameraDepth(dispatchThreadId);
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
+    float depth = LoadCameraDepth(dispatchThreadId.xy);
     float linearEyeDepth = LinearEyeDepth(depth, _ZBufferParams);
     float coc = (1.0 - FocusDist / linearEyeDepth) * MaxCoC;
 
@@ -52,15 +54,16 @@ void KMainPhysical(uint2 dispatchThreadId : SV_DispatchThreadID)
     float nearCoC = clamp(coc * nearBlend, -1.0, 0.0);
     float farCoC = saturate(coc);
 
-    _OutputCoCTexture[COORD_TEXTURE2D_X(dispatchThreadId)] = farCoC + nearCoC;
+    _OutputCoCTexture[COORD_TEXTURE2D_X(dispatchThreadId.xy)] = farCoC + nearCoC;
 }
 
 // Manual CoC using near & far planes
 // This will accentuate rendering artifacts if used incorrectly
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void KMainManual(uint2 dispatchThreadId : SV_DispatchThreadID)
+void KMainManual(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
-    float depth = LoadCameraDepth(dispatchThreadId);
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+    float depth = LoadCameraDepth(dispatchThreadId.xy);
     float linearEyeDepth = LinearEyeDepth(depth, _ZBufferParams);
 
     float nearBlend = GetFixedNearBlend(linearEyeDepth);
@@ -71,5 +74,5 @@ void KMainManual(uint2 dispatchThreadId : SV_DispatchThreadID)
     float farCoC = (linearEyeDepth - FarStart) / (FarEnd - FarStart);
     farCoC = saturate(farCoC);
 
-    _OutputCoCTexture[COORD_TEXTURE2D_X(dispatchThreadId)] = -nearCoC + farCoC;
+    _OutputCoCTexture[COORD_TEXTURE2D_X(dispatchThreadId.xy)] = -nearCoC + farCoC;
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCoCDilate.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCoCDilate.compute
@@ -81,8 +81,10 @@ void VerticalPass(uint2 pixelCoord, uint topMostIndex)
 #define GROUP_SIZE 8
 
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void KMain(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, uint2 dispatchThreadId : SV_DispatchThreadID)
+void KMain(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, uint3 dispatchThreadId : SV_DispatchThreadID)
 {
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
     // Upper-left pixel coordinate of quad that this thread will read
     int2 threadUL = (groupThreadId << 1) + (groupId << 3) - 4;
     uint2 uthreadUL = uint2(max(0, threadUL));
@@ -104,6 +106,6 @@ void KMain(uint2 groupId : SV_GroupID, uint2 groupThreadId : SV_GroupThreadID, u
 
     GroupMemoryBarrierWithGroupSync();
 
-    VerticalPass(dispatchThreadId, (groupThreadId.y << 3u) + groupThreadId.x);
+    VerticalPass(dispatchThreadId.xy, (groupThreadId.y << 3u) + groupThreadId.x);
 }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCoCReproject.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCoCReproject.compute
@@ -23,9 +23,11 @@ CBUFFER_END
 #define GROUP_SIZE 8
 
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void KMain(uint2 dispatchThreadId : SV_DispatchThreadID)
+void KMain(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
-    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId), _ScreenSize.zw, uint2(GROUP_SIZE, GROUP_SIZE));
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
+    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId.xy), _ScreenSize.zw, uint2(GROUP_SIZE, GROUP_SIZE));
     float2 uv = posInputs.positionNDC;
 
 #if 0

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCombine.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldCombine.compute
@@ -35,9 +35,11 @@ CBUFFER_END
 #define GROUP_SIZE 8
 
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void MAIN(uint2 dispatchThreadId : SV_DispatchThreadID)
+void MAIN(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
-    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId), _ScreenSize.zw, uint2(GROUP_SIZE, GROUP_SIZE));
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
+    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId.xy), _ScreenSize.zw, uint2(GROUP_SIZE, GROUP_SIZE));
     float2 uv = posInputs.positionNDC * _ScreenToTargetScale.xy;
 
     float3 outColor = LOAD_TEXTURE2D_X(_InputTexture, posInputs.positionSS).xyz;
@@ -98,15 +100,17 @@ void MAIN(uint2 dispatchThreadId : SV_DispatchThreadID)
 }
 
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void KMainPreCombineFar(uint2 dispatchThreadId : SV_DispatchThreadID)
+void KMainPreCombineFar(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
-    float3 baseColor = LOAD_TEXTURE2D_X(_InputTexture, dispatchThreadId).xyz;
-    float3 farColor = LOAD_TEXTURE2D_X(_InputFarTexture, dispatchThreadId).xyz;
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
+    float3 baseColor = LOAD_TEXTURE2D_X(_InputTexture, dispatchThreadId.xy).xyz;
+    float3 farColor = LOAD_TEXTURE2D_X(_InputFarTexture, dispatchThreadId.xy).xyz;
 
     float3 dstColor = float3(0.0, 0.0, 0.0);
     float dstAlpha = 1.0;
 
-    float coc = LOAD_TEXTURE2D_X(_InputCoCTexture, dispatchThreadId).x;
+    float coc = LOAD_TEXTURE2D_X(_InputCoCTexture, dispatchThreadId.xy).x;
 
     if (coc > 0.0)
     {
@@ -117,5 +121,5 @@ void KMainPreCombineFar(uint2 dispatchThreadId : SV_DispatchThreadID)
         dstAlpha = saturate(1.0 - blend);
     }
 
-    _OutputTexture[COORD_TEXTURE2D_X(dispatchThreadId)] = baseColor * dstAlpha + dstColor;
+    _OutputTexture[COORD_TEXTURE2D_X(dispatchThreadId.xy)] = baseColor * dstAlpha + dstColor;
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldGather.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldGather.compute
@@ -52,7 +52,7 @@ CBUFFER_END
 void MAIN(uint groupThreadId : SV_GroupThreadID)
 #else
 [numthreads(GROUP_RES, GROUP_RES, 1)]
-void MAIN(uint2 dispatchThreadId : SV_DispatchThreadID)
+void MAIN(uint3 dispatchThreadId : SV_DispatchThreadID)
 #endif
 {
 #if USE_TILES
@@ -67,12 +67,14 @@ void MAIN(uint2 dispatchThreadId : SV_DispatchThreadID)
 
     // Compute the actual pixel coordinate we're working
     uint2 dispatchThreadId = gs_tileCoord + uint2(groupThreadId % GROUP_RES, groupThreadId / GROUP_RES);
+#else
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
 #endif
 
-    if (any(dispatchThreadId >= uint2(_TexelSize.xy)))
+    if (any(dispatchThreadId.xy >= uint2(_TexelSize.xy)))
         return; // Out of bounds, discard
 
-    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId), _TexelSize.zw, uint2(GROUP_RES, GROUP_RES));
+    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId.xy), _TexelSize.zw, uint2(GROUP_RES, GROUP_RES));
     float2 uv = posInputs.positionNDC;
     float2 barrelUV = (uv * 2.0 - 1.0) * BarrelClipping;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldMip.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldMip.compute
@@ -29,9 +29,11 @@ CTYPE LoadPixel(uint index)
 
 // Generate four mips in one pass
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void MAIN(uint2 dispatchThreadId : SV_DispatchThreadID, uint groupIndex : SV_GroupIndex)
+void MAIN(uint3 dispatchThreadId : SV_DispatchThreadID, uint groupIndex : SV_GroupIndex)
 {
-    uint2 ul = dispatchThreadId << 1u;
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
+    uint2 ul = dispatchThreadId.xy << 1u;
 
     // First mip
     CTYPE color = _InputTexture[COORD_TEXTURE2D_X(ul)];

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldMipSafe.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldMipSafe.compute
@@ -18,9 +18,11 @@ CBUFFER_END
 #define GROUP_SIZE 8
 
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void KMain(uint2 dispatchThreadId : SV_DispatchThreadID)
+void KMain(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
-    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId), _TexelSize.zw, uint2(GROUP_SIZE, GROUP_SIZE));
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
+    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId.xy), _TexelSize.zw, uint2(GROUP_SIZE, GROUP_SIZE));
     float2 uv =ClampAndScaleUVForBilinear(posInputs.positionNDC);
     _OutputTexture[COORD_TEXTURE2D_X(posInputs.positionSS)] = SAMPLE_TEXTURE2D_X_LOD(_InputTexture, sampler_LinearClamp, uv, 0.0).xyz;
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldPrefilter.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldPrefilter.compute
@@ -30,10 +30,12 @@ CBUFFER_END
 #define GROUP_SIZE 8
 
 [numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
-void MAIN(uint2 dispatchThreadId : SV_DispatchThreadID)
+void MAIN(uint3 dispatchThreadId : SV_DispatchThreadID)
 {
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
+
     float2 texelSize = _ScreenSize.zw * _TargetScale.x;
-    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId), texelSize, uint2(GROUP_SIZE, GROUP_SIZE));
+    PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId.xy), texelSize, uint2(GROUP_SIZE, GROUP_SIZE));
     float2 uv = posInputs.positionNDC;
 
 #if FULL_RES


### PR DESCRIPTION
### Purpose of this PR
Add depth-of-field support with stereo instancing

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp-xr-spi-dof&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
For XR, we don't implement the tile version as recommended by @Chman