### PR TITLE
Fix camera-relative issue with punctual lights stereo instancing

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed exposure to properly support TEXTURE2D_X
 - Fixed TerrainLit basemap texture generation
 - Fixed a bug that caused nans when material classification was enabled and a tile contained one standard material + a material with transmission.
+- Fixed camera-relative issue with punctual lights and XR single-pass instancing
 
 ### Changed
 - Refactor PixelCoordToViewDirWS to be VR compatible and to compute it only once per frame

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightEvaluation.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightEvaluation.hlsl
@@ -218,7 +218,7 @@ void ModifyDistancesForFillLighting(inout float4 distances, float lightSqRadius)
 // distances = {d, d^2, 1/d, d_proj}
 void GetPunctualLightVectors(float3 positionWS, LightData light, out float3 L, out float3 lightToSample, out float4 distances)
 {
-    lightToSample = positionWS - light.positionRWS;
+    lightToSample = StereoCameraRelativeEyeToCenter(positionWS - light.positionRWS);
     int lightType = light.lightType;
 
     distances.w = dot(lightToSample, light.forward);


### PR DESCRIPTION
### Purpose of this PR
Account for camera-relative during punctual light evaluation with XR single-pass instancing

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp-xr-fix-punctual-cr&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None

---
### Comments to reviewers
More details here: https://fogbugz.unity3d.com/f/cases/1136402/
