### PR TITLE
Add "Experimental" tag to various menus regarding the 2D renderer

### DIFF
--- a/com.unity.render-pipelines.lightweight/Editor/2D/Renderer2DMenus.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/2D/Renderer2DMenus.cs
@@ -83,65 +83,64 @@ namespace UnityEditor.Experimental.Rendering.LWRP
             return false;
         }
 
-        //[MenuItem("GameObject/Light/2D/Freeform Light 2D", false, -100, true)]
-        [MenuItem("GameObject/Light/2D/Freeform Light 2D", false, -100)]
+        [MenuItem("GameObject/Light/2D/Freeform Light 2D (Experimental)", false, -100)]
         static void CreateFreeformLight2D(MenuCommand menuCommand)
         {
             CreateLight(menuCommand, "Freeform Light 2D", Light2D.LightType.Freeform);
         }
 
-        [MenuItem("GameObject/Light/2D/Freeform Light 2D", true, -100)]
+        [MenuItem("GameObject/Light/2D/Freeform Light 2D (Experimental)", true, -100)]
         static bool CreateFreeformLight2DValidation()
         {
             return CreateLightValidation();
         }
 
-        [MenuItem("GameObject/Light/2D/Sprite Light 2D", false, -100)]
+        [MenuItem("GameObject/Light/2D/Sprite Light 2D (Experimental)", false, -100)]
         static void CreateSpriteLight2D(MenuCommand menuCommand)
         {
             CreateLight(menuCommand, "Sprite Light 2D", Light2D.LightType.Sprite);
         }
-        [MenuItem("GameObject/Light/2D/Sprite Light 2D", true, -100)]
+        [MenuItem("GameObject/Light/2D/Sprite Light 2D (Experimental)", true, -100)]
         static bool CreateSpriteLight2DValidation()
         {
             return CreateLightValidation();
         }
 
-        [MenuItem("GameObject/Light/2D/Parametric Light 2D", false, -100)]
+        [MenuItem("GameObject/Light/2D/Parametric Light 2D (Experimental)", false, -100)]
         static void CreateParametricLight2D(MenuCommand menuCommand)
         {
             CreateLight(menuCommand, "Parametric Light 2D", Light2D.LightType.Parametric);
         }
-        [MenuItem("GameObject/Light/2D/Parametric Light 2D", true, -100)]
+        [MenuItem("GameObject/Light/2D/Parametric Light 2D (Experimental)", true, -100)]
         static bool CreateParametricLight2DValidation()
         {
             return CreateLightValidation();
         }
 
-        [MenuItem("GameObject/Light/2D/Point Light 2D", false, -100)]
+        [MenuItem("GameObject/Light/2D/Point Light 2D (Experimental)", false, -100)]
         static void CreatePointLight2D(MenuCommand menuCommand)
         {
             CreateLight(menuCommand, "Point Light 2D", Light2D.LightType.Point);
         }
 
-        [MenuItem("GameObject/Light/2D/Point Light 2D", true, -100)]
+        [MenuItem("GameObject/Light/2D/Point Light 2D (Experimental)", true, -100)]
         static bool CreatePointLight2DValidation()
         {
             return CreateLightValidation();
         }
 
-        [MenuItem("GameObject/Light/2D/Global Light 2D", false, -100)]
+        [MenuItem("GameObject/Light/2D/Global Light 2D (Experimental)", false, -100)]
         static void CreateGlobalLight2D(MenuCommand menuCommand)
         {
             CreateLight(menuCommand, "Global Light 2D", Light2D.LightType.Global);
         }
-        [MenuItem("GameObject/Light/2D/Global Light 2D", true, -100)]
+        [MenuItem("GameObject/Light/2D/Global Light 2D (Experimental)", true, -100)]
         static bool CreateGlobalLight2DValidation()
         {
             return CreateLightValidation();
         }
 
