### PR TITLE
Lw/strip hw tier variants

### DIFF
--- a/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineAssetEditor.cs
@@ -50,8 +50,9 @@ namespace UnityEditor.Rendering.LWRP
             public static GUIContent srpBatcher = EditorGUIUtility.TrTextContent("SRP Batcher (Experimental)", "If enabled, the render pipeline uses the SRP batcher.");
             public static GUIContent dynamicBatching = EditorGUIUtility.TrTextContent("Dynamic Batching", "If enabled, the render pipeline will batch drawcalls with few triangles together by copying their vertex buffers into a shared buffer on a per-frame basis.");
             public static GUIContent mixedLightingSupportLabel = EditorGUIUtility.TrTextContent("Mixed Lighting", "Support for mixed light mode.");
-            
+
             public static GUIContent shaderVariantLogLevel = EditorGUIUtility.TrTextContent("Shader Variant Log Level", "Controls the level logging in of shader variants information is outputted when a build is performed. Information will appear in the Unity console when the build finishes.");
+            public static GUIContent stripGraphicsTierShaderVariants = EditorGUIUtility.TrTextContent("Strip Graphics Tier Shader Variants", "Controls if shaders of higher graphics tier than Tier1 should be stripped from the build or now/");
 
             // Dropdown menu options
             public static string[] mainLightOptions = { "Disabled", "Per Pixel" };
@@ -100,12 +101,14 @@ namespace UnityEditor.Rendering.LWRP
 
         SerializedProperty m_ShaderVariantLogLevel;
 
+        SerializedProperty m_StripGraphicsTierShaderVariants;
+
         internal static LightRenderingMode selectedLightRenderingMode;
 
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
-            
+
             DrawGeneralSettings();
             DrawQualitySettings();
             DrawLightingSettings();
@@ -156,6 +159,7 @@ namespace UnityEditor.Rendering.LWRP
             m_MixedLightingSupportedProp = serializedObject.FindProperty("m_MixedLightingSupported");
 
             m_ShaderVariantLogLevel = serializedObject.FindProperty("m_ShaderVariantLogLevel");
+            m_StripGraphicsTierShaderVariants = serializedObject.FindProperty("m_StripGraphicsTierShaderVariants");
             selectedLightRenderingMode = (LightRenderingMode)m_AdditionalLightsRenderingModeProp.intValue;
         }
 
@@ -302,6 +306,7 @@ namespace UnityEditor.Rendering.LWRP
                 EditorGUILayout.PropertyField(m_SupportsDynamicBatching, Styles.dynamicBatching);
                 EditorGUILayout.PropertyField(m_MixedLightingSupportedProp, Styles.mixedLightingSupportLabel);
                 EditorGUILayout.PropertyField(m_ShaderVariantLogLevel, Styles.shaderVariantLogLevel);
+                EditorGUILayout.PropertyField(m_StripGraphicsTierShaderVariants, Styles.stripGraphicsTierShaderVariants);
                 EditorGUI.indentLevel--;
                 EditorGUILayout.Space();
                 EditorGUILayout.Space();

--- a/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineAssetEditor.cs
@@ -52,7 +52,7 @@ namespace UnityEditor.Rendering.LWRP
             public static GUIContent mixedLightingSupportLabel = EditorGUIUtility.TrTextContent("Mixed Lighting", "Support for mixed light mode.");
 
             public static GUIContent shaderVariantLogLevel = EditorGUIUtility.TrTextContent("Shader Variant Log Level", "Controls the level logging in of shader variants information is outputted when a build is performed. Information will appear in the Unity console when the build finishes.");
-            public static GUIContent stripGraphicsTierShaderVariants = EditorGUIUtility.TrTextContent("Strip Graphics Tier Shader Variants", "Controls if shaders of higher graphics tier than Tier1 should be stripped from the build or now/");
+            public static GUIContent stripGraphicsTierShaderVariants = EditorGUIUtility.TrTextContent("Strip Graphics Tiers", "Controls if shaders of higher graphics tier than Tier1 should be stripped from the build or not.");
 
             // Dropdown menu options
             public static string[] mainLightOptions = { "Disabled", "Per Pixel" };

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderPreprocessor.cs
@@ -151,7 +151,7 @@ namespace UnityEditor.Rendering.LWRP
             if (!isShadowVariant && compilerData.shaderKeywordSet.IsEnabled(m_SoftShadows))
                 return true;
 
-            if (isAdditionalShadow && !compilerData.shaderKeywordSet.IsEnabled(m_AdditionalLightsPixel)) 
+            if (isAdditionalShadow && !compilerData.shaderKeywordSet.IsEnabled(m_AdditionalLightsPixel))
                 return true;
 
             return false;
@@ -174,8 +174,11 @@ namespace UnityEditor.Rendering.LWRP
             return false;
         }
 
