### PR TITLE
Optimized classes scanning done through CoreUtils.

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Volume/VolumeComponentEditor.cs
+++ b/com.unity.render-pipelines.core/Editor/Volume/VolumeComponentEditor.cs
@@ -55,10 +55,9 @@ namespace UnityEditor.Rendering
             s_ParameterDrawers.Clear();
 
             // Look for all the valid parameter drawers
-            var types = CoreUtils.GetAllAssemblyTypes()
+            var types = CoreUtils.GetAllTypesDerivedFrom<VolumeParameterDrawer>()
                 .Where(
-                    t => t.IsSubclassOf(typeof(VolumeParameterDrawer))
-                    && t.IsDefined(typeof(VolumeParameterDrawerAttribute), false)
+                    t => t.IsDefined(typeof(VolumeParameterDrawerAttribute), false)
                     && !t.IsAbstract
                     );
 

--- a/com.unity.render-pipelines.core/Editor/Volume/VolumeComponentListEditor.cs
+++ b/com.unity.render-pipelines.core/Editor/Volume/VolumeComponentListEditor.cs
@@ -41,10 +41,9 @@ namespace UnityEditor.Rendering
             m_Editors = new List<VolumeComponentEditor>();
 
             // Gets the list of all available component editors
-            var editorTypes = CoreUtils.GetAllAssemblyTypes()
+            var editorTypes = CoreUtils.GetAllTypesDerivedFrom<VolumeComponentEditor>()
                 .Where(
-                    t => t.IsSubclassOf(typeof(VolumeComponentEditor))
-                    && t.IsDefined(typeof(VolumeComponentEditorAttribute), false)
+                    t => t.IsDefined(typeof(VolumeComponentEditorAttribute), false)
                     && !t.IsAbstract
                     );
 

--- a/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
@@ -415,6 +415,15 @@ namespace UnityEngine.Rendering
             return m_AssemblyTypes;
         }
 
+        public static IEnumerable<Type> GetAllTypesDerivedFrom<T>()
+        {
+#if UNITY_EDITOR && UNITY_2019_2_OR_NEWER
+            return UnityEditor.TypeCache.GetTypesDerivedFrom<T>();
+#else
+            return GetAllAssemblyTypes().Where(t => t.IsSubclassOf(typeof(T)));
+#endif
+        }
+
         public static void Destroy(params UnityObject[] objs)
         {
             if (objs == null)

--- a/com.unity.render-pipelines.core/Runtime/Volume/VolumeManager.cs
+++ b/com.unity.render-pipelines.core/Runtime/Volume/VolumeManager.cs
@@ -66,8 +66,8 @@ namespace UnityEngine.Rendering
             m_ComponentsDefaultState.Clear();
 
             // Grab all the component types we can find
-            baseComponentTypes = CoreUtils.GetAllAssemblyTypes()
-                .Where(t => t.IsSubclassOf(typeof(VolumeComponent)) && !t.IsAbstract);
+            baseComponentTypes = CoreUtils.GetAllTypesDerivedFrom<VolumeComponent>()
+                .Where(t => !t.IsAbstract);
 
             // Keep an instance of each type to be used in a virtual lowest priority global volume
             // so that we have a default state to fallback to when exiting volumes

--- a/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugUIHandlerCanvasEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugUIHandlerCanvasEditor.cs
@@ -19,8 +19,8 @@ namespace UnityEngine.Experimental.Rendering.UI
 
         static DebugUIHandlerCanvasEditor()
         {
-            s_Types = CoreUtils.GetAllAssemblyTypes()
-                .Where(t => t.IsSubclassOf(typeof(DebugUI.Widget)) && !t.IsAbstract)
+            s_Types = CoreUtils.GetAllTypesDerivedFrom<DebugUI.Widget>()
+                .Where(t => !t.IsAbstract)
                 .Select(t => t.AssemblyQualifiedName)
                 .ToArray();
 

--- a/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugWindow.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Core/Debugging/DebugWindow.cs
@@ -88,15 +88,12 @@ namespace UnityEditor.Experimental.Rendering
 
         static void RebuildTypeMaps()
         {
-            var assemblyTypes = CoreUtils.GetAllAssemblyTypes();
-
             // Map states to widget (a single state can map to several widget types if the value to
             // serialize is the same)
             var attrType = typeof(DebugStateAttribute);
-            var stateTypes = assemblyTypes
+            var stateTypes = CoreUtils.GetAllTypesDerivedFrom<DebugState>()
                 .Where(
-                    t => t.IsSubclassOf(typeof(DebugState))
-                    && t.IsDefined(attrType, false)
+                    t => t.IsDefined(attrType, false)
                     && !t.IsAbstract
                     );
 
@@ -112,10 +109,9 @@ namespace UnityEditor.Experimental.Rendering
 
             // Drawers
             attrType = typeof(DebugUIDrawerAttribute);
-            var types = assemblyTypes
+            var types = CoreUtils.GetAllTypesDerivedFrom<DebugUIDrawer>()
                 .Where(
-                    t => t.IsSubclassOf(typeof(DebugUIDrawer))
-                    && t.IsDefined(attrType, false)
+                    t => t.IsDefined(attrType, false)
                     && !t.IsAbstract
                     );
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyManager.cs
@@ -131,7 +131,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 m_SkyTypesDict = new Dictionary<int, Type>();
 
-                var skyTypes = CoreUtils.GetAllAssemblyTypes().Where(t => t.IsSubclassOf(typeof(SkySettings)) && !t.IsAbstract);
+                var skyTypes = CoreUtils.GetAllTypesDerivedFrom<SkySettings>().Where(t => !t.IsAbstract);
                 foreach (Type skyType in skyTypes)
                 {
                     var uniqueIDs = skyType.GetCustomAttributes(typeof(SkyUniqueID), false);


### PR DESCRIPTION
### Purpose of this PR
Added type extraction helper to CoreUtils -  CoreUtils.GetAllTypesDerivedFrom.
Using UnityEditor.TypeCache API (available in Unity 2019.2) provides significant performance boost compared to direct IsSubclassOf usage.

Before:
![Domainreload impact before](https://i.imgur.com/eMF5u56.png "Domainreload impact before")

After:
![Domainreload impact after](https://i.imgur.com/nHbQJx4.png "Domainreload impact before")

---
### Release Notes
Optimized classes scanning in the Editor.

---
### Testing status
**Katana Tests**: Green
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=scripting%2Ftypecache&unity_branch=trunk

**Manual Tests**: What did you do?
- [X] Opened test project + Run graphic tests locally
- [X] Built a player

---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: Medium - Might affect classes scanning

---
### Comments to reviewers
