### PR TITLE
Fix emission node shader graph preview

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed issue when switching mode in ReflectionProbe and PlanarReflectionProbe
 - Fixed issue where migratable component version where not always serialized when part of prefab's instance
 - Fixed an issue where shadow would not be rendered properly when light layer are not enabled
+- Fixed emission node breaking the main shader graph preview in certain conditions.
 
 ### Changed
 - DensityVolume scripting API will no longuer allow to change between advance and normal edition mode

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
@@ -91,26 +91,26 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
         public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
         {
-            if (generationMode.IsPreview())
-                return;
-
             var sb = new ShaderStringBuilder();
 
             var colorValue = GetSlotValue(kEmissionColorInputSlotId, generationMode);
             var intensityValue = GetSlotValue(kEmissionIntensityInputSlotId, generationMode);
             var exposureWeightValue = GetSlotValue(kEmissionExposureWeightInputSlotId, generationMode);
+            var outputValue = GetSlotValue(kEmissionOutputSlotId, generationMode);
             
             if (intensityUnit == EmissiveIntensityUnit.EV100)
                 intensityValue = "ConvertEvToLuminance(" + intensityValue + ")";
             
-            sb.AppendLine(@"{0}3 {1} = {2}({3}, {4}, {5}, {6});",
+            string inverseExposureMultiplier = (generationMode.IsPreview()) ? "1.0" : "GetInverseCurrentExposureMultiplier()";
+            
+            sb.AppendLine(@"{0}3 {1} = {2}({3}.xyz, {4}, {5}, {6});",
                 precision,
-                GetVariableNameForNode(),
+                outputValue,
                 GetFunctionName(),
                 colorValue,
                 intensityValue,
                 exposureWeightValue,
-                "GetInverseCurrentExposureMultiplier()"
+                inverseExposureMultiplier
             );
 
             visitor.AddShaderChunk(sb.ToString(), true);
@@ -160,14 +160,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             properties.Add(new PreviewProperty(PropertyType.Vector3)
             {
-                name = GetVariableNameForNode(),
+                name = GetVariableNameForSlot(kEmissionColorInputSlotId),
                 vector4Value = outputColor
             });
-        }
-
-        public override string GetVariableNameForSlot(int slotId)
-        {
-            return GetVariableNameForNode();
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR
+ Fix emission node shader graph breaking the main preview caused by `GetInverseCurrentExposureMultiplier` not being defined when the shader graph preview is generated.
+ Fix the emission node main preview parameter (allow to tweak the inputs and see immediately the result in the main preview)

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixEmissionNodeShaderGraphPreview&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
