### PR TITLE
Fix misaligned inputs

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where the main preview was always redrawing.
 - When you set a Master Node as active, the Main Preview now shows the correct result.
 - When you save a graph that contains a Sub Graph node, the Shader Graph window no longer freezes.
+- Fixed an issue causing default inputs to be misaligned in certain cases.
 
 ## [6.6.0] - 2019-04-01
 ### Added

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -504,21 +504,19 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             foreach (var port in inputContainer.Children().OfType<ShaderPort>())
             {
-                if (port.slot.isConnected || m_PortInputContainer.Children().OfType<PortInputView>().Any(a => Equals(a.slot, port.slot)))
+                if (port.slot.isConnected)
                 {
                     continue;
                 }
+
+                var portInputView = m_PortInputContainer.Children().OfType<PortInputView>().FirstOrDefault(a => Equals(a.slot, port.slot));
+                if (portInputView == null)
+                {
+                    portInputView = new PortInputView(port.slot) { style = { position = Position.Absolute } };
+                    m_PortInputContainer.Add(portInputView);
+                }
                 
-                var portInputView = new PortInputView(port.slot) { style = { position = Position.Absolute } };
-                m_PortInputContainer.Add(portInputView);
-                if (float.IsNaN(port.layout.width))
-                {
-                    port.RegisterCallback<GeometryChangedEvent>(UpdatePortInput);
-                }
-                else
-                {
-                    SetPortInputPosition(port, portInputView);
-                }
+                port.RegisterCallback<GeometryChangedEvent>(UpdatePortInput);
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR
Fixes [FB1143543](https://fogbugz.unity3d.com/f/cases/1143543/). Sub-graphs can have misaligned default-value-subnodes when an errors come up & the user changes the # of outputs. Here's what the issue looks like:

![Issue GIF](https://fogbugz.unity3d.com/default.asp?ixAttachment=299212&pg=pgDownload&pgType=pgFile&sFilename=SubGraphFloatingDefaultSubNode0.gif)

The fix was to always re-set position of the default inputs, even if they're not new, and to always use GeometryChangedEvent callback to set it rather than setting it directly in some cases.

---
### Testing status
**Katana Tests**: On the way https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?unity_branch=trunk&ScriptableRenderLoop_branch=sg%2Ffix-misaligned-inputs&automation-tools_branch=master&sort=1-asc

**Manual Tests**: What did you do?
- Verify misalignment without fix
- Verify correct placement with fix

**Automated Tests**: nil

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None