### PR TITLE
Lw/fix particles distortion

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a case where built-in Shader time values could be out of sync with actual time. [case 1142495](https://fogbugz.unity3d.com/f/cases/1142495/)
 - Fixed an issue that caused forward renderer resources to not load properly when you upgraded LWRP from an older version to 7.0.0. [case 1154925](https://issuetracker.unity3d.com/issues/lwrp-upgrading-lwrp-package-to-7-dot-0-0-breaks-forwardrenderdata-asset-in-resource-files)
 - Fixed GC spikes caused by LWRP allocating heap memory every frame.
+- Fixed distortion effect on particle unlit shader.
 
 ### Changed
 - Replaced beginCameraRendering callbacks by non obsolete implementation in Light2D

--- a/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlit.shader
+++ b/com.unity.render-pipelines.lightweight/Shaders/Particles/ParticlesUnlit.shader
@@ -90,6 +90,7 @@ Shader "Lightweight Render Pipeline/Particles/Unlit"
             #pragma shader_feature _FLIPBOOKBLENDING_ON
             #pragma shader_feature _SOFTPARTICLES_ON
             #pragma shader_feature _FADING_ON
+            #pragma shader_feature _DISTORTION_ON
             
             // -------------------------------------
             // Unity defined keywords


### PR DESCRIPTION
Merged #3661 into this working branch so we can run tests and add release notes.

### Purpose of this PR
The distortion effect was not working with unlit shaders. Its very useful on action games to make a classic shockwave effect with a simple quad that must not be affected by light.

---
### Release Notes
Fixed distortion effect on particle unlit shader.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None