### PR TITLE
Fix for Unlit nodes not calling OnGeneratePass on pass generation

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed some resources to handle more than 2 instanced views for XR
 - Fixed issue with black screen (NaN) produced on old GPU hardware or intel GPU hardware with gaussian pyramid
 - Fixed issue with disabled punctual light would still render when only directional light is present
+- Fix for ShaderGraph Unlit masternode not writing velocity
 
 ### Changed
 - DensityVolume scripting API will no longuer allow to change between advance and normal edition mode

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitSubShader.cs
@@ -261,8 +261,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             return activeFields;
         }
 
-        private static bool GenerateShaderPassUnlit(AbstractMaterialNode masterNode, Pass pass, GenerationMode mode, SurfaceMaterialOptions materialOptions, ShaderGenerator result, List<string> sourceAssetDependencyPaths)
+        private static bool GenerateShaderPassUnlit(UnlitMasterNode masterNode, Pass pass, GenerationMode mode, SurfaceMaterialOptions materialOptions, ShaderGenerator result, List<string> sourceAssetDependencyPaths)
         {
+            pass.OnGeneratePass(masterNode);
+
             // apply master node options to active fields
             HashSet<string> activeFields = GetActiveFieldsFromMasterNode(masterNode, pass);
 


### PR DESCRIPTION
### Purpose of this PR
Unlit shaders didn't call OnGeneratePass on pass generation, as a result stencil was not set correctly (leading for example to per object motion vectors not being written)

This is a fix for https://fogbugz.unity3d.com/f/cases/1138782/ 

---
### Release Notes
Fix for ShaderGraph Unlit masternode not writing velocity. 

---
### Testing status
**Katana Tests**:  https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=HDRP%2Ffix-unlit-SG-node-not-calling-ongeneratepass&unity_branch=trunk [All green]


---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: Low
