### PR TITLE
Fix exposure to support TEXTURE2D_X

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed deserialization crash at runtime
 - Fix for ShaderGraph Unlit masternode not writing velocity
 - Fixed a crash when assiging a new HDRP asset with the 'Verify Saving Assets' option enabled
+- Fixed exposure to properly support TEXTURE2D_X
 
 ### Changed
 

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
@@ -674,7 +674,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             kernel = cs.FindKernel("KPrePass");
             cmd.SetComputeIntParams(cs, HDShaderIDs._Variants, m_ExposureVariants);
             cmd.SetComputeTextureParam(cs, kernel, HDShaderIDs._PreviousExposureTexture, prevExposure);
-            cmd.SetComputeTextureParam(cs, kernel, HDShaderIDs._InputTexture, sourceTex);
+            cmd.SetComputeTextureParam(cs, kernel, HDShaderIDs._SourceTexture, sourceTex);
             cmd.SetComputeTextureParam(cs, kernel, HDShaderIDs._OutputTexture, m_TempTexture1024);
             cmd.DispatchCompute(cs, kernel, 1024 / 8, 1024 / 8, 1);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/Exposure.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/Exposure.compute
@@ -14,6 +14,7 @@
 TEXTURE2D(_ExposureCurveTexture);
 TEXTURE2D(_PreviousExposureTexture);
 TEXTURE2D(_InputTexture);
+TEXTURE2D_X(_SourceTexture);
 
 RW_TEXTURE2D(float2, _OutputTexture);
 
@@ -120,6 +121,9 @@ void KManualCameraExposure(uint2 dispatchThreadId : SV_DispatchThreadID)
 [numthreads(8,8,1)]
 void KPrePass(uint2 dispatchThreadId : SV_DispatchThreadID)
 {
+    // XRTODO: experiment sampling all eyes with interleaving instead of reading just the first eye
+    UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(0);
+
     PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId), 1.0 / 1024.0, uint2(8u, 8u));
     float2 uv = ClampAndScaleUVForBilinear(posInputs.positionNDC);
     float luma;
@@ -131,7 +135,7 @@ void KPrePass(uint2 dispatchThreadId : SV_DispatchThreadID)
         {
             // Color buffer
             float prevExposure = ConvertEV100ToExposure(GetPreviousExposureEV100());
-            float3 color = SAMPLE_TEXTURE2D_LOD(_InputTexture, sampler_LinearClamp, uv, 0.0).xyz;
+            float3 color = SAMPLE_TEXTURE2D_X_LOD(_SourceTexture, sampler_LinearClamp, uv, 0.0).xyz;
             luma = Luminance(color / prevExposure);
             break;
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -563,6 +563,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public static readonly int _Variants                       = Shader.PropertyToID("_Variants");
         public static readonly int _InputTexture                   = Shader.PropertyToID("_InputTexture");
         public static readonly int _OutputTexture                  = Shader.PropertyToID("_OutputTexture");
+        public static readonly int _SourceTexture                  = Shader.PropertyToID("_SourceTexture");
         public static readonly int _InputHistoryTexture            = Shader.PropertyToID("_InputHistoryTexture");
         public static readonly int _OutputHistoryTexture           = Shader.PropertyToID("_OutputHistoryTexture");
 


### PR DESCRIPTION
### Purpose of this PR
Exposure code was broken since we switched to TEXTURE2D_X

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp-exposure-texture2dx&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
_InputTexture is used in multiple different contexts in the shader code. I've added _SourceTexture to differentiate where we need to sample the source camera texture or an intermediate temp texture.