### PR TITLE
[Backport 2019.2] Move IGeneratesBodyCode to ShaderStringBuilder

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/DiffusionProfileNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/DiffusionProfileNode.cs
@@ -98,14 +98,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 #pragma warning restore 618
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             uint hash = 0;
             
             if (diffusionProfile != null)
                 hash = (diffusionProfile.profile.hash);
             
-            visitor.AddShaderChunk(precision + " " + GetVariableNameForSlot(0) + " = asfloat(uint(" + hash + "));", true);
+            sb.AppendLine(precision + " " + GetVariableNameForSlot(0) + " = asfloat(uint(" + hash + "));");
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
@@ -89,10 +89,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
-
             var colorValue = GetSlotValue(kEmissionColorInputSlotId, generationMode);
             var intensityValue = GetSlotValue(kEmissionIntensityInputSlotId, generationMode);
             var exposureWeightValue = GetSlotValue(kEmissionExposureWeightInputSlotId, generationMode);
@@ -112,8 +110,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 exposureWeightValue,
                 inverseExposureMultiplier
             );
-
-            visitor.AddShaderChunk(sb.ToString(), true);
         }
 
         string GetFunctionName()

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs
@@ -66,18 +66,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
-
             string exposure = generationMode.IsPreview() ? "1.0" : exposureFunctions[exposureType];
 
             sb.AppendLine("{0} {1} = {2};",
                 precision,
                 GetVariableNameForSlot(kExposureOutputSlotId),
                 exposure);
-
-            visitor.AddShaderChunk(sb.ToString(), true);
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
@@ -94,10 +94,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
-
             string exposureMultiplier = (exposure.isOn || generationMode.IsPreview()) ? "1.0" : "GetInverseCurrentExposureMultiplier()";
             string uv = GetSlotValue(kUvInputSlotId, generationMode);
             string lod = GetSlotValue(kLodInputSlotId, generationMode);
@@ -110,8 +108,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 lod,
                 exposureMultiplier
             );
-
-            visitor.AddShaderChunk(sb.ToString(), true);
         }
 
         public bool RequiresCameraOpaqueTexture(ShaderStageCapability stageCapability)

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ParallaxOcclusionMappingNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ParallaxOcclusionMappingNode.cs
@@ -129,7 +129,7 @@ return objectScale;");
                 });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             string amplitude = GetSlotValue(kAmplitudeSlotId, generationMode);
             string steps = GetSlotValue(kStepsSlotId, generationMode);
@@ -144,7 +144,7 @@ return objectScale;");
             string tmpViewDirUV = GetVariableNameForNode() + "_ViewDirUV";
             string tmpOutHeight = GetVariableNameForNode() + "_OutHeight";
 
