### PR TITLE
fix wrong time for calling MarkSceneAsDirty

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Migration/MigrationDescription.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Migration/MigrationDescription.cs
@@ -102,7 +102,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 UnityEditor.PrefabUtility.RecordPrefabInstancePropertyModifications(target as UnityEngine.Object);
             }
-            UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene());
 #endif
             return true;
         }


### PR DESCRIPTION
### Purpose of this PR
Fix huge regression introduced in https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3168

MarkSceneAsDirty cannot be called while doing graphic tests

---
### Release Notes

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-regression-markscenedirty-test-graphic&unity_branch=trunk&automation-tools_branch=master

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally (Has issue on 1205 locally (it is not stable locally on some machine), and 8104 have same issue on graph that it have before the regression)
- [x] Built a player
- Other: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
