### PR TITLE
Re-fix HD PBR node preview in shader graph

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRSubShader.cs
@@ -226,7 +226,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 PBRMasterNode.PositionSlotId
             },
-            UseInPreview = false,
+            UseInPreview = true,
 
             OnGeneratePassImpl = (IMasterNode node, ref Pass pass) =>
             {


### PR DESCRIPTION
### Purpose of this PR
Fix the preview of the PBR master node: https://fogbugz.unity3d.com/f/cases/1136387

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FReFixHDPBRNodePreview&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low