### PR TITLE
Fixed a typo in the Particle Unlit Shader

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - in the Shadergraph Unlit Master node, Premultiply no longer acts the same as Alpha. [case 1114708](https://fogbugz.unity3d.com/f/cases/1114708/)
 - Fixed an issue where Lightprobe data was missing if it was needed per-pixel and GPU instancing was enabled.
 - The Soft ScreenSpaceShadows Shader variant no longer gets stripped form builds. [case 1138236](https://fogbugz.unity3d.com/f/cases/1138236/)
+- Fixed a typo in the Particle Unlit Shader, so Soft Particles now work correctly.
 
 ## [6.6.0] - 2019-04-01
 ### Added

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
@@ -126,7 +126,7 @@ VaryingsParticle vertParticleUnlit(AttributesParticle input)
     output.texcoord2AndBlend.z = input.texcoordBlend;
 #endif
     
-#if defined(SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     output.projectedPosition = ComputeScreenPos(vertexInput.positionCS);
 #endif
 


### PR DESCRIPTION
### Purpose of this PR
Fixed a typo in the Particle Unlit Shader, so Soft Particles now work correctly. Original fix provided by Github user @CarlLee here https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3421

---
### Release Notes
Fixes the keyword spelling in the vertex shader in the Unlit Particle shader

---
### Testing status
**Katana Tests**: Does not affect Katana tests

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player

**Automated Tests**: Current test framework makes this issue un-testable

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low, single line change of a shader

**Halo Effect**: None, only effects one feature of one LWRP shader

---
### Comments to reviewers
Notes for the reviewers you have assigned.
