### PR TITLE
Backport of #3275

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
@@ -92,13 +92,13 @@ real3 TransformWorldToHClipDir(real3 directionWS)
 }
 
 // Transforms normal from object to world space
-real3 TransformObjectToWorldNormal(real3 normalOS)
+float3 TransformObjectToWorldNormal(float3 normalOS)
 {
 #ifdef UNITY_ASSUME_UNIFORM_SCALING
     return TransformObjectToWorldDir(normalOS);
 #else
     // Normal need to be multiply by inverse transpose
-    return normalize(mul(normalOS, (real3x3)GetWorldToObjectMatrix()));
+    return normalize(mul(normalOS, GetWorldToObjectMatrix()));
 #endif
 }
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
@@ -98,7 +98,7 @@ float3 TransformObjectToWorldNormal(float3 normalOS)
     return TransformObjectToWorldDir(normalOS);
 #else
     // Normal need to be multiply by inverse transpose
-    return normalize(mul(normalOS, GetWorldToObjectMatrix()));
+    return normalize(mul(normalOS, (float3x3)GetWorldToObjectMatrix()));
 #endif
 }
 

--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [5.11.0] - 2019-XX-XX
 ### Fixed
 - Fixed an issue that caused transparent objects to sort incorrectly.
+- Fixed artifacts that appeared due to precision errors in large scaled objects.
 
 ## [5.10.0] - 2019-03-19
 ### Added

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Core.hlsl
@@ -45,7 +45,7 @@ struct VertexNormalInputs
 {
     real3 tangentWS;
     real3 bitangentWS;
-    real3 normalWS;
+    float3 normalWS;
 };
 
 VertexPositionInputs GetVertexPositionInputs(float3 positionOS)


### PR DESCRIPTION
### Purpose of this PR
Backport of https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3275

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

Running at the moment
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=backport%2Flw%2Fnormals-to-floats&unity_branch=trunk&automation-tools_branch=master