-        [MenuItem("Assets/Create/Rendering/Lightweight Render Pipeline/2D Renderer", priority = CoreUtils.assetCreateMenuPriority1 + 1)]
+        [MenuItem("Assets/Create/Rendering/Lightweight Render Pipeline/2D Renderer (Experimental)", priority = CoreUtils.assetCreateMenuPriority1 + 1)]
         static void Create2DRendererData()
         {
             Renderer2DData.Create2DRendererData((instance) =>

--- a/com.unity.render-pipelines.lightweight/Editor/2D/Renderer2DUpgrader.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/2D/Renderer2DUpgrader.cs
@@ -55,7 +55,7 @@ namespace UnityEditor.Experimental.Rendering.LWRP
             }
         }
 
-        [MenuItem("Edit/Render Pipeline/LWRP 2D Renderer/Upgrade Scene to 2D Renderer")]
+        [MenuItem("Edit/Render Pipeline/Lightweight Render Pipeline/2D Renderer/Upgrade Scene to 2D Renderer (Experimental)")]
         static void UpgradeSceneTo2DRenderer()
         {
             if (!EditorUtility.DisplayDialog("2D Renderer Upgrader", "The upgrade will change the material references of Sprite Renderers in currently open scene(s) to a lit material. You can't undo this operation. Make sure you save the scene(s) before proceeding.", "Proceed", "Cancel"))
@@ -71,7 +71,7 @@ namespace UnityEditor.Experimental.Rendering.LWRP
             }
         }
 
