### PR TITLE
Allow normalWS be directly written for TerrainLit shader [2019.2]

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
@@ -58,6 +58,18 @@ UNITY_INSTANCING_BUFFER_START(Terrain)
 UNITY_DEFINE_INSTANCED_PROP(float4, _TerrainPatchInstanceData)  // float4(xBase, yBase, skipScale, ~)
 UNITY_INSTANCING_BUFFER_END(Terrain)
 
+float4 ConstructTerrainTangent(float3 normal, float3 positiveZ)
+{
+    // Consider a flat terrain. It should have tangent be (1, 0, 0) and bitangent be (0, 0, 1) as the UV of the terrain grid mesh is a scale of the world XZ position.
+    // In CreateWorldToTangent function (in SpaceTransform.hlsl), it is cross(normal, tangent) * sgn for the bitangent vector.
+    // It is not true in a left-handed coordinate system for the terrain bitangent, if we provide 1 as the tangent.w. It would produce (0, 0, -1) instead of (0, 0, 1).
+    // Also terrain's tangent calculation was wrong in a left handed system because cross((0,0,1), terrainNormalOS) points to the wrong direction as negative X.
+    // Therefore all the 4 xyzw components of the tangent needs to be flipped to correct the tangent frame.
+    // (See TerrainLitData.hlsl - GetSurfaceAndBuiltinData)
+    float3 tangent = cross(normal, positiveZ);
+    return float4(tangent, -1);
+}
+
 AttributesMesh ApplyMeshModification(AttributesMesh input)
 {
 #ifdef UNITY_INSTANCING_ENABLED
@@ -84,14 +96,7 @@ AttributesMesh ApplyMeshModification(AttributesMesh input)
 #endif
 
 #ifdef ATTRIBUTES_NEED_TANGENT
-    // Consider a flat terrain. It should have tangent be (1, 0, 0) and bitangent be (0, 0, 1) as the UV of the terrain grid mesh is a scale of the world XZ position.
-    // In CreateWorldToTangent function (in SpaceTransform.hlsl), it is cross(normal, tangent) * sgn for the bitangent vector.
-    // It is not true in a left-handed coordinate system for the terrain bitangent, if we provide 1 as the tangent.w. It would produce (0, 0, -1) instead of (0, 0, 1).
-    // Also terrain's tangent calculation was wrong in a left handed system because cross((0,0,1), terrainNormalOS) points to the wrong direction as negative X.
-    // Therefore all the 4 xyzw components of the tangent needs to be flipped to correct the tangent frame.
-    // (See TerrainLitData.hlsl - GetSurfaceAndBuiltinData)
-    input.tangentOS.xyz = cross(input.normalOS, float3(0, 0, 1));
-    input.tangentOS.w = -1;
+    input.tangentOS = ConstructTerrainTangent(input.normalOS, float3(0, 0, 1));
 #endif
     return input;
 }
@@ -134,23 +139,8 @@ float3 ConvertToNormalTS(float3 normalData, float3 tangentWS, float3 bitangentWS
 void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionInputs posInput, out SurfaceData surfaceData, out BuiltinData builtinData)
 {
 #ifdef ENABLE_TERRAIN_PERPIXEL_NORMAL
-    {
-        // Consider a flat terrain.It should have tangent be(1, 0, 0) and bitangent be(0, 0, 1) as the UV of the terrain grid mesh is a scale of the world XZ position.
-        // In CreateWorldToTangent function(in SpaceTransform.hlsl), it is cross(normal, tangent) * sgn for the bitangent vector.
-        // It is not true in a left - handed coordinate system for the terrain bitangent, if we provide 1 as the tangent.w.It would produce(0, 0, -1) instead of(0, 0, 1).
-        // Also terrain's tangent calculation was wrong in a left handed system because I used `cross((0,0,1), terrainNormalOS)`. It points to the wrong direction as negative X.
-        // Therefore all the 4 xyzw components of the tangent needs to be flipped to correct the tangent frame.
-        // (See ApplyMeshModification in TerrainLitDataMeshModification.hlsl)
-        float3 normalOS = SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_TerrainNormalmapTexture, (input.texCoord0.xy + 0.5f) * _TerrainHeightmapRecipSize.xy).rgb * 2 - 1;
-        float3 normalWS = mul((float3x3)GetObjectToWorldMatrix(), normalOS);
-        float4 tangentWS;
-        tangentWS.xyz = cross(normalWS, GetObjectToWorldMatrix()._13_23_33);
-        tangentWS.w = -1;
-
-        input.worldToTangent = BuildWorldToTangent(tangentWS, normalWS);
-
-        input.texCoord0.xy *= _TerrainHeightmapRecipSize.zw;
-    }
+    float2 terrainNormalMapUV = (input.texCoord0.xy + 0.5f) * _TerrainHeightmapRecipSize.xy;
+    input.texCoord0.xy *= _TerrainHeightmapRecipSize.zw;
 #endif
 
     // terrain lightmap uvs are always taken from uv0
