### PR TITLE
Force AA on Shader Graph windows

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [6.7.0] - 2019-XX-XX
+### Changed
+- Anti-aliasing (4x) is now enabled on Shader Graph windows.
+
 ### Fixed
 - When you perform an undo or redo to an inactive Shader Graph window, the window no longer breaks.
 - When you rapidly perform an undo or redo, Shader Graph windows no longer break.

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -172,6 +172,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
+        void OnEnable()
+        {
+            this.SetAntiAliasing(4);
+        }
+
         void OnDisable()
         {
             graphEditorView = null;


### PR DESCRIPTION
### Purpose of this PR
Enables 4x AA on Shader Graph windows. This vastly improves drawing quality in general, and even more so when zoomed out.

![Screenshot 2019-04-29 at 15 31 25](https://user-images.githubusercontent.com/123919/56900356-eec3ee00-6a95-11e9-8873-30a95870557a.png)

![Screenshot 2019-04-29 at 15 31 47](https://user-images.githubusercontent.com/123919/56900357-eec3ee00-6a95-11e9-8fe8-6e700f6c814b.png)

If you want to compare pixels up close: https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=78e79aca-6a85-11e9-8106-0edaf8f81e27

---
### Testing status
**Katana Tests**: Running here https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?unity_branch=trunk&ScriptableRenderLoop_branch=sg%2Fforce-aa&automation-tools_branch=master

**Manual Tests**: Squint at screen with/without changes to ensure there's a difference. Also made sure that performance was not impacted on my computer by opening up the profiler. This was tested on a 2015 MacBook Pro running macOS 10.14.2 connected to a non-retina display.

**Automated Tests**: Nothing

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None