### PR TITLE
LWRP XR Eye Texture Reallocation

### DIFF
--- a/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
@@ -194,6 +194,7 @@ namespace UnityEngine.Rendering.LWRP
         {
             const float kRenderScaleThreshold = 0.05f;
             cameraData.camera = camera;
+            cameraData.isStereoEnabled = IsStereoEnabled(camera);
 
             int msaaSamples = 1;
             if (camera.allowMSAA && settings.msaaSampleCount > 1)
@@ -201,18 +202,26 @@ namespace UnityEngine.Rendering.LWRP
 
             if (Camera.main == camera && camera.cameraType == CameraType.Game && camera.targetTexture == null)
             {
+                bool msaaSampleCountHasChanged = false;
+                int currentQualitySettingsSampleCount = QualitySettings.antiAliasing;
+                if (currentQualitySettingsSampleCount != msaaSamples &&
+                    !(currentQualitySettingsSampleCount == 0 && msaaSamples == 1))
+                {
+                    msaaSampleCountHasChanged = true;
+                }
+
                 // There's no exposed API to control how a backbuffer is created with MSAA
                 // By settings antiAliasing we match what the amount of samples in camera data with backbuffer
                 // We only do this for the main camera and this only takes effect in the beginning of next frame.
                 // This settings should not be changed on a frame basis so that's fine.
                 QualitySettings.antiAliasing = msaaSamples;
+
+                if (cameraData.isStereoEnabled && msaaSampleCountHasChanged)
+                    XR.XRDevice.UpdateEyeTextureMSAASetting();
             }
             
             cameraData.isSceneViewCamera = camera.cameraType == CameraType.SceneView;
-            cameraData.isStereoEnabled = IsStereoEnabled(camera);
-
             cameraData.isHdrEnabled = camera.allowHDR && settings.supportsHDR;
-
             cameraData.postProcessLayer = camera.GetComponent<PostProcessLayer>();
             cameraData.postProcessEnabled = cameraData.postProcessLayer != null && cameraData.postProcessLayer.isActiveAndEnabled;
 


### PR DESCRIPTION
### Purpose of this PR
The purpose of this PR is to automatically reallocate the xr device eye texture when the MSAA sample count has changed at runtime.

---
### Release Notes
When rendering in stereo mode, the eye texture will be reallocated any time the MSAA sample count is changed at runtime.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
I will be running the Katana tests shortly.

https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=xr%2Flwrp%2Fmsaa-eye-texture-update&unity_branch=trunk

https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=xr%2Flwrp%2Fmsaa-eye-texture-update&unity_branch=editor%2Ftech%2Fmodes-improvements

**Manual Tests**: What did you do?
I tested locally in editor.  QA will be testing on device.
---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low - Only affects XR

**Halo Effect**: None, Low, Medium, High?
Low

### Notes to Reviewers
The core engine will force sample counts of 1 to be 0 in the QualitySettings.  I thought about changing the default value of the msaaSamples variable to 0 but I don't know if that would break anything.  Therefore I have an additional check for that specific situation. 