### PR TITLE
Vfx/fix/2019.1/floatfield focus

### DIFF
--- a/com.unity.visualeffectgraph/Editor/VisualElementExtensions.cs
+++ b/com.unity.visualeffectgraph/Editor/VisualElementExtensions.cs
@@ -28,12 +28,6 @@ static class VisualElementExtensions
         return (GUIView)m_OwnerPropertyInfo.GetValue(panel, new object[] {});
     }
 
-    // HasFocus on textField should really see if the child TextInput hasFocus
-    public static bool HasFocus<T>(this TextInputBaseField<T> texInput)
-    {
-        return ((VisualElement)texInput.Query(TextInputBaseField<T>.textInputUssName)).HasFocus();
-    }
-
     public static bool HasFocus(this VisualElement visualElement)
     {
         if (visualElement.panel == null) return false;
@@ -85,13 +79,7 @@ static class VisualElementExtensions
 
     public static Vector2 BoundToGlobal(this VisualElement visualElement, Vector2 position)
     {
-        /*do
-        {*/
         position = visualElement.worldTransform.MultiplyPoint3x4(position);
-        /*
-        visualElement = visualElement.parent;
-    }
-    while (visualElement != null;)*/
 
         return position;
     }


### PR DESCRIPTION
### Purpose of this PR
Fix the problem when we type things like ".5" in a float field. The root problem is how we detect if a floatfield has the focus (to not overrride it if it does). The fix remove a temporary hack previously needed for UIElement and that is no longer working..

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
tests with vfx samples, in the blackboard float field as well as in the node's.


**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
