### PR TITLE
Fix diffusion profile needlessly set to dirty when checking the hash

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Utilities/DiffusionProfileHashTable.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Utilities/DiffusionProfileHashTable.cs
@@ -87,8 +87,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // If the asset is not in the list, we regenerate it's hash using the GUID (which leads to the same result every time)
             else if (!diffusionProfileHashes.ContainsKey(profile.GetInstanceID()))
             {
-                profile.profile.hash = GenerateUniqueHash(profile);
-                EditorUtility.SetDirty(profile);
+                uint newHash = GenerateUniqueHash(profile);
+                if (newHash != profile.profile.hash)
+                {
+                    profile.profile.hash = newHash;
+                    EditorUtility.SetDirty(profile);
+                }
             }
             else // otherwise, no issue, we don't change the hash and we keep it to check for collisions
                 diffusionProfileHashes.Add(profile.GetInstanceID(), profile.profile.hash);


### PR DESCRIPTION
### Purpose of this PR
Fix diffusion profile needlessly set to dirty when checking the hash

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixDiffusionProfileUselessSetDirty&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
