### PR TITLE
Fix FB Case 1141507 - Sample Gradient Divide by Zero

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When you rapidly perform an undo or redo, Shader Graph windows no longer break.
 - Sub Graphs that contain references to non-existing Sub Graphs no longer break the Sub Graph Importer.
 - You can now reference sub-assets such as Textures.
+- Sample Gradient no longer performs division by zero on color keys.
 
 ## [6.6.0] - 2019-04-01
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Gradient/SampleGradientNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Gradient/SampleGradientNode.cs
@@ -34,7 +34,7 @@ namespace UnityEditor.ShaderGraph
     [unroll]
     for (int c = 1; c < 8; c++)
     {
-        {precision} colorPos = saturate((Time - Gradient.colors[c-1].w) / (Gradient.colors[c].w - Gradient.colors[c-1].w)) * step(c, Gradient.colorsLength-1);
+        {precision} colorPos = saturate((Time - Gradient.colors[c-1].w) / max((Gradient.colors[c].w - Gradient.colors[c-1].w), 0.001)) * step(c, Gradient.colorsLength-1);
         color = lerp(color, Gradient.colors[c].rgb, lerp(colorPos, step(0.01, colorPos), Gradient.type));
     }
 #ifndef UNITY_COLORSPACE_GAMMA
@@ -44,7 +44,7 @@ namespace UnityEditor.ShaderGraph
     [unroll]
     for (int a = 1; a < 8; a++)
     {
-        {precision} alphaPos = saturate((Time - Gradient.alphas[a-1].y) / (Gradient.alphas[a].y - Gradient.alphas[a-1].y)) * step(a, Gradient.alphasLength-1);
+        {precision} alphaPos = saturate((Time - Gradient.alphas[a-1].y) / max((Gradient.alphas[a].y - Gradient.alphas[a-1].y), 0.001)) * step(a, Gradient.alphasLength-1);
         alpha = lerp(alpha, Gradient.alphas[a].x, lerp(alphaPos, step(0.01, alphaPos), Gradient.type));
     }
     Out = {precision}4(color, alpha);


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Fixing fogbugz case 1141507
Sample Gradient node tossed console errors trying to display issues when dividing by zero. Sample Gradient node no longer divides by zero, or throws those errors.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.
only touches sample gradient node

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
Katana is Green

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup?

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low

**Halo Effect**: None, Low, Medium, High?
Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
