### PR TITLE
Fixed crash on exception when saving, case 1136543

### DIFF
--- a/com.unity.shadergraph/Editor/AssetCallbacks/CreateShaderSubGraph.cs
+++ b/com.unity.shadergraph/Editor/AssetCallbacks/CreateShaderSubGraph.cs
@@ -19,7 +19,7 @@ namespace UnityEditor.ShaderGraph
             graph.AddNode(outputNode);
             outputNode.AddSlot(ConcreteSlotValueType.Vector4);
             graph.path = "Sub Graphs";
-            File.WriteAllText(pathName, EditorJsonUtility.ToJson(graph));
+            FileUtilities.WriteShaderGraphToDisk(pathName, graph);
             AssetDatabase.Refresh();
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -876,7 +876,7 @@ namespace UnityEditor.ShaderGraph
             var graph = new GraphData();
             graph.AddNode(node);
             graph.path = "Shader Graphs";
-            File.WriteAllText(pathName, EditorJsonUtility.ToJson(graph));
+            FileUtilities.WriteShaderGraphToDisk(pathName, graph);
             AssetDatabase.Refresh();
 
             UnityEngine.Object obj = AssetDatabase.LoadAssetAtPath<Shader>(pathName);

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -464,7 +464,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void UpdateShaderGraphOnDisk(string path)
         {
-            if(FileUtilities.WriteShaderGraphToDisk(path, graphObject.graph, true))
+            if(FileUtilities.WriteShaderGraphToDisk(path, graphObject.graph))
                 AssetDatabase.ImportAsset(path);
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -214,10 +214,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 if (string.IsNullOrEmpty(path) || graphObject == null)
                     return;
 
-                bool VCSEnabled = (VersionControl.Provider.enabled && VersionControl.Provider.isActive);
-                CheckoutIfValid(path, VCSEnabled);
-
-                    UpdateShaderGraphOnDisk(path);
+                UpdateShaderGraphOnDisk(path);
 
                 graphObject.isDirty = false;
                 var windows = Resources.FindObjectsOfTypeAll<MaterialGraphEditWindow>();
@@ -467,7 +464,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void UpdateShaderGraphOnDisk(string path)
         {
-            if(FileUtilities.WriteShaderGraphToDisk(path, graphObject.graph))
+            if(FileUtilities.WriteShaderGraphToDisk(path, graphObject.graph, true))
                 AssetDatabase.ImportAsset(path);
         }
 
@@ -557,25 +554,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_FrameAllAfterLayout = false;
             foreach (var node in m_GraphObject.graph.GetNodes<AbstractMaterialNode>())
                 node.Dirty(ModificationScope.Node);
-        }
-
-        void CheckoutIfValid(string path, bool VCSEnabled)
-        {
-            if (VCSEnabled)
-            {
-                var asset = VersionControl.Provider.GetAssetByPath(path);
-                if (asset != null)
-                {
-                    if (VersionControl.Provider.CheckoutIsValid(asset))
-                    {
-                        var task = VersionControl.Provider.Checkout(asset, VersionControl.CheckoutMode.Both);
-                        task.Wait();
-
-                        if (!task.success)
-                            Debug.Log(task.text + " " + task.resultCode);
-                    }
-                }
-            }
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -434,8 +434,8 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
             }
 
-            File.WriteAllText(path, EditorJsonUtility.ToJson(subGraph));
-            AssetDatabase.ImportAsset(path);
+            if(FileUtilities.WriteShaderGraphToDisk(path, subGraph))
+                AssetDatabase.ImportAsset(path);
 
             var loadedSubGraph = AssetDatabase.LoadAssetAtPath(path, typeof(SubGraphAsset)) as SubGraphAsset;
             if (loadedSubGraph == null)
@@ -467,8 +467,8 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void UpdateShaderGraphOnDisk(string path)
         {
-            File.WriteAllText(path, EditorJsonUtility.ToJson(graphObject.graph, true));
-            AssetDatabase.ImportAsset(path);
+            if(FileUtilities.WriteShaderGraphToDisk(path, graphObject.graph))
+                AssetDatabase.ImportAsset(path);
         }
 
         private void Rebuild()

