### PR TITLE
Added check for GCAlloc when rendering what's on camera

### DIFF
--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Common/TestRunner/HDRP_GraphicTestRunner.cs
@@ -48,6 +48,21 @@ public class HDRP_GraphicTestRunner
         {
             // Standard Test
             ImageAssert.AreEqual(testCase.ReferenceImage, camera, (settings != null)?settings.ImageComparisonSettings:null);
+
+#if CHECK_ALLOCATIONS_WHEN_RENDERING
+            // Does it allocate memory when it renders what's on camera?
+            bool allocatesMemory = false;
+            try
+            {
+                ImageAssert.AllocatesMemory(camera, 512, 512); // 512 used for height and width to render
+            }
+            catch (AssertionException)
+            {
+                allocatesMemory = true;
+            }
+            if (allocatesMemory)
+                Assert.Fail("Allocated memory when rendering what is on camera");
+#endif
         }
         else
         {


### PR DESCRIPTION
### Purpose of this PR

Ray had notice in the past a memory leak happening per frame and costing performance in one of our Spotlight partner's project.

This PR adds a check for GC_Alloc in a generic way so that it is run against *all* our existing HDRP tests.
Currently this results on most of the tests failing which exception of:

- 8101_Opaque
- 8102_Transparent
- 8104_Unlit

But these tests do print a message that says `No RenderPipelineAsset has been assigned in the test settings. This may result in a wrong test.`

Since so many tests hit some type of memory leak, I made the GC_Alloc checking contingent on having a CHECK_ALLOCATIONS_WHEN_RENDERING define on build settings (and currently did not add this). This way developers can add this define locally, run the tests, see which ones failed, fix the leaks. Once we have all the leaks fixed, we can set this define permanently so that we don't get any regressions.

---
### Testing status
**Katana Tests**: Katana SRP tests are when CHECK_ALLOCATIONS_WHEN_RENDERING is NOT defined (see note above)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (suppress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 

**Automated Tests**:  See description. This is a change that affects all HDRP automated tests, but not fully enabled yet.

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrp%2Fmemory-test-GCAlloc&unity_branch=trunk&automation-tools_branch=master&sort=1-asc

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