-            visitor.AddShaderChunk(String.Format(@"
+            sb.AppendLines(String.Format(@"
 {0}3 {5} = IN.{3} * GetDisplacementObjectScale().xzy;
 float {6} = {5}.z;
 float {7} = {4} * 0.01;
@@ -164,7 +164,8 @@ PerPixelHeightDisplacementParam {1};
                 tmpMaxHeight,
                 tmpViewDirUV
                 ));
-            visitor.AddShaderChunk(String.Format(@"
+
+            sb.AppendLines(String.Format(@"
 {0} {11};
 {0}2 {1} = {9} + ParallaxOcclusionMapping({2}, {3}, {4}, {5}, {6}, {11});
 

--- a/com.unity.shadergraph/Editor/Data/Interfaces/IGeneratesBodyCode.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/IGeneratesBodyCode.cs
@@ -2,6 +2,6 @@ namespace UnityEditor.ShaderGraph
 {
     interface IGeneratesBodyCode
     {
-        void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode);
+        void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode);
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/ChannelMixerNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/ChannelMixerNode.cs
@@ -68,7 +68,7 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             var inputValue = GetSlotValue(InputSlotId, generationMode);
@@ -83,7 +83,7 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}({1}, _{2}_Red, _{2}_Green, _{2}_Blue, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/ChannelMixerNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/ChannelMixerNode.cs
@@ -68,9 +68,8 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             var inputValue = GetSlotValue(InputSlotId, generationMode);
             var outputValue = GetSlotValue(OutputSlotId, generationMode);
 
@@ -82,8 +81,6 @@ namespace UnityEditor.ShaderGraph
                 sb.AppendLine("{0}3 _{1}_Blue = {0}3 ({2}, {3}, {4});", precision, GetVariableNameForNode(), channelMixer.outBlue[0], channelMixer.outBlue[1], channelMixer.outBlue[2]);
             }
             sb.AppendLine("{0}({1}, _{2}_Red, _{2}_Green, _{2}_Blue, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/InvertColorsNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/InvertColorsNode.cs
@@ -102,7 +102,7 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
 
@@ -127,7 +127,7 @@ namespace UnityEditor.ShaderGraph
 
             sb.AppendLine("{0}({1}, _{2}_InvertColors, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)
@@ -153,21 +153,6 @@ namespace UnityEditor.ShaderGraph
                 overrideReferenceName = string.Format("_{0}_InvertColors", GetVariableNameForNode()),
                 generatePropertyBlock = false
             });
-        }
-
-        public void GenerateNodeFunction(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
-        {
-            var sb = new ShaderStringBuilder();
-            sb.AppendLine("void {0}({1} In, {2} InvertColors, out {3} Out)",
-                GetFunctionName(),
-                FindInputSlot<MaterialSlot>(InputSlotId).concreteValueType.ToString(precision),
-                FindInputSlot<MaterialSlot>(InputSlotId).concreteValueType.ToString(precision),
-                FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision));
-            using (sb.BlockScope())
-            {
-                sb.AppendLine("Out = abs(InvertColors - In);");
-            }
-            visitor.AddShaderChunk(sb.ToString(), true);
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/InvertColorsNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Adjustment/InvertColorsNode.cs
@@ -102,10 +102,8 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
-
             var inputValue = GetSlotValue(InputSlotId, generationMode);
             var outputValue = GetSlotValue(OutputSlotId, generationMode);
             sb.AppendLine("{0} {1};", FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision), GetVariableNameForSlot(OutputSlotId));
@@ -126,8 +124,6 @@ namespace UnityEditor.ShaderGraph
             }
 
             sb.AppendLine("{0}({1}, _{2}_InvertColors, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Mask/ChannelMaskNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Mask/ChannelMaskNode.cs
@@ -84,13 +84,13 @@ namespace UnityEditor.ShaderGraph
             return string.Format("void {0} ({1} {2}, out {3} {4})", GetFunctionName(), NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindInputSlot<DynamicVectorMaterialSlot>(InputSlotId).concreteValueType), argIn, NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindOutputSlot<DynamicVectorMaterialSlot>(OutputSlotId).concreteValueType), argOut);
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             ValidateChannelCount();
             string inputValue = GetSlotValue(InputSlotId, generationMode);
             string outputValue = GetSlotValue(OutputSlotId, generationMode);
-            visitor.AddShaderChunk(string.Format("{0} {1};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindInputSlot<MaterialSlot>(InputSlotId).concreteValueType), GetVariableNameForSlot(OutputSlotId)), true);
-            visitor.AddShaderChunk(GetFunctionCallBody(inputValue, outputValue), true);
+            sb.AppendLine(string.Format("{0} {1};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindInputSlot<MaterialSlot>(InputSlotId).concreteValueType), GetVariableNameForSlot(OutputSlotId)));
+            sb.AppendLine(GetFunctionCallBody(inputValue, outputValue));
         }
 
         string GetFunctionCallBody(string inputValue, string outputValue)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
@@ -61,18 +61,14 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { InputSlotId, OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
-
             var inputValue = GetSlotValue(InputSlotId, generationMode);
             var outputValue = GetSlotValue(OutputSlotId, generationMode);
             sb.AppendLine("{0} {1};", FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision), GetVariableNameForSlot(OutputSlotId));
             sb.AppendLine("{0}3x3 _{1}_TangentMatrix = {0}3x3(IN.{2}SpaceTangent, IN.{2}SpaceBiTangent, IN.{2}SpaceNormal);", precision, GetVariableNameForNode(), NeededCoordinateSpace.World.ToString());
             sb.AppendLine("{0}3 _{1}_Position = IN.{2}SpacePosition;", precision, GetVariableNameForNode(), NeededCoordinateSpace.World.ToString());
             sb.AppendLine("{0}({1},_{2}_Position,_{2}_TangentMatrix, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromHeightNode.cs
@@ -61,7 +61,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { InputSlotId, OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
 
@@ -72,7 +72,7 @@ namespace UnityEditor.ShaderGraph
             sb.AppendLine("{0}3 _{1}_Position = IN.{2}SpacePosition;", precision, GetVariableNameForNode(), NeededCoordinateSpace.World.ToString());
             sb.AppendLine("{0}({1},_{2}_Position,_{2}_TangentMatrix, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromTextureNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromTextureNode.cs
@@ -46,7 +46,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { TextureInputId, UVInputId, SamplerInputId, OffsetInputId, StrengthInputId, OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var textureValue = GetSlotValue(TextureInputId, generationMode);
             var uvValue = GetSlotValue(UVInputId, generationMode);
@@ -62,11 +62,8 @@ namespace UnityEditor.ShaderGraph
             else
                 samplerValue = string.Format("sampler{0}", GetSlotValue(TextureInputId, generationMode));
 
-            var sb = new ShaderStringBuilder();
             sb.AppendLine("{0} {1};", FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision), GetVariableNameForSlot(OutputSlotId));
             sb.AppendLine("{0}({1}, {2}, {3}, {4}, {5}, {6});", GetFunctionName(), textureValue, samplerValue, uvValue, offsetValue, strengthValue, outputValue);
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromTextureNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalFromTextureNode.cs
@@ -46,7 +46,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { TextureInputId, UVInputId, SamplerInputId, OffsetInputId, StrengthInputId, OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var textureValue = GetSlotValue(TextureInputId, generationMode);
             var uvValue = GetSlotValue(UVInputId, generationMode);
@@ -66,35 +66,7 @@ namespace UnityEditor.ShaderGraph
             sb.AppendLine("{0} {1};", FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision), GetVariableNameForSlot(OutputSlotId));
             sb.AppendLine("{0}({1}, {2}, {3}, {4}, {5}, {6});", GetFunctionName(), textureValue, samplerValue, uvValue, offsetValue, strengthValue, outputValue);
 
-            visitor.AddShaderChunk(sb.ToString(), false);
-        }
-
-        public void GenerateNodeFunction(ShaderGenerator visitor, GenerationMode generationMode)
-        {
-            var sb = new ShaderStringBuilder();
-            sb.AppendLine("void {0}({1} Texture, {2} Sampler, {3} UV, {4} Offset, {5} Strength, out {6} Out)", GetFunctionName(),
-                FindInputSlot<MaterialSlot>(TextureInputId).concreteValueType.ToString(precision),
-                FindInputSlot<MaterialSlot>(SamplerInputId).concreteValueType.ToString(precision),
-                FindInputSlot<MaterialSlot>(UVInputId).concreteValueType.ToString(precision),
-                FindInputSlot<MaterialSlot>(OffsetInputId).concreteValueType.ToString(precision),
-                FindInputSlot<MaterialSlot>(StrengthInputId).concreteValueType.ToString(precision),
-                FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision));
-            using (sb.BlockScope())
-            {
-                sb.AppendLine("Offset = pow(Offset, 3) * 0.1;");
-                sb.AppendLine("{0}2 offsetU = float2(UV.x + Offset, UV.y);", precision);
-                sb.AppendLine("{0}2 offsetV = float2(UV.x, UV.y + Offset);", precision);
-
-                sb.AppendLine("{0} normalSample = Texture.Sample(Sampler, UV).x;", precision);
-                sb.AppendLine("{0} uSample = Texture.Sample(Sampler, offsetU).x;", precision);
-                sb.AppendLine("{0} vSample = Texture.Sample(Sampler, offsetV).x;", precision);
-
-                sb.AppendLine("{0}3 va = float3(1, 0, (uSample - normalSample) * Strength);", precision);
-                sb.AppendLine("{0}3 vb = float3(0, 1, (vSample - normalSample) * Strength);", precision);
-                sb.AppendLine("Out = normalize(cross(va, vb));");
-            }
-
-            visitor.AddShaderChunk(sb.ToString(), true);
+            sb1.AppendLine(sb.ToString());
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Channel/FlipNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Channel/FlipNode.cs
@@ -104,7 +104,7 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
 
@@ -129,7 +129,7 @@ namespace UnityEditor.ShaderGraph
 
             sb.AppendLine("{0}({1}, _{2}_Flip, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)
@@ -155,21 +155,6 @@ namespace UnityEditor.ShaderGraph
                 overrideReferenceName = string.Format("_{0}_Flip", GetVariableNameForNode()),
                 generatePropertyBlock = false
             });
-        }
-
-        public void GenerateNodeFunction(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
-        {
-            var sb = new ShaderStringBuilder();
-            sb.AppendLine("void {0}({1} In, {2} Flip, out {3} Out)",
-                GetFunctionName(),
-                FindInputSlot<MaterialSlot>(InputSlotId).concreteValueType.ToString(precision),
-                FindInputSlot<MaterialSlot>(InputSlotId).concreteValueType.ToString(precision),
-                FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision));
-            using (sb.BlockScope())
-            {
-                sb.AppendLine("Out = (Flip * -2 + 1) * In;");
-            }
-            visitor.AddShaderChunk(sb.ToString(), true);
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Channel/FlipNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Channel/FlipNode.cs
@@ -104,10 +104,8 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
-
             var inputValue = GetSlotValue(InputSlotId, generationMode);
             var outputValue = GetSlotValue(OutputSlotId, generationMode);
             sb.AppendLine("{0} {1};", FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision), GetVariableNameForSlot(OutputSlotId));
@@ -128,8 +126,6 @@ namespace UnityEditor.ShaderGraph
             }
 
             sb.AppendLine("{0}({1}, _{2}_Flip, {3});", GetFunctionName(), inputValue, GetVariableNameForNode(), outputValue);
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Channel/SplitNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Channel/SplitNode.cs
@@ -39,7 +39,7 @@ namespace UnityEditor.ShaderGraph
 
         static int[] s_OutputSlots = {OutputSlotRId, OutputSlotGId, OutputSlotBId, OutputSlotAId};
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var inputValue = GetSlotValue(InputSlotId, generationMode);
 
@@ -56,7 +56,7 @@ namespace UnityEditor.ShaderGraph
             {
                 var outputFormat = numInputChannels == 1 ? inputValue : string.Format("{0}[{1}]", inputValue, i);
                 var outputValue = i >= numInputChannels ? "0" : outputFormat;
-                visitor.AddShaderChunk(string.Format("{0} {1} = {2};", precision, GetVariableNameForSlot(s_OutputSlots[i]), outputValue), true);
+                sb.AppendLine(string.Format("{0} {1} = {2};", precision, GetVariableNameForSlot(s_OutputSlots[i]), outputValue));
             }
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Channel/SwizzleNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Channel/SwizzleNode.cs
@@ -123,7 +123,7 @@ namespace UnityEditor.ShaderGraph
                 alphaChannel = TextureChannel.Red;
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             ValidateChannelCount();
             var outputSlotType = FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType.ToString(precision);
@@ -131,22 +131,18 @@ namespace UnityEditor.ShaderGraph
             var inputValue = GetSlotValue(InputSlotId, generationMode);
             var inputValueType = FindInputSlot<MaterialSlot>(InputSlotId).concreteValueType;
             if (inputValueType == ConcreteSlotValueType.Vector1)
-                visitor.AddShaderChunk(string.Format("{0} {1} = {2};", outputSlotType, outputName, inputValue), false);
+                sb.AppendLine(string.Format("{0} {1} = {2};", outputSlotType, outputName, inputValue));
             else if (generationMode == GenerationMode.ForReals)
-                visitor.AddShaderChunk(string.Format("{0} {1} = {2}.{3}{4}{5}{6};",
+                sb.AppendLine("{0} {1} = {2}.{3}{4}{5}{6};",
                         outputSlotType,
                         outputName,
                         inputValue,
                         s_ComponentList[m_RedChannel].ToString(CultureInfo.InvariantCulture),
                         s_ComponentList[m_GreenChannel].ToString(CultureInfo.InvariantCulture),
                         s_ComponentList[m_BlueChannel].ToString(CultureInfo.InvariantCulture),
-                        s_ComponentList[m_AlphaChannel].ToString(CultureInfo.InvariantCulture)), false);
+                        s_ComponentList[m_AlphaChannel].ToString(CultureInfo.InvariantCulture));
             else
-                visitor.AddShaderChunk(string.Format("{0} {1} = {0}({3}[((int){2} >> 0) & 3], {3}[((int){2} >> 2) & 3], {3}[((int){2} >> 4) & 3], {3}[((int){2} >> 6) & 3]);",
-                        outputSlotType,
-                        outputName,
-                        GetVariableNameForNode(), // Name of the uniform we encode swizzle values into
-                        inputValue), false);
+                sb.AppendLine("{0} {1} = {0}({3}[((int){2} >> 0) & 3], {3}[((int){2} >> 2) & 3], {3}[((int){2} >> 4) & 3], {3}[((int){2} >> 6) & 3]);", outputSlotType, outputName, GetVariableNameForNode(), inputValue);
         }
 
         public override void CollectShaderProperties(PropertyCollector properties, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/CodeFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/CodeFunctionNode.cs
@@ -340,13 +340,13 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             s_TempSlots.Clear();
             GetOutputSlots(s_TempSlots);
             foreach (var outSlot in s_TempSlots)
             {
-                visitor.AddShaderChunk(GetParamTypeName(outSlot) + " " + GetVariableNameForSlot(outSlot.id) + ";", true);
+                sb.AppendLine(GetParamTypeName(outSlot) + " " + GetVariableNameForSlot(outSlot.id) + ";");
             }
 
             string call = GetFunctionName() + "(";
@@ -369,7 +369,7 @@ namespace UnityEditor.ShaderGraph
             }
             call += ");";
 
-            visitor.AddShaderChunk(call, true);
+            sb.AppendLine(call);
         }
 
         private string GetParamTypeName(MaterialSlot slot)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/BooleanNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/BooleanNode.cs
@@ -53,12 +53,12 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             if (generationMode.IsPreview())
                 return;
 
-            visitor.AddShaderChunk(precision + " " + GetVariableNameForNode() + " = " + (m_Value ? 1 : 0) + ";", true);
+            sb.AppendLine(precision + " " + GetVariableNameForNode() + " = " + (m_Value ? 1 : 0) + ";");
         }
 
         public override string GetVariableNameForSlot(int slotId)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ColorNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ColorNode.cs
@@ -74,19 +74,12 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             if (generationMode.IsPreview())
                 return;
 
-            visitor.AddShaderChunk(string.Format(
-                    @"{0}4 {1} = IsGammaSpace() ? {0}4({2}, {3}, {4}, {5}) : {0}4(SRGBToLinear({0}3({2}, {3}, {4})), {5});"
-                    , precision
-                    , GetVariableNameForNode()
-                    , NodeUtils.FloatToShaderValue(color.color.r)
-                    , NodeUtils.FloatToShaderValue(color.color.g)
-                    , NodeUtils.FloatToShaderValue(color.color.b)
-                    , NodeUtils.FloatToShaderValue(color.color.a)), true);
+            sb.AppendLine(@"{0}4 {1} = IsGammaSpace() ? {0}4({2}, {3}, {4}, {5}) : {0}4(SRGBToLinear({0}3({2}, {3}, {4})), {5});", precision, GetVariableNameForNode(), NodeUtils.FloatToShaderValue(color.color.r), NodeUtils.FloatToShaderValue(color.color.g), NodeUtils.FloatToShaderValue(color.color.b), NodeUtils.FloatToShaderValue(color.color.a));
         }
 
         public override string GetVariableNameForSlot(int slotId)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ConstantNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ConstantNode.cs