@@ -160,12 +150,30 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
     InitializeTerrainLitSurfaceData(terrainLitSurfaceData);
     TerrainLitShade(input.texCoord0.xy, terrainLitSurfaceData);
 
+#ifdef ENABLE_TERRAIN_PERPIXEL_NORMAL
+    #ifdef TERRAIN_PERPIXEL_NORMAL_OVERRIDE
+        float3 normalWS = terrainLitSurfaceData.normalData.xyz; // normalData directly contains normal in world space.
+        surfaceData.normalWS = normalWS;
+    #else
+        float3 normalOS = SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_TerrainNormalmapTexture, terrainNormalMapUV).rgb * 2 - 1;
+        float3 normalWS = mul((float3x3)GetObjectToWorldMatrix(), normalOS);
+    #endif
+    float4 tangentWS = ConstructTerrainTangent(normalWS, GetObjectToWorldMatrix()._13_23_33);
+    input.worldToTangent = BuildWorldToTangent(tangentWS, normalWS);
+#endif
+    surfaceData.tangentWS = normalize(input.worldToTangent[0].xyz); // The tangent is not normalize in worldToTangent for mikkt. Tag: SURFACE_GRADIENT
+
+#if !defined(ENABLE_TERRAIN_PERPIXEL_NORMAL) || !defined(TERRAIN_PERPIXEL_NORMAL_OVERRIDE)
+    float3 normalTS = ConvertToNormalTS(terrainLitSurfaceData.normalData, input.worldToTangent[0], input.worldToTangent[1]);
+    GetNormalWS(input, normalTS, surfaceData.normalWS, float3(1.0, 1.0, 1.0));
+#endif
+    surfaceData.geomNormalWS = input.worldToTangent[2];
+
     surfaceData.baseColor = terrainLitSurfaceData.albedo;
     surfaceData.perceptualSmoothness = terrainLitSurfaceData.smoothness;
     surfaceData.metallic = terrainLitSurfaceData.metallic;
     surfaceData.ambientOcclusion = terrainLitSurfaceData.ao;
 
-    surfaceData.tangentWS = normalize(input.worldToTangent[0].xyz); // The tangent is not normalize in worldToTangent for mikkt. Tag: SURFACE_GRADIENT
     surfaceData.subsurfaceMask = 0;
     surfaceData.thickness = 1;
     surfaceData.diffusionProfileHash = 0;
@@ -185,11 +193,6 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
     surfaceData.transmittanceColor = float3(1.0, 1.0, 1.0);
     surfaceData.atDistance = 1000000.0;
     surfaceData.transmittanceMask = 0.0;
-
-    float3 normalTS = ConvertToNormalTS(terrainLitSurfaceData.normalData, input.worldToTangent[0], input.worldToTangent[1]);
-    GetNormalWS(input, normalTS, surfaceData.normalWS, float3(1.0, 1.0, 1.0));
-
-    surfaceData.geomNormalWS = input.worldToTangent[2];
 
     float3 bentNormalWS = surfaceData.normalWS;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_BasemapGen.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_BasemapGen.shader
@@ -96,35 +96,6 @@ Shader "Hidden/HDRP/TerrainLit_BasemapGen"
 
         Pass
         {
-            // _NormalMap pass will get ignored by terrain basemap generation code. Put here so that the VTC can use it to generate cache for normal maps.
-            Tags
-            {
-                "Name" = "_NormalMap"
-                "Format" = "R16G16_Float"
-                "Size" = "1"
-            }
-
-            ZTest Always Cull Off ZWrite Off
-            Blend One [_DstBlend]
-
-            HLSLPROGRAM
-
-            #define OVERRIDE_SPLAT_SAMPLER_NAME sampler_Normal0
-            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit_Splatmap.hlsl"
-
-            float2 Frag(Varyings input) : SV_Target
-            {
-                TerrainLitSurfaceData surfaceData;
-                InitializeTerrainLitSurfaceData(surfaceData);
-                TerrainSplatBlend(input.texcoord.zw, input.texcoord.xy, surfaceData);
-                return surfaceData.normalData.xy; // RT format is supposed to be floating point
-            }
-
-            ENDHLSL
-        }
-
-        Pass
-        {
             Tags
             {
                 "Name" = "_MetallicTex"


### PR DESCRIPTION
### Purpose of this PR

If macro `TERRAIN_PERPIXEL_NORMAL_OVERRIDE` is defined together with `ENABLE_TERRAIN_PERPIXEL_NORMAL`, the world space normal vector will be directly written without sampling the terrain normal map texture and tangent space detail normal maps.

This allows clipmap to pre blend the splatting normals with the terrain normal texture.

---
### Release Notes
N/A (internal).

---
### Testing status
**Katana Tests**: Running.

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
Please backport to 2019.2 release of HDRP (if you have branched off already. Mentioning only because trunk has branched off for 2019.3).
