### PR TITLE
Add support for negative mean height values to the height fog

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Sky/AtmosphericScattering/VolumetricFogEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Sky/AtmosphericScattering/VolumetricFogEditor.cs
@@ -48,6 +48,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             PropertyField(m_GlobalLightProbeDimmer, s_GlobalLightProbeDimmerLabel);
             PropertyField(m_MaxFogDistance);
             PropertyField(m_EnableDistantFog,       s_EnableDistantFog);
+            
+            if (m_MeanHeight.value.floatValue < m_BaseHeight.value.floatValue)
+            {
+                m_MeanHeight.value.floatValue = m_BaseHeight.value.floatValue;
+                serializedObject.ApplyModifiedProperties();
+            }
 
             if (m_EnableDistantFog.value.boolValue)
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/AtmosphericScattering/VolumetricFog.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/AtmosphericScattering/VolumetricFog.cs
@@ -8,7 +8,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public ColorParameter        albedo                 = new ColorParameter(Color.white);
         public MinFloatParameter     meanFreePath           = new MinFloatParameter(1000000.0f, 1.0f);
         public FloatParameter        baseHeight             = new FloatParameter(0.0f);
-        public MinFloatParameter     meanHeight             = new MinFloatParameter(10.0f, 1.0f);
+        public FloatParameter        meanHeight             = new FloatParameter(10.0f);
         public ClampedFloatParameter anisotropy             = new ClampedFloatParameter(0.0f, -1.0f, 1.0f);
         public ClampedFloatParameter globalLightProbeDimmer = new ClampedFloatParameter(1.0f, 0.0f, 1.0f);
         public BoolParameter         enableDistantFog       = new BoolParameter(false);
@@ -33,7 +33,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             float relativeMeanHeight = Mathf.Max(0.01f, meanHeight.value - baseHeight.value);
 
-            // FogExponent = 1 / BaseRelative(MeanHeight)
+            // FogExponent = 1 / BaseRelative(MeanHeight).
             cmd.SetGlobalVector(HDShaderIDs._HeightFogExponents,  new Vector2(1.0f / relativeMeanHeight, relativeMeanHeight));
             cmd.SetGlobalFloat( HDShaderIDs._HeightFogBaseHeight, crBaseHeight);
             cmd.SetGlobalFloat( HDShaderIDs._GlobalFogAnisotropy, anisotropy.value);


### PR DESCRIPTION
### Purpose of this PR
While height fog's base height can take any value, the mean height is erroneously clamped to 0. This PR fixes this behavior.

---
### Release Notes
Add support for negative mean height values to the height fog.

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-neg-mean-height&automation-tools_branch=master&unity_branch=trunk

**Manual Tests**: tested manually.