@@ -59,9 +59,9 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { kOutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            visitor.AddShaderChunk(precision + " " + GetVariableNameForNode() + " = " + m_constantList[constant].ToString(CultureInfo.InvariantCulture) + ";", true);
+            sb.AppendLine(precision + " " + GetVariableNameForNode() + " = " + m_constantList[constant].ToString(CultureInfo.InvariantCulture) + ";");
         }
 
         public override string GetVariableNameForSlot(int slotId)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/IntegerNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/IntegerNode.cs
@@ -56,12 +56,12 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             if (generationMode.IsPreview())
                 return;
 
-            visitor.AddShaderChunk(precision + " " + GetVariableNameForNode() + " = " + m_Value + ";", true);
+            sb.AppendLine(precision + " " + GetVariableNameForNode() + " = " + m_Value + ";");
         }
 
         public override string GetVariableNameForSlot(int slotId)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/SliderNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/SliderNode.cs
@@ -57,12 +57,12 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             if (generationMode.IsPreview())
                 return;
 
-            visitor.AddShaderChunk(precision + " " + GetVariableNameForNode() + " = " + m_Value.x + ";", true);
+            sb.AppendLine(precision + " " + GetVariableNameForNode() + " = " + m_Value.x + ";");
         }
 
         public override string GetVariableNameForSlot(int slotId)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector1Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector1Node.cs
@@ -32,10 +32,10 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { OutputSlotId, InputSlotXId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var inputValue = GetSlotValue(InputSlotXId, generationMode);
-            visitor.AddShaderChunk(precision + " " + GetVariableNameForSlot(OutputSlotId) + " = " + inputValue + ";", false);
+            sb.AppendLine(precision + " " + GetVariableNameForSlot(OutputSlotId) + " = " + inputValue + ";");
         }
 
         public AbstractShaderProperty AsShaderProperty()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector2Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector2Node.cs
@@ -36,7 +36,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { OutputSlotId, InputSlotXId, InputSlotYId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var inputXValue = GetSlotValue(InputSlotXId, generationMode);
             var inputYValue = GetSlotValue(InputSlotYId, generationMode);
@@ -47,7 +47,7 @@ namespace UnityEditor.ShaderGraph
                     outputName,
                     inputXValue,
                     inputYValue);
-            visitor.AddShaderChunk(s, false);
+            sb.AppendLine(s);
         }
 
         public AbstractShaderProperty AsShaderProperty()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector3Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector3Node.cs
