### PR TITLE
Changed HDCamera to only cleanup cameras when they are destroyed or disabled.

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [7.0.0-preview] - 2019-XX-XX
 
+### Fixed
+- Fixed an issue with history buffers causing effects like TAA or auto exposure to flicker when more than one camera was visible in the editor
+
 ## [6.7.0-preview] - 2019-05-16
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -63,7 +63,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public bool volumetricHistoryIsValid   = false; // Contains garbage otherwise
         public int  colorPyramidHistoryMipCount = 0;
         public VolumetricLightingSystem.VBufferParameters[] vBufferParams; // Double-buffered
-        
+
         // XR multipass and instanced views are supported (see XRSystem)
         XRPass m_XRPass;
         public XRPass xr { get { return m_XRPass; } }
@@ -129,12 +129,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         // XRTODO: remove and replace occurences by viewCount
         public int computePassCount { get => viewCount; }
-
-        // The only way to reliably keep track of a frame change right now is to compare the frame
-        // count Unity gives us. We need this as a single camera could be rendered several times per
-        // frame and some matrices only have to be computed once. Realistically this shouldn't
-        // happen, but you never know...
-        int m_LastFrameActive;
 
         public bool clearDepth
         {
@@ -241,7 +235,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // That way you will never update an HDCamera and forget to update the dependent system.
         // NOTE: This function must be called only once per rendering (not frame, as a single camera can be rendered multiple times with different parameters during the same frame)
         // Otherwise, previous frame view constants will be wrong.
-        public void Update(FrameSettings currentFrameSettings, VolumetricLightingSystem vlSys, MSAASamples msaaSamples, int frameIndex, XRPass xrPass)
+        public void Update(FrameSettings currentFrameSettings, VolumetricLightingSystem vlSys, MSAASamples msaaSamples, XRPass xrPass)
         {
             // store a shortcut on HDAdditionalCameraData (done here and not in the constructor as
             // we don't create HDCamera at every frame and user can change the HDAdditionalData later (Like when they create a new scene).
@@ -320,8 +314,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             var screenWidth = m_ActualWidth;
             var screenHeight = m_ActualHeight;
-
-            m_LastFrameActive = frameIndex;
 
             m_msaaSamples = msaaSamples;
 
@@ -711,7 +703,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void Reset()
         {
-            m_LastFrameActive = -1;
             isFirstFrame = true;
         }
 
@@ -769,13 +760,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
         // Look for any camera that hasn't been used in the last frame and remove them from the pool.
-        public static void CleanUnused(int frameIndex)
+        public static void CleanUnused()
         {
-            int frameCheck = frameIndex - 1;
-
             foreach (var kvp in s_Cameras)
             {
-                if (kvp.Value.m_LastFrameActive < frameCheck)
+                // Unfortunately, the scene view camera is always isActiveAndEnabled==false so we can't rely on this. For this reason we never release it (which should be fine in the editor)
+                if (kvp.Value.camera != null && kvp.Value.camera.cameraType == CameraType.SceneView)
+                    continue;
+
+                if (kvp.Value.camera == null || !kvp.Value.camera.isActiveAndEnabled)
                     s_Cleanup.Add(kvp.Key);
             }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -971,7 +971,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 if (newFrame)
                 {
-                    HDCamera.CleanUnused(m_FrameCount);
+                    HDCamera.CleanUnused();
 
                     // Make sure both are never 0.
                     m_LastTime = (m_Time > 0) ? m_Time : t;
@@ -1797,7 +1797,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     {
                         m_LightLoop.BuildGPULightLists(hdCamera, cmd, m_SharedRTManager.GetDepthStencilBuffer(hdCamera.frameSettings.IsEnabled(FrameSettingsField.MSAA)), m_SharedRTManager.GetStencilBufferCopy(), m_SkyManager.IsLightingSkyValid());
                     }
-                    
+
                     RenderContactShadows();
                 }
 
@@ -2192,7 +2192,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             hdCamera = HDCamera.GetOrCreate(camera, xrPass);
 
             // From this point, we should only use frame settings from the camera
-            hdCamera.Update(currentFrameSettings, m_VolumetricLightingSystem, m_MSAASamples, m_FrameCount, xrPass);
+            hdCamera.Update(currentFrameSettings, m_VolumetricLightingSystem, m_MSAASamples, xrPass);
 
             // Custom Render requires a proper HDCamera, so we return after the HDCamera was setup
             if (additionalCameraData != null && additionalCameraData.hasCustomRender)


### PR DESCRIPTION
### Purpose of this PR
Now HDCamera (and their history buffers) will only be cleaned up when they are disabled or destroyed.
The previous system was testing a frame index but this does not work at all in the editor when game view and scene view are not necessarily rendered every frame. This caused flickering of effects such as TAA or auto exposure.

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-hdcamera-cleanup&automation-tools_branch=master&unity_branch=trunk&sort=1-asc)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
