### PR TITLE
Fix camera-relative previous camera position

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -568,14 +568,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             if (ShaderConfig.s_CameraRelativeRendering != 0)
             {
-                viewConstants.prevWorldSpaceCameraPos = viewConstants.worldSpaceCameraPos - viewConstants.prevWorldSpaceCameraPos;
+                Vector3 cameraDisplacement = viewConstants.worldSpaceCameraPos - viewConstants.prevWorldSpaceCameraPos;
+
+                viewConstants.prevWorldSpaceCameraPos -= viewConstants.worldSpaceCameraPos; // Make it relative w.r.t. the curr cam pos
+
                 // This fixes issue with cameraDisplacement stacking in prevViewProjMatrix when same camera renders multiple times each logical frame
                 // causing glitchy motion blur when editor paused.
                 if (m_LastFrameActive != Time.frameCount)
                 {
-                    Matrix4x4 cameraDisplacement = Matrix4x4.Translate(viewConstants.prevWorldSpaceCameraPos);
-                    viewConstants.prevViewProjMatrix *= cameraDisplacement; // Now prevViewProjMatrix correctly transforms this frame's camera-relative positionWS
+                    viewConstants.prevViewProjMatrix *= Matrix4x4.Translate(cameraDisplacement); // Now prevViewProjMatrix correctly transforms this frame's camera-relative positionWS
                 }
+            }
             }
             else
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -579,7 +579,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     viewConstants.prevViewProjMatrix *= Matrix4x4.Translate(cameraDisplacement); // Now prevViewProjMatrix correctly transforms this frame's camera-relative positionWS
                 }
             }
-            }
             else
             {
                 Matrix4x4 noTransViewMatrix = viewMatrix;


### PR DESCRIPTION
### Purpose of this PR
Fix camera-relative previous camera position

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-prev-cam-pos&automation-tools_branch=master&unity_branch=trunk