@@ -38,7 +38,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { OutputSlotId, InputSlotXId, InputSlotYId, InputSlotZId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var inputXValue = GetSlotValue(InputSlotXId, generationMode);
             var inputYValue = GetSlotValue(InputSlotYId, generationMode);
@@ -51,7 +51,7 @@ namespace UnityEditor.ShaderGraph
                     inputXValue,
                     inputYValue,
                     inputZValue);
-            visitor.AddShaderChunk(s, false);
+            sb.AppendLine(s);
         }
 
         public AbstractShaderProperty AsShaderProperty()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector4Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/Vector4Node.cs
@@ -41,7 +41,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { OutputSlotId, InputSlotXId, InputSlotYId, InputSlotZId, InputSlotWId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var inputXValue = GetSlotValue(InputSlotXId, generationMode);
             var inputYValue = GetSlotValue(InputSlotYId, generationMode);
@@ -56,7 +56,7 @@ namespace UnityEditor.ShaderGraph
                     inputYValue,
                     inputZValue,
                     inputWValue);
-            visitor.AddShaderChunk(s, true);
+            sb.AppendLine(s);
         }
 
         public AbstractShaderProperty AsShaderProperty()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/ScreenPositionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/ScreenPositionNode.cs
@@ -47,9 +47,9 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { kOutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            visitor.AddShaderChunk(string.Format("{0}4 {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId), m_ScreenSpaceType.ToValueAsVariable()), true);
+            sb.AppendLine(string.Format("{0}4 {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId), m_ScreenSpaceType.ToValueAsVariable()));
         }
 
         public bool RequiresScreenPosition(ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/UVNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/UVNode.cs
@@ -42,9 +42,9 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            visitor.AddShaderChunk(string.Format("{0}4 {1} = IN.{2};", precision, GetVariableNameForSlot(OutputSlotId), m_OutputChannel.GetUVName()), true);
+            sb.AppendLine(string.Format("{0}4 {1} = IN.{2};", precision, GetVariableNameForSlot(OutputSlotId), m_OutputChannel.GetUVName()));
         }
 
         public bool RequiresMeshUV(UVChannel channel, ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Gradient/GradientNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Gradient/GradientNode.cs
@@ -94,19 +94,15 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             if (generationMode.IsPreview())
             {
-                visitor.AddShaderChunk(string.Format("Gradient {0} = {1};", 
-                    GetVariableNameForSlot(outputSlotId), 
-                    GradientUtils.GetGradientForPreview(GetVariableNameForNode())));
+                sb.AppendLine("Gradient {0} = {1};", GetVariableNameForSlot(outputSlotId), GradientUtils.GetGradientForPreview(GetVariableNameForNode()));
             }
             else
             {
-                visitor.AddShaderChunk(string.Format("Gradient {0} = {1}", 
-                    GetVariableNameForSlot(outputSlotId), 
-                    GradientUtils.GetGradientValue(gradient, precision, true, ";")));
+                sb.AppendLine("Gradient {0} = {1}", GetVariableNameForSlot(outputSlotId), GradientUtils.GetGradientValue(gradient, precision, true, ";"));
             }
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix2Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix2Node.cs
@@ -72,7 +72,7 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
@@ -86,7 +86,7 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}2x2 {1} = {0}2x2 (_{1}_m0.x, _{1}_m0.y, _{1}_m1.x, _{1}_m1.y);",
                 precision, GetVariableNameForNode());
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix2Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix2Node.cs
@@ -72,9 +72,8 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
             {
                 sb.AppendLine("{0}2 _{1}_m0 = {0}2 ({2}, {3});", precision, GetVariableNameForNode(),
@@ -86,7 +85,6 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}2x2 {1} = {0}2x2 (_{1}_m0.x, _{1}_m0.y, _{1}_m1.x, _{1}_m1.y);",
                 precision, GetVariableNameForNode());
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix3Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix3Node.cs
@@ -89,9 +89,8 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
             {
                 sb.AppendLine("{0}3 _{1}_m0 = {0}3 ({2}, {3}, {4});", precision, GetVariableNameForNode(),
@@ -109,7 +108,6 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}3x3 {1} = {0}3x3 (_{1}_m0.x, _{1}_m0.y, _{1}_m0.z, _{1}_m1.x, _{1}_m1.y, _{1}_m1.z, _{1}_m2.x, _{1}_m2.y, _{1}_m2.z);",
                 precision, GetVariableNameForNode());
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix3Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix3Node.cs
@@ -89,7 +89,7 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
@@ -109,7 +109,7 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}3x3 {1} = {0}3x3 (_{1}_m0.x, _{1}_m0.y, _{1}_m0.z, _{1}_m1.x, _{1}_m1.y, _{1}_m1.z, _{1}_m2.x, _{1}_m2.y, _{1}_m2.z);",
                 precision, GetVariableNameForNode());
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix4Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix4Node.cs
@@ -106,7 +106,7 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
@@ -134,7 +134,7 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}4x4 {1} = {0}4x4 (_{1}_m0.x, _{1}_m0.y, _{1}_m0.z, _{1}_m0.w, _{1}_m1.x, _{1}_m1.y, _{1}_m1.z, _{1}_m1.w, _{1}_m2.x, _{1}_m2.y, _{1}_m2.z, _{1}_m2.w, _{1}_m3.x, _{1}_m3.y, _{1}_m3.z, _{1}_m3.w);",
                 precision, GetVariableNameForNode());
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix4Node.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/Matrix4Node.cs
@@ -106,9 +106,8 @@ namespace UnityEditor.ShaderGraph
             });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
             {
                 sb.AppendLine("{0}4 _{1}_m0 = {0}4 ({2}, {3}, {4}, {5});", precision, GetVariableNameForNode(),
@@ -134,7 +133,6 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}4x4 {1} = {0}4x4 (_{1}_m0.x, _{1}_m0.y, _{1}_m0.z, _{1}_m0.w, _{1}_m1.x, _{1}_m1.y, _{1}_m1.z, _{1}_m1.w, _{1}_m2.x, _{1}_m2.y, _{1}_m2.z, _{1}_m2.w, _{1}_m3.x, _{1}_m3.y, _{1}_m3.z, _{1}_m3.w);",
                 precision, GetVariableNameForNode());
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/DielectricSpecularNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/DielectricSpecularNode.cs
@@ -86,9 +86,8 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { kOutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
             {
                 switch (material.type)
@@ -115,7 +114,6 @@ namespace UnityEditor.ShaderGraph
                     sb.AppendLine("{0} {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material.type].ToString(CultureInfo.InvariantCulture));
                     break;
             }
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/DielectricSpecularNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/DielectricSpecularNode.cs
@@ -86,7 +86,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { kOutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             if (!generationMode.IsPreview())
@@ -115,7 +115,7 @@ namespace UnityEditor.ShaderGraph
                     sb.AppendLine("{0} {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material.type].ToString(CultureInfo.InvariantCulture));
                     break;
             }
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/MetalReflectanceNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/MetalReflectanceNode.cs
@@ -76,9 +76,9 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { kOutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            visitor.AddShaderChunk(string.Format("{0}3 {1} = {0}3{2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material].ToString(CultureInfo.InvariantCulture)), true);
+            sb.AppendLine(string.Format("{0}3 {1} = {0}3{2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material].ToString(CultureInfo.InvariantCulture)));
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/PropertyNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/PropertyNode.cs
@@ -106,7 +106,7 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var graph = owner as GraphData;
             var property = graph.properties.FirstOrDefault(x => x.guid == propertyGuid);
@@ -119,7 +119,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is Vector2ShaderProperty)
             {
@@ -127,7 +127,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is Vector3ShaderProperty)
             {
@@ -135,7 +135,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is Vector4ShaderProperty)
             {
@@ -143,7 +143,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is ColorShaderProperty)
             {
@@ -151,7 +151,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is BooleanShaderProperty)
             {
@@ -159,7 +159,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is Matrix2ShaderProperty)
             {
@@ -167,7 +167,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is Matrix3ShaderProperty)
             {
@@ -175,7 +175,7 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is Matrix4ShaderProperty)
             {
@@ -183,15 +183,17 @@ namespace UnityEditor.ShaderGraph
                         , precision
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                visitor.AddShaderChunk(result, true);
+                sb.AppendLine(result);
             }
             else if (property is SamplerStateShaderProperty)
             {
                 SamplerStateShaderProperty samplerStateProperty = property as SamplerStateShaderProperty;
-                var result = string.Format("SamplerState {0} = {1};"
+                var result = string.Format("SamplerState {0} = {1}_{2}_{3};"
                         , GetVariableNameForSlot(OutputSlotId)
-                        , samplerStateProperty.referenceName);
-                visitor.AddShaderChunk(result, true);
+                        , samplerStateProperty.referenceName
+                        , samplerStateProperty.value.filter
+                        , samplerStateProperty.value.wrap);
+                sb.AppendLine(result);
             }
             else if (property is GradientShaderProperty)
             {
@@ -200,14 +202,14 @@ namespace UnityEditor.ShaderGraph
                     var result = string.Format("Gradient {0} = {1};"
                         , GetVariableNameForSlot(OutputSlotId) 
                         , GradientUtils.GetGradientForPreview(property.referenceName));
-                    visitor.AddShaderChunk(result, true);
+                    sb.AppendLine(result);
                 }
                 else
                 {
                     var result = string.Format("Gradient {0} = {1};"
                         , GetVariableNameForSlot(OutputSlotId)
                         , property.referenceName);
-                    visitor.AddShaderChunk(result, true);
+                    sb.AppendLine(result);
                 }
             }
         }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleCubemapNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleCubemapNode.cs
@@ -47,7 +47,7 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             //Sampler input slot
             var samplerSlot = FindInputSlot<MaterialSlot>(SamplerInputId);
@@ -63,7 +63,7 @@ namespace UnityEditor.ShaderGraph
                     , GetSlotValue(NormalInputId, generationMode)
                     , GetSlotValue(LODInputId, generationMode));
 
-            visitor.AddShaderChunk(result, true);
+            sb.AppendLine(result);
         }
 
         public NeededCoordinateSpace RequiresViewDirection(ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DArrayNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DArrayNode.cs
@@ -52,7 +52,7 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var uvName = GetSlotValue(UVInput, generationMode);
             var indexName = GetSlotValue(IndexInputId, generationMode);
@@ -70,12 +70,12 @@ namespace UnityEditor.ShaderGraph
                     , uvName
                     , indexName);
 
-            visitor.AddShaderChunk(result, true);
+            sb.AppendLine(result);
 
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.r;", precision, GetVariableNameForSlot(OutputSlotRId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.g;", precision, GetVariableNameForSlot(OutputSlotGId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.b;", precision, GetVariableNameForSlot(OutputSlotBId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.a;", precision, GetVariableNameForSlot(OutputSlotAId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
+            sb.AppendLine(string.Format("{0} {1} = {2}.r;", precision, GetVariableNameForSlot(OutputSlotRId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.g;", precision, GetVariableNameForSlot(OutputSlotGId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.b;", precision, GetVariableNameForSlot(OutputSlotBId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.a;", precision, GetVariableNameForSlot(OutputSlotAId), GetVariableNameForSlot(OutputSlotRGBAId)));
         }
 
         public bool RequiresMeshUV(UVChannel channel, ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DLODNode.cs
@@ -96,7 +96,7 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var uvName = GetSlotValue(UVInput, generationMode);
 
@@ -115,24 +115,24 @@ namespace UnityEditor.ShaderGraph
                     , uvName
                     , lodSlot);
 
-            visitor.AddShaderChunk(result, true);
+            sb.AppendLine(result);
 
             if (textureType == TextureType.Normal)
             {
                 if (normalMapSpace == NormalMapSpace.Tangent)
                 {
-                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
+                    sb.AppendLine(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)));
                 }
                 else
                 {
-                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
+                    sb.AppendLine(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)));
                 }
             }
 
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.r;", precision, GetVariableNameForSlot(OutputSlotRId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.g;", precision, GetVariableNameForSlot(OutputSlotGId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.b;", precision, GetVariableNameForSlot(OutputSlotBId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.a;", precision, GetVariableNameForSlot(OutputSlotAId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
+            sb.AppendLine(string.Format("{0} {1} = {2}.r;", precision, GetVariableNameForSlot(OutputSlotRId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.g;", precision, GetVariableNameForSlot(OutputSlotGId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.b;", precision, GetVariableNameForSlot(OutputSlotBId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.a;", precision, GetVariableNameForSlot(OutputSlotAId), GetVariableNameForSlot(OutputSlotRGBAId)));
         }
 
         public bool RequiresMeshUV(UVChannel channel, ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture2DNode.cs
@@ -100,7 +100,7 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var uvName = GetSlotValue(UVInput, generationMode);
 
@@ -116,24 +116,24 @@ namespace UnityEditor.ShaderGraph
                     , edgesSampler.Any() ? GetSlotValue(SamplerInput, generationMode) : "sampler" + id
                     , uvName);
 
-            visitor.AddShaderChunk(result, true);
+            sb.AppendLine(result);
 
             if (textureType == TextureType.Normal)
             {
                 if (normalMapSpace == NormalMapSpace.Tangent)
                 {
-                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
+                    sb.AppendLine(string.Format("{0}.rgb = UnpackNormalmapRGorAG({0});", GetVariableNameForSlot(OutputSlotRGBAId)));
                 }
                 else
                 {
-                    visitor.AddShaderChunk(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)), true);
+                    sb.AppendLine(string.Format("{0}.rgb = UnpackNormalRGB({0});", GetVariableNameForSlot(OutputSlotRGBAId)));
                 }
             }
 
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.r;", precision, GetVariableNameForSlot(OutputSlotRId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.g;", precision, GetVariableNameForSlot(OutputSlotGId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.b;", precision, GetVariableNameForSlot(OutputSlotBId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2}.a;", precision, GetVariableNameForSlot(OutputSlotAId), GetVariableNameForSlot(OutputSlotRGBAId)), true);
+            sb.AppendLine(string.Format("{0} {1} = {2}.r;", precision, GetVariableNameForSlot(OutputSlotRId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.g;", precision, GetVariableNameForSlot(OutputSlotGId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.b;", precision, GetVariableNameForSlot(OutputSlotBId), GetVariableNameForSlot(OutputSlotRGBAId)));
+            sb.AppendLine(string.Format("{0} {1} = {2}.a;", precision, GetVariableNameForSlot(OutputSlotAId), GetVariableNameForSlot(OutputSlotRGBAId)));
         }
 
         public bool RequiresMeshUV(UVChannel channel, ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture3DNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/SampleTexture3DNode.cs
@@ -37,7 +37,7 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var uvName = GetSlotValue(UVInput, generationMode);
 
@@ -53,7 +53,7 @@ namespace UnityEditor.ShaderGraph
                     , edgesSampler.Any() ? GetSlotValue(SamplerInput, generationMode) : "sampler" + id
                     , uvName);
 
-            visitor.AddShaderChunk(result, true);
+            sb.AppendLine(result);
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/TexelSizeNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Texture/TexelSizeNode.cs
@@ -34,10 +34,10 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-			visitor.AddShaderChunk(string.Format("{0} {1} = {2}_TexelSize.z;", precision, GetVariableNameForSlot(OutputSlotWId), GetSlotValue(TextureInputId, generationMode)), true);
-			visitor.AddShaderChunk(string.Format("{0} {1} = {2}_TexelSize.w;", precision, GetVariableNameForSlot(OutputSlotHId), GetSlotValue(TextureInputId, generationMode)), true);
+			sb.AppendLine(string.Format("{0} {1} = {2}_TexelSize.z;", precision, GetVariableNameForSlot(OutputSlotWId), GetSlotValue(TextureInputId, generationMode)));
+			sb.AppendLine(string.Format("{0} {1} = {2}_TexelSize.w;", precision, GetVariableNameForSlot(OutputSlotHId), GetSlotValue(TextureInputId, generationMode)));
         }
 
         public bool RequiresMeshUV(UVChannel channel, ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
@@ -51,7 +51,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { Input1SlotId, Input2SlotId, OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             var input1Value = GetSlotValue(Input1SlotId, generationMode);
@@ -61,7 +61,7 @@ namespace UnityEditor.ShaderGraph
             sb.AppendLine("{0} {1};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType), GetVariableNameForSlot(OutputSlotId));
             sb.AppendLine("{0}({1}, {2}, {3});", GetFunctionHeader(), input1Value, input2Value, outputValue);
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         string GetFunctionName()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
@@ -51,17 +51,14 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { Input1SlotId, Input2SlotId, OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             var input1Value = GetSlotValue(Input1SlotId, generationMode);
             var input2Value = GetSlotValue(Input2SlotId, generationMode);
             var outputValue = GetSlotValue(OutputSlotId, generationMode);
 
             sb.AppendLine("{0} {1};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType), GetVariableNameForSlot(OutputSlotId));
             sb.AppendLine("{0}({1}, {2}, {3});", GetFunctionHeader(), input1Value, input2Value, outputValue);
-
-            sb1.AppendLine(sb.ToString());
         }
 
         string GetFunctionName()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixConstructionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixConstructionNode.cs
@@ -64,9 +64,8 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new int[] { InputSlotM0Id, InputSlotM1Id, InputSlotM2Id, InputSlotM3Id, Output4x4SlotId, Output3x3SlotId, Output2x2SlotId });
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             var inputM0Value = GetSlotValue(InputSlotM0Id, generationMode);
             var inputM1Value = GetSlotValue(InputSlotM1Id, generationMode);
             var inputM2Value = GetSlotValue(InputSlotM2Id, generationMode);
@@ -84,8 +83,6 @@ namespace UnityEditor.ShaderGraph
                 GetVariableNameForSlot(Output4x4SlotId),
                 GetVariableNameForSlot(Output3x3SlotId),
                 GetVariableNameForSlot(Output2x2SlotId));
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixConstructionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixConstructionNode.cs
@@ -64,7 +64,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new int[] { InputSlotM0Id, InputSlotM1Id, InputSlotM2Id, InputSlotM3Id, Output4x4SlotId, Output3x3SlotId, Output2x2SlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             var inputM0Value = GetSlotValue(InputSlotM0Id, generationMode);
@@ -85,7 +85,7 @@ namespace UnityEditor.ShaderGraph
                 GetVariableNameForSlot(Output3x3SlotId),
                 GetVariableNameForSlot(Output2x2SlotId));
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public void GenerateNodeFunction(FunctionRegistry registry, GraphContext graphContext, GenerationMode generationMode)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixSplitNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixSplitNode.cs
@@ -65,7 +65,7 @@ namespace UnityEditor.ShaderGraph
 
         static int[] s_OutputSlots = {OutputSlotRId, OutputSlotGId, OutputSlotBId, OutputSlotAId};
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             var inputValue = GetSlotValue(InputSlotId, generationMode);
 
@@ -121,7 +121,7 @@ namespace UnityEditor.ShaderGraph
                             break;
                     }
                 }
-                visitor.AddShaderChunk(string.Format("{0}{1} {2} = {3};", precision, concreteRowCount, GetVariableNameForSlot(s_OutputSlots[r]), outputValue), true);
+                sb.AppendLine(string.Format("{0}{1} {2} = {3};", precision, concreteRowCount, GetVariableNameForSlot(s_OutputSlots[r]), outputValue));
             }
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Vector/TransformNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Vector/TransformNode.cs
@@ -95,7 +95,7 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { InputSlotId, OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
             NodeUtils.SlotConfigurationExceptionIfBadConfiguration(this, new[] { InputSlotId }, new[] { OutputSlotId });
             string inputValue = string.Format("{0}.xyz", GetSlotValue(InputSlotId, generationMode));
@@ -190,12 +190,12 @@ namespace UnityEditor.ShaderGraph
                 }
             }
             if (requiresTransposeTangentTransform)
-                visitor.AddShaderChunk(string.Format("float3x3 {0} = transpose(float3x3(IN.{1}SpaceTangent, IN.{1}SpaceBiTangent, IN.{1}SpaceNormal));", transposeTargetTransformString, CoordinateSpace.World.ToString()), true);
+                sb.AppendLine(string.Format("float3x3 {0} = transpose(float3x3(IN.{1}SpaceTangent, IN.{1}SpaceBiTangent, IN.{1}SpaceNormal));", transposeTargetTransformString, CoordinateSpace.World.ToString()));
             else if (requiresTangentTransform)
-                visitor.AddShaderChunk(string.Format("float3x3 {0} = float3x3(IN.{1}SpaceTangent, IN.{1}SpaceBiTangent, IN.{1}SpaceNormal);", targetTransformString, tangentTransformSpace), true);
-            visitor.AddShaderChunk(string.Format("{0} {1} = {2};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType),
+                sb.AppendLine(string.Format("float3x3 {0} = float3x3(IN.{1}SpaceTangent, IN.{1}SpaceBiTangent, IN.{1}SpaceNormal);", targetTransformString, tangentTransformSpace));
+            sb.AppendLine("{0} {1} = {2};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, FindOutputSlot<MaterialSlot>(OutputSlotId).concreteValueType),
                     GetVariableNameForSlot(OutputSlotId),
-                    transformString), true);
+                    transformString);
         }
 
         bool RequiresWorldSpaceTangentTransform()

--- a/com.unity.shadergraph/Editor/Data/Nodes/UV/FlipbookNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/UV/FlipbookNode.cs
@@ -79,7 +79,7 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             var uvValue = GetSlotValue(UVSlotId, generationMode);
@@ -95,7 +95,7 @@ namespace UnityEditor.ShaderGraph
             }
             sb.AppendLine("{0}({1}, {2}, {3}, {4}, _{5}_Invert, {6});", GetFunctionName(), uvValue, widthValue, heightValue, tileValue, GetVariableNameForNode(), outputValue);
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/UV/FlipbookNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/UV/FlipbookNode.cs
@@ -79,9 +79,8 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
-        public void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             var uvValue = GetSlotValue(UVSlotId, generationMode);
             var widthValue = GetSlotValue(WidthSlotId, generationMode);
             var heightValue = GetSlotValue(HeightSlotId, generationMode);
@@ -94,8 +93,6 @@ namespace UnityEditor.ShaderGraph
                 sb.AppendLine("{0}2 _{1}_Invert = {0}2 ({2}, {3});", precision, GetVariableNameForNode(), invertX.isOn ? 1 : 0, invertY.isOn ? 1 : 0);
             }
             sb.AppendLine("{0}({1}, {2}, {3}, {4}, _{5}_Invert, {6});", GetFunctionName(), uvValue, widthValue, heightValue, tileValue, GetVariableNameForNode(), outputValue);
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public override void CollectPreviewMaterialProperties(List<PreviewProperty> properties)

