### PR TITLE
Update git attributes to avoid asset CRLF conversion on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Unity assets are always serialized using lf endings
+*.asset text eol=lf


### PR DESCRIPTION
### Purpose of this PR
Update git attributes to avoid asset CRLF conversion on windows, as unity only serialize text assets using LF line endings it avoids to have asset changed.

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FUpdateGitAttributesForAssets&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None
