### PR TITLE
Lw/fix transparent sortflag

### DIFF
--- a/TestProjects/LWGraphicsTest/Assets/Scenes/045_CustomLWPipe/CustomLWPipe.cs
+++ b/TestProjects/LWGraphicsTest/Assets/Scenes/045_CustomLWPipe/CustomLWPipe.cs
@@ -9,7 +9,7 @@ public class CustomLWPipe : ScriptableRenderer
 
     public CustomLWPipe(CustomRenderGraphData data) : base(data)
     {
-        m_RenderOpaqueForwardPass = new DrawObjectsPass("Render Opaques", RenderPassEvent.BeforeRenderingOpaques + 1, RenderQueueRange.opaque, -1, StencilState.defaultValue, 0);
+        m_RenderOpaqueForwardPass = new DrawObjectsPass("Render Opaques", true, RenderPassEvent.BeforeRenderingOpaques + 1, RenderQueueRange.opaque, -1, StencilState.defaultValue, 0);
         m_ForwardLights = new ForwardLights();
     }
 

--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [5.11.0] - 2019-XX-XX
+### Fixed
+- Fixed issue that caused transparent objects to sort incorrectly.
 
 ## [5.10.0] - 2019-03-19
 ### Added

--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [5.11.0] - 2019-XX-XX
 ### Fixed
-- Fixed issue that caused transparent objects to sort incorrectly.
+- Fixed an issue that caused transparent objects to sort incorrectly.
 
 ## [5.10.0] - 2019-03-19
 ### Added

--- a/com.unity.render-pipelines.lightweight/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/ForwardRenderer.cs
@@ -56,12 +56,12 @@ namespace UnityEngine.Rendering.LWRP
             m_AdditionalLightsShadowCasterPass = new AdditionalLightsShadowCasterPass(RenderPassEvent.BeforeRenderingShadows);
             m_DepthPrepass = new DepthOnlyPass(RenderPassEvent.BeforeRenderingPrepasses, RenderQueueRange.opaque, data.opaqueLayerMask);
             m_ScreenSpaceShadowResolvePass = new ScreenSpaceShadowResolvePass(RenderPassEvent.BeforeRenderingPrepasses, screenspaceShadowsMaterial);
-            m_RenderOpaqueForwardPass = new DrawObjectsPass("Render Opaques", RenderPassEvent.BeforeRenderingOpaques, RenderQueueRange.opaque, data.opaqueLayerMask, m_DefaultStencilState, stencilData.stencilReference);
+            m_RenderOpaqueForwardPass = new DrawObjectsPass("Render Opaques", true, RenderPassEvent.BeforeRenderingOpaques, RenderQueueRange.opaque, data.opaqueLayerMask, m_DefaultStencilState, stencilData.stencilReference);
             m_CopyDepthPass = new CopyDepthPass(RenderPassEvent.BeforeRenderingOpaques, copyDepthMaterial);
             m_OpaquePostProcessPass = new PostProcessPass(RenderPassEvent.BeforeRenderingOpaques, true);
             m_DrawSkyboxPass = new DrawSkyboxPass(RenderPassEvent.BeforeRenderingSkybox);
             m_CopyColorPass = new CopyColorPass(RenderPassEvent.BeforeRenderingTransparents, samplingMaterial, downsamplingMethod);
-            m_RenderTransparentForwardPass = new DrawObjectsPass("Render Transparents", RenderPassEvent.BeforeRenderingTransparents, RenderQueueRange.transparent, data.transparentLayerMask, m_DefaultStencilState, stencilData.stencilReference);
+            m_RenderTransparentForwardPass = new DrawObjectsPass("Render Transparents", false, RenderPassEvent.BeforeRenderingTransparents, RenderQueueRange.transparent, data.transparentLayerMask, m_DefaultStencilState, stencilData.stencilReference);
             m_PostProcessPass = new PostProcessPass(RenderPassEvent.BeforeRenderingPostProcessing);
             m_CapturePass = new CapturePass(RenderPassEvent.AfterRendering);
             m_FinalBlitPass = new FinalBlitPass(RenderPassEvent.AfterRendering, blitMaterial);

--- a/com.unity.render-pipelines.lightweight/Runtime/Passes/DrawObjectsPass.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/Passes/DrawObjectsPass.cs
@@ -14,8 +14,9 @@ namespace UnityEngine.Rendering.LWRP
         RenderStateBlock m_RenderStateBlock;
         List<ShaderTagId> m_ShaderTagIdList = new List<ShaderTagId>();
         string m_ProfilerTag;
+        bool m_IsOpaque;
 
-        public DrawObjectsPass(string profilerTag, RenderPassEvent evt, RenderQueueRange renderQueueRange, LayerMask layerMask, StencilState stencilState, int stencilReference)
+        public DrawObjectsPass(string profilerTag, bool opaque, RenderPassEvent evt, RenderQueueRange renderQueueRange, LayerMask layerMask, StencilState stencilState, int stencilReference)
         {
             m_ProfilerTag = profilerTag;
             m_ShaderTagIdList.Add(new ShaderTagId("LightweightForward"));
@@ -23,6 +24,7 @@ namespace UnityEngine.Rendering.LWRP
             renderPassEvent = evt;
             m_FilteringSettings = new FilteringSettings(renderQueueRange, layerMask);
             m_RenderStateBlock = new RenderStateBlock(RenderStateMask.Nothing);
+            m_IsOpaque = opaque;
 
             if (stencilState.enabled)
             {
@@ -42,7 +44,7 @@ namespace UnityEngine.Rendering.LWRP
                 cmd.Clear();
 
                 Camera camera = renderingData.cameraData.camera;
-                var sortFlags = renderingData.cameraData.defaultOpaqueSortFlags;
+                var sortFlags = (m_IsOpaque) ? renderingData.cameraData.defaultOpaqueSortFlags : SortingCriteria.CommonTransparent;
                 var drawSettings = CreateDrawingSettings(m_ShaderTagIdList, ref renderingData, sortFlags);
                 context.DrawRenderers(renderingData.cullResults, ref drawSettings, ref m_FilteringSettings, ref m_RenderStateBlock);
 


### PR DESCRIPTION
### Purpose of this PR
Fixed issue that caused transparent object to sort incorretly.

---
### Release Notes
Added

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lw%2Ffix-transparent-sortflag&automation-tools_branch=master&unity_branch=2019.1%2Fstaging

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
