### PR TITLE
Fix nullreference when importingproject

### DIFF
--- a/com.unity.render-pipelines.lightweight/Runtime/Data/LightweightRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/Data/LightweightRenderPipelineAsset.cs
@@ -90,7 +90,7 @@ namespace UnityEngine.Rendering.LWRP
 
         [SerializeField] RendererType m_RendererType = RendererType.ForwardRenderer;
         [SerializeField] internal ScriptableRendererData m_RendererData = null;
-        
+
         // General settings
         [SerializeField] bool m_RequireDepthTexture = false;
         [SerializeField] bool m_RequireOpaqueTexture = false;
@@ -406,7 +406,7 @@ namespace UnityEngine.Rendering.LWRP
             get { return m_ShaderVariantLogLevel; }
             set { m_ShaderVariantLogLevel = value; }
         }
-        
+
         public bool useSRPBatcher
         {
             get { return m_UseSRPBatcher; }


### PR DESCRIPTION
### Purpose of this PR
 Fix NullReference error when importing a clean project. Caused by accessing defaultShader property and ScriptableRendererData not being loaded. 

 I added a workaround to fix the issue. It seems the real issue is that AssetDatabase.LoadAssetAtPath is not properly loading the scriptableRendererData when calling it while importing project. 

---
### Release Notes


---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Any test projects to go with this to help reviewers?

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lw/fix-nullreference-when-importingproject&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
