### PR TITLE
fixed 'Expected' and 'Actual' in Lightweight unit tests that were the wrong way around

### DIFF
--- a/com.unity.render-pipelines.lightweight/Tests/Editor/EditorTests.cs
+++ b/com.unity.render-pipelines.lightweight/Tests/Editor/EditorTests.cs
@@ -11,7 +11,7 @@ class EditorTests
         LightweightRenderPipelineAsset asset = LightweightRenderPipelineAsset.Create();
         Assert.AreNotEqual(null, asset.defaultMaterial);
         Assert.AreNotEqual(null, asset.defaultParticleMaterial);
-        Assert.AreNotEqual(null, asset.defaultLineMaterial,);
+        Assert.AreNotEqual(null, asset.defaultLineMaterial);
         Assert.AreNotEqual(null, asset.defaultTerrainMaterial);
         Assert.AreNotEqual(null, asset.defaultShader);
 

--- a/com.unity.render-pipelines.lightweight/Tests/Editor/EditorTests.cs
+++ b/com.unity.render-pipelines.lightweight/Tests/Editor/EditorTests.cs
@@ -9,20 +9,20 @@ class EditorTests
     public void ValidateNewAssetResources()
     {
         LightweightRenderPipelineAsset asset = LightweightRenderPipelineAsset.Create();
-        Assert.AreNotEqual(asset.defaultMaterial, null);
-        Assert.AreNotEqual(asset.defaultParticleMaterial, null);
-        Assert.AreNotEqual(asset.defaultLineMaterial, null);
-        Assert.AreNotEqual(asset.defaultTerrainMaterial, null);
-        Assert.AreNotEqual(asset.defaultShader, null);
+        Assert.AreNotEqual(null, asset.defaultMaterial);
+        Assert.AreNotEqual(null, asset.defaultParticleMaterial);
+        Assert.AreNotEqual(null, asset.defaultLineMaterial,);
+        Assert.AreNotEqual(null, asset.defaultTerrainMaterial);
+        Assert.AreNotEqual(null, asset.defaultShader);
 
         // LWRP doesn't override the following materials
-        Assert.AreEqual(asset.defaultUIMaterial, null);
-        Assert.AreEqual(asset.defaultUIOverdrawMaterial, null);
-        Assert.AreEqual(asset.defaultUIETC1SupportedMaterial, null);
-        Assert.AreEqual(asset.default2DMaterial, null);
+        Assert.AreEqual(null, asset.defaultUIMaterial);
+        Assert.AreEqual(null, asset.defaultUIOverdrawMaterial);
+        Assert.AreEqual(null, asset.defaultUIETC1SupportedMaterial);
+        Assert.AreEqual(null, asset.default2DMaterial);
 
-        Assert.AreNotEqual(asset.m_EditorResourcesAsset, null, "Editor Resources should be initialized when creating a new pipeline.");
-        Assert.AreNotEqual(asset.m_RendererData, null, "A default renderer data should be created when creating a new pipeline.");
+        Assert.AreNotEqual(null, asset.m_EditorResourcesAsset, "Editor Resources should be initialized when creating a new pipeline.");
+        Assert.AreNotEqual(null, asset.m_RendererData, "A default renderer data should be created when creating a new pipeline.");
         ScriptableObject.DestroyImmediate(asset);
     }
 

--- a/com.unity.render-pipelines.lightweight/Tests/Runtime/RuntimeTests.cs
+++ b/com.unity.render-pipelines.lightweight/Tests/Runtime/RuntimeTests.cs
@@ -20,7 +20,7 @@ class RuntimeTests
         camera.Render();
         yield return null;
         
-        Assert.AreEqual(GraphicsSettings.lightsUseLinearIntensity, QualitySettings.activeColorSpace == ColorSpace.Linear,
+        Assert.AreEqual(QualitySettings.activeColorSpace == ColorSpace.Linear, GraphicsSettings.lightsUseLinearIntensity,
             "GraphicsSettings.lightsUseLinearIntensity must match active color space.");
 
         GraphicsSettings.renderPipelineAsset = prevAsset;
@@ -41,13 +41,13 @@ class RuntimeTests
         camera.Render();
         yield return null;
 
-        Assert.AreEqual(Shader.globalRenderPipeline, "LightweightPipeline", "Wrong render pipeline shader tag.");
+        Assert.AreEqual("LightweightPipeline", Shader.globalRenderPipeline, "Wrong render pipeline shader tag.");
 
         GraphicsSettings.renderPipelineAsset = null;
         camera.Render();
         yield return null;
 
-        Assert.AreEqual(Shader.globalRenderPipeline, "", "Render Pipeline shader tag is not restored.");
+        Assert.AreEqual("", Shader.globalRenderPipeline, "Render Pipeline shader tag is not restored.");
         GraphicsSettings.renderPipelineAsset = prevAsset;
 
         ScriptableObject.DestroyImmediate(asset);


### PR DESCRIPTION
### Purpose of this PR
The 'expected' and 'actual' args in the Lightweight package unit tests were the wrong way around, leading to misleading error messages

**Automated Tests**:  Corrected existing automated tests

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None