--- a/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
@@ -76,7 +76,7 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
         {
             var sb = new ShaderStringBuilder();
             sb.AppendLine("{0}3 {1}_UV = {2} * {3};", precision, GetVariableNameForNode(),
@@ -167,7 +167,7 @@ namespace UnityEditor.ShaderGraph
                     break;
             }
 
-            visitor.AddShaderChunk(sb.ToString(), false);
+            sb1.AppendLine(sb.ToString());
         }
 
         public NeededCoordinateSpace RequiresPosition(ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
@@ -76,9 +76,8 @@ namespace UnityEditor.ShaderGraph
         }
 
         // Node generations
-        public virtual void GenerateNodeCode(ShaderStringBuilder sb1, GraphContext graphContext, GenerationMode generationMode)
+        public virtual void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             sb.AppendLine("{0}3 {1}_UV = {2} * {3};", precision, GetVariableNameForNode(),
                 GetSlotValue(PositionInputId, generationMode), GetSlotValue(TileInputId, generationMode));
 
@@ -166,8 +165,6 @@ namespace UnityEditor.ShaderGraph
                     , GetVariableNameForNode());
                     break;
             }
-
-            sb1.AppendLine(sb.ToString());
         }
 
         public NeededCoordinateSpace RequiresPosition(ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -12,6 +13,8 @@ namespace UnityEditor.ShaderGraph
     [Title("Utility", "Custom Function")]
     class CustomFunctionNode : AbstractMaterialNode, IGeneratesBodyCode, IGeneratesFunction, IHasSettings
     {
+        static string[] s_ValidExtensions = { ".hlsl", ".cginc" };
+        static string s_InvalidFileType = "Source file is not a valid file type. Valid file extensions are .hlsl and .cginc";
         static string s_MissingOutputSlot = "A Custom Function Node must have at least one output slot";
 
         public CustomFunctionNode()
@@ -35,7 +38,7 @@ namespace UnityEditor.ShaderGraph
 
         private static string m_DefaultFunctionName = "Enter function name here...";
 
-        public string functionName 
+        public string functionName
         {
             get => m_FunctionName;
             set => m_FunctionName = value;
@@ -44,7 +47,7 @@ namespace UnityEditor.ShaderGraph
         public static string defaultFunctionName => m_DefaultFunctionName;
 
         [SerializeField]
-        private string m_FunctionSource = m_DefaultFunctionSource;
+        private string m_FunctionSource;
 
         private static string m_DefaultFunctionSource = "Enter function source file path here...";
 
@@ -53,8 +56,6 @@ namespace UnityEditor.ShaderGraph
             get => m_FunctionSource;
             set => m_FunctionSource = value;
         }
-
-        public static string defaultFunctionSource => m_DefaultFunctionSource;
 
         [SerializeField]
         private string m_FunctionBody = m_DefaultFunctionBody;
@@ -79,23 +80,21 @@ namespace UnityEditor.ShaderGraph
                 if(generationMode == GenerationMode.Preview && slots.Count != 0)
                 {
                     slots.OrderBy(s => s.id);
-                    sb.AppendLine("{0} _{1}_{2};",
+                    sb.AppendLine("{0} {1};",
                         NodeUtils.ConvertConcreteSlotValueTypeToString(precision, slots[0].concreteValueType),
-                        GetVariableNameForNode(),
-                        NodeUtils.GetHLSLSafeName(slots[0].shaderOutputName));
+                        GetVariableNameForSlot(slots[0].id));
                 }
                 return;
             }
-            
+
             foreach (var argument in slots)
-                sb.AppendLine("{0} _{1}_{2};",
+                sb.AppendLine("{0} {1};",
                     NodeUtils.ConvertConcreteSlotValueTypeToString(precision, argument.concreteValueType),
-                    GetVariableNameForNode(),
-                    NodeUtils.GetHLSLSafeName(argument.shaderOutputName));
+                    GetVariableNameForSlot(argument.id));
 
             string call = string.Format("{0}_{1}(", functionName, precision);
             bool first = true;
-            
+
             slots.Clear();
             GetInputSlots<MaterialSlot>(slots);
             foreach (var argument in slots)
@@ -113,7 +112,7 @@ namespace UnityEditor.ShaderGraph
                 if (!first)
                     call += ", ";
                 first = false;
-                call += string.Format("_{0}_{1}", GetVariableNameForNode(), NodeUtils.GetHLSLSafeName(argument.shaderOutputName));
+                call += GetVariableNameForSlot(argument.id);
             }
             call += ");";
             sb.AppendLine(call);
