### PR TITLE
Add a define check in the HDSceneColorNode to output black in the metapass.

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
@@ -85,7 +85,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                             {
                                 s.AppendLine("exposureMultiplier = 1.0;");
                             }
-                            s.AppendLine("#if defined(REQUIRE_OPAQUE_TEXTURE) && defined(_SURFACE_TYPE_TRANSPARENT)");
+                            s.AppendLine("#if defined(REQUIRE_OPAQUE_TEXTURE) && defined(_SURFACE_TYPE_TRANSPARENT) && defined(SHADERPASS) && (SHADERPASS != SHADERPASS_LIGHT_TRANSPORT)");
                             s.AppendLine("return SampleCameraColor(uv, lod) * exposureMultiplier;", precision);
                             s.AppendLine("#endif");
                             s.AppendLine("return float3(0.0, 0.0, 0.0);");


### PR DESCRIPTION
### Purpose of this PR
If the HDSceneColorNode is somehow plugged in the emission input of the master node, and that the material is set to enable emissive GI, then the lightmapper will read uncertain values (can come from any of the previous rendered frames).
This PR uses the defines to output a black color in that case.

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrp%2FHDSceneColor-EmissionFallback&automation-tools_branch=master&unity_branch=trunk

**Manual Tests**: What did you do?
- [x] Build lighting with HDSceneColor node as emission input, and check that the baked color is black.

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
