### PR TITLE
Force AA on Shader Graph windows (backport #3480)

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [5.14.0] - 2019-XX-XX
+### Changed
+- Anti-aliasing (4x) is now enabled on Shader Graph windows.
+
 ### Fixed
 - When you perform an undo or redo to an inactive Shader Graph window, the window no longer breaks.
 - When you rapidly perform an undo or redo, Shader Graph windows no longer break.

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -42,7 +42,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             get { return m_MessageManager ?? (m_MessageManager = new MessageManager()); }
         }
-        
+
         GraphEditorView graphEditorView
         {
             get { return m_GraphEditorView; }
@@ -170,6 +170,11 @@ namespace UnityEditor.ShaderGraph.Drawing
                 Debug.LogException(e);
                 throw;
             }
+        }
+
+        void OnEnable()
+        {
+            this.SetAntiAliasing(4);
         }
 
         void OnDisable()


### PR DESCRIPTION
### Purpose of this PR
Backport PR #3480 to enable AA on Shader Graph windows

---
### Testing status
**Katana Tests**: Running here https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?unity_branch=2019.1%2Fstaging&ScriptableRenderLoop_branch=sg%2F2019.1%2Fforce-aa&automation-tools_branch=master&sort=1-asc

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None