### PR TITLE
Update Raytracing textures for compatibility with DX11 texture arrays

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Textures/TextureXR.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Textures/TextureXR.cs
@@ -17,6 +17,8 @@ namespace UnityEngine.Experimental.Rendering
                 {
                     case GraphicsDeviceType.Direct3D11:
                         return SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOne;
+                    case GraphicsDeviceType.Direct3D12:
+                        return SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOne;
                 }
 
                 return false;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingAmbientOcclusion.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingAmbientOcclusion.cs
@@ -43,13 +43,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_SharedRTManager = sharedRTManager;
 
             // Intermediate buffer that holds the pre-denoised texture
-            m_IntermediateBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "IntermediateAOBuffer");
+            m_IntermediateBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, xrInstancing: true, useDynamicScale: true, useMipMap: false, name: "IntermediateAOBuffer");
 
             // Buffer that holds the average distance of the rays
             m_HitDistanceBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "HitDistanceBuffer");
 
             // Buffer that holds the uncompressed normal buffer
-            m_ViewSpaceNormalBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "ViewSpaceNormalBuffer");
+            m_ViewSpaceNormalBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, xrInstancing: true, useDynamicScale: true, useMipMap: false, name: "ViewSpaceNormalBuffer");
         }
 
         public void Release()
@@ -69,7 +69,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void SetDefaultAmbientOcclusionTexture(CommandBuffer cmd)
         {
-            cmd.SetGlobalTexture(HDShaderIDs._AmbientOcclusionTexture, Texture2D.blackTexture);
+            cmd.SetGlobalTexture(HDShaderIDs._AmbientOcclusionTexture, TextureXR.GetBlackTexture());
             cmd.SetGlobalVector(HDShaderIDs._AmbientOcclusionParam, Vector4.zero);
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingIndirectDiffuse.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingIndirectDiffuse.cs
@@ -44,8 +44,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_SharedRTManager = sharedRTManager;
             m_GBufferManager = gbufferManager;
 
-            m_IndirectDiffuseTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "IndirectDiffuseBuffer");
-            m_DenoiseBuffer0 = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "IndirectDiffuseBuffer");
+            m_IndirectDiffuseTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, xrInstancing: true, useDynamicScale: true, useMipMap: false, name: "IndirectDiffuseBuffer");
+            m_DenoiseBuffer0 = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, xrInstancing: true, useDynamicScale: true, useMipMap: false, name: "IndirectDiffuseBuffer");
         }
 
         public void Release()
@@ -62,7 +62,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         static RTHandleSystem.RTHandle IndirectDiffuseHistoryBufferAllocatorFunction(string viewName, int frameIndex, RTHandleSystem rtHandleSystem)
         {
             return rtHandleSystem.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat,
-                                        enableRandomWrite: true, useMipMap: true, autoGenerateMips: false,
+                                        enableRandomWrite: true, xrInstancing: true, useMipMap: true, autoGenerateMips: false,
                                         name: string.Format("IndirectDiffuseHistoryBuffer{0}", frameIndex));
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
@@ -47,8 +47,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_SharedRTManager = sharedRTManager;
             m_GbufferManager = gbufferManager;
 
-            m_LightingTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "LightingBuffer");
-            m_HitPdfTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "HitPdfBuffer");
+            m_LightingTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, xrInstancing: true, useDynamicScale: true, useMipMap: false, name: "LightingBuffer");
+            m_HitPdfTexture = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat, enableRandomWrite: true, xrInstancing: true, useDynamicScale: true, useMipMap: false, name: "HitPdfBuffer");
             m_VarianceBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R8_UNorm, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "VarianceBuffer");
             m_MinBoundBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.B10G11R11_UFloatPack32, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "MinBoundBuffer");
             m_MaxBoundBuffer = RTHandles.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.B10G11R11_UFloatPack32, enableRandomWrite: true, useDynamicScale: true, useMipMap: false, name: "MaxBoundBuffer");
