### PR TITLE
Vfx/fix/2019.1/edge dynamic operator

### DIFF
--- a/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXVariableOperatorControllerTests.cs
+++ b/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXVariableOperatorControllerTests.cs
@@ -1,4 +1,4 @@
-﻿#if !UNITY_EDITOR_OSX || MAC_FORCE_TESTS
+#if !UNITY_EDITOR_OSX || MAC_FORCE_TESTS
 using System;
 using NUnit.Framework;
 using UnityEngine;
@@ -177,7 +177,7 @@ namespace UnityEditor.VFX.Test
 
             var secondLink = m_ViewController.dataEdges.First(t => t.input == input && t.output == output);
 
-            m_ViewController.RemoveElement(secondLink);
+            m_ViewController.RemoveElement(secondLink,true);
 
             Assert.AreEqual(2, operatorModel.inputSlots.Count);
 

--- a/com.unity.visualeffectgraph/CHANGELOG.md
+++ b/com.unity.visualeffectgraph/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add missing blend value slot in Inherit Source Attribute blocks [Case 1120568](https://issuetracker.unity3d.com/issues/source-attribute-blend-source-attribute-blocks-are-not-useful-without-the-blend-value)
 - Visual Effect Inspector Cosmetic Improvements
 - Exception while removing a sub-slot of a dynamic operator
+- Issue that remove the edge when dragging an edge from slot to the same slot.
+- Exception when undoing an edge deletion on a dynamic operator. 
+- Exception regarding undo/redo when dragging a edge linked to a dynamic operator on another slot.
 
 ## [5.7.0-preview] - 2019-03-07
 

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXDataAnchor.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXDataAnchor.cs
@@ -210,11 +210,6 @@ namespace UnityEditor.VFX.UI
             VFXDataEdge dataEdge = edge as VFXDataEdge;
             VFXDataEdgeController edgeController = new VFXDataEdgeController(dataEdge.input.controller, dataEdge.output.controller);
 
-            if (dataEdge.controller != null)
-            {
-                view.controller.RemoveElement(dataEdge.controller);
-            }
-
             view.controller.AddElement(edgeController);
         }
 

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/Controller/VFXViewController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/Controller/VFXViewController.cs
@@ -393,8 +393,9 @@ namespace UnityEditor.VFX.UI
 
             bool change = RecreateNodeEdges();
 
-            if (change)
+            if (change || m_ForceDataEdgeNotification)
             {
+                m_ForceDataEdgeNotification = false;
                 NotifyChange(Change.dataEdge);
             }
 
@@ -624,7 +625,7 @@ namespace UnityEditor.VFX.UI
             edge.OnDisable();
         }
 
-        public void Remove(IEnumerable<Controller> removedControllers)
+        public void Remove(IEnumerable<Controller> removedControllers, bool explicitDelete = false)
         {
             var removedContexts = new HashSet<VFXContextController>(removedControllers.OfType<VFXContextController>());
 
@@ -633,11 +634,13 @@ namespace UnityEditor.VFX.UI
 
             foreach (var controller in removed)
             {
-                RemoveElement(controller);
+                RemoveElement(controller, explicitDelete);
             }
         }
 
-        public void RemoveElement(Controller element)
+        bool m_ForceDataEdgeNotification;
+
+        public void RemoveElement(Controller element, bool explicitDelete = false)
         {
             if (element is VFXContextController)
             {
@@ -746,12 +749,16 @@ namespace UnityEditor.VFX.UI
 
                 if (to != null)
                 {
-                    to.sourceNode.OnEdgeGoingToBeRemoved(to);
+                    if( explicitDelete )
+                    {
+                        to.sourceNode.OnEdgeGoingToBeRemoved(to);
+                    }
                     var slot = to.model;
                     if (slot != null)
                     {
                         slot.UnlinkAll();
                     }
+                    m_ForceDataEdgeNotification = true;
                 }
             }
             else if (element is VFXGroupNodeController)

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
@@ -439,7 +439,7 @@ namespace UnityEditor.VFX.UI
             {
                 parametersToRemove = parametersToRemove.Concat(controller.RemoveCategory(m_Blackboard.GetCategoryIndex(category)));
             }
-            controller.Remove(selection.OfType<IControlledElement>().Select(t => t.controller).Concat(parametersToRemove.Cast<Controller>()));
+            controller.Remove(selection.OfType<IControlledElement>().Select(t => t.controller).Concat(parametersToRemove.Cast<Controller>()), true);
         }
 
         void IControlledElement.OnControllerChanged(ref ControllerChangedEvent e)
@@ -1139,6 +1139,12 @@ namespace UnityEditor.VFX.UI
             else if (change.elementsToRemove != null)
             {
                 controller.Remove(change.elementsToRemove.OfType<IControlledElement>().Where(t => t.controller != null).Select(t => t.controller));
+                
+                foreach( var dataEdge in change.elementsToRemove.OfType<VFXDataEdge>())
+                {
+                    RemoveElement(dataEdge);
+                    dataEdges.Remove(dataEdge.controller);
+                }
             }
 
             return change;


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Fixed
- Issue that remove the edge when dragging an edge from slot to the same slot.
- Exception when undoing an edge deletion on a dynamic operator. 
- Exception regarding undo/redo when dragging a edge linked to a dynamic operator on another slot.

backport of : https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3231

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
