### PR TITLE
fix for Distortion effect

### DIFF
--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlit.shader
@@ -90,6 +90,7 @@ Shader "Lightweight Render Pipeline/Particles/Unlit"
             #pragma shader_feature _FLIPBOOKBLENDING_ON
             #pragma shader_feature _SOFTPARTICLES_ON
             #pragma shader_feature _FADING_ON
+            #pragma shader_feature _DISTORTION_ON
             
             // -------------------------------------
             // Unity defined keywords


### PR DESCRIPTION
### Purpose of this PR
The distortion effect was not working with unlit shaders. Its very useful on action games to make a classic shockwave effect with a simple quad that must not be affected by light.

---
### Release Notes
Fixed distortion effect on particle unlit shader.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

