### PR TITLE
Fix for Texture nodes crashing in SubGraphs with SRP Batching turned on.

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -676,7 +676,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             var graph = new ShaderGenerator();
             {
                 graph.AddShaderChunk("// Shared Graph Properties (uniform inputs)");
-                graph.AddShaderChunk(sharedProperties.GetPropertiesDeclaration(1));
+                graph.AddShaderChunk(sharedProperties.GetPropertiesDeclaration(1, mode));
 
                 if (vertexActive)
                 {

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/LightWeightPBRSubShader.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/LightWeightPBRSubShader.cs
@@ -400,7 +400,7 @@ namespace UnityEditor.Rendering.LWRP
             // -------------------------------------
             // Combine Graph sections
 
-            graph.AppendLine(shaderProperties.GetPropertiesDeclaration(1));
+            graph.AppendLine(shaderProperties.GetPropertiesDeclaration(1, mode));
 
             graph.AppendLine(vertexDescriptionInputStruct.ToString());
             graph.AppendLine(surfaceDescriptionInputStruct.ToString());

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/LightWeightUnlitSubShader.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/LightWeightUnlitSubShader.cs
@@ -363,7 +363,7 @@ namespace UnityEngine.Rendering.LWRP
             // -------------------------------------
             // Combine Graph sections
 
-            graph.AppendLine(shaderProperties.GetPropertiesDeclaration(1));
+            graph.AppendLine(shaderProperties.GetPropertiesDeclaration(1, mode));
 
             graph.AppendLine(vertexDescriptionInputStruct.ToString());
             graph.AppendLine(surfaceDescriptionInputStruct.ToString());

--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -1101,7 +1101,7 @@ namespace UnityEditor.ShaderGraph
                 finalShader.AppendLine(@"#include ""Packages/com.unity.shadergraph/ShaderGraphLibrary/Functions.hlsl""");
                 finalShader.AppendNewLine();
 
-                finalShader.AppendLines(shaderProperties.GetPropertiesDeclaration(0));
+                finalShader.AppendLines(shaderProperties.GetPropertiesDeclaration(0, mode));
 
                 finalShader.AppendLines(surfaceDescriptionInputStruct.ToString());
                 finalShader.AppendNewLine();

--- a/com.unity.shadergraph/Editor/Data/Util/PropertyCollector.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/PropertyCollector.cs
@@ -37,23 +37,27 @@ namespace UnityEditor.ShaderGraph
             return sb.ToString();
         }
 
-        public string GetPropertiesDeclaration(int baseIndentLevel)
+        public string GetPropertiesDeclaration(int baseIndentLevel, GenerationMode mode)
         {
             var builder = new ShaderStringBuilder(baseIndentLevel);
-            GetPropertiesDeclaration(builder);
+            GetPropertiesDeclaration(builder, mode);
             return builder.ToString();
         }
 
-        public void GetPropertiesDeclaration(ShaderStringBuilder builder)
+        public void GetPropertiesDeclaration(ShaderStringBuilder builder, GenerationMode mode)
         {
+            var batchAll = mode == GenerationMode.Preview;
             builder.AppendLine("CBUFFER_START(UnityPerMaterial)");
-            foreach (var prop in m_Properties.Where(n => n.isBatchable && n.generatePropertyBlock))
+            foreach (var prop in m_Properties.Where(n => batchAll || (n.generatePropertyBlock && n.isBatchable)))
             {
                 builder.AppendLine(prop.GetPropertyDeclarationString());
             }
             builder.AppendLine("CBUFFER_END");
             builder.AppendNewLine();
 
+            if (batchAll)
+                return;
+            
             foreach (var prop in m_Properties.Where(n => !n.isBatchable || !n.generatePropertyBlock))
             {
                 builder.AppendLine(prop.GetPropertyDeclarationString());


### PR DESCRIPTION
### Purpose of this PR
Fix HUP Crash Bug with SG & SRP Batcher: https://fogbugz.unity3d.com/f/cases/1131758/
---
### Release Notes
Fix crash in Sub Graphs when dragging a texture onto the graph while SRP Batcher is enabled.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: What did you do?
- [ X ] Opened test project + Run graphic tests locally
- Other: 
Manual verification that broken case is fixed, tested non-broken cases also still work.

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low
**Halo Effect**: None, Low, Medium, High?
Low