### PR TITLE
Disabled test 017

### DIFF
--- a/TestProjects/LWGraphicsTest/ProjectSettings/EditorBuildSettings.asset
+++ b/TestProjects/LWGraphicsTest/ProjectSettings/EditorBuildSettings.asset
@@ -44,7 +44,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/016_Lighting_Scene_Directional.unity
     guid: 54170d1ce2ca64699a0d82056387d56f
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/017_Lighting_Scene_DirectionalBaked.unity
     guid: 245a2b08a4f72437193b06846a5c8e33
   - enabled: 0


### PR DESCRIPTION
### Purpose of this PR
Needed to disable test 017 since baked lighting has changed how it behaves regarding Auto Generate, digging into it this is a bigger issue and for fixing right now disabling the test is the only course of action.

---
### Release Notes
N/A

---
### Testing status
**Katana Tests**: Ran locally

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: Removed failing test

---
### Overall Product Risks
**Technical Risk**: Medium, we are now not testing baked directional lighting and cutout baked lighting(recent regression)

**Halo Effect**: None

---
### Comments to reviewers
Holding up the rest of SRP, since we are all in one repo, LWRP doesn't have the bandwidth to fix this in a timely manner.