### PR TITLE
[VFX] Fix package build to 2019.2 (ugui)

### DIFF
--- a/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXExpressionMathTests.cs
+++ b/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXExpressionMathTests.cs
@@ -378,7 +378,7 @@ namespace UnityEditor.VFX.Test
             yield return new Min_Max_Expression_Folding_TestCase() { name = "min(1, (sub(x, 0))", expression = new VFXExpressionMin(one, new VFXExpressionSubtract(x, zero)), saturateExpected = false };
         }
 
-        [Test]
+       //[Test] //This test is unstable, need investigation
         public void Min_Max_Expression_Folding([ValueSource("k_Min_Max_Expression_Folding_TestCase_Names")] string testCaseName)
         {
             var testCase = k_Min_Max_Expression_Folding_TestCase.First(o => o.name == testCaseName);

--- a/com.unity.visualeffectgraph/Unity.VisualEffectGraph.Runtime.asmdef
+++ b/com.unity.visualeffectgraph/Unity.VisualEffectGraph.Runtime.asmdef
@@ -2,6 +2,7 @@
     "name": "Unity.VisualEffectGraph.Runtime",
     "references": [
         "Unity.Timeline",
+		"Unity.ugui",
         "Unity.RenderPipelines.HighDefinition.Runtime"
     ],
     "optionalUnityReferences": [],


### PR DESCRIPTION
### Purpose of this PR
Fix package build due to this PR (not yet landed into trunk) : 
https://ono.unity3d.com/unity/unity/pull-request/86178/_/2019.2/ui/pkg

Additionally, I'm disabling an unstable editor test (already disabled on master).

---
### Release Notes
N/A

---
### Testing status
**Katana Tests**: No need (katana is enoughly busy)
**Manual Tests**:
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: N/A
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=vfx%2Ffix%2Fbuild-unity-ugui&automation-tools_branch=master&unity_branch=2019.2%2Fstaging&sort=1-asc
---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: Low

