### PR TITLE
Fix HDRI sky intensity in lux mode

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed cascade shadows border sometime causing artefacts between cascades
 - Restored shadows in the Cascade Shadow debug visualization
 - `camera.RenderToCubemap` use proper face culling
+- Fixed HDRI sky intensity lux mode
 
 ### Changed
 - When rendering reflection probe disable all specular lighting and for metals use fresnelF0 as diffuse color for bake lighting.

--- a/com.unity.render-pipelines.high-definition/Editor/Sky/HDRISky/HDRISkyEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Sky/HDRISky/HDRISkyEditor.cs
@@ -92,10 +92,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 m_CommonUIElementsMask &= ~(uint)(SkySettingsUIElement.Exposure | SkySettingsUIElement.Multiplier);
                 m_CommonUIElementsMask |= (uint)SkySettingsUIElement.IndentExposureAndMultiplier;
 
-                // Show the multiplier as read-only
-                EditorGUI.BeginDisabledGroup(true);
-                PropertyField(m_UpperHemisphereLuxValue);
-                EditorGUI.EndDisabledGroup();
+                // Show the multiplier
+                EditorGUILayout.HelpBox(System.String.Format("Upper hemisphere lux value: {0}\nAbsolute multiplier: {1}",
+                    m_UpperHemisphereLuxValue.value.floatValue,
+                    (m_DesiredLuxValue.value.floatValue / m_UpperHemisphereLuxValue.value.floatValue)
+                ), MessageType.Info);
                 EditorGUI.indentLevel--;
             }
             else

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/HDRISky/HDRISkyRenderer.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/HDRISky/HDRISkyRenderer.cs
@@ -41,7 +41,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             float luxMultiplier = m_HdriSkyParams.desiredLuxValue.value / m_HdriSkyParams.upperHemisphereLuxValue.value;
             float multiplier = (m_HdriSkyParams.skyIntensityMode == SkyIntensityMode.Exposure) ? m_HdriSkyParams.multiplier.value : luxMultiplier;
-            float exposure = (m_HdriSkyParams.skyIntensityMode == SkyIntensityMode.Exposure) ? GetExposure(m_HdriSkyParams, builtinParams.debugSettings) : 0;
+            float exposure = (m_HdriSkyParams.skyIntensityMode == SkyIntensityMode.Exposure) ? GetExposure(m_HdriSkyParams, builtinParams.debugSettings) : 1;
             float phi = Mathf.Deg2Rad * -m_HdriSkyParams.rotation; // -rotation to match Legacy...
 
             m_SkyHDRIMaterial.SetTexture(HDShaderIDs._Cubemap, m_HdriSkyParams.hdriSky);


### PR DESCRIPTION
### Purpose of this PR

+ Fix the lux intensity mode for HDRI sky that was black no matter the desired lux value.
+ Changed the upper hemisphere lux value field by an info box
![image](https://user-images.githubusercontent.com/6877923/53884353-b4048300-401b-11e9-8824-307741310344.png)

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixHDRILuxIntensity&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
