### PR TITLE
Checkout baked files when baking probes with HDRP's reflection system

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed Light intensity not played in the player when recorded with animation/timeline
 - Fixed some issues when multi editing HDRenderPipelineAsset
 - Fixed emission node breaking the main shader graph preview in certain conditions.
+- Fixed checkout of baked probe asset when baking probes.
 
 ### Changed
 - DensityVolume scripting API will no longuer allow to change between advance and normal edition mode

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDBakedReflectionSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDBakedReflectionSystem.cs
@@ -513,7 +513,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             (uint)StaticEditorFlags.ReflectionProbeStatic
                         );
                         HDBakingUtilities.CreateParentDirectoryIfMissing(targetFile);
-                        Checkout(targetFile, CheckoutMode.Both);
+                        if (Provider.isActive)
+                            Checkout(targetFile, CheckoutMode.Both);
                         HDTextureUtilities.WriteTextureFileToDisk(cubeRT, targetFile);
                         break;
                     }
@@ -532,11 +533,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             out CameraSettings cameraSettings, out CameraPositionSettings cameraPositionSettings
                         );
                         HDBakingUtilities.CreateParentDirectoryIfMissing(targetFile);
-                        Checkout(targetFile, CheckoutMode.Both);
+                        if (Provider.isActive)
+                            Checkout(targetFile, CheckoutMode.Both);
                         HDTextureUtilities.WriteTextureFileToDisk(planarRT, targetFile);
                         var renderData = new HDProbe.RenderData(cameraSettings, cameraPositionSettings);
                         var targetRenderDataFile = targetFile + ".renderData";
-                        Checkout(targetRenderDataFile, CheckoutMode.Both);
+                        if (Provider.isActive)
+                            Checkout(targetRenderDataFile, CheckoutMode.Both);
                         HDBakingUtilities.TrySerializeToDisk(renderData, targetRenderDataFile);
                         break;
                     }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDBakedReflectionSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDBakedReflectionSystem.cs
@@ -6,9 +6,11 @@ using System.Reflection;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEditor;
 using UnityEditor.Experimental.Rendering;
+using UnityEditor.VersionControl;
 using UnityEngine.Assertions;
 using UnityEngine.Rendering;
 using UnityEngine.SceneManagement;
+using static UnityEditor.VersionControl.Provider;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
@@ -47,7 +49,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         Hash128[] m_StateHashes;
         HDProbeBakedState[] m_HDProbeBakedStates = new HDProbeBakedState[0];
         float m_DateSinceLastLegacyWarning = float.MinValue;
-        Dictionary<UnityEngine.Rendering.RenderPipeline, float> m_DateSinceLastInvalidSRPWarning 
+        Dictionary<UnityEngine.Rendering.RenderPipeline, float> m_DateSinceLastInvalidSRPWarning
             = new Dictionary<UnityEngine.Rendering.RenderPipeline, float>();
 
         HDBakedReflectionSystem() : base(1)
@@ -88,7 +90,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // On the C# side, we don't have non blocking asset import APIs, and we don't want to block the
             //   UI when the user is editing the world.
             //   So, we skip the baking when the user is editing any UI control.
-            if (GUIUtility.hotControl != 0) 
+            if (GUIUtility.hotControl != 0)
                 return;
 
             if (!IsCurrentSRPValid(out HDRenderPipeline hdPipeline))
@@ -511,6 +513,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             (uint)StaticEditorFlags.ReflectionProbeStatic
                         );
                         HDBakingUtilities.CreateParentDirectoryIfMissing(targetFile);
+                        Checkout(targetFile, CheckoutMode.Both);
                         HDTextureUtilities.WriteTextureFileToDisk(cubeRT, targetFile);
                         break;
                     }
@@ -529,9 +532,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             out CameraSettings cameraSettings, out CameraPositionSettings cameraPositionSettings
                         );
                         HDBakingUtilities.CreateParentDirectoryIfMissing(targetFile);
+                        Checkout(targetFile, CheckoutMode.Both);
                         HDTextureUtilities.WriteTextureFileToDisk(planarRT, targetFile);
                         var renderData = new HDProbe.RenderData(cameraSettings, cameraPositionSettings);
-                        HDBakingUtilities.TrySerializeToDisk(renderData, targetFile + ".renderData");
+                        var targetRenderDataFile = targetFile + ".renderData";
+                        Checkout(targetRenderDataFile, CheckoutMode.Both);
+                        HDBakingUtilities.TrySerializeToDisk(renderData, targetRenderDataFile);
                         break;
                     }
             }


### PR DESCRIPTION
### Purpose of this PR
Checks out files before writing baked asset to disk.
This is useful when using Perforce as VCS.

---
### Testing status
**Katana Tests**: [ABV Passed](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=HDRP%2FReflectionSystemVCS&unity_branch=trunk)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: -

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