@@ -57,7 +57,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         static RTHandleSystem.RTHandle ReflectionHistoryBufferAllocatorFunction(string viewName, int frameIndex, RTHandleSystem rtHandleSystem)
         {
             return rtHandleSystem.Alloc(Vector2.one, filterMode: FilterMode.Point, colorFormat: GraphicsFormat.R16G16B16A16_SFloat,
-                                        enableRandomWrite: true, useMipMap: true, autoGenerateMips: false,
+                                        enableRandomWrite: true, useMipMap: true, xrInstancing: true, autoGenerateMips: false,
                                         name: string.Format("ReflectionHistoryBuffer{0}", frameIndex));
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/IndirectDiffuseAccumulation.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/IndirectDiffuseAccumulation.compute
@@ -22,12 +22,12 @@
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceLighting.hlsl"
 
 // Input textures for the spatial filtering
-Texture2D<float>                    _DepthTexture;
+TEXTURE2D_X(_DepthTexture);
 
 // Buffers for the temporal filtering
 TEXTURE2D_X(_IndirectDiffuseHistorybufferRW);
 TEXTURE2D_X(_DenoiseInputTexture);
-RWTexture2D<float4>         _DenoiseOutputTextureRW;
+RW_TEXTURE2D_X(float4,      _DenoiseOutputTextureRW);
 int                         _RaytracingDenoiseRadius;
 
 Texture2D<float4>           _GBufferTexture0;
@@ -55,7 +55,7 @@ void RaytracingIndirectDiffuseTAA(uint2 groupThreadId : SV_GroupThreadID, uint2 
     uint2 centerCoord = groupId * KERNEL_TILE_SIZE + groupThreadId;
     centerCoord.x = centerCoord.x + (unity_StereoEyeIndex * _ScreenSize.x);
 
-    float depth = LOAD_TEXTURE2D(_DepthTexture, centerCoord).r;
+    float depth = LOAD_TEXTURE2D_X(_DepthTexture, centerCoord).r;
     PositionInputs posInputs = GetPositionInput_Stereo(centerCoord, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, unity_StereoEyeIndex);
 
     float2 closest = GetClosestFragment(posInputs);
@@ -103,7 +103,7 @@ void RaytracingIndirectDiffuseTAA(uint2 groupThreadId : SV_GroupThreadID, uint2 
     color = Unmap(lerp(color, history, feedback));
     color = clamp(color, 0.0, CLAMP_MAX);
     
-    _DenoiseOutputTextureRW[centerCoord] = float4(color, LOAD_TEXTURE2D_X(_DenoiseInputTexture, centerCoord).w);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(centerCoord)] = float4(color, LOAD_TEXTURE2D_X(_DenoiseInputTexture, centerCoord).w);
 }
 
 // ----------------------------------------------------------------------------
@@ -139,7 +139,7 @@ BilateralData TapBilateralData(uint2 coordSS)
 
     if (DEPTH_WEIGHT > 0.0 || PLANE_WEIGHT > 0.0)
     {
-        posInput.deviceDepth = LOAD_TEXTURE2D(_DepthTexture, coordSS).r;
+        posInput.deviceDepth = LOAD_TEXTURE2D_X(_DepthTexture, coordSS).r;
         key.z = Linear01Depth(posInput.deviceDepth, _ZBufferParams);
     }
 
@@ -232,5 +232,5 @@ void IndirectDiffuseFilter(uint2 groupThreadId : SV_GroupThreadID, uint2 groupId
 
     // Store the intermediate result
     float3 reflection = reflSum / wSum;
-    _DenoiseOutputTextureRW[centerCoord] = float4(reflection, 1.0);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(centerCoord)] = float4(reflection, 1.0);
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusion.raytrace
@@ -16,14 +16,13 @@
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingSampling.hlsl"
 
 // The target acceleration structure that we will evaluate the reflexion in
-Texture2D<float>			          	_StencilTexture;
-Texture2D<float>						_DepthTexture;
+TEXTURE2D_X(_DepthTexture);
 
 // Output structure of the reflection raytrace shader
 float                                   _RaytracingAOIntensity;
-RWTexture2D<float4> 					_AmbientOcclusionTextureRW;
+RW_TEXTURE2D_X(float4, 					_AmbientOcclusionTextureRW);
 RWTexture2D<float> 						_RaytracingHitDistanceTexture;
-RWTexture2D<float4> 					_RaytracingVSNormalTexture;
+RW_TEXTURE2D_X(float4, 					_RaytracingVSNormalTexture);
 
 [shader("miss")]
 void MissShaderAmbientOcclusion(inout RayIntersection rayIntersection : SV_RayPayload)
@@ -44,10 +43,10 @@ void RayGenAmbientOcclusion()
     uint2 scramblingValue = ScramblingValue(currentPixelCoord.x, currentPixelCoord.y);
 
     // Reset the value of this pixel
-    _AmbientOcclusionTextureRW[currentPixelCoord] = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    _AmbientOcclusionTextureRW[COORD_TEXTURE2D_X(currentPixelCoord)] = float4(0.0f, 0.0f, 0.0f, 0.0f);
 	
 	// Read the depth value
-	float depthValue  = _DepthTexture[currentPixelCoord];
+	float depthValue  = _DepthTexture[COORD_TEXTURE2D_X(currentPixelCoord)];
 	if (depthValue == UNITY_RAW_FAR_CLIP_VALUE)
 		return;
 
@@ -121,10 +120,10 @@ void RayGenAmbientOcclusion()
 	finalColor = pow(finalColor, _RaytracingAOIntensity);
 
 	// Alright we are done
-    _AmbientOcclusionTextureRW[currentPixelCoord] = float4(1.0 - finalColor, 1.0f);
+    _AmbientOcclusionTextureRW[COORD_TEXTURE2D_X(currentPixelCoord)] = float4(1.0 - finalColor, 1.0f);
     _RaytracingHitDistanceTexture[currentPixelCoord] = minDistance;
     float3 normalWS = mul(_InvViewMatrix, float4(normalData.normalWS, 0.0f)).xyz;
-    _RaytracingVSNormalTexture[currentPixelCoord] = float4(normalWS, 1.0f);
+    _RaytracingVSNormalTexture[COORD_TEXTURE2D_X(currentPixelCoord)] = float4(normalWS, 1.0f);
 }
 
 // Fallback default any hit shader for this raytrace shader

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusionFilter.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingAmbientOcclusionFilter.compute
@@ -16,17 +16,13 @@
 // Tile size of this compute
 #define AMBIENT_OCCLUSION_TILE_SIZE 8
 
