### PR TITLE
Adding the Base64 strings back into the TestResult xml file

### DIFF
--- a/com.unity.testframework.graphics/Runtime/ImageAssert.cs
+++ b/com.unity.testframework.graphics/Runtime/ImageAssert.cs
@@ -160,6 +160,8 @@ namespace UnityEngine.TestTools.Graphics
                         diffImage.SetPixels32(diffPixelsArray, 0);
                         diffImage.Apply(false);
 
+                        TestContext.CurrentContext.Test.Properties.Set("DiffImage", Convert.ToBase64String(diffImage.EncodeToPNG()) );
+
                         failedImageMessage.DiffImage = diffImage.EncodeToPNG();
                         failedImageMessage.ExpectedImage = expected.EncodeToPNG();
                         throw;
@@ -174,6 +176,7 @@ namespace UnityEngine.TestTools.Graphics
 #else
                 PlayerConnection.instance.Send(FailedImageMessage.MessageId, failedImageMessage.Serialize());
 #endif
+                TestContext.CurrentContext.Test.Properties.Set("Image", Convert.ToBase64String(actual.EncodeToPNG()));
                 throw;
             }
         }


### PR DESCRIPTION
### Purpose of this PR
Adding the Base64 strings back into the TestResult xml file so that the images can still be viewed when running tests on Katana.

---
### Testing status
Katana:
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=base64-in-xml&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Yamato:
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/base64-in-xml/.yamato%252Fupm-ci-shadergraph.yml%2523ShaderGraph_Windows64_Standalone_trunk/143537/job

base64 appearing in xml: https://yamato-artifactviewer.prd.cds.internal.unity3d.com/55954eb6-fd27-42b8-8c04-4ec785a65268%2Flogs%2FTestProjects%2FShaderGraph%2Fupm-ci~%2Ftest-results%2Fplaymode/TestResults.xml

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
This should not affect any of the player connection work
