### PR TITLE
[Backport] Remove ShaderGraph tests from HD and LW Test Projects.

### DIFF
--- a/TestProjects/HDRP_Tests/Packages/manifest.json
+++ b/TestProjects/HDRP_Tests/Packages/manifest.json
@@ -39,7 +39,6 @@
   "testables": [
     "com.unity.render-pipelines.core",
     "com.unity.render-pipelines.high-definition",
-    "com.unity.shadergraph",
     "com.unity.testframework.graphics"
   ]
 }

--- a/TestProjects/LWGraphicsTest/Packages/manifest.json
+++ b/TestProjects/LWGraphicsTest/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.unity.render-pipelines.lightweight": "file:../../../com.unity.render-pipelines.lightweight",
     "com.unity.shadergraph": "file:../../../com.unity.shadergraph",
     "com.unity.testframework.graphics": "file:../../../com.unity.testframework.graphics",
-    
+
     "com.unity.xr.legacyinputhelpers": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -40,7 +40,6 @@
   "testables": [
     "com.unity.render-pipelines.core",
     "com.unity.render-pipelines.lightweight",
-    "com.unity.shadergraph",
     "com.unity.testframework.graphics"
   ]
 }


### PR DESCRIPTION
### Purpose of this PR
Backport of https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3562 to allow SG Editor tests to reference project assets by no longer running SG editor tests inside the HD and LW test projects.

### Testing status
**Katana Tests**: Running - https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=2019.2%2Fsg%2Fremove-tests-from-rps&automation-tools_branch=master&unity_branch=2019.2%2Fstaging&sort=1-asc

**Manual Tests**: What did you do?
- [X] Opened test project + Run graphic tests locally

---
### Overall Product Risks
**Technical Risk**: None - removed test runs were redundant

**Halo Effect**: None - test config only
