### PR TITLE
Skip UpdateSkyEnvironment if in matcap view to avoid retriggering of …

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1660,7 +1660,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             // Caution: We require sun light here as some skies use the sun light to render, it means that UpdateSkyEnvironment must be called after PrepareLightsForGPU.
             // TODO: Try to arrange code so we can trigger this call earlier and use async compute here to run sky convolution during other passes (once we move convolution shader to compute).
-            UpdateSkyEnvironment(hdCamera, cmd);
+            if(m_CurrentDebugDisplaySettings.GetDebugLightingMode() != DebugLightingMode.MatcapView)
+                UpdateSkyEnvironment(hdCamera, cmd);
 
             hdCamera.xr.StartLegacyStereo(camera, cmd, renderContext);
 


### PR DESCRIPTION
It created perf problems when matcap view was on 