### PR TITLE
Use depth prepass in the shader graph preview

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
@@ -157,7 +157,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 FabricMasterNode.PositionSlotId
             },
-            UseInPreview = false,
+            UseInPreview = true,
 
             OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
@@ -164,7 +164,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 HairMasterNode.PositionSlotId
             },
-            UseInPreview = false,
+            UseInPreview = true,
 
             OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
@@ -253,7 +253,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 HDLitMasterNode.PositionSlotId
             },
-            UseInPreview = false,
+            UseInPreview = true,
 
             OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
@@ -177,7 +177,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 StackLitMasterNode.PositionSlotId
             },
-            UseInPreview = false,
+            UseInPreview = true,
 
             OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
             {

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [6.5.0] - 2019-XX-XX
 
+### Fixed
+- Fixed master preview for HDRP master nodes when alpha clip is enabled.
+
 ## [6.4.0] - 2019-02-21
 ### Fixed
 - Fixed the Transform node, so going from Tangent Space to any other space now works as expected.


### PR DESCRIPTION
### Purpose of this PR
Fix alpha clip breaking the shader graph preview on HDRP master nodes
https://fogbugz.unity3d.com/f/cases/1126636/

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixDepthClipShaderGraphPreview&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
