### PR TITLE
Fix tube light mesh size

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -726,8 +726,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             else
                 lightSize = new Vector3(shapeWidth, shapeHeight, transform.localScale.z);
 
-            lightSize = Vector3.Max(Vector3.one * k_MinAreaWidth, lightSize);
+            if (lightTypeExtent == LightTypeExtent.Tube)
+                lightSize.y = k_MinAreaWidth;
             lightSize.z = k_MinAreaWidth;
+
+            lightSize = Vector3.Max(Vector3.one * k_MinAreaWidth, lightSize);
             m_Light.transform.localScale = lightSize;
             m_Light.areaSize = lightSize;
 


### PR DESCRIPTION
### Purpose of this PR
Fix the y scale of tube lights not set to min area light size

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixTubeLigghtMeshSize&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
