### PR TITLE
Add _TERRAIN_BLEND_DENSITY macro

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Splatmap.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Splatmap.hlsl
@@ -138,7 +138,7 @@ void TerrainSplatBlend(float2 controlUV, float2 splatBaseUV, inout TerrainLitSur
     ZERO_INITIALIZE_ARRAY(float, weights, _LAYER_COUNT);
 
     #ifdef _MASKMAP
-        #ifdef _TERRAIN_BLEND_HEIGHT
+        #if defined(_TERRAIN_BLEND_HEIGHT)
             // Modify blendMask to take into account the height of the layer. Higher height should be more visible.
             float maxHeight = masks[0].z;
             maxHeight = max(maxHeight, masks[1].z);
@@ -176,7 +176,7 @@ void TerrainSplatBlend(float2 controlUV, float2 splatBaseUV, inout TerrainLitSur
             #ifdef _TERRAIN_8_LAYERS
                 blendMasks1 = weightedHeights1 / sumHeight.xxxx;
             #endif
-        #else
+        #elif defined(_TERRAIN_BLEND_DENSITY)
             // Denser layers are more visible.
             float4 opacityAsDensity0 = saturate((float4(albedo[0].a, albedo[1].a, albedo[2].a, albedo[3].a) - (float4(1.0, 1.0, 1.0, 1.0) - blendMasks0)) * 20.0); // 20.0 is the number of steps in inputAlphaMask (Density mask. We decided 20 empirically)
             opacityAsDensity0 += 0.001f * blendMasks0;		// if all weights are zero, default to what the blend mask says

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Splatmap_Includes.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Splatmap_Includes.hlsl
@@ -4,6 +4,10 @@
     #define _LAYER_COUNT 4
 #endif
 
+#ifndef _TERRAIN_BLEND_HEIGHT
+    #define _TERRAIN_BLEND_DENSITY // enable density blending by default and use DiffuseRemap.w to control whether the density blending is enabled for a layer
+#endif
+
 #define DECLARE_TERRAIN_LAYER_PROPS(n)  \
     float4 _Splat##n##_ST;              \
     float _Metallic##n;                 \


### PR DESCRIPTION
### Purpose of this PR
The macro is for controlling whether density blend mode should be enabled. It's not currently configurable and will be enabled if height blending is not enabled, to retain the old behaviour.

---
### Release Notes
TBD.

---
### Testing status
**Katana Tests**: Running, but should be green as the change is trivial.

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
