### PR TITLE
Re-enable SMAA stencil 

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
@@ -2108,6 +2108,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     break;
             }
 
+            // -----------------------------------------------------------------------------
+            // Clear
+            HDUtils.SetRenderTarget(cmd, camera, SMAAEdgeTex, ClearFlag.Color);
+            HDUtils.SetRenderTarget(cmd, camera, SMAABlendTex, ClearFlag.Color);
 
             // -----------------------------------------------------------------------------
             // EdgeDetection stage

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/SubpixelMorphologicalAntialiasing.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/SubpixelMorphologicalAntialiasing.shader
@@ -20,14 +20,13 @@ Shader "Hidden/PostProcessing/SubpixelMorphologicalAntialiasing"
         // Edge detection 
         Pass
         {
-            // TODO: Re-enable stencil after investigation on why it breaks.
-            //Stencil
-            //{
-            //    WriteMask [_StencilMask]
-            //    Ref [_StencilRef]
-            //    Comp Always
-            //    Pass Replace
-            //}
+            Stencil
+            {
+                WriteMask [_StencilMask]
+                Ref [_StencilRef]
+                Comp Always
+                Pass Replace
+            }
 
             HLSLPROGRAM
 
@@ -41,15 +40,14 @@ Shader "Hidden/PostProcessing/SubpixelMorphologicalAntialiasing"
         // Blend Weights Calculation
         Pass
         {
-        // TODO: Re-enable stencil after investigation on why it breaks.
-            //Stencil
-            //{
-            //    WriteMask[_StencilMask]
-            //    ReadMask [_StencilMask]
-            //    Ref [_StencilRef]
-            //    Comp Equal
-            //    Pass Replace
-            //}
+            Stencil
+            {
+                WriteMask[_StencilMask]
+                ReadMask [_StencilMask]
+                Ref [_StencilRef]
+                Comp Equal
+                Pass Replace
+            }
 
             HLSLPROGRAM
 


### PR DESCRIPTION
### Purpose of this PR
This re-enable smaa stencil optimization. SMAA intermediate textures need to be cleared. This leads to smaller wins, but still sensible win. 

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Freenable-smaa-stencil&automation-tools_branch=master&unity_branch=trunk [Running]

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: Low
