### PR TITLE
Fix FB#1140846 - Saving Subgraphs with < Vector1,2,3,4, Matrix2x2, Matrix3x3, Gradient > input now Freezes Shader Graph

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -519,7 +519,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             foreach (var portInputView in m_PortInputContainer.Children().OfType<PortInputView>().ToList())
             {
                 var slot = portInputView.slot;
-                portInputView.style.display = expanded && !node.owner.GetEdges(node.GetSlotReference(slot.id)).Any() ? DisplayStyle.Flex : DisplayStyle.None;
+                portInputView.isVisible = expanded && !node.owner.GetEdges(node.GetSlotReference(slot.id)).Any();
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/PortInputView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/PortInputView.cs
@@ -27,6 +27,17 @@ namespace UnityEditor.ShaderGraph.Drawing
         VisualElement m_Control;
         VisualElement m_Container;
         EdgeControl m_EdgeControl;
+        
+        private bool m_IsVisible;
+        public bool isVisible
+        { 
+            get => m_IsVisible; 
+            set
+            {
+                style.display = value == true ? DisplayStyle.Flex : DisplayStyle.None;
+                m_IsVisible = value;
+            }
+        }
 
         public PortInputView(MaterialSlot slot)
         {
@@ -91,6 +102,9 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void Recreate()
         {
+            if(!isVisible)
+                return;
+
             RemoveFromClassList("type" + m_SlotType);
             m_SlotType = slot.concreteValueType;
             AddToClassList("type" + m_SlotType);


### PR DESCRIPTION
### Purpose of this PR
This PR provides a non-perfect solution to lessen the impact of the case FB#1140846. Currently, saving a Shader Graph containing a Sub Graph node with connected input edges freezes the GraphView window. This PR adds a safety check to see if the input is visible before updating the UI for it.

This fixes the hang and therefore massively reduces the impact of this bug, however it does not fix the root issue. Now after saving, if you disconnect the edge the port input view that is recreated does not actually change the underlying value until the graph is reopened.

It appears that this is due to the lack of a node modified listener, however it only reproduces with Sub Graph nodes and my fear is it is going to go much deeper into the new Sub Graph code.

Regardless I believe the layer of safety I have added in this PR makes sense to add.

@pbbastian Can you take a look at this PR and see if you can track down the root cause? Familiarity wit the new sub graph code seems to be very important here...

---
### Release Notes
Changelog

---
### Testing status
**Katana Tests**: 
Will run after a second opinion...

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [x] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup? N/A

Any test projects to go with this to help reviewers? N/A

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low - Adds a layer of safety that should always have been there

**Halo Effect**: None, Low, Medium, High? Low - only affects non-visible UI code

---
### Comments to reviewers
Notes for the reviewers you have assigned.