--- a/com.unity.shadergraph/Editor/Util/FileUtilities.cs
+++ b/com.unity.shadergraph/Editor/Util/FileUtilities.cs
@@ -5,9 +5,9 @@ using UnityEditor.VersionControl;
 
 namespace UnityEditor.ShaderGraph
 {
-    public class FileUtilities
+    static class FileUtilities
     {
-        public static bool WriteShaderGraphToDisk<T>(string path, T data, bool prettyPrint = false)
+        public static bool WriteShaderGraphToDisk<T>(string path, T data)
         {
             if (data == null)
             {
@@ -18,7 +18,7 @@ namespace UnityEditor.ShaderGraph
 
             try
             {
-                File.WriteAllText(path, EditorJsonUtility.ToJson(data, prettyPrint));
+                File.WriteAllText(path, EditorJsonUtility.ToJson(data, true));
             }
             catch (Exception e)
             {
@@ -27,7 +27,7 @@ namespace UnityEditor.ShaderGraph
                 {
                         FileInfo fileInfo = new FileInfo(path);
                         fileInfo.IsReadOnly = false;
-                        File.WriteAllText(path, EditorJsonUtility.ToJson(data, prettyPrint));
+                        File.WriteAllText(path, EditorJsonUtility.ToJson(data, true));
                         return true;
                 }
                 Debug.LogException(e);

--- a/com.unity.shadergraph/Editor/Util/FileUtilities.cs
+++ b/com.unity.shadergraph/Editor/Util/FileUtilities.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using Debug = UnityEngine.Debug;
+
+namespace UnityEditor.ShaderGraph
+{
+    public class FileUtilities
+    {
+        public static bool WriteShaderGraphToDisk<T>(string path, T data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            try
+            {
+                File.WriteAllText(path, EditorJsonUtility.ToJson(data, true));
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/com.unity.shadergraph/Editor/Util/FileUtilities.cs
+++ b/com.unity.shadergraph/Editor/Util/FileUtilities.cs
@@ -6,23 +6,52 @@ namespace UnityEditor.ShaderGraph
 {
     public class FileUtilities
     {
-        public static bool WriteShaderGraphToDisk<T>(string path, T data)
+        public static bool WriteShaderGraphToDisk<T>(string path, T data, bool prettyPrint = false)
         {
             if (data == null)
             {
                 throw new ArgumentNullException(nameof(data));
             }
 
+            CheckoutIfValid(path);
+
             try
             {
-                File.WriteAllText(path, EditorJsonUtility.ToJson(data, true));
+                File.WriteAllText(path, EditorJsonUtility.ToJson(data, prettyPrint));
             }
             catch (Exception e)
             {
+                if (e.GetBaseException() is UnauthorizedAccessException &&
+                    (File.GetAttributes(path) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                {
+                        FileInfo fileInfo = new FileInfo(path);
+                        fileInfo.IsReadOnly = false;
+                        File.WriteAllText(path, EditorJsonUtility.ToJson(data, prettyPrint));
+                        return true;
+                }
                 Debug.LogException(e);
                 return false;
             }
             return true;
+        }
+
+        static void CheckoutIfValid(string path)
+        {
+            if (VersionControl.Provider.enabled && VersionControl.Provider.isActive)
+            {
+                var asset = VersionControl.Provider.GetAssetByPath(path);
+                if (asset != null)
+                {
+                    if (VersionControl.Provider.CheckoutIsValid(asset))
+                    {
+                        var task = VersionControl.Provider.Checkout(asset, VersionControl.CheckoutMode.Both);
+                        task.Wait();
+
+                        if (!task.success)
+                            Debug.Log(task.text + " " + task.resultCode);
+                    }
+                }
+            }
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Util/FileUtilities.cs
+++ b/com.unity.shadergraph/Editor/Util/FileUtilities.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Debug = UnityEngine.Debug;
+using UnityEditor.VersionControl;
 
 namespace UnityEditor.ShaderGraph
 {
@@ -42,9 +43,9 @@ namespace UnityEditor.ShaderGraph
                 var asset = VersionControl.Provider.GetAssetByPath(path);
                 if (asset != null)
                 {
-                    if (VersionControl.Provider.CheckoutIsValid(asset))
+                    if (!VersionControl.Provider.IsOpenForEdit(asset))
                     {
-                        var task = VersionControl.Provider.Checkout(asset, VersionControl.CheckoutMode.Both);
+                        var task = VersionControl.Provider.Checkout(asset, VersionControl.CheckoutMode.Asset);
                         task.Wait();
 
                         if (!task.success)

--- a/com.unity.shadergraph/Editor/Util/FileUtilities.cs.meta
+++ b/com.unity.shadergraph/Editor/Util/FileUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0970d6d44fd28864389bbdd8dbddbf03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
Case https://fogbugz.unity3d.com/f/cases/1136543/ lists an issue where attempting to save a read-only (not checked out) graph when VCS is disconnected results in a crash.
---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
In progress

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- Other: 
---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
