### PR TITLE
Fix editor resources asset refereces breaking when upgrading the HDRP asset

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -22,7 +22,22 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         protected override UnityEngine.Rendering.RenderPipeline CreatePipeline()
         {
-            return new HDRenderPipeline(this);
+            // safe: When we return a null render pipline it will do nothing in the rendering
+            HDRenderPipeline pipeline = null;
+
+            // We need to do catch every errors that happend during the HDRP build, when we upgrade the
+            // HDRP package, some required assets are not yet imported by the package manager when the
+            // pipeline is created so in that case, we just return a null pipeline. Some error may appear
+            // when we upgrade the pipeline but it's better than breaking HDRP resources an causing more
+            // errors.
+            try
+            {
+                pipeline = new HDRenderPipeline(this);
+            } catch (Exception e) {
+                UnityEngine.Debug.LogError(e);
+            }
+
+            return pipeline;
         }
 
         protected override void OnValidate()

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/ResourceReloader.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipelineResources/ResourceReloader.cs
@@ -126,7 +126,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             else
                 result = AssetDatabase.LoadAssetAtPath(path, type);
             if (IsNull(result))
-                UnityEngine.Debug.LogWarning(
+                throw new Exception(
                     String.Format("Cannot load. Incorrect path: {0} Null returned.", path));
             return result;
         }


### PR DESCRIPTION
### Purpose of this PR
Fix editor resources asset refereces breaking when upgrading the HDRP asset

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FFixEditorResourcesWhenUpgrading&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low