### PR TITLE
[Hdrp] fix normal handle densityvolume [Backport with 3124 & 3152]

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `camera.RenderToCubemap` use proper face culling
 - Fixed multi-edition light handles and inspector shapes
 - Fixed light's LightLayer field when multi-editing
+- Fixed normal blend edition handles on DensityVolume
 
 ### Added
 - Added a new FrameSettings: Specular Lighting to toggle the specular during the rendering

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/VolumetricLighting/SerializedDensityVolume.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/VolumetricLighting/SerializedDensityVolume.cs
@@ -66,9 +66,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             else
             {
                 positiveFade.vector3Value = negativeFade.vector3Value = new Vector3(
-                    size.vector3Value.x > 0.00001 ? (size.vector3Value.x - editorUniformFade.floatValue) / size.vector3Value.x : 0f,
-                    size.vector3Value.y > 0.00001 ? (size.vector3Value.y - editorUniformFade.floatValue) / size.vector3Value.y : 0f,
-                    size.vector3Value.z > 0.00001 ? (size.vector3Value.z - editorUniformFade.floatValue) / size.vector3Value.z : 0f
+                    size.vector3Value.x > 0.00001 ? 1f - ((size.vector3Value.x - editorUniformFade.floatValue) / size.vector3Value.x) : 0f,
+                    size.vector3Value.y > 0.00001 ? 1f - ((size.vector3Value.y - editorUniformFade.floatValue) / size.vector3Value.y) : 0f,
+                    size.vector3Value.z > 0.00001 ? 1f - ((size.vector3Value.z - editorUniformFade.floatValue) / size.vector3Value.z) : 0f
                     );
             }
             m_SerializedObject.ApplyModifiedProperties();

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/DensityVolume.Migration.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/DensityVolume.Migration.cs
@@ -39,7 +39,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
         static readonly MigrationDescription<Version, DensityVolume> k_Migration = MigrationDescription.New(
-            MigrationStep.New(Version.ScaleIndependent, (DensityVolume data) => data.parameters.size = data.transform.lossyScale),
+            MigrationStep.New(Version.ScaleIndependent, (DensityVolume data) =>
+            {
+                data.parameters.size = data.transform.lossyScale;
+
+                //missing migrated data.
+                //when migrated prior to this fix, density volumes have to be manually set on advance mode.
+                data.parameters.m_EditorAdvancedFade = true;
+            }),
             MigrationStep.New(Version.FixUniformBlendDistanceToBeMetric, (DensityVolume data) => data.parameters.MigrateToFixUniformBlendDistanceToBeMetric())
         );
 


### PR DESCRIPTION
### Purpose of this PR
Hopefully last PR on the subject.
Fix an issue where normal mode blend handles assigning 1-value to the density volume system

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: 

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally (graphic tests are green except 1205 that have nothing in common with current PR and is also red on HDRP/staging)
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**:

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
To be backported along https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3124 and https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3152