### PR TITLE
fix serialized data not existing in runtime

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed some resources to handle more than 2 instanced views for XR
 - Fixed issue with black screen (NaN) produced on old GPU hardware or intel GPU hardware with gaussian pyramid
 - Fixed issue with disabled punctual light would still render when only directional light is present
+- Fixed deserialization crash at runtime
 
 ### Changed
 - DensityVolume scripting API will no longuer allow to change between advance and normal edition mode

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [6.7.0-preview] - 2019-XX-XX
 
+### Added
+
+### Fixed
+- Fixed deserialization crash at runtime
+
+### Changed
+
 ## [6.6.0-preview] - 2019-04-01
 
 ### Added
@@ -72,7 +79,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed some resources to handle more than 2 instanced views for XR
 - Fixed issue with black screen (NaN) produced on old GPU hardware or intel GPU hardware with gaussian pyramid
 - Fixed issue with disabled punctual light would still render when only directional light is present
-- Fixed deserialization crash at runtime
 
 ### Changed
 - DensityVolume scripting API will no longuer allow to change between advance and normal edition mode

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -259,21 +259,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // The first thing we need to do is to set the defines that depend on the render pipeline settings
             m_Asset.EvaluateSettings();
 
-            // Check that the serialized Resources are not broken
-            if ((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineResources == null)
-                (GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineResources
-                    = UnityEditor.AssetDatabase.LoadAssetAtPath<RenderPipelineResources>(HDUtils.GetHDRenderPipelinePath() + "Runtime/RenderPipelineResources/HDRenderPipelineResources.asset");
-            ResourceReloader.ReloadAllNullIn((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineResources);
-
-            if ((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineEditorResources == null)
-                (GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineEditorResources
-                    = UnityEditor.AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
-            ResourceReloader.ReloadAllNullIn((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineEditorResources);
+            UpdateResourcesIfNeeded();
 #endif
-
-            // Upgrade the resources (re-import every references in RenderPipelineResources) if the resource version mismatches
-            // It's done here because we know every HDRP assets have been imported before
-            UpgradeResourcesIfNeeded();
 
             // Initial state of the RTHandle system.
             // Tells the system that we will require MSAA or not so that we can avoid wasteful render texture allocation.
@@ -393,17 +380,28 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             CameraCaptureBridge.enabled = true;
         }
 
-        void UpgradeResourcesIfNeeded()
-        {
 #if UNITY_EDITOR
-            //possible because deserialized along the asset
-            m_Asset.renderPipelineResources.UpgradeIfNeeded();
-            //however it is not possible to call the same way the editor resources.
-            //Reason: we pass here before the asset are accessible on disk.
-            //Migration is done at deserialisation time for this scriptableobject
-            //Note: renderPipelineResources can be migrated at deserialisation time too to have a more unified API
-#endif
+        void UpdateResourcesIfNeeded()
+        {
+            // The first thing we need to do is to set the defines that depend on the render pipeline settings
+            m_Asset.EvaluateSettings();
+
+            // Check that the serialized Resources are not broken
+            if ((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineResources == null)
+                (GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineResources
+                    = UnityEditor.AssetDatabase.LoadAssetAtPath<RenderPipelineResources>(HDUtils.GetHDRenderPipelinePath() + "Runtime/RenderPipelineResources/HDRenderPipelineResources.asset");
+            ResourceReloader.ReloadAllNullIn((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineResources);
+
+            if ((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineEditorResources == null)
+                (GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineEditorResources
+                    = UnityEditor.AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
+            ResourceReloader.ReloadAllNullIn((GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineEditorResources);
+
+            // Upgrade the resources (re-import every references in RenderPipelineResources) if the resource version mismatches
+            // It's done here because we know every HDRP assets have been imported before
+            (GraphicsSettings.renderPipelineAsset as HDRenderPipelineAsset).renderPipelineResources?.UpgradeIfNeeded();
         }
+#endif
 
         void InitializeRenderTextures()
         {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -259,7 +259,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // The first thing we need to do is to set the defines that depend on the render pipeline settings
             m_Asset.EvaluateSettings();
 
-            UpdateResourcesIfNeeded();
+            UpgradeResourcesIfNeeded();
 #endif
 
             // Initial state of the RTHandle system.
@@ -381,7 +381,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
 #if UNITY_EDITOR
-        void UpdateResourcesIfNeeded()
+        void UpgradeResourcesIfNeeded()
         {
             // The first thing we need to do is to set the defines that depend on the render pipeline settings
             m_Asset.EvaluateSettings();

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.Migration.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.Migration.cs
@@ -1,8 +1,9 @@
-#if UNITY_EDITOR //formerly migration were only handled in editor for this asset
 using System;
 using UnityEngine.Serialization;
 
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
@@ -14,6 +15,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             First,
             RemovedEditorOnlyResources = 4
         }
+
+        [HideInInspector, SerializeField, FormerlySerializedAs("version")]
+        Version m_Version = Version.First;  //keep former creation affectation
+
+#if UNITY_EDITOR //formerly migration were only handled in editor for this asset
+        Version IVersionable<Version>.version { get { return (Version)m_Version; } set { m_Version = value; } }
 
         static readonly MigrationDescription<Version, RenderPipelineResources> k_Migration = MigrationDescription.New(
             MigrationStep.New(Version.RemovedEditorOnlyResources, (RenderPipelineResources i) =>
@@ -27,11 +34,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             })
         );
 
-        [HideInInspector, SerializeField, FormerlySerializedAs("version")]
-        Version m_Version = Version.First;  //keep former creation affectation
-        Version IVersionable<Version>.version { get { return (Version)m_Version; } set { m_Version = value; } }
-
         public void UpgradeIfNeeded() => k_Migration.Migrate(this);
+#endif
     }
 }
-#endif

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.Migration.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.Migration.cs
@@ -19,9 +19,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         [HideInInspector, SerializeField, FormerlySerializedAs("version")]
         Version m_Version = Version.First;  //keep former creation affectation
 
-#if UNITY_EDITOR //formerly migration were only handled in editor for this asset
         Version IVersionable<Version>.version { get { return (Version)m_Version; } set { m_Version = value; } }
 
+#if UNITY_EDITOR //formerly migration were only handled in editor for this asset
         static readonly MigrationDescription<Version, RenderPipelineResources> k_Migration = MigrationDescription.New(
             MigrationStep.New(Version.RemovedEditorOnlyResources, (RenderPipelineResources i) =>
             {


### PR DESCRIPTION
### Purpose of this PR
Fix serialisation issue of data not existing at runtime in resources

At desserialisation time, a crash can occurs:
```
[...]
The file 'D:/UP/New folder (10)/serialisation-issue_Data/sharedassets0.assets' is corrupted! Remove it and launch unity again!
[Position out of bounds!]
 
(Filename: C:\buildslave\unity\build\Runtime/Serialize/SerializationCaching/CachedReader.cpp Line: 220)

Crash!!!
SymInit: Symbol-SearchPath: '.;D:\UP\New folder (10);D:\UP\New folder (10);C:\WINDOWS;C:\WINDOWS\system32;SRV*C:\websymbols*http://msdl.microsoft.com/download/symbols;', symOptions: 534, UserName: 'Utilisateur'
OS-Version: 10.0.0
D:\UP\New folder (10)\serialisation-issue.exe:serialisation-issue.exe (00007FF6629A0000), size: 667648 (result: 0), SymType: '-deferred-', PDB: '', fileVersion: 2019.1.0.18463
C:\WINDOWS\SYSTEM32\ntdll.dll:ntdll.dll (00007FFAE8290000), size: 2019328 (result: 0), SymType: '-deferred-', PDB: '', fileVersion: 10.0.17763.348
C:\WINDOWS\System32\KERNEL32.DLL:KERNEL32.DLL (00007FFAE7F90000), size: 733184 (result: 0), SymType: '-deferred-', PDB: '', fileVersion: 10.0.17763.379
C:\WINDOWS\System32\KERNELBASE.dll:KERNELBASE.dll (00007FFAE4AB0000), size: 2699264 (result: 0), SymType: '-deferred-', PDB: '', fileVersion: 10.0.17763.348
D:\UP\New folder (10)\UnityPlayer.dll:UnityPlayer.dll (00007FFA52FB0000), size: 24870912 (result: 0), SymType: '-deferred-', PDB: '', fileVersion: 2019.1.0.18463
[...]
```
Now the version number always exist either we are in editor assembly or not.

Note: this crash only appears in some case. It seams using Text Mesh Pro reveal it for some reason.

---
### Release Notes

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-resources-version-serialisation-tmpro-conflict&unity_branch=trunk&automation-tools_branch=master

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