-        bool StripUnused(ShaderFeatures features, Shader shader, ShaderSnippetData snippetData, ShaderCompilerData compilerData)
+        bool StripUnused(ShaderFeatures features, Shader shader, ShaderSnippetData snippetData, ShaderCompilerData compilerData, bool stripTiers)
         {
+            if (stripTiers && compilerData.graphicsTier != GraphicsTier.Tier1)
+                return true;
+
             if (StripUnusedShader(features, shader, compilerData))
                 return true;
 
@@ -221,11 +224,13 @@ namespace UnityEditor.Rendering.LWRP
 
             ShaderFeatures features = GetSupportedShaderFeatures(lwrpAsset);
 
+            bool stripTiers = lwrpAsset.stripGraphicsTierShaderVariants;
+
             int prevVariantCount = compilerDataList.Count;
 
             for (int i = 0; i < compilerDataList.Count; ++i)
             {
-                if (StripUnused(features, shader, snippetData, compilerDataList[i]))
+                if (StripUnused(features, shader, snippetData, compilerDataList[i], stripTiers))
                 {
                     compilerDataList.RemoveAt(i);
                     --i;

--- a/com.unity.render-pipelines.lightweight/Runtime/Data/LightweightRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/Data/LightweightRenderPipelineAsset.cs
@@ -84,7 +84,7 @@ namespace UnityEngine.Rendering.LWRP
 
         [SerializeField] RendererType m_RendererType = RendererType.ForwardRenderer;
         [SerializeField] internal ScriptableRendererData m_RendererData = null;
-        
+
         // General settings
         [SerializeField] bool m_RequireDepthTexture = false;
         [SerializeField] bool m_RequireOpaqueTexture = false;
@@ -129,6 +129,8 @@ namespace UnityEngine.Rendering.LWRP
         [SerializeField] ShadowResolution m_ShadowAtlasResolution = ShadowResolution._256;
 
         [SerializeField] ShaderVariantLogLevel m_ShaderVariantLogLevel = ShaderVariantLogLevel.Disabled;
+
+        [SerializeField] bool m_StripGraphicsTierShaderVariants = false;
 
 #if UNITY_EDITOR
         [NonSerialized]
@@ -410,7 +412,13 @@ namespace UnityEngine.Rendering.LWRP
             get { return m_ShaderVariantLogLevel; }
             set { m_ShaderVariantLogLevel = value; }
         }
-        
+
+        public bool stripGraphicsTierShaderVariants
+        {
+            get { return m_StripGraphicsTierShaderVariants; }
+            set { m_StripGraphicsTierShaderVariants = value; }
+        }
+
         public bool useSRPBatcher
         {
             get { return m_UseSRPBatcher; }

--- a/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
@@ -85,6 +85,10 @@ namespace UnityEngine.Rendering.LWRP
             Lightmapping.SetDelegate(lightsDelegate);
 
             CameraCaptureBridge.enabled = true;
+
+            // force set tier to tier1 if we have tier stripping on
+            if (asset.stripGraphicsTierShaderVariants)
+                Graphics.activeTier = GraphicsTier.Tier1;
         }
 
         protected override void Dispose(bool disposing)
@@ -103,6 +107,10 @@ namespace UnityEngine.Rendering.LWRP
 
         protected override void Render(ScriptableRenderContext renderContext, Camera[] cameras)
         {
+            // force set tier to tier1 if we have tier stripping on
+            if (asset.stripGraphicsTierShaderVariants)
+                Graphics.activeTier = GraphicsTier.Tier1;
+
             BeginFrameRendering(renderContext, cameras);
 
             GraphicsSettings.lightsUseLinearIntensity = (QualitySettings.activeColorSpace == ColorSpace.Linear);
@@ -132,6 +140,10 @@ namespace UnityEngine.Rendering.LWRP
             LWRPAdditionalCameraData additionalCameraData = null;
             if (camera.cameraType == CameraType.Game || camera.cameraType == CameraType.VR)
                 additionalCameraData = camera.gameObject.GetComponent<LWRPAdditionalCameraData>();
+
+            // force set tier to tier1 if we have tier stripping on
+            if (asset.stripGraphicsTierShaderVariants)
+                Graphics.activeTier = GraphicsTier.Tier1;
 
             InitializeCameraData(settings, camera, additionalCameraData, out var cameraData);
             SetupPerCameraShaderConstants(cameraData);
@@ -219,7 +231,7 @@ namespace UnityEngine.Rendering.LWRP
                 if (cameraData.isStereoEnabled && msaaSampleCountHasChanged)
                     XR.XRDevice.UpdateEyeTextureMSAASetting();
             }
-            
+
             cameraData.isSceneViewCamera = camera.cameraType == CameraType.SceneView;
             cameraData.isHdrEnabled = camera.allowHDR && settings.supportsHDR;
             cameraData.postProcessLayer = camera.GetComponent<PostProcessLayer>();
@@ -242,7 +254,7 @@ namespace UnityEngine.Rendering.LWRP
 
             bool anyShadowsEnabled = settings.supportsMainLightShadows || settings.supportsAdditionalLightShadows;
             cameraData.maxShadowDistance = (anyShadowsEnabled) ? settings.shadowDistance : 0.0f;
-            
+
             if (additionalCameraData != null)
             {
                 cameraData.maxShadowDistance = (additionalCameraData.renderShadows) ? cameraData.maxShadowDistance : 0.0f;
@@ -389,7 +401,7 @@ namespace UnityEngine.Rendering.LWRP
             int maxVisibleAdditionalLights = LightweightRenderPipeline.maxVisibleAdditionalLights;
 
             lightData.mainLightIndex = mainLightIndex;
-            
+
             if (settings.additionalLightsRenderingMode != LightRenderingMode.Disabled)
             {
                 lightData.additionalLightsCount =


### PR DESCRIPTION
### Purpose of this PR
Currently we generate up to three tiers of shaders from C++ side, even though tiers are actually deprecated by SRP. This PR adds a way of users to explicitly strip anything but tier one shaders by a checkbox in the LWRP asset.

---
### Release Notes
Added checkbox to LW Asset to allow for shader tier stripping.

---
### Testing status
**Katana Tests**: HDRP tests failed, LW tests passed (https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders/proj57-Test%20PlayMode%20-%20Windows/builds/4041?automation-tools_branch=master&ScriptableRenderLoop_branch=lw/strip-hw-tier-variants&unity_branch=trunk)
This PR only touches LW code so HDRP fails is unrelated.

**Manual Tests**: What did you do?
- [x ] Opened test project + Run graphic tests locally
- [ x] Built a player
- [x ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: Build a player with custom tier settings, stepped through C# code to see variants where actually stripped.
---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low