### PR TITLE
Added OnEnable and OnDisable to the HDRaytracingEnvironment,cs to all…

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingEnvironment.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingEnvironment.cs
@@ -173,6 +173,26 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 hdPipeline.m_RayTracingManager.RegisterEnvironment(this);
             }
         }
+
+        void OnEnable()
+        {
+            // Grab the High Definition RP
+            HDRenderPipeline hdPipeline = RenderPipelineManager.currentPipeline as HDRenderPipeline;
+            if (hdPipeline != null)
+            {
+                hdPipeline.m_RayTracingManager.RegisterEnvironment(this);
+            }
+        }
+
+        void OnDisable()
+        {
+            // Grab the High Definition RP
+            HDRenderPipeline hdPipeline = RenderPipelineManager.currentPipeline as HDRenderPipeline;
+            if (hdPipeline != null)
+            {
+                hdPipeline.m_RayTracingManager.UnregisterEnvironment(this);
+            }
+        }
         void OnDestroy()
         {
             // Grab the High Definition RP


### PR DESCRIPTION
…ow for multiple environments that can be toggled on and off.

### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

Added OnEnable and OnDisable to the HDRaytracingEnvironment,cs to allow for multiple environments that can be toggled on and off.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low

**Halo Effect**: None, Low, Medium, High?
None
---
### Comments to reviewers
Notes for the reviewers you have assigned.
Discussed previously and guided by Anis