### PR TITLE
[backport 2019.1] Miscellaneous Shader Graph Fixes

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
@@ -80,7 +80,7 @@ namespace UnityEditor.ShaderGraph
 
         public override AbstractMaterialNode ToConcreteNode()
         {
-            return new Texture2DAssetNode { texture = value.textureArray };
+            return new Texture2DArrayAssetNode { texture = value.textureArray };
         }
 
         public override AbstractShaderProperty Copy()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Gradient/GradientNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Gradient/GradientNode.cs
@@ -90,7 +90,7 @@ namespace UnityEditor.ShaderGraph
 
         public sealed override void UpdateNodeAfterDeserialization()
         {
-            AddSlot(new GradientMaterialSlot(OutputSlotId, kOutputSlotName, kOutputSlotName, SlotType.Output, 0));
+            AddSlot(new GradientMaterialSlot(OutputSlotId, kOutputSlotName, kOutputSlotName, SlotType.Output));
             RemoveSlotsNameNotMatching(new[] { OutputSlotId });
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -122,24 +122,27 @@ namespace UnityEditor.ShaderGraph
             if(!IsValidFunction())
                 return;
 
-            registry.ProvideFunction(functionName, builder =>
+            switch (sourceType)
             {
-                switch (sourceType)
-                {
-                    case HlslSourceType.File:
+                case HlslSourceType.File:
+                    registry.ProvideFunction(functionSource, builder =>
+                    {
                         builder.AppendLine($"#include \"{functionSource}\"");
-                        break;
-                    case HlslSourceType.String:
+                    });
+                    break;
+                case HlslSourceType.String:
+                    registry.ProvideFunction(functionName, builder =>
+                    {
                         builder.AppendLine(GetFunctionHeader());
-                        using(builder.BlockScope())
+                        using (builder.BlockScope())
                         {
                             builder.AppendLines(functionBody);
                         }
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            });
+                    });
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
 
         private string GetFunctionHeader()

--- a/com.unity.shadergraph/Editor/Drawing/Inspector/MasterPreviewView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/MasterPreviewView.cs
@@ -172,6 +172,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector
             if (m_Graph.previewData.serializedMesh.mesh != changedMesh)
             {
                 m_Graph.previewData.rotation = Quaternion.identity;
+                m_PreviewScrollPosition = Vector2.zero;
             }
 
             m_Graph.previewData.serializedMesh.mesh = changedMesh;

--- a/com.unity.shadergraph/Editor/Drawing/Views/ReorderableSlotListView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/ReorderableSlotListView.cs
@@ -208,6 +208,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             else
                 m_Node.GetOutputSlots<MaterialSlot>(slots);
 
+            // Store the edges
+            Dictionary<MaterialSlot, List<IEdge>> edgeDict = new Dictionary<MaterialSlot, List<IEdge>>();
+            foreach (MaterialSlot slot in slots)
+                edgeDict.Add(slot, (List<IEdge>)slot.owner.owner.GetEdges(slot.slotReference));
+
             // Get reorder slots so need to remove them all then re-add
             foreach (MaterialSlot slot in slots)
                 m_Node.RemoveSlot(slot.id);
@@ -217,10 +222,19 @@ namespace UnityEditor.ShaderGraph.Drawing
             
             // Now add the slots back based on the list order
             // For each list entry get the slot with that ID
-            for(int i = 0; i < list.list.Count; i++)
+            for (int i = 0; i < list.list.Count; i++)
             {
                 var currentSlot = slots.Where(s => s.id == (int)list.list[i]).FirstOrDefault();
                 m_Node.AddSlot(currentSlot);
+            }
+
+            // Reconnect the edges
+            foreach (KeyValuePair<MaterialSlot, List<IEdge>> entry in edgeDict)
+            {
+                foreach (IEdge edge in entry.Value)
+                {
+                    m_Node.owner.Connect(edge.outputSlot, edge.inputSlot);
+                }
             }
 
             RecreateList();


### PR DESCRIPTION
### Purpose of this PR
Backport of #3349 

For 20% I joined in on some bug smashing, this will be the first PR. Fixed the following bugs:

---

https://fogbugz.unity3d.com/f/cases/1127892/: Converting a Texture2D Array Property to Inline Silently Fails
Was caused by ToConcreteNode() returning Texture2DAssetNode instead of Texture2DArrayAssetNode.

![Texture2DConvertToInline](https://user-images.githubusercontent.com/3393041/55770616-cff3ae00-5a39-11e9-9d06-5c81b7d98c89.gif)

---

https://fogbugz.unity3d.com/f/cases/1135978/: Gradient, dragging from Input results in nothing in node creation menu
The shader stage was set to the meaningless value of 0 which resulted in the menu not finding it because it wasn't compatible with any stage (acceptable values are 1, 2, 3); now uses the default which is all stages.

(see ^ fogbugz case for before)
![GradientFix](https://user-images.githubusercontent.com/3393041/55770597-bfdbce80-5a39-11e9-94ff-4ba8e973db40.gif)

---

https://fogbugz.unity3d.com/f/cases/1138033/: Having multiple Custom Function Nodes with multiple functions from the same source produces errors
Was caused by the string builder attempting to add the same include multiple times. Now provides Function Source in the registry to prevent it from being added twice.

![CustomFunctionFix0](https://user-images.githubusercontent.com/3393041/55840294-d2104800-5adf-11e9-832e-e8e8e6220a22.gif)

---

https://fogbugz.unity3d.com/f/cases/1139341/: Changing meshes resets the rotation of the mesh, until it is dragged in which case the previously value is used.
Implemented fix option 1: makes more sense for the rotation to start anew when changing the shape.

(see ^ fogbugz case for before)
![PreviewRotationFix0](https://user-images.githubusercontent.com/3393041/55770634-e26de780-5a39-11e9-8527-2ccb375616de.gif)

---

https://fogbugz.unity3d.com/f/cases/1143544/: Sub-graphs causes connections to be lost when outputs are reordered
Now uses a dictionary to stores the slot and the edges associated with that slot, and reconnects everything after everything has been removed and added.

(see ^ fogbugz case for before)
![ReorderableListFix](https://user-images.githubusercontent.com/3393041/55770641-e8fc5f00-5a39-11e9-8db2-081afbe81685.gif)

---

### Testing status

**Manual**: Tested each bug and confirmed that it's fix (see gifs), will add Wyatt since people aren't allowed to qa themselves.

**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=2019.1%2Fsg%2Fmisc-minor-fixes&automation-tools_branch=master&unity_branch=2019.1%2Fstaging

---

### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**:  Low