@@ -124,24 +123,33 @@ namespace UnityEditor.ShaderGraph
             if(!IsValidFunction())
                 return;
 
-            registry.ProvideFunction(functionName, builder =>
+            switch (sourceType)
             {
-                switch (sourceType)
-                {
-                    case HlslSourceType.File:
-                        builder.AppendLine($"#include \"{functionSource}\"");
-                        break;
-                    case HlslSourceType.String:
+                case HlslSourceType.File:
+                    registry.ProvideFunction(functionSource, builder =>
+                    {
+                        string path = AssetDatabase.GUIDToAssetPath(functionSource);
+
+                        // This is required for upgrading without console errors
+                        if(string.IsNullOrEmpty(path))
+                            path = functionSource;
+
+                        builder.AppendLine($"#include \"{path}\"");
+                    });
+                    break;
+                case HlslSourceType.String:
+                    registry.ProvideFunction(functionName, builder =>
+                    {
                         builder.AppendLine(GetFunctionHeader());
-                        using(builder.BlockScope())
+                        using (builder.BlockScope())
                         {
                             builder.AppendLines(functionBody);
                         }
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            });
+                    });
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
 
         private string GetFunctionHeader()
@@ -203,8 +211,31 @@ namespace UnityEditor.ShaderGraph
             }
             else
             {
-                bool validFunctionSource = !string.IsNullOrEmpty(functionSource) && functionSource != m_DefaultFunctionSource;
-                return validFunctionName & validFunctionSource;
+                if(!validFunctionName || string.IsNullOrEmpty(functionSource) || functionSource == m_DefaultFunctionSource)
+                    return false;
+
+                string path = AssetDatabase.GUIDToAssetPath(functionSource);
+                if(string.IsNullOrEmpty(path))
+                    path = functionSource;
+
+                string extension = Path.GetExtension(path);
+                return s_ValidExtensions.Contains(extension);
+            }
+        }
+
+        void ValidateSlotName()
+        {
+            List<MaterialSlot> slots = new List<MaterialSlot>();
+            GetSlots(slots);
+
+            foreach (var slot in slots)
+            {
+                var error = NodeUtils.ValidateSlotName(slot.RawDisplayName(), out string errorMessage);
+                if (error)
+                {
+                    owner.AddValidationError(tempId, errorMessage);
+                    break;
+                }
             }
         }
 
