### PR TITLE
[Backport 6.7.x] Fix Custom Function Node variable names

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [6.7.0] - 2019-XX-XX
 ### Fixed
+- Fixed an error in `Custom Function Node` port naming.
 - When you perform an undo or redo to an inactive Shader Graph window, the window no longer breaks.
 - When you rapidly perform an undo or redo, Shader Graph windows no longer break.
 - Sub Graphs that contain references to non-existing Sub Graphs no longer break the Sub Graph Importer.

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -79,17 +79,17 @@ namespace UnityEditor.ShaderGraph
                 if(generationMode == GenerationMode.Preview && slots.Count != 0)
                 {
                     slots.OrderBy(s => s.id);
-                    visitor.AddShaderChunk(string.Format("{0} _{1}_{2};",
+                    visitor.AddShaderChunk(string.Format("{0} {1};",
                         NodeUtils.ConvertConcreteSlotValueTypeToString(precision, slots[0].concreteValueType),
-                        GetVariableNameForNode(), NodeUtils.GetHLSLSafeName(slots[0].shaderOutputName)));
+                        GetVariableNameForSlot(slots[0].id)));
                 }
                 return;
             }
             
             foreach (var argument in slots)
-                visitor.AddShaderChunk(string.Format("{0} _{1}_{2};",
+                visitor.AddShaderChunk(string.Format("{0} {1};",
                     NodeUtils.ConvertConcreteSlotValueTypeToString(precision, argument.concreteValueType),
-                    GetVariableNameForNode(), NodeUtils.GetHLSLSafeName(argument.shaderOutputName)));
+                    GetVariableNameForSlot(argument.id)));
 
             string call = string.Format("{0}_{1}(", functionName, precision);
             bool first = true;
@@ -111,7 +111,7 @@ namespace UnityEditor.ShaderGraph
                 if (!first)
                     call += ", ";
                 first = false;
-                call += string.Format("_{0}_{1}", GetVariableNameForNode(), NodeUtils.GetHLSLSafeName(argument.shaderOutputName));
+                call += GetVariableNameForSlot(argument.id);
             }
             call += ");";
             visitor.AddShaderChunk(call, true);


### PR DESCRIPTION
### Purpose of this PR
Backport of commit [0f93c34](https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3626/commits/19602c045b5048fdb4d1dc3bccac481b7f28b8df) from PR #3625. I have extracted the individual fix from the larger batch fix PR.

This regression is HUP as it makes Custom Function Node (recently introduced) completely non-functional.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
Running