-// Input integration textures
-RWTexture2D<float4>         _SourceTexture;
-RWTexture2D<float4>         _OutputTexture;
-
 // ScreenSpace buffers
-Texture2D<float>			_DepthTexture;
+TEXTURE2D_X(_DepthTexture);
 
 // Buffers for the temporal filtering
-RWTexture2D<float>          _AOHistorybufferRW;
+RWTexture2D<float>			   _AOHistorybufferRW;
 TEXTURE2D_X(_DenoiseInputTexture);
-RWTexture2D<float4>         _DenoiseOutputTextureRW;
+RW_TEXTURE2D_X(float4,         _DenoiseOutputTextureRW);
 
 // Filter parameters
 int                         _RaytracingDenoiseRadius;
@@ -43,7 +39,7 @@ void AOCopyTAAHistory(uint2 groupThreadId : SV_GroupThreadID, uint2 groupId : SV
     float currentValue = LOAD_TEXTURE2D_X(_DenoiseInputTexture, centerCoord).x;
 
     // Merge them into the previous buffer
-    _DenoiseOutputTextureRW[centerCoord] = float4(currentValue, historyValue, 0, 0);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(centerCoord)] = float4(currentValue, historyValue, 0, 0);
 }
 
 [numthreads(AMBIENT_OCCLUSION_TILE_SIZE, AMBIENT_OCCLUSION_TILE_SIZE, 1)]
@@ -53,7 +49,7 @@ void AOApplyTAA(uint2 groupThreadId : SV_GroupThreadID, uint2 groupId : SV_Group
     uint2 centerCoord = groupId * AMBIENT_OCCLUSION_TILE_SIZE + groupThreadId;
     centerCoord.x = centerCoord.x + (unity_StereoEyeIndex * _ScreenSize.x);
 
-    float depth = LOAD_TEXTURE2D(_DepthTexture, centerCoord).r;
+    float depth = LOAD_TEXTURE2D_X(_DepthTexture, centerCoord).r;
     PositionInputs posInputs = GetPositionInput_Stereo(centerCoord, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, unity_StereoEyeIndex);
 
     float2 closest = GetClosestFragment(posInputs);
@@ -102,7 +98,7 @@ void AOApplyTAA(uint2 groupThreadId : SV_GroupThreadID, uint2 groupId : SV_Group
     color = clamp(color, 0.0, CLAMP_MAX);
     
     _AOHistorybufferRW[centerCoord] = color;
-    _DenoiseOutputTextureRW[centerCoord] = float4(color, color, color, 1.0);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(centerCoord)] = float4(color, color, color, 1.0);
 }
 
 // ----------------------------------------------------------------------------
