### PR TITLE
Change ifdef guard to 2019.2 for backport

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
@@ -78,7 +78,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             splitData.cullingSphere.Set(0.0f, 0.0f, 0.0f, float.NegativeInfinity);
             splitData.cullingPlaneCount = 0;
 
-#if UNITY_2019_3_OR_NEWER
+#if UNITY_2019_2_OR_NEWER
             // This used to be fixed to .6f, but is now configureable.
             splitData.shadowCascadeBlendCullingFactor = .6f;
 #endif


### PR DESCRIPTION
### Purpose of this PR
The sphere used in culling objects between shadow cascades was modified by 0.6 in SRP before. This was to make an overlap between objects such that different cascades could overlap. A [PR](https://ono.unity3d.com/unity/unity/pull-request/87025/_/2019.2/graphics/shadows/expose-cascade-multiplier) makes this multiplier configurable from script. This PR sets the value in HDRP to 0.6 as was hardcoded before.

---
### Release Notes
Makes HDRP behave as expected when the [PR](https://ono.unity3d.com/unity/unity/pull-request/87025/_/2019.2/graphics/shadows/expose-cascade-multiplier) lands.

---
### Testing status
**Katana Tests**: Katana tests are running

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=2019.2/shadow-cascade-multiplier&automation-tools_branch=master&unity_branch=2019.2/graphics/shadows/expose-cascade-multiplier&sort=1-asc

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
---

### Comments to reviewers
This PR should not be merged before [PR](https://ono.unity3d.com/unity/unity/pull-request/87025/_/2019.2/graphics/shadows/expose-cascade-multiplier) lands.

The original bug case is [case 1088730](https://fogbugz.unity3d.com/f/cases/1088730/)