### PR TITLE
VGPR usage optimizations (reorganizing + force shadow data to scalar)

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/HDShadow.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/HDShadow.hlsl
@@ -28,6 +28,10 @@ float GetDirectionalShadowAttenuation(HDShadowContext shadowContext, float3 posi
 
 float GetPunctualShadowAttenuation(HDShadowContext shadowContext, float2 positionSS, float3 positionWS, float3 normalWS, int shadowDataIndex, float3 L, float L_dist, bool pointLight, bool perspecive)
 {
+#if (defined(SUPPORTS_WAVE_INTRINSICS) && !defined(LIGHTLOOP_DISABLE_TILE_AND_CLUSTER))
+    shadowDataIndex = WaveReadLaneFirst(shadowDataIndex);
+#endif
+
     // Note: Here we assume that all the shadow map cube faces have been added contiguously in the buffer to retreive the shadow information
     HDShadowData sd = shadowContext.shadowDatas[shadowDataIndex];
 
@@ -49,6 +53,10 @@ float GetPunctualShadowAttenuation(HDShadowContext shadowContext, float3 positio
 
 float GetPunctualShadowClosestDistance(HDShadowContext shadowContext, SamplerState sampl, real3 positionWS, int shadowDataIndex, float3 L, float3 lightPositionWS, bool pointLight)
 {
+#if (defined(SUPPORTS_WAVE_INTRINSICS) && !defined(LIGHTLOOP_DISABLE_TILE_AND_CLUSTER))
+    shadowDataIndex = WaveReadLaneFirst(shadowDataIndex);
+#endif
+
     // Note: Here we assume that all the shadow map cube faces have been added contiguously in the buffer to retreive the shadow information
     // TODO: if on the light type to retrieve the good shadow data
     HDShadowData sd = shadowContext.shadowDatas[shadowDataIndex];

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -126,20 +126,6 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
     AggregateLighting aggregateLighting;
     ZERO_INITIALIZE(AggregateLighting, aggregateLighting); // LightLoop is in charge of initializing the struct
 
-    uint i = 0; // Declare once to avoid the D3D11 compiler warning.
-
-    if (featureFlags & LIGHTFEATUREFLAGS_DIRECTIONAL)
-    {
-        for (i = 0; i < _DirectionalLightCount; ++i)
-        {
-            if (IsMatchingLightLayer(_DirectionalLightDatas[i].lightLayers, builtinData.renderingLayers))
-            {
-                DirectLighting lighting = EvaluateBSDF_Directional(context, V, posInput, preLightData, _DirectionalLightDatas[i], bsdfData, builtinData);
-                AccumulateDirectLighting(lighting, aggregateLighting);
-            }
-        }
-    }
-
     if (featureFlags & LIGHTFEATUREFLAGS_PUNCTUAL)
     {
         uint lightCount, lightStart;
@@ -207,6 +193,19 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
                     DirectLighting lighting = EvaluateBSDF_Punctual(context, V, posInput, preLightData, s_lightData, bsdfData, builtinData);
                     AccumulateDirectLighting(lighting, aggregateLighting);
                 }
+            }
+        }
+    }
+
+    uint i = 0; // Declare once to avoid the D3D11 compiler warning.
+    if (featureFlags & LIGHTFEATUREFLAGS_DIRECTIONAL)
+    {
+        for (i = 0; i < _DirectionalLightCount; ++i)
+        {
+            if (IsMatchingLightLayer(_DirectionalLightDatas[i].lightLayers, builtinData.renderingLayers))
+            {
+                DirectLighting lighting = EvaluateBSDF_Directional(context, V, posInput, preLightData, _DirectionalLightDatas[i], bsdfData, builtinData);
+                AccumulateDirectLighting(lighting, aggregateLighting);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -211,58 +211,6 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         }
     }
 
-    if (featureFlags & LIGHTFEATUREFLAGS_AREA)
-    {
-        uint lightCount, lightStart;
-
-    #ifndef LIGHTLOOP_DISABLE_TILE_AND_CLUSTER
-        GetCountAndStart(posInput, LIGHTCATEGORY_AREA, lightStart, lightCount);
-    #else
-        lightCount = _AreaLightCount;
-        lightStart = _PunctualLightCount;
-    #endif
-
-        // COMPILER BEHAVIOR WARNING!
-        // If rectangle lights are before line lights, the compiler will duplicate light matrices in VGPR because they are used differently between the two types of lights.
-        // By keeping line lights first we avoid this behavior and save substantial register pressure.
-        // TODO: This is based on the current Lit.shader and can be different for any other way of implementing area lights, how to be generic and ensure performance ?
-
-        if (lightCount > 0)
-        {
-            i = 0;
-
-            uint      last      = lightCount - 1;
-            LightData lightData = FetchLight(lightStart, i);
-
-            while (i <= last && lightData.lightType == GPULIGHTTYPE_TUBE)
-            {
-                lightData.lightType = GPULIGHTTYPE_TUBE; // Enforce constant propagation
-                lightData.cookieIndex = -1;              // Enforce constant propagation
-
-                if (IsMatchingLightLayer(lightData.lightLayers, builtinData.renderingLayers))
-                {
-                    DirectLighting lighting = EvaluateBSDF_Area(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
-                    AccumulateDirectLighting(lighting, aggregateLighting);
-                }
-
-                lightData = FetchLight(lightStart, min(++i, last));
-            }
-
-            while (i <= last) // GPULIGHTTYPE_RECTANGLE
-            {
-                lightData.lightType = GPULIGHTTYPE_RECTANGLE; // Enforce constant propagation
-
-                if (IsMatchingLightLayer(lightData.lightLayers, builtinData.renderingLayers))
-                {
-                    DirectLighting lighting = EvaluateBSDF_Area(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
-                    AccumulateDirectLighting(lighting, aggregateLighting);
-                }
-
-                lightData = FetchLight(lightStart, min(++i, last));
-            }
-        }
-    }
-
     // Define macro for a better understanding of the loop
     // TODO: this code is now much harder to understand...
 #define EVALUATE_BSDF_ENV_SKY(envLightData, TYPE, type) \
@@ -412,6 +360,58 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
     }
 #undef EVALUATE_BSDF_ENV
 #undef EVALUATE_BSDF_ENV_SKY
+
+    if (featureFlags & LIGHTFEATUREFLAGS_AREA)
+    {
+        uint lightCount, lightStart;
+
+    #ifndef LIGHTLOOP_DISABLE_TILE_AND_CLUSTER
+        GetCountAndStart(posInput, LIGHTCATEGORY_AREA, lightStart, lightCount);
+    #else
+        lightCount = _AreaLightCount;
+        lightStart = _PunctualLightCount;
+    #endif
+
+        // COMPILER BEHAVIOR WARNING!
+        // If rectangle lights are before line lights, the compiler will duplicate light matrices in VGPR because they are used differently between the two types of lights.
+        // By keeping line lights first we avoid this behavior and save substantial register pressure.
+        // TODO: This is based on the current Lit.shader and can be different for any other way of implementing area lights, how to be generic and ensure performance ?
+
+        if (lightCount > 0)
+        {
+            i = 0;
+
+            uint      last      = lightCount - 1;
+            LightData lightData = FetchLight(lightStart, i);
+
+            while (i <= last && lightData.lightType == GPULIGHTTYPE_TUBE)
+            {
+                lightData.lightType = GPULIGHTTYPE_TUBE; // Enforce constant propagation
+                lightData.cookieIndex = -1;              // Enforce constant propagation
+
+                if (IsMatchingLightLayer(lightData.lightLayers, builtinData.renderingLayers))
+                {
+                    DirectLighting lighting = EvaluateBSDF_Area(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
+                    AccumulateDirectLighting(lighting, aggregateLighting);
+                }
+
+                lightData = FetchLight(lightStart, min(++i, last));
+            }
+
+            while (i <= last) // GPULIGHTTYPE_RECTANGLE
+            {
+                lightData.lightType = GPULIGHTTYPE_RECTANGLE; // Enforce constant propagation
+
+                if (IsMatchingLightLayer(lightData.lightLayers, builtinData.renderingLayers))
+                {
+                    DirectLighting lighting = EvaluateBSDF_Area(context, V, posInput, preLightData, lightData, bsdfData, builtinData);
+                    AccumulateDirectLighting(lighting, aggregateLighting);
+                }
+
+                lightData = FetchLight(lightStart, min(++i, last));
+            }
+        }
+    }
 
     // Also Apply indiret diffuse (GI)
     // PostEvaluateBSDF will perform any operation wanted by the material and sum everything into diffuseLighting and specularLighting

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -197,18 +197,6 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
         }
     }
 
-    uint i = 0; // Declare once to avoid the D3D11 compiler warning.
-    if (featureFlags & LIGHTFEATUREFLAGS_DIRECTIONAL)
-    {
-        for (i = 0; i < _DirectionalLightCount; ++i)
-        {
-            if (IsMatchingLightLayer(_DirectionalLightDatas[i].lightLayers, builtinData.renderingLayers))
-            {
-                DirectLighting lighting = EvaluateBSDF_Directional(context, V, posInput, preLightData, _DirectionalLightDatas[i], bsdfData, builtinData);
-                AccumulateDirectLighting(lighting, aggregateLighting);
-            }
-        }
-    }
 
     // Define macro for a better understanding of the loop
     // TODO: this code is now much harder to understand...
@@ -359,6 +347,19 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
     }
 #undef EVALUATE_BSDF_ENV
 #undef EVALUATE_BSDF_ENV_SKY
+
+    uint i = 0; // Declare once to avoid the D3D11 compiler warning.
+    if (featureFlags & LIGHTFEATUREFLAGS_DIRECTIONAL)
+    {
+        for (i = 0; i < _DirectionalLightCount; ++i)
+        {
+            if (IsMatchingLightLayer(_DirectionalLightDatas[i].lightLayers, builtinData.renderingLayers))
+            {
+                DirectLighting lighting = EvaluateBSDF_Directional(context, V, posInput, preLightData, _DirectionalLightDatas[i], bsdfData, builtinData);
+                AccumulateDirectLighting(lighting, aggregateLighting);
+            }
+        }
+    }
 
     if (featureFlags & LIGHTFEATUREFLAGS_AREA)
     {

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/SurfaceShading.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/SurfaceShading.hlsl
@@ -99,6 +99,7 @@ DirectLighting ShadeSurface_Directional(LightLoopContext lightLoopContext,
 
         if (surfaceReflection)
         {
+            attenuation *= ComputeMicroShadowing(bsdfData, NdotL);
             float intensity = attenuation * NdotL;
 
             lighting.diffuse  = diffuseBsdf  * (intensity * light.diffuseDimmer);
@@ -117,7 +118,6 @@ DirectLighting ShadeSurface_Directional(LightLoopContext lightLoopContext,
             lighting.specular = 0; // No spec trans, the compiler should optimize
         }
 
-        color *= ComputeMicroShadowing(bsdfData, NdotL);
         // Save ALU by applying light and cookie colors only once.
         lighting.diffuse  *= color;
         lighting.specular *= color;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/SurfaceShading.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/SurfaceShading.hlsl
@@ -99,7 +99,6 @@ DirectLighting ShadeSurface_Directional(LightLoopContext lightLoopContext,
 
         if (surfaceReflection)
         {
-            attenuation    *= ComputeMicroShadowing(bsdfData, NdotL);
             float intensity = attenuation * NdotL;
 
             lighting.diffuse  = diffuseBsdf  * (intensity * light.diffuseDimmer);
@@ -118,6 +117,7 @@ DirectLighting ShadeSurface_Directional(LightLoopContext lightLoopContext,
             lighting.specular = 0; // No spec trans, the compiler should optimize
         }
 
+        color *= ComputeMicroShadowing(bsdfData, NdotL);
         // Save ALU by applying light and cookie colors only once.
         lighting.diffuse  *= color;
         lighting.specular *= color;


### PR DESCRIPTION
### Purpose of this PR
This PR overall significantly reduces VGPR usage with few changes, mainly moving blocks around in the lightloop and force the punctual light shadow data to be loaded as scalar (guaranteed since lights are scalarized already) . 

I have not tried _everything_, so this must be considered a good first step. I tried for a bit more to analyse the shaders, but couldn't immediately find something more,  but that doesn't mean there might be something. 

Changes with this PR (only variants that had a diff, the non-present ones have 0 difference, increase in VGPRs are marked with a 🙁 everything else is a win):

| Variant name |      VGPR Diff on PS4  |  VGPR Diff on Xbox |
|----------|:-------------:|:------:|
| Deferred_Indirect_Fptl_Variant3 |  **-8** | **-8** |
| Deferred_Indirect_Fptl_Variant4 |  **-4** | **-12** |
| Deferred_Indirect_Fptl_Variant5 |  0 | **-4** |
| Deferred_Indirect_Fptl_Variant7 |  **-4** | **-16** |
| Deferred_Indirect_Fptl_Variant8 |  **-20** | **-20** |
| Deferred_Indirect_Fptl_Variant9 |  **-4** | **-8** |
| Deferred_Indirect_Fptl_Variant10 |  **-8** | **0** |
| Deferred_Indirect_Fptl_Variant11 |  **-20** | **-24** |
| Deferred_Indirect_Fptl_Variant12 |  **-4** | **-8** |
| Deferred_Indirect_Fptl_Variant14 |  **-12** | **-16** |
| Deferred_Indirect_Fptl_Variant15 |  **-4** | **0** |
| Deferred_Indirect_Fptl_Variant16 |  **0** | **-28** |
| Deferred_Indirect_Fptl_Variant17 |  **-8** | **0** |
| Deferred_Indirect_Fptl_Variant18 |  **-4** | **-4** |
| Deferred_Indirect_Fptl_Variant19 |  **0** | **-12** |
| Deferred_Indirect_Fptl_Variant20 |  **+8** 🙁 | **0** | 
| Deferred_Indirect_Fptl_Variant22 |  **0**  | **-8** | 
| Deferred_Indirect_Fptl_Variant23 |  **+4** 🙁  | **-4** | 
| Deferred_Indirect_Fptl_Variant24 |  **-4**  | **-8** | 
| Deferred_Indirect_Fptl_Variant26 |  **+4** 🙁  | **0** | 
| Deferred_Indirect_Fptl_Variant27 |  **-4**  | **-8** | 
| Deferred_Indirect_Fptl_Variant28 |  **-4**  | **0** | 


The variants that got slightly worse on PS4 (but still a win on xbox one) are: 
**20**: clear coat + dir light + env light 
**23**: Iridescence + dir light + punctual
 **26**: Iridescence + dir light + punctual + env 

so less common variants, while more widely used variants (e.g. dir light + punctual + standard lit) got better and lots got much better. 

__ Shadow mask variants data weren't gathered on xbox here the changes on PS4 __ 

| Variant name |      VGPR Diff on PS4  |
|----------|:-------------:|
| Deferred_Indirect_ShadowMask_Fptl_Variant4 |  **-4** |
| Deferred_Indirect_ShadowMask_Fptl_Variant6 |  **-8** | 
| Deferred_Indirect_ShadowMask_Fptl_Variant7 |  **-4** | 
| Deferred_Indirect_ShadowMask_Fptl_Variant8  |  **-20** | 
| Deferred_Indirect_ShadowMask_Fptl_Variant9  |  **-4** |
| Deferred_Indirect_ShadowMask_Fptl_Variant10 |  **-8** |
| Deferred_Indirect_ShadowMask_Fptl_Variant11|  **-20** | 
| Deferred_Indirect_ShadowMask_Fptl_Variant12 |  **-4** |
| Deferred_Indirect_ShadowMask_Fptl_Variant14 |  **-12** |
| Deferred_Indirect_ShadowMask_Fptl_Variant15 |  **-4** | 
| Deferred_Indirect_ShadowMask_Fptl_Variant16 |  **+4** 🙁  |
| Deferred_Indirect_ShadowMask_Fptl_Variant17 |  **-8** |
| Deferred_Indirect_ShadowMask_Fptl_Variant18 |  **-4** |
| Deferred_Indirect_ShadowMask_Fptl_Variant20 |  **+4** 🙁  |
| Deferred_Indirect_ShadowMask_Fptl_Variant23 |  **+4** 🙁  |
| Deferred_Indirect_ShadowMask_Fptl_Variant24 |  **-4**  |
| Deferred_Indirect_ShadowMask_Fptl_Variant25 |  **+8** 🙁  |
| Deferred_Indirect_ShadowMask_Fptl_Variant26 |  **-4**  |
| Deferred_Indirect_ShadowMask_Fptl_Variant27 |  **-4**  |
| Deferred_Indirect_ShadowMask_Fptl_Variant28 |  **-4**  |



---
### Release Notes
Optimize light loop. 

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp%2Flight-loop-shuffling&unity_branch=trunk [All green]

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 


---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**:  Medium
