### PR TITLE
[2019.2] Reduce the group size of the deferred lighting pass from 16x16 to 8x8

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
@@ -122,18 +122,20 @@ CBUFFER_END
 RW_TEXTURE2D_X(float3, diffuseLightingUAV);
 RW_TEXTURE2D_X(float4, specularLightingUAV);
 
-
+#define GROUP_SIZE (TILE_SIZE_FPTL / 2) // 4x 8x8 groups per a 16x16 tile
 
 #ifdef USE_INDIRECT
 
 StructuredBuffer<uint> g_TileList;
 // Indirect
-[numthreads(TILE_SIZE_FPTL, TILE_SIZE_FPTL, 1)]
+[numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
 void SHADE_OPAQUE_ENTRY(uint2 groupThreadId : SV_GroupThreadID, uint groupId : SV_GroupID)
 {
-    uint  tileIndex   = g_TileList[g_TileListOffset + groupId];
+    uint  tileIndex   = g_TileList[g_TileListOffset + (groupId / 4)];
     uint2 tileCoord   = uint2((tileIndex >> TILE_INDEX_SHIFT_X) & TILE_INDEX_MASK, (tileIndex >> TILE_INDEX_SHIFT_Y) & TILE_INDEX_MASK); // see builddispatchindirect.compute
-    uint2 pixelCoord  = tileCoord * GetTileSize() + groupThreadId;
+    uint2 pixelCoord  = tileCoord * GetTileSize()
+                      + uint2(groupId & 1, (groupId >> 1) & 1) * GROUP_SIZE
+                      + groupThreadId;
 
     UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(tileIndex >> TILE_INDEX_SHIFT_EYE);
 
@@ -151,12 +153,12 @@ void SHADE_OPAQUE_ENTRY(uint2 groupThreadId : SV_GroupThreadID, uint groupId : S
 #else
 
 // Direct
-[numthreads(TILE_SIZE_FPTL, TILE_SIZE_FPTL, 1)]
+[numthreads(GROUP_SIZE, GROUP_SIZE, 1)]
 void SHADE_OPAQUE_ENTRY(uint3 dispatchThreadId : SV_DispatchThreadID, uint2 groupId : SV_GroupID)
 {
     UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(dispatchThreadId.z);
 
-    uint2 tileCoord    = (TILE_SIZE_FPTL * groupId) / GetTileSize();
+    uint2 tileCoord    = (GROUP_SIZE * groupId) / GetTileSize();
     uint2 pixelCoord   = dispatchThreadId.xy;
     uint  featureFlags = UINT_MAX;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -2873,7 +2873,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         }
                         else
                         {
-                            cmd.DispatchCompute(deferredComputeShader, kernel, numTilesX, numTilesY, hdCamera.computePassCount);
+                            // 4x 8x8 groups per a 16x16 tile.
+                            cmd.DispatchCompute(deferredComputeShader, kernel, numTilesX * 2, numTilesY * 2, hdCamera.computePassCount);
                         }
                     }
                 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/builddispatchindirect.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/builddispatchindirect.compute
@@ -11,7 +11,7 @@
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl"
 
 #ifdef PLATFORM_LANE_COUNT      // We can infer the size of a wave. This is currently not possible on non-consoles, so we have to fallback to a sensible default in those cases.
-#define NR_THREADS              PLATFORM_LANE_COUNT 
+#define NR_THREADS              PLATFORM_LANE_COUNT
 #else
 #define NR_THREADS              64                                  // default to 64 threads per group on other platforms..
 #endif
@@ -41,18 +41,22 @@ void BUILDINDIRECT(uint3 dispatchThreadId : SV_DispatchThreadID)
     if ((featureFlags & MATERIAL_FEATURE_MASK_FLAGS) != 0)
     {
         uint variant = FeatureFlagsToTileVariant(featureFlags);
-        uint offset;
+        uint tileOffset;
 
 #if IS_DRAWINSTANCEDINDIRECT
         // We are filling up an indirect argument buffer for DrawInstancedIndirect.
-        InterlockedAdd(g_DispatchIndirectBuffer[variant * 4 + 1], 1, offset);
+        InterlockedAdd(g_DispatchIndirectBuffer[variant * 4 + 1], 1, tileOffset);
 #else
+        uint prevGroupCnt;
+
         // We are filling up an indirect argument buffer for DispatchIndirect.
-        InterlockedAdd(g_DispatchIndirectBuffer[variant * 3 + 0], 1, offset);
+        // The buffer contains {groupCntX, groupCntY, groupCntZ} = {groupCnt, 0, 0}.
+        InterlockedAdd(g_DispatchIndirectBuffer[variant * 3 + 0], 4, prevGroupCnt);
+        tileOffset = prevGroupCnt / 4; // 4x 8x8 groups per a 16x16 tile
 #endif
 
         // See LightDefinitions class in LightLoop.cs
         uint tileIndex = (unity_StereoEyeIndex << TILE_INDEX_SHIFT_EYE) | (tileY << TILE_INDEX_SHIFT_Y) | (tileX << TILE_INDEX_SHIFT_X);
-        g_TileList[variant * g_NumTiles + offset] = tileIndex;
+        g_TileList[variant * g_NumTiles + tileOffset] = tileIndex;
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Nvidia claims there is a large perf loss from using large group sizes on their HW.
On AMD, it may or may not be faster, and should not be slower.
Therefore, this is a large optimization for Nvidia and a no-op for AMD.

---
### Release Notes
Reduce the group size of the deferred lighting pass from 16x16 to 8x8

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Fdeferred-group-size&automation-tools_branch=master&unity_branch=2019.2%2Fstaging

**Manual Tests**: We need to test this on the PS4. I can test on Nvidia.

---
### Comments to reviewers
Need help perf testing this one.
