### PR TITLE
[metal] Adding workaround for metal compiler crash

### DIFF
--- a/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc
+++ b/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc
@@ -350,7 +350,13 @@ float4 SampleGradient(float v,float u)
 float SampleCurve(float4 curveData,float u)
 {
     float uNorm = (u * curveData.x) + curveData.y;
+
+#if defined(SHADER_API_METAL)
+    // Workaround metal compiler crash that is caused by switch statement uint byte shift
+    switch(asint(curveData.w) >> 2)
+#else
     switch(asuint(curveData.w) >> 2)
+#endif
     {
         case 1: uNorm = HalfTexelOffset(frac(min(1.0f - 1e-10f,uNorm))); break; // clamp end. Dont clamp at 1 or else the frac will make it 0...
         case 2: uNorm = HalfTexelOffset(frac(max(0.0f,uNorm))); break; // clamp start


### PR DESCRIPTION
### Purpose of this PR
Workaround metal compiler crash that is caused by switch statement uint byte shift

---
### Release Notes
Workaround metal compiler crash that is caused by switch statement uint byte shift

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders/proj57-All%20Tests/builds/3389?automation-tools_branch=master&ScriptableRenderLoop_branch=metal/vfx-shader-workaround&unity_branch=trunk

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