@@ -138,7 +134,7 @@ BilateralData TapBilateralData(uint2 coordSS)
 
     if (DEPTH_WEIGHT > 0.0 || PLANE_WEIGHT > 0.0)
     {
-        posInput.deviceDepth = LOAD_TEXTURE2D(_DepthTexture, coordSS).r;
+        posInput.deviceDepth = LOAD_TEXTURE2D_X(_DepthTexture, coordSS).r;
         key.z = Linear01Depth(posInput.deviceDepth, _ZBufferParams);
     }
 
@@ -231,5 +227,5 @@ void AOBilateralFilter(uint2 groupThreadId : SV_GroupThreadID, uint2 groupId : S
 
     // Store the intermediate result
     float ao = aoSum / wSum;
-    _DenoiseOutputTextureRW[centerCoord] = float4(ao, ao, ao, 1.0);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(centerCoord)] = float4(ao, ao, ao, 1.0);
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflectionFilter.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingReflectionFilter.compute
@@ -26,10 +26,10 @@
 #define RAYTRACING_REFLECTION_TILE_SIZE 8
 
 // Input textures for the spatial filtering
-Texture2D<float>                    _DepthTexture;
+TEXTURE2D_X(_DepthTexture);
 Texture2DArray<float>               _NoiseTexture;
-Texture2D<float4>                   _SsrLightingTextureRW;
-Texture2D<float4>                   _SsrHitPointTexture;
+Texture2DArray<float4>              _SsrLightingTextureRW;
+Texture2DArray<float4>              _SsrHitPointTexture;
 Texture2D<float4>                   _SsrClearCoatMaskTexture;
 
 // Output Textures for the spatial filtering
@@ -47,7 +47,7 @@ float                               _TemporalAccumuationWeight;
 // Buffers for the temporal filtering
 TEXTURE2D_X(_ReflectionHistorybufferRW);
 TEXTURE2D_X(_DenoiseInputTexture);
-RWTexture2D<float4>         _DenoiseOutputTextureRW;
+RW_TEXTURE2D_X(float4,      _DenoiseOutputTextureRW);
 int                         _RaytracingDenoiseRadius;
 
 [numthreads(RAYTRACING_REFLECTION_TILE_SIZE, RAYTRACING_REFLECTION_TILE_SIZE, 1)]
