### PR TITLE
Fix use of GetHashCode in SubGraphNode

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
@@ -27,6 +27,12 @@ namespace UnityEditor.ShaderGraph
         [NonSerialized]
         MaterialSubGraphAsset m_SubGraph;
 
+        [SerializeField]
+        List<string> m_PropertyGuids = new List<string>();
+
+        [SerializeField]
+        List<int> m_PropertyIds = new List<int>();
+
         [Serializable]
         private class SubGraphHelper
         {
@@ -127,7 +133,7 @@ namespace UnityEditor.ShaderGraph
             var arguments = new List<string>();
             foreach (var prop in referencedGraph.properties)
             {
-                var inSlotId = prop.guid.GetHashCode();
+                var inSlotId = m_PropertyIds[m_PropertyGuids.IndexOf(prop.guid.ToString())];
 
                 if (prop is TextureShaderProperty)
                     arguments.Add(string.Format("TEXTURE2D_ARGS({0}, sampler{0})", GetSlotValue(inSlotId, generationMode)));
@@ -222,7 +228,15 @@ namespace UnityEditor.ShaderGraph
                         throw new ArgumentOutOfRangeException();
                 }
 
-                var id = prop.guid.GetHashCode();
+                var propertyString = prop.guid.ToString();
+                var propertyIndex = m_PropertyGuids.IndexOf(propertyString);
+                if (propertyIndex < 0)
+                {
+                    propertyIndex = m_PropertyGuids.Count;
+                    m_PropertyGuids.Add(propertyString);
+                    m_PropertyIds.Add(prop.guid.GetHashCode());
+                }
+                var id = m_PropertyIds[propertyIndex];
                 MaterialSlot slot = MaterialSlot.CreateMaterialSlot(slotType, id, prop.displayName, prop.referenceName, SlotType.Input, prop.defaultValue, ShaderStageCapability.All);
                 // copy default for texture for niceness
                 if (slotType == SlotValueType.Texture2D && propType == PropertyType.Texture2D)


### PR DESCRIPTION
### Purpose of this PR
Serialise mapping from property GUID to port ID in SubGraphNode. This makes serialisation stable after a re-save.

---
### Testing status
**Katana Tests**: On the way https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?unity_branch=trunk&ScriptableRenderLoop_branch=sg%2Ffix-subgraph-gethashcode&automation-tools_branch=master

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] ~Built a player~ Only touches Editor-only code
- [x] ~Checked new UI names with UX convention~ No UI changes
- [x] ~Tested UI multi-edition + Undo/Redo~ No UI changes
- [x] C# and shader warnings (suppress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
