### PR TITLE
[LWRP] Replace beginCameraRendering callbacks by non obsolete implementation

### DIFF
--- a/com.unity.render-pipelines.lightweight/Runtime/2D/Light2D.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/2D/Light2D.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine.Serialization;
+using UnityEngine.Rendering;
 
 #if UNITY_EDITOR
 using UnityEditor.Experimental.SceneManagement;
@@ -226,7 +227,7 @@ namespace UnityEngine.Experimental.Rendering.LWRP
         public static string[] s_LightIconPaths = new string[] { s_ParametricLightIconPath, s_FreeformLightIconPath, s_SpriteLightIconPath, s_PointLightIconPath, s_GlobalLightIconPath };
 #endif
 
-        internal static void SetupCulling(Camera camera)
+        internal static void SetupCulling(ScriptableRenderContext context, Camera camera)
         {
             if (Light2DManager.cullingGroup == null)
                 return;
@@ -395,7 +396,7 @@ namespace UnityEngine.Experimental.Rendering.LWRP
             if (Light2DManager.cullingGroup == null)
             {
                 Light2DManager.cullingGroup = new CullingGroup();
-                RenderPipeline.beginCameraRendering += SetupCulling;
+                RenderPipelineManager.beginCameraRendering += SetupCulling;
             }
 
             if (!Light2DManager.lights[m_BlendStyleIndex].Contains(this))
@@ -425,7 +426,7 @@ namespace UnityEngine.Experimental.Rendering.LWRP
             {
                 Light2DManager.cullingGroup.Dispose();
                 Light2DManager.cullingGroup = null;
-                RenderPipeline.beginCameraRendering -= SetupCulling;
+                RenderPipelineManager.beginCameraRendering -= SetupCulling;
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR
Replace beginCameraRendering callbacks by non obsolete implementation (use `RenderPipelineManager` instead of `RenderPipeline`)

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=LWRP%2Ffix%2Fuse_proper_srp_api&automation-tools_branch=master&unity_branch=trunk

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

---
### Overall Product Risks
**Technical Risk**:  Low

**Halo Effect**: Low
