### PR TITLE
Fix issue causing controls to stick around (backport #3254)

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - You can now use Sub Graphs in other Sub Graphs.
 
+### Fixed
+- Default input fields now correctly hide and show when connections change.
+
 ## [5.9.0] - 2019-03-15
 
 ## [5.8.0] - 2019-03-13

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -528,11 +528,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             foreach (var portInputView in m_PortInputContainer.Children().OfType<PortInputView>().ToList())
             {
                 var slot = portInputView.slot;
-                var display = expanded && !node.owner.GetEdges(node.GetSlotReference(slot.id)).Any() ? DisplayStyle.Flex : DisplayStyle.None;
-                if (display != portInputView.style.display)
-                {
-                    portInputView.style.display = display;
-                }
+                portInputView.style.display = expanded && !node.owner.GetEdges(node.GetSlotReference(slot.id)).Any() ? DisplayStyle.Flex : DisplayStyle.None;
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -193,8 +193,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                 // -----------------------------------------------------------------------------------
                 //titleButtonContainer.Add(m_SettingsButton);
                 //titleButtonContainer.Add(m_CollapseButton);
-
-                RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
             }
         }
 
@@ -350,6 +348,8 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_NodeSettingsView.visible = true;
 
                 m_SettingsButton.AddToClassList("clicked");
+                RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+                OnGeometryChanged(null);
             }
             else
             {
@@ -357,6 +357,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                 m_NodeSettingsView.visible = false;
                 m_SettingsButton.RemoveFromClassList("clicked");
+                UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
             }
         }
 
@@ -459,11 +460,12 @@ namespace UnityEditor.ShaderGraph.Drawing
                     inputContainer.Sort((x, y) => slots.IndexOf(((ShaderPort)x).slot) - slots.IndexOf(((ShaderPort)y).slot));
                 if (outputContainer.childCount > 0)
                     outputContainer.Sort((x, y) => slots.IndexOf(((ShaderPort)x).slot) - slots.IndexOf(((ShaderPort)y).slot));
+
+                UpdatePortInputs();
+                UpdatePortInputVisibilities();
             }
 
             RefreshExpandedState(); //This should not be needed. GraphView needs to improve the extension api here
-            UpdatePortInputs();
-            UpdatePortInputVisibilities();
 
             foreach (var listener in m_ControlItems.Children().OfType<AbstractMaterialNodeModificationListener>())
             {
@@ -495,39 +497,42 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     var portInputView = new PortInputView(port.slot) { style = { position = Position.Absolute } };
                     m_PortInputContainer.Add(portInputView);
-                    port.RegisterCallback<GeometryChangedEvent>(evt => UpdatePortInput((ShaderPort)evt.target));
+                    if (float.IsNaN(port.layout.width))
+                    {
+                        port.RegisterCallback<GeometryChangedEvent>(UpdatePortInput);
+                    }
+                    else
+                    {
+                        SetPortInputPosition(port, portInputView);
+                    }
                 }
             }
         }
 
-        void UpdatePortInput(ShaderPort port)
+        void UpdatePortInput(GeometryChangedEvent evt)
         {
+            var port = (ShaderPort)evt.target;
             var inputView = m_PortInputContainer.Children().OfType<PortInputView>().First(x => Equals(x.slot, port.slot));
+            SetPortInputPosition(port, inputView);
+            port.UnregisterCallback<GeometryChangedEvent>(UpdatePortInput);
+        }
 
-            var currentRect = new Rect(inputView.resolvedStyle.left, inputView.resolvedStyle.top, inputView.resolvedStyle.width, inputView.resolvedStyle.height);
-            var targetRect = new Rect(0.0f, 0.0f, port.layout.width, port.layout.height);
-            targetRect = port.ChangeCoordinatesTo(inputView.hierarchy.parent, targetRect);
-            var centerY = targetRect.center.y;
-            var centerX = targetRect.xMax - currentRect.width;
-            currentRect.center = new Vector2(centerX, centerY);
-
-            inputView.style.top = currentRect.yMin;
-            var newHeight = inputView.parent.layout.height;
-            foreach (var element in inputView.parent.Children())
-                newHeight = Mathf.Max(newHeight, element.style.top.value.value + element.layout.height);
-            if (Math.Abs(inputView.parent.style.height.value.value - newHeight) > 1e-3)
-                inputView.parent.style.height = newHeight;
+        void SetPortInputPosition(ShaderPort port, PortInputView inputView)
+        {
+            inputView.style.top = port.layout.y;
+            inputView.parent.style.height = inputContainer.layout.height;
         }
 
         public void UpdatePortInputVisibilities()
         {
-            foreach (var portInputView in m_PortInputContainer.Children().OfType<PortInputView>())
+            foreach (var portInputView in m_PortInputContainer.Children().OfType<PortInputView>().ToList())
             {
                 var slot = portInputView.slot;
-                var oldVisibility = portInputView.visible;
-                portInputView.visible = expanded && !node.owner.GetEdges(node.GetSlotReference(slot.id)).Any();
-                if (portInputView.visible != oldVisibility)
-                    m_PortInputContainer.MarkDirtyRepaint();
+                var display = expanded && !node.owner.GetEdges(node.GetSlotReference(slot.id)).Any() ? DisplayStyle.Flex : DisplayStyle.None;
+                if (display != portInputView.style.display)
+                {
+                    portInputView.style.display = display;
+                }
             }
         }
 

--- a/com.unity.shadergraph/Editor/Resources/Styles/MaterialNodeView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/MaterialNodeView.uss
@@ -121,7 +121,7 @@ MaterialNodeView > #portInputContainer {
     position: absolute;
     width: 232;
     left: -220;
-    top: 46;
+    top: 42;
 }
 
 MaterialNodeView > #settings-container {


### PR DESCRIPTION
### Purpose of this PR
Backports #3254. When connecting nodes that cause a value upcast, the control doesn't get painted off the graph until the upcasting node is removed.

---
### Release Notes
See change log

---
### Testing status
**Katana Tests**: Katana does not test this code at all.

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [x] Checked new UI names with UX convention
- [x] ~Tested UI multi-edition +~ Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- Other: Able to reproduce bug before changes, inable to after changes

**Automated Tests**: Nothing

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None
