### PR TITLE
Fix single-pass instancing on Vulkan

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed single-pass instancing on PSVR
 - Fixed Vulkan shader issue with Texture2DArray in ScreenSpaceShadow.compute by re-arranging code (workaround)
 - Fixed camera-relative issue with lights and XR single-pass instancing
+- Fixed single-pass instancing on Vulkan
 
 ### Changed
 - Refactor PixelCoordToViewDirWS to be VR compatible and to compute it only once per frame

--- a/com.unity.render-pipelines.high-definition/Runtime/Core/Textures/TextureXR.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Core/Textures/TextureXR.cs
@@ -12,7 +12,6 @@ namespace UnityEngine.Experimental.Rendering
         {
             get
             {
-                // XRTODO: Vulkan, Mac with metal only for OS 10.14+, etc
                 switch (SystemInfo.graphicsDeviceType)
                 {
                     case GraphicsDeviceType.Direct3D11:
@@ -20,6 +19,9 @@ namespace UnityEngine.Experimental.Rendering
                         return SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOne;
 
                     case GraphicsDeviceType.PlayStation4:
+                        return true;
+
+                    case GraphicsDeviceType.Vulkan:
                         return true;
                 }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/TextureXR.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/TextureXR.hlsl
@@ -5,7 +5,7 @@
 // XRTODO: update supported platforms based on Unity version (for required C++ fixes)
 
 // Must be in sync with C# with property useTexArray in TextureXR.cs
-#if (defined(SHADER_API_D3D11) && !defined(SHADER_API_XBOXONE)) || defined(SHADER_API_PSSL)
+#if (defined(SHADER_API_D3D11) && !defined(SHADER_API_XBOXONE)) || defined(SHADER_API_PSSL) || defined(SHADER_API_VULKAN)
     #define UNITY_TEXTURE2D_X_ARRAY_SUPPORTED
 #endif
 


### PR DESCRIPTION
### Purpose of this PR
Enable texarray support for Vulkan

---
### Testing status
**Katana Tests**: N/A (Vulkan is not run on Katana)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] C# and shader warnings (supress shader cache to see them)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
VR single-pass instancing still requires C++ changes to properly render right eye (will come later).
Non-VR mode will now use texture array by default (similar to DX11, DX12 and PS4).