### PR TITLE
Hdrp/fix culling null result in probes

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [6.6.0-preview] - 2019-XX-XX
 
+### Fixed
+- Fixed null culling result occuring when changing scene that was causing crashes
+
 ## [6.5.0-preview] - 2019-03-07
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1058,6 +1058,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     {
                         var visibleProbe = cullingResults.cullingResults.visibleReflectionProbes[i];
 
+                        // TODO: The following fix is temporary.
+                        // We should investigate why we got null cull result when we change scene
                         if (visibleProbe == null || visibleProbe.Equals(null) || visibleProbe.reflectionProbe == null || visibleProbe.reflectionProbe.Equals(null))
                             continue;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1058,6 +1058,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     {
                         var visibleProbe = cullingResults.cullingResults.visibleReflectionProbes[i];
 
+                        if (visibleProbe == null || visibleProbe.Equals(null) || visibleProbe.reflectionProbe == null || visibleProbe.reflectionProbe.Equals(null))
+                            continue;
+
                         var additionalReflectionData =
                             visibleProbe.reflectionProbe.GetComponent<HDAdditionalReflectionData>()
                             ?? visibleProbe.reflectionProbe.gameObject.AddComponent<HDAdditionalReflectionData>();


### PR DESCRIPTION
### Purpose of this PR
Fixed null culling result occuring when changing scene that was causing crashes

---
### Release Notes
Fixed null culling result occuring when changing scene that was causing crashes

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-culling-null-result-in-probes&unity_branch=trunk&automation-tools_branch=master

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
