### PR TITLE
Fixed compile errors in XRGraphics.cs when ENABLE_VR is not defined

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [6.6.0] - 2019-04-01
+### Fixed
+- Fixed compile errors in XRGraphics.cs when ENABLE_VR is not defined
 
 ## [6.5.0] - 2019-03-07
 

--- a/com.unity.render-pipelines.core/Runtime/Common/XRGraphics.cs
+++ b/com.unity.render-pipelines.core/Runtime/Common/XRGraphics.cs
@@ -1,5 +1,8 @@
 using System;
 using UnityEditor;
+
+#if ENABLE_VR
+
 #if UNITY_2017_2_OR_NEWER
 using UnityEngine.XR;
 using XRSettings = UnityEngine.XR.XRSettings;
@@ -7,6 +10,8 @@ using XRSettings = UnityEngine.XR.XRSettings;
 using UnityEngine.VR;
 using XRSettings = UnityEngine.VR.VRSettings;
 #endif
+
+#endif // ENABLE_VR
 
 namespace UnityEngine.Rendering
 {
@@ -26,10 +31,11 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                    return 1.0f;
-                else
+#if ENABLE_VR
+                if (enabled)
                     return XRSettings.eyeTextureResolutionScale;
+#endif
+                return 1.0f;
             }
         }
 
@@ -37,10 +43,11 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                    return 1.0f;
-                else
+#if ENABLE_VR
+                if (enabled)
                     return XRSettings.renderViewportScale;
+#endif
+                return 1.0f;    
             }
         }
 
@@ -67,9 +74,11 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                    return false;
-                return XRSettings.isDeviceActive;
+#if ENABLE_VR
+                if (enabled)
+                    return XRSettings.isDeviceActive;
+#endif
+                return false;
             }
         }
 
@@ -77,9 +86,11 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                    return "No XR device loaded";
-                return XRSettings.loadedDeviceName;
+#if ENABLE_VR
+                if (enabled)
+                    return XRSettings.loadedDeviceName;
+#endif
+                return "No XR device loaded";
             }
         }
 
@@ -87,9 +98,11 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                    return new string[1];
-                return XRSettings.supportedDevices;
+#if ENABLE_VR
+                if (enabled)
+                    return XRSettings.supportedDevices;
+#endif
+                return new string[1];
             }
         }
 
@@ -97,22 +110,25 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                    return StereoRenderingMode.SinglePass;
-#if UNITY_2018_3_OR_NEWER
-                return (StereoRenderingMode)XRSettings.stereoRenderingMode;
-#else // Reverse engineer it
-                if (!enabled)
-                    return StereoRenderingMode.SinglePassMultiView;
-                if (eyeTextureDesc.vrUsage == VRTextureUsage.TwoEyes)
+#if ENABLE_VR
+                if (enabled)
                 {
-                    if (eyeTextureDesc.dimension == UnityEngine.Rendering.TextureDimension.Tex2DArray)
-                        return StereoRenderingMode.SinglePassInstanced;
-                    return StereoRenderingMode.SinglePassDoubleWide;
+    #if UNITY_2018_3_OR_NEWER
+                    return (StereoRenderingMode)XRSettings.stereoRenderingMode;
+    #else // Reverse engineer it
+                    if (eyeTextureDesc.vrUsage == VRTextureUsage.TwoEyes)
+                    {
+                        if (eyeTextureDesc.dimension == UnityEngine.Rendering.TextureDimension.Tex2DArray)
+                            return StereoRenderingMode.SinglePassInstanced;
+                        return StereoRenderingMode.SinglePassDoubleWide;
+                    }
+                    else
+                        return StereoRenderingMode.MultiPass;
+    #endif // UNITY_2018_3_OR_NEWER
                 }
-                else
-                    return StereoRenderingMode.MultiPass;
-#endif
+#endif // ENABLE_VR
+
+                return StereoRenderingMode.SinglePass;
             }
         }
 
@@ -120,12 +136,11 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                {
-                    return new RenderTextureDescriptor(0, 0);
-                }
-
-                return XRSettings.eyeTextureDesc;
+#if ENABLE_VR
+                if (enabled)
+                    return XRSettings.eyeTextureDesc;
+#endif
+                return new RenderTextureDescriptor(0, 0);
             }
         }
 
@@ -133,26 +148,23 @@ namespace UnityEngine.Rendering
         {
             get
             {
-                if (!enabled)
-                {
-                    return 0;
-                }
-
-                return XRSettings.eyeTextureWidth;
+#if ENABLE_VR
+                if (enabled)
+                    return XRSettings.eyeTextureWidth;
+#endif
+                return 0;
             }
         }
         public static int eyeTextureHeight
         {
             get
             {
-                if (!enabled)
-                {
-                    return 0;
-                }
-
-                return XRSettings.eyeTextureHeight;
+#if ENABLE_VR
+                if (enabled)
+                    return XRSettings.eyeTextureHeight;
+#endif
+                return 0;          
             }
         }
-
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Fixed compile errors in XRGraphics.cs when ENABLE_VR is not defined

---
### Testing status
**Katana Tests**: [green](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp-xrgraphics-vr-enable&unity_branch=trunk)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Issue was reported from the platforms team
