### PR TITLE
Hide Shadow Quality settings from HDAsset UI

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -263,8 +263,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             --EditorGUI.indentLevel;
             
             EditorGUILayout.DelayedIntField(serialized.renderPipelineSettings.hdShadowInitParams.maxShadowRequests, k_MaxRequestContent);
-            
-            EditorGUILayout.PropertyField(serialized.renderPipelineSettings.hdShadowInitParams.shadowQuality, k_FilteringQuality);
+
+            bool isDeferredOnly = serialized.renderPipelineSettings.supportedLitShaderMode.intValue == (int)RenderPipelineSettings.SupportedLitShaderMode.DeferredOnly;
+
+            // Deferred Only mode does not allow to change filtering quality, but rather it is hardcoded. 
+            if (!isDeferredOnly)
+            {
+                EditorGUILayout.PropertyField(serialized.renderPipelineSettings.hdShadowInitParams.shadowQuality, k_FilteringQuality);
+            }
         }
 
         static void Drawer_SectionDecalSettings(SerializedHDRenderPipelineAsset serialized, Editor owner)

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -267,7 +267,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool isDeferredOnly = serialized.renderPipelineSettings.supportedLitShaderMode.intValue == (int)RenderPipelineSettings.SupportedLitShaderMode.DeferredOnly;
 
             // Deferred Only mode does not allow to change filtering quality, but rather it is hardcoded. 
-            if (!isDeferredOnly)
+            if (isDeferredOnly)
+            {
+                serialized.renderPipelineSettings.hdShadowInitParams.shadowQuality.intValue = (int)HDShadowQuality.Low;
+            }
+            else
             {
                 EditorGUILayout.PropertyField(serialized.renderPipelineSettings.hdShadowInitParams.shadowQuality, k_FilteringQuality);
             }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
@@ -132,6 +132,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             maxShadowRequests = k_DefaultMaxShadowRequests,
             shadowMapsDepthBits = k_DefaultShadowMapDepthBits,
             useDynamicViewportRescale = true,
+            shadowQuality = HDShadowQuality.Low,
         };
 
         public const int k_DefaultShadowAtlasResolution = 4096;


### PR DESCRIPTION
### Purpose of this PR
This caused some confusions in the demo team and to be fair, I see it creating more confusion to users as well. 

The quality for deferred is hardcoded in the shader to Low, so exposing a varying option is misleading. 