@@ -214,10 +245,26 @@ namespace UnityEditor.ShaderGraph
             {
                 owner.AddValidationError(tempId, s_MissingOutputSlot, ShaderCompilerMessageSeverity.Warning);
             }
-            
+            if(sourceType == HlslSourceType.File)
+            {
+                if(!string.IsNullOrEmpty(functionSource))
+                {
+                    string path = AssetDatabase.GUIDToAssetPath(functionSource);
+                    if(!string.IsNullOrEmpty(path))
+                    {
+                        string extension = path.Substring(path.LastIndexOf('.'));
+                        if(!s_ValidExtensions.Contains(extension))
+                        {
+                            owner.AddValidationError(tempId, s_InvalidFileType, ShaderCompilerMessageSeverity.Error);
+                        }
+                    }
+                }
+            }
+            ValidateSlotName();
+
             base.ValidateNode();
         }
-        
+
         public override void GetSourceAssetDependencies(List<string> paths)
         {
             base.GetSourceAssetDependencies(paths);
@@ -228,7 +275,7 @@ namespace UnityEditor.ShaderGraph
                     paths.Add(dependencyPath);
             }
         }
-        
+
         public VisualElement CreateSettingsElement()
         {
             PropertySheet ps = new PropertySheet();
@@ -236,6 +283,28 @@ namespace UnityEditor.ShaderGraph
             ps.Add(new ReorderableSlotListView(this, SlotType.Output));
             ps.Add(new HlslFunctionView(this));
             return ps;
+        }
+
+        public override void OnAfterDeserialize()
+        {
+            base.OnAfterDeserialize();
+
+            // Handle upgrade from legacy asset path version
+            // If functionSource is not empty or a guid then assume it is legacy version
+            // If asset can be loaded from path then get its guid
+            // Otherwise it was the default string so set to empty
+            Guid guid;
+            if(!string.IsNullOrEmpty(functionSource) && !Guid.TryParse(functionSource, out guid))
+            {
+                string guidString = string.Empty;
+                TextAsset textAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(functionSource);
+                if(textAsset != null)
+                {
+                    long localId;
+                    AssetDatabase.TryGetGUIDAndLocalFileIdentifier(textAsset, out guidString, out localId);
+                }
+                functionSource = guidString;
+            }
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/IsFrontFaceNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/IsFrontFaceNode.cs
@@ -28,9 +28,9 @@ namespace UnityEditor.ShaderGraph
             RemoveSlotsNameNotMatching(new[] { OutputSlotId });
         }
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            visitor.AddShaderChunk(string.Format("{0} {1} = max(0, IN.{2});", precision, GetVariableNameForSlot(OutputSlotId), ShaderGeneratorNames.FaceSign), true);
+            sb.AppendLine(string.Format("{0} {1} = max(0, IN.{2});", precision, GetVariableNameForSlot(OutputSlotId), ShaderGeneratorNames.FaceSign));
         }
 
 		public bool RequiresFaceSign(ShaderStageCapability stageCapability = ShaderStageCapability.Fragment)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
