### PR TITLE
Leave light lists in a clean state when we don't need to build them anymore 

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed the Stop NaN feature
 - Fixed some resources to handle more than 2 instanced views for XR
 - Fixed issue with black screen (NaN) produced on old GPU hardware or intel GPU hardware with gaussian pyramid
+- Fixed issue with disabled punctual light would still render when only directional light is present
 
 ### Changed
 - DensityVolume scripting API will no longuer allow to change between advance and normal edition mode

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -2372,7 +2372,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
             var isProjectionOblique = GeometryUtils.IsProjectionMatrixOblique(m_LightListProjMatrices[0]);
 
-            // If we don't need to run the light list, we still run it for the first frame that is not needed in order to clean up all the relevant lists.
+            // If we don't need to run the light list, we still run it for the first frame that is not needed in order to keep the lists in a clean state. 
             if (!runLightList && m_hasRunLightListPrevFrame)
             {
                 m_hasRunLightListPrevFrame = false;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -2384,7 +2384,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
 
             // generate screen-space AABBs (used for both fptl and clustered).
-            if (runLightList)
+            if (m_lightCount != 0)
             {
                 temp.SetRow(0, new Vector4(1.0f, 0.0f, 0.0f, 0.0f));
                 temp.SetRow(1, new Vector4(0.0f, 1.0f, 0.0f, 0.0f));

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -282,6 +282,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         int m_lightCount = 0;
         int m_densityVolumeCount = 0;
         bool m_enableBakeShadowMask = false; // Track if any light require shadow mask. In this case we will need to enable the keyword shadow mask
+        bool m_hasRunLightListPrevFrame = false;
 
         // This value is used to compute the area shadow when using raytracing by the HDRaytracingShadowManager
         public int areaLightCount { get { return m_areaLightCount; } }
@@ -2370,6 +2371,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_LightListInvProjscrMatrices[0] = m_LightListProjscrMatrices[0].inverse;
             }
             var isProjectionOblique = GeometryUtils.IsProjectionMatrixOblique(m_LightListProjMatrices[0]);
+
+            // If we don't need to run the light list, we still run it for the first frame that is not needed in order to clean up all the relevant lists.
+            if (!runLightList && m_hasRunLightListPrevFrame)
+            {
+                m_hasRunLightListPrevFrame = false;
+                runLightList = true;
+            }
+            else
+            {
+                m_hasRunLightListPrevFrame = runLightList;
+            }
 
             // generate screen-space AABBs (used for both fptl and clustered).
             if (runLightList)


### PR DESCRIPTION
This is a fairly quick (but not so dirty) fix for the issue to go forward with the package. I'll try to get a nicer cleanup solution soon. 

Fix for https://fogbugz.unity3d.com/f/cases/1139761/ .

Katana: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=HDRP%2Fclean-light-list-when-not-building-it&unity_branch=trunk