### PR TITLE
Post-processing scene view tweaks

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - When rendering reflection probe disable all specular lighting and for metals use fresnelF0 as diffuse color for bake lighting.
 - DensityVolume scripting API will no longuer allow to change between advance and normal edition mode
+- Disabled depth of field, lens distortion and panini projection in the scene view
 
 ## [6.4.0-preview] - 2019-02-21
 

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Resources.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 953470d2157c5e643b1d0d0fba18337e
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
- Disabled DOF in the scene view as there's currently no clean way to set physical camera settings for the scene view so it's stuck to the default values.
- Disabled Panini Projection & Lens Distortion in the scene view because they break the selection outlines.

---
### Testing status
**Katana Tests**: [Link](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Fpostfx-sceneview-tweaks&automation-tools_branch=master&unity_branch=trunk).

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- Other:
Manually tested depth of field, panini projection and lens distortion in the scene view.

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None