### PR TITLE
Enabled support for CBUFFER on OpenGL Core and OpenGL ES 3 backends.

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [5.11.0] - 2019-XX-XX
+### Added
+- Enabled support for CBUFFER on OpenGL Core and OpenGL ES 3 backends.
 
 ## [5.10.0] - 2019-03-19
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/GLCore.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/GLCore.hlsl
@@ -17,8 +17,8 @@
 
 #define ERROR_ON_UNSUPPORTED_FUNCTION(funcName) #error #funcName is not supported on GLCORE
 
-#define CBUFFER_START(name)
-#define CBUFFER_END
+#define CBUFFER_START(name) cbuffer name {
+#define CBUFFER_END };
 
 #define PLATFORM_SUPPORTS_EXPLICIT_BINDING 1
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/API/GLES3.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/API/GLES3.hlsl
@@ -17,8 +17,8 @@
 
 #define ERROR_ON_UNSUPPORTED_FUNCTION(funcName) #error #funcName is not supported on GLES 3.0
 
-#define CBUFFER_START(name)
-#define CBUFFER_END
+#define CBUFFER_START(name) cbuffer name {
+#define CBUFFER_END };
 
 
 // flow control attributes


### PR DESCRIPTION
### Purpose of this PR
Enabled support for CBUFFER on OpenGL Core and OpenGL ES 3 backends. This is required for SRP batcher to work.

---
### Release Notes
Enabled support for CBUFFER on OpenGL Core and OpenGL ES 3 backends.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=backports%2FCBUFFER_on_GL&unity_branch=2019.1%2Fstaging

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup?
Nothing.

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
None

**Halo Effect**: None, Low, Medium, High?
Medium (all GL3 + GLCore)

---
### Comments to reviewers
Notes for the reviewers you have assigned.
