### PR TITLE
Fix deferred shading for XR single-pass instancing

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added custom BaseShaderPreprocessor in HDEditorUtils.GetBaseShaderPreprocessorList()
 - Fixed compile issue when USE_XR_SDK is not defined
 - Fixed procedural sky sun disk intensity for high directional light intensities
+- Fixed deferred shading for XR single-pass instancing after lightloop refactor
 
 ### Changed
 - Optimization: Reduce the group size of the deferred lighting pass from 16x16 to 8x8

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/DeferredTile.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/DeferredTile.shader
@@ -357,11 +357,13 @@ Shader "Hidden/HDRP/DeferredTile"
             struct Attributes
             {
                 uint vertexID  : SV_VertexID;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
             };
 
             struct Varyings
             {
                 float4 positionCS : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             struct Outputs
@@ -377,12 +379,16 @@ Shader "Hidden/HDRP/DeferredTile"
             Varyings Vert(Attributes input)
             {
                 Varyings output;
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
                 output.positionCS = GetFullScreenTriangleVertexPosition(input.vertexID);
                 return output;
             }
 
             Outputs Frag(Varyings input)
             {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
                 // This need to stay in sync with deferred.compute
 
                 // input.positionCS is SV_Position


### PR DESCRIPTION
### Purpose of this PR
Add macros to deferred shader after https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3718

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp-xr-spi-def-fix&unity_branch=trunk)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None