### PR TITLE
Add exposure and HD scene color nodes

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added an option in preferences to toggle the light emission normalization
 - Added Homothety and Symetry quick edition modifier on volume used in ReflectionProbe, PlanarReflectionProbe and DensityVolume
 - Added multi-edition support for DecalProjectorComponent
+- Added an exposure node to retrieve the current, inverse and previous frame exposure value.
+- Added an HD scene color node which allow to sample the scene color with mips and a toggle to remove the exposure.
 
 ### Fixed
 - Fixed HDRI sky intensity lux mode

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System;
+using UnityEngine;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph;
+using UnityEditor.ShaderGraph.Drawing.Controls;
+using UnityEngine.Experimental.Rendering.HDPipeline;
+
+namespace UnityEditor.Experimental.Rendering.HDPipeline
+{
+    [Title("Input", "High Definition Render Pipeline", "Exposure")]
+    class ExposureNode : AbstractMaterialNode, IGeneratesBodyCode
+    {
+        public enum ExposureType
+        {
+            CurrentMultiplier,
+            InverseCurrentMultiplier,
+            PreviousMultiplier,
+            InversePreviousMultiplier,
+        }
+
+        static Dictionary<ExposureType, string> exposureFunctions = new Dictionary<ExposureType, string>()
+        {
+            {ExposureType.CurrentMultiplier, "GetCurrentExposureMultiplier()"},
+            {ExposureType.PreviousMultiplier, "GetPreviousExposureMultiplier()"},
+            {ExposureType.InverseCurrentMultiplier, "GetInverseCurrentExposureMultiplier()"},
+            {ExposureType.InversePreviousMultiplier, "GetInversePreviousExposureMultiplier()"},
+        };
+
+        public ExposureNode()
+        {
+            name = "Exposure";
+            UpdateNodeAfterDeserialization();
+        }
+
+        public override string documentationURL
+        {
+            // TODO: write the doc
+            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/Exposure-Node"; }
+        }
+
+        [SerializeField]
+        ExposureType        m_ExposureType;
+        [EnumControl]
+        public ExposureType exposureType
+        {
+            get => m_ExposureType;
+            set
+            {
+                m_ExposureType = value;
+                Dirty(ModificationScope.Node);
+            }
+        }
+
+        const int kExposureOutputSlotId = 0;
+        const string kExposureOutputSlotName = "Output";
+
+        public override bool hasPreview { get { return false; } }
+
+        public sealed override void UpdateNodeAfterDeserialization()
+        {
+            AddSlot(new ColorRGBMaterialSlot(kExposureOutputSlotId, kExposureOutputSlotName, kExposureOutputSlotName , SlotType.Output, Color.black, ColorMode.Default));
+
+            RemoveSlotsNameNotMatching(new[] {
+                kExposureOutputSlotId,
+            });
+        }
+
+        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        {
+            var sb = new ShaderStringBuilder();
+
+            string exposure = generationMode.IsPreview() ? "1.0" : exposureFunctions[exposureType];
+
+            sb.AppendLine("{0} {1} = {2};",
+                precision,
+                GetVariableNameForSlot(kExposureOutputSlotId),
+                exposure);
+
+            visitor.AddShaderChunk(sb.ToString(), true);
+        }
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a81111b7fbadb1408603fe95bd103ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System;
+using UnityEngine;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph;
+using UnityEditor.ShaderGraph.Drawing.Controls;
+using UnityEngine.Experimental.Rendering.HDPipeline;
+
+namespace UnityEditor.Experimental.Rendering.HDPipeline
+{
+    [Title("Input", "High Definition Render Pipeline", "HD Scene Color")]
+    class HDSceneColorNode : AbstractMaterialNode, IGeneratesBodyCode, IGeneratesFunction, IMayRequireCameraOpaqueTexture, IMayRequireScreenPosition
+    {
+        public HDSceneColorNode()
+        {
+            name = "HD Scene Color";
+            UpdateNodeAfterDeserialization();
+        }
+
+        public override string documentationURL
+        {
+            // TODO: write the doc
+            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/HD-Scene-Color-Node"; }
+        }
+
+        [SerializeField]
+        bool                m_Exposure;
+        [ToggleControl]
+        public ToggleData   exposure
+        {
+            get => new ToggleData(m_Exposure);
+            set
+            {
+                m_Exposure = value.isOn;
+                Dirty(ModificationScope.Node);
+            }
+        }
+
+        const int kUvInputSlotId = 0;
+        const string kUvInputSlotName = "UV";
+        const int kLodInputSlotId = 1;
+        const string kLodInputSlotName = "Lod";
+
+        const int kColorOutputSlotId = 2;
+        const string kColorOutputSlotName = "Output";
+
+        public override bool hasPreview { get { return false; } }
+
+        public sealed override void UpdateNodeAfterDeserialization()
+        {
+            AddSlot(new ScreenPositionMaterialSlot(kUvInputSlotId, kUvInputSlotName, kUvInputSlotName, ScreenSpaceType.Default));
+            AddSlot(new Vector1MaterialSlot(kLodInputSlotId, kLodInputSlotName, kLodInputSlotName, SlotType.Input, 0, ShaderStageCapability.Fragment));
+            AddSlot(new ColorRGBMaterialSlot(kColorOutputSlotId, kColorOutputSlotName, kColorOutputSlotName , SlotType.Output, Color.black, ColorMode.HDR));
+
+            RemoveSlotsNameNotMatching(new[] {
+                kUvInputSlotId,
+                kLodInputSlotId,
+                kColorOutputSlotId,
+            });
+        }
+
+        string GetFunctionName()
+        {
+            return "Unity_HDRP_SampleSceneColor";
+        }
+
+        public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)
+        {
+            registry.ProvideFunction(GetFunctionName(), s =>
+                {
+                    s.AppendLine("{1}3 {0}({1}2 uv, {1} lod, {1} exposureMultiplier)",
+                        GetFunctionName(),
+                        precision
+                    );
+                    using (s.BlockScope())
+                    {
+                        if (generationMode.IsPreview())
+                        {
+                            s.AppendLine("// Sampling the scene color is not supported in the preview");
+                            s.AppendLine("return float3(0.0, 0.0, 0.0);");
+                        }
+                        else
+                        {
+                            if (exposure.isOn)
+                            {
+                                s.AppendLine("exposureMultiplier = 1.0;");
+                            }
+                            s.AppendLine("#if defined(REQUIRE_OPAQUE_TEXTURE) && defined(_SURFACE_TYPE_TRANSPARENT)");
+                            s.AppendLine("return SampleCameraColor(uv, lod) * exposureMultiplier;", precision);
+                            s.AppendLine("#endif");
+                            s.AppendLine("return float3(0.0, 0.0, 0.0);");
+                        }
+                    }
+                });
+        }
+
+        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        {
+            var sb = new ShaderStringBuilder();
+
+            string exposureMultiplier = (exposure.isOn || generationMode.IsPreview()) ? "1.0" : "GetInverseCurrentExposureMultiplier()";
+            string uv = GetSlotValue(kUvInputSlotId, generationMode);
+            string lod = GetSlotValue(kLodInputSlotId, generationMode);
+
+            sb.AppendLine("{0}3 {1} = {2}({3}.xy, {4}, {5});",
+                precision,
+                GetVariableNameForSlot(kColorOutputSlotId),
+                GetFunctionName(),
+                uv,
+                lod,
+                exposureMultiplier
+            );
+
+            visitor.AddShaderChunk(sb.ToString(), true);
+        }
+
+        public bool RequiresCameraOpaqueTexture(ShaderStageCapability stageCapability)
+        {
+            return true;
+        }
+
+        public bool RequiresScreenPosition(ShaderStageCapability stageCapability = ShaderStageCapability.All)
+        {
+            return true;
+        }
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 107dcfb3b4f5eb7479c57e445acae996
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderGraphFunctions.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderGraphFunctions.hlsl
@@ -17,7 +17,8 @@ float shadergraph_HDSampleSceneDepth(float2 uv)
 float3 shadergraph_HDSampleSceneColor(float2 uv)
 {
 #if defined(REQUIRE_OPAQUE_TEXTURE) && defined(_SURFACE_TYPE_TRANSPARENT)
-	return SampleCameraColor(uv);
+    // We always remove the pre-exposure when we sample the scene color
+	return SampleCameraColor(uv) * GetInverseCurrentExposureMultiplier();
 #endif
     return float3(0, 0, 0);
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -326,14 +326,24 @@ float SampleCameraDepth(float2 uv)
     return LoadCameraDepth(uint2(uv * _ScreenSize.xy));
 }
 
+float3 LoadCameraColor(uint2 pixelCoords, uint lod)
+{
+    return LOAD_TEXTURE2D_X_LOD(_ColorPyramidTexture, pixelCoords, lod).rgb;
+}
+
+float3 SampleCameraColor(float2 uv, float lod)
+{
+    return SAMPLE_TEXTURE2D_X_LOD(_ColorPyramidTexture, s_trilinear_clamp_sampler, uv, lod).rgb;
+}
+
 float3 LoadCameraColor(uint2 pixelCoords)
 {
-    return LOAD_TEXTURE2D_X_LOD(_ColorPyramidTexture, pixelCoords, 0).rgb;
+    return LoadCameraColor(pixelCoords, 0);
 }
 
 float3 SampleCameraColor(float2 uv)
 {
-    return LoadCameraColor(uint2(uv * _ScreenSize.xy));
+    return SampleCameraColor(uv, 0);
 }
 
 float4x4 OptimizeProjectionMatrix(float4x4 M)


### PR DESCRIPTION
### Purpose of this PR
Add exposure and HD scene color nodes

![image](https://user-images.githubusercontent.com/6877923/54629107-2bec9780-4a77-11e9-99f5-3b1764e44e56.png)
![image](https://user-images.githubusercontent.com/6877923/54629143-3ad34a00-4a77-11e9-92e5-e51398b275a5.png)
![SceneColorLod](https://user-images.githubusercontent.com/6877923/54675901-c690b900-4aff-11e9-8854-be78d9e8f8a5.gif)

Will need to update the emission graphic test when merged

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FAddExposureAndHDSceneColorNode&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