@@ -162,16 +162,15 @@ namespace UnityEditor.ShaderGraph
         }
 
 
-        public void GenerateNodeCode(ShaderGenerator visitor, GraphContext graphContext, GenerationMode generationMode)
+        public void GenerateNodeCode(ShaderStringBuilder sb, GraphContext graphContext, GenerationMode generationMode)
         {
-            var sb = new ShaderStringBuilder();
             if (subGraphData == null || hasError)
             {
                 var outputSlots = new List<MaterialSlot>();
                 GetOutputSlots(outputSlots);
                 foreach (var slot in outputSlots)
                 {
-                    visitor.AddShaderChunk($"{NodeUtils.ConvertConcreteSlotValueTypeToString(precision, slot.concreteValueType)} {GetVariableNameForSlot(slot.id)} = {slot.GetDefaultValue(GenerationMode.ForReals)};");
+                    sb.AppendLine($"{NodeUtils.ConvertConcreteSlotValueTypeToString(precision, slot.concreteValueType)} {GetVariableNameForSlot(slot.id)} = {slot.GetDefaultValue(GenerationMode.ForReals)};");
                 }
                 
                 return;
@@ -180,11 +179,9 @@ namespace UnityEditor.ShaderGraph
             var inputVariableName = $"_{GetVariableNameForNode()}";
             
             GraphUtil.GenerateSurfaceInputTransferCode(sb, subGraphData.requirements, subGraphData.inputStructName, inputVariableName);
-            
-            visitor.AddShaderChunk(sb.ToString());
 
             foreach (var outSlot in subGraphData.outputs)
-                visitor.AddShaderChunk(string.Format("{0} {1};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, outSlot.concreteValueType), GetVariableNameForSlot(outSlot.id)));
+                sb.AppendLine("{0} {1};", NodeUtils.ConvertConcreteSlotValueTypeToString(precision, outSlot.concreteValueType), GetVariableNameForSlot(outSlot.id));
 
             var arguments = new List<string>();
             foreach (var prop in subGraphData.inputs)
@@ -209,10 +206,7 @@ namespace UnityEditor.ShaderGraph
             foreach (var outSlot in subGraphData.outputs)
                 arguments.Add(GetVariableNameForSlot(outSlot.id));
 
-            visitor.AddShaderChunk(
-                string.Format("{0}({1});"
-                    , subGraphData.functionName
-                    , arguments.Aggregate((current, next) => string.Format("{0}, {1}", current, next))));
+            sb.AppendLine("{0}({1});", subGraphData.functionName, arguments.Aggregate((current, next) => string.Format("{0}, {1}", current, next)));
         }
 
         public void OnEnable()

--- a/com.unity.shadergraph/Editor/Importers/SubGraphDatabaseImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/SubGraphDatabaseImporter.cs
@@ -298,7 +298,7 @@ namespace UnityEditor.ShaderGraph
 
                 // Now generate outputs
                 foreach (var output in subGraphData.outputs)
-                    arguments.Add($"out {output.concreteValueType.ToString(outputNode.precision)} {output.shaderOutputName}_{output.id}");
+                    arguments.Add($"out {output.concreteValueType.ToString(outputNode.precision)} {output.shaderOutputName}");
 
                 // Create the function prototype from the arguments
                 sb.AppendLine("void {0}({1})"
@@ -309,19 +309,14 @@ namespace UnityEditor.ShaderGraph
                 using (sb.BlockScope())
                 {
                     // Just grab the body from the active nodes
-                    var bodyGenerator = new ShaderGenerator();
                     foreach (var node in nodes)
                     {
                         if (node is IGeneratesBodyCode)
-                            (node as IGeneratesBodyCode).GenerateNodeCode(bodyGenerator, graphContext, GenerationMode.ForReals);
+                            (node as IGeneratesBodyCode).GenerateNodeCode(sb, graphContext, GenerationMode.ForReals);
                     }
 
                     foreach (var slot in subGraphData.outputs)
-                    {
-                        bodyGenerator.AddShaderChunk($"{slot.shaderOutputName}_{slot.id} = {outputNode.GetSlotValue(slot.id, GenerationMode.ForReals)};");
-                    }
-
-                    sb.Append(bodyGenerator.GetShaderString(1));
+                        sb.AppendLine("{0} = {1};", slot.shaderOutputName, outputNode.GetSlotValue(slot.id, GenerationMode.ForReals));
                 }
             });
             


### PR DESCRIPTION
### Purpose of this PR 
Backport #3602
This PR refactors IGeneratesBodyCode to use ShaderStringBuilder instead of ShaderGenerator. This is a requirement for future PRs (such as #3600) as well as a general quality of life improvement for developers.

---
### Release Notes
N/A

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low - Wide refactor but minimal danger in the change.

**Halo Effect**: None, Low, Medium, High? Low - Afffects all nodes but minimal danger.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