@@ -64,7 +64,7 @@ void RaytracingReflectionFilter(uint3 dispatchThreadId : SV_DispatchThreadID, ui
     int localIndex = (fullResCoord.x & 1) + (fullResCoord.y & 1) * 2;
 
     // Fetch the depth
-    float depth = LOAD_TEXTURE2D(_DepthTexture, fullResCoord).x;
+    float depth = LOAD_TEXTURE2D_X(_DepthTexture, fullResCoord).x;
 
     NormalData normalData;
     DecodeFromNormalBuffer(fullResCoord, normalData);
@@ -125,7 +125,7 @@ void RaytracingReflectionFilter(uint3 dispatchThreadId : SV_DispatchThreadID, ui
             continue;
             
             // Fetch the target color
-            float4 sampleColor = _SsrLightingTextureRW[sourceCoord];
+            float4 sampleColor = _SsrLightingTextureRW[COORD_TEXTURE2D_X(sourceCoord)];
 
             // Compute the position of the actual source pixel
             uint subPixel =  clamp(floor(sampleColor.w * 4.0f), 0, 3);
@@ -133,7 +133,7 @@ void RaytracingReflectionFilter(uint3 dispatchThreadId : SV_DispatchThreadID, ui
             uint2 actualSourceCoord = sourceCoord + shift;
 
             // Fetch the Depth
-            float sampleDepth = LOAD_TEXTURE2D(_DepthTexture, actualSourceCoord).x;
+            float sampleDepth = LOAD_TEXTURE2D_X(_DepthTexture, actualSourceCoord).x;
             // If this the background, it should not be used as a valid sample
             if(sampleDepth == 0.0f) continue;
 
@@ -145,7 +145,7 @@ void RaytracingReflectionFilter(uint3 dispatchThreadId : SV_DispatchThreadID, ui
 
             // Let's fetch the half res sample's properties
             // Get the direction and pdf
-            float4 directionPDF = _SsrHitPointTexture[sourceCoord];
+            float4 directionPDF = _SsrHitPointTexture[COORD_TEXTURE2D_X(sourceCoord)];
 
             // If this direction is under the candidate surface, then it is not valid
             if(dot(directionPDF.xyz, normalWS) <= 0.0f) continue;
@@ -244,7 +244,7 @@ void RaytracingReflectionTAA(uint2 groupThreadId : SV_GroupThreadID, uint2 group
     uint2 centerCoord = groupId * RAYTRACING_REFLECTION_TILE_SIZE + groupThreadId;
     centerCoord.x = centerCoord.x + (unity_StereoEyeIndex * _ScreenSize.x);
 
-    float depth = LOAD_TEXTURE2D(_DepthTexture, centerCoord).r;
+    float depth = LOAD_TEXTURE2D_X(_DepthTexture, centerCoord).r;
     PositionInputs posInputs = GetPositionInput_Stereo(centerCoord, _ScreenSize.zw, depth, UNITY_MATRIX_I_VP, UNITY_MATRIX_V, unity_StereoEyeIndex);
 
     float2 closest = GetClosestFragment(posInputs);
@@ -292,7 +292,7 @@ void RaytracingReflectionTAA(uint2 groupThreadId : SV_GroupThreadID, uint2 group
     color = Unmap(lerp(color, history, feedback));
     color = clamp(color, 0.0, CLAMP_MAX);
     
-    _DenoiseOutputTextureRW[centerCoord] = float4(color, LOAD_TEXTURE2D_X(_DenoiseInputTexture, centerCoord).w);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(centerCoord)] = float4(color, LOAD_TEXTURE2D_X(_DenoiseInputTexture, centerCoord).w);
 }
 
 // ----------------------------------------------------------------------------
@@ -329,7 +329,7 @@ BilateralData TapBilateralData(uint2 coordSS)
 
     if (DEPTH_WEIGHT > 0.0 || PLANE_WEIGHT > 0.0)
     {
-        posInput.deviceDepth = LOAD_TEXTURE2D(_DepthTexture, coordSS).r;
+        posInput.deviceDepth = LOAD_TEXTURE2D_X(_DepthTexture, coordSS).r;
         key.z = Linear01Depth(posInput.deviceDepth, _ZBufferParams);
     }
 
@@ -426,5 +426,5 @@ void ReflBilateralFilter(uint2 groupThreadId : SV_GroupThreadID, uint2 groupId :
 
     // Store the intermediate result
     float3 reflection = reflSum / wSum;
-    _DenoiseOutputTextureRW[centerCoord] = float4(reflection, 1.0);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(centerCoord)] = float4(reflection, 1.0);
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingRenderer.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/RaytracingRenderer.raytrace
@@ -25,7 +25,7 @@ Texture2D<float>						_DepthTexture;
 
 // Output structure of the reflection raytrace shader
 Texture2D<float> 						_RaytracingFlagMask;
-RWTexture2D<float4> 					_CameraColorTextureRW;
+RW_TEXTURE2D_X(float4, 					_CameraColorTextureRW);
 RWTexture2D<float4> 					_RaytracingPrimaryDebug;
 
 [shader("miss")]
@@ -84,7 +84,7 @@ void RayGenRenderer()
 
 	// Alright we are done :D
 	_RaytracingPrimaryDebug[currentPixelCoord] = float4(rayIntersection.color * GetCurrentExposureMultiplier(), 1.0);
-    _CameraColorTextureRW[currentPixelCoord] = float4(rayIntersection.color * GetCurrentExposureMultiplier(), 1.0);
+    _CameraColorTextureRW[COORD_TEXTURE2D_X(currentPixelCoord)] = float4(rayIntersection.color * GetCurrentExposureMultiplier(), 1.0);
 }
 
 [shader("closesthit")]


### PR DESCRIPTION
### Purpose of this PR
For VR single-pass instancing support, HDRP was updated to use Texture2DArrays by default when DX11 is set as the API. 

Although DXR requires DX12, in terms of shader code, SHADER_API_D3D11 is set. So raytracing shaders need to be updated to expect Texture2D arrays for depth textures, color buffers, etc. 

This changeset updates texture declarations in raytracing shaders and associated compute shaders to restore previous real-time raytracing functionality, but with texture arrays where appropriate.  

---
### Release Notes
To be clear, this changeset does nothing to add XR support to real-time raytracing. It just makes the raytracing code compatible with the architectural changes needed to enable XR SPI. 

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 
Tested by enabling all effects and all spatio-temporal filters for those effects.
![image](https://user-images.githubusercontent.com/3450690/55838515-9b373380-5ad9-11e9-8829-5004c18d81b5.png)

**Automated Tests**: What did you setup?
None.

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low

**Halo Effect**: None, Low, Medium, High?
Low- changes a restricted to raytracing code, but some of it (the filters and associated raytracing shaders) is interdependent

---
### Comments to reviewers