-        [MenuItem("Edit/Render Pipeline/LWRP 2D Renderer/Upgrade Project to 2D Renderer")]
+        [MenuItem("Edit/Render Pipeline/Lightweight Render Pipeline/2D Renderer/Upgrade Project to 2D Renderer (Experimental)")]
         static void UpgradeProjectTo2DRenderer()
         {
             if (!EditorUtility.DisplayDialog("2D Renderer Upgrader", "The upgrade will search for all prefabs in your project that use Sprite Renderers and change the material references of those Sprite Renderers to a lit material. You can't undo this operation. It's highly recommended to backup your project before proceeding.", "Proceed", "Cancel"))

--- a/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineMaterialUpgrader.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/LightweightRenderPipelineMaterialUpgrader.cs
@@ -12,7 +12,7 @@ namespace UnityEditor.Rendering.LWRP
         {
         }
         
-        [MenuItem("Edit/Render Pipeline/Upgrade Project Materials to LightweightRP Materials", priority = CoreUtils.editMenuPriority2)]
+        [MenuItem("Edit/Render Pipeline/Lightweight Render Pipeline/Upgrade Project Materials to LightweightRP Materials", priority = CoreUtils.editMenuPriority2)]
         private static void UpgradeProjectMaterials()
         {
             List<MaterialUpgrader> upgraders = new List<MaterialUpgrader>();
@@ -21,7 +21,7 @@ namespace UnityEditor.Rendering.LWRP
             MaterialUpgrader.UpgradeProjectFolder(upgraders, "Upgrade to LightweightRP Materials", MaterialUpgrader.UpgradeFlags.LogMessageWhenNoUpgraderFound);
         }
 
-        [MenuItem("Edit/Render Pipeline/Upgrade Selected Materials to LightweightRP Materials", priority = CoreUtils.editMenuPriority2)]
+        [MenuItem("Edit/Render Pipeline/Lightweight Render Pipeline/Upgrade Selected Materials to LightweightRP Materials", priority = CoreUtils.editMenuPriority2)]
         private static void UpgradeSelectedMaterials()
         {
             List<MaterialUpgrader> upgraders = new List<MaterialUpgrader>();

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/CreateSpriteLitShaderGraph.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/CreateSpriteLitShaderGraph.cs
@@ -4,7 +4,7 @@ namespace UnityEditor.Experimental.Rendering.LWRP
 {
     class CreateSpriteLitShaderGraph
     {
-        [MenuItem("Assets/Create/Shader/2D Renderer/Lit Sprite Graph", false, 208)]
+        [MenuItem("Assets/Create/Shader/2D Renderer/Sprite Lit Graph (Experimental)", false, 208)]
         public static void CreateMaterialGraph()
         {
             GraphUtil.CreateNewGraph(new SpriteLitMasterNode());

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/CreateSpriteUnlitShaderGraph.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/CreateSpriteUnlitShaderGraph.cs
@@ -4,7 +4,7 @@ namespace UnityEditor.Experimental.Rendering.LWRP
 {
     class CreateSpriteUnlitShaderGraph
     {
-        [MenuItem("Assets/Create/Shader/2D Renderer/Unlit Sprite Graph", false, 208)]
+        [MenuItem("Assets/Create/Shader/2D Renderer/Sprite Unlit Graph (Experimental)", false, 208)]
         public static void CreateMaterialGraph()
         {
             GraphUtil.CreateNewGraph(new SpriteUnlitMasterNode());

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/SpriteLitMasterNode.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/SpriteLitMasterNode.cs
@@ -8,7 +8,7 @@ using UnityEditor.ShaderGraph;
 namespace UnityEditor.Experimental.Rendering.LWRP
 {
     [Serializable]
-    [Title("Master", "Sprite lit")]
+    [Title("Master", "Sprite Lit (Experimental)")]
     class SpriteLitMasterNode : MasterNode<ISpriteLitSubShader>, IMayRequirePosition
     {
         public const string PositionName = "Position";
@@ -30,7 +30,7 @@ namespace UnityEditor.Experimental.Rendering.LWRP
         public sealed override void UpdateNodeAfterDeserialization()
         {
             base.UpdateNodeAfterDeserialization();
-            name = "Lit Sprite Master";
+            name = "Sprite Lit Master";
 
             AddSlot(new PositionMaterialSlot(PositionSlotId, PositionName, PositionName, CoordinateSpace.Object, ShaderStageCapability.Vertex));
             AddSlot(new ColorRGBAMaterialSlot(ColorSlotId, ColorSlotName, ColorSlotName, SlotType.Input, Color.white, ShaderStageCapability.Fragment));

--- a/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/SpriteUnlitMasterNode.cs
+++ b/com.unity.render-pipelines.lightweight/Editor/ShaderGraph/MasterNodes/SpriteUnlitMasterNode.cs
@@ -11,7 +11,7 @@ using UnityEditor.ShaderGraph;
 namespace UnityEditor.Experimental.Rendering.LWRP
 {
     [Serializable]
-    [Title("Master", "Sprite Unlit")]
+    [Title("Master", "Sprite Unlit (Experimental)")]
     class SpriteUnlitMasterNode : MasterNode<ISpriteUnlitSubShader>, IMayRequirePosition
     {
         public const string PositionName = "Position";

--- a/com.unity.render-pipelines.lightweight/Runtime/2D/Light2D.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/2D/Light2D.cs
@@ -116,6 +116,7 @@ namespace UnityEngine.Experimental.Rendering.LWRP
     //     Fix parametric mesh code so that the vertices, triangle, and color arrays are only recreated when number of sides change
     //     Change code to update mesh only when it is on screen. Maybe we can recreate a changed mesh if it was on screen last update (in the update), and if it wasn't set it dirty. If dirty, in the OnBecameVisible function create the mesh and clear the dirty flag.
     [ExecuteAlways, DisallowMultipleComponent]
+    [AddComponentMenu("Rendering/2D/Light 2D (Experimental)")]
     sealed public partial class Light2D : MonoBehaviour
     {
         /// <summary>

--- a/com.unity.render-pipelines.lightweight/Runtime/2D/PixelPerfectCamera.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/2D/PixelPerfectCamera.cs
@@ -6,7 +6,7 @@ namespace UnityEngine.Experimental.Rendering.LWRP
     /// The Pixel Perfect Camera component ensures your pixel art remains crisp and clear at different resolutions, and stable in motion.
     /// </summary>
     [DisallowMultipleComponent]
-    [AddComponentMenu("Rendering/2D/Pixel Perfect Camera")]
+    [AddComponentMenu("Rendering/2D/Pixel Perfect Camera (Experimental)")]
     [RequireComponent(typeof(Camera))]
     public class PixelPerfectCamera : MonoBehaviour, IPixelPerfectCamera
     {


### PR DESCRIPTION
### Purpose of this PR
Backporting #3606 

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Any test projects to go with this to help reviewers?

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
