### PR TITLE
Fix cascade border 

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -21,13 +21,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed mutiselection issue with HDLight Inspector
 - Fixed HDAdditionalCameraData data migration
 - Fixed failing builds when light explorer window is open
+- Fixed cascade shadows border sometime causing artefacts between cascades
+- Restored shadows in the Cascade Shadow debug visualization
 
 ### Added
 - Added a new FrameSettings: Specular Lighting to toggle the specular during the rendering
 
 ### Changed
 - When rendering reflection probe disable all specular lighting and for metals use fresnelF0 as diffuse color for bake lighting.
-
 
 ## [6.4.0-preview] - 2019-02-21
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -8,7 +8,7 @@
 // LightLoop
 // ----------------------------------------------------------------------------
 
-void ApplyDebug(LightLoopContext lightLoopContext, float3 positionWS, inout float3 diffuseLighting, inout float3 specularLighting)
+void ApplyDebug(LightLoopContext lightLoopContext, PositionInputs posInput, BSDFData bsdfData, inout float3 diffuseLighting, inout float3 specularLighting)
 {
 #ifdef DEBUG_DISPLAY
     if (_DebugLightingMode == DEBUGLIGHTINGMODE_DIFFUSE_LIGHTING)
@@ -40,16 +40,24 @@ void ApplyDebug(LightLoopContext lightLoopContext, float3 positionWS, inout floa
         diffuseLighting = float3(1.0, 1.0, 1.0);
         if (_DirectionalShadowIndex >= 0)
         {
-            real  alpha;
+            real alpha;
             int cascadeCount;
 
-            int shadowSplitIndex = EvalShadow_GetSplitIndex(lightLoopContext.shadowContext, _DirectionalShadowIndex, positionWS, alpha, cascadeCount);
+            int shadowSplitIndex = EvalShadow_GetSplitIndex(lightLoopContext.shadowContext, _DirectionalShadowIndex, posInput.positionWS, alpha, cascadeCount);
             if (shadowSplitIndex >= 0)
             {
+                float shadow = 1.0;
+                if (_DirectionalShadowIndex >= 0)
+                {
+                    DirectionalLightData light = _DirectionalLightDatas[_DirectionalShadowIndex];
+                    float3 shadowBiasNormal = GetNormalForShadowBias(bsdfData);
+                    shadow = EvaluateRuntimeSunShadow(lightLoopContext, posInput, light, shadowBiasNormal);
+                }
+
                 float3 cascadeShadowColor = lerp(s_CascadeColors[shadowSplitIndex], s_CascadeColors[shadowSplitIndex + 1], alpha);
                 // We can't mix with the lighting as it can be HDR and it is hard to find a good lerp operation for this case that is still compliant with
                 // exposure. So disable exposure instead and replace color.
-                diffuseLighting = cascadeShadowColor;
+                diffuseLighting = cascadeShadowColor * shadow;
             }
 
         }
@@ -402,12 +410,12 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         }
     }
 #undef EVALUATE_BSDF_ENV
-#undef EVALUATE_BSDF_ENV_SKY    
+#undef EVALUATE_BSDF_ENV_SKY
 
     // Also Apply indiret diffuse (GI)
     // PostEvaluateBSDF will perform any operation wanted by the material and sum everything into diffuseLighting and specularLighting
     PostEvaluateBSDF(   context, V, posInput, preLightData, bsdfData, builtinData, aggregateLighting,
                         diffuseLighting, specularLighting);
 
-    ApplyDebug(context, posInput.positionWS, diffuseLighting, specularLighting);
+    ApplyDebug(context, posInput, bsdfData, diffuseLighting, specularLighting);
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAlgorithms.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAlgorithms.hlsl
@@ -335,12 +335,17 @@ int EvalShadow_GetSplitIndex(HDShadowContext shadowContext, int index, float3 po
     }
     int shadowSplitIndex = i < _CascadeShadowCount ? i : -1;
 
-    float3 cascadeDir = dsd.cascadeDirection.xyz;
-    cascadeCount     = dsd.cascadeDirection.w;
-    float border      = dsd.cascadeBorders[shadowSplitIndex];
-          alpha      = border <= 0.0 ? 0.0 : saturate((relDistance - (1.0 - border)) / border);
-    float  cascDot    = dot(cascadeDir, wposDir);
-          alpha      = lerp(alpha, 0.0, saturate(-cascDot * 4.0));
+    cascadeCount = dsd.cascadeDirection.w;
+    float border = dsd.cascadeBorders[shadowSplitIndex];
+    alpha = border <= 0.0 ? 0.0 : saturate((relDistance - (1.0 - border)) / border);
+
+    // The above code will generate transitions on the whole cascade sphere boundary.
+    // It means that depending on the light and camera direction, sometimes the transition appears on the wrong side of the cascade
+    // To avoid that we attenuate the effect (lerp to 0.0) when view direction and cascade center to pixel vector face opposite directions.
+    // This way you only get fade out on the right side of the cascade.
+    float3 viewDir = GetWorldSpaceViewDir(positionWS);
+    float  cascDot = dot(viewDir, wposDir);
+    alpha = lerp(alpha, 0.0, saturate(cascDot * 4.0));
 
     return shadowSplitIndex;
 }


### PR DESCRIPTION
### Purpose of this PR
- Shadow Cascade debug visualization shows shadows again
- Fixed an issue where sometimes, fading between cascade was wrong
---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 
Enabled cascade borders (which are not exposed by default) and made sure they were still working as intended.

**Automated Tests**: What did you setup?
Running:
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-cascade-border&automation-tools_branch=master&unity_branch=trunk

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low, could change behavior of existing cascade border settings.

**Halo Effect**: None, Low, Medium, High?
None, only touches a very specific part of shadow code
