### PR TITLE
Toggle preview windows for selected nodes

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -164,33 +164,40 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
             }
 
-            string collapsePreviewText = "Collapse Previews";
+            DropdownMenuAction.Status expandPreviewAction = DropdownMenuAction.Status.Disabled;
+            DropdownMenuAction.Status collapsePreviewAction = DropdownMenuAction.Status.Disabled;
+            string expandPreviewText = "View/Expand Previews";
+            string collapsePreviewText = "View/Collapse Previews";
+            if (selection.Count == 1)
+            {
+                collapsePreviewText = "View/Collapse Preview";
+                expandPreviewText = "View/Expand Preview";
+            }
+
+            DropdownMenuAction.Status minimizeAction = DropdownMenuAction.Status.Disabled;
+            DropdownMenuAction.Status maximizeAction = DropdownMenuAction.Status.Disabled;
+
             foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
             {
-                if (selectedNode.node.hasPreview && selectedNode.node.previewExpanded)
+                if (selectedNode.node.hasPreview)
                 {
-                    if (selection.Count == 1)
-                    {
-                        collapsePreviewText = "Collapse Preview";
-                    }
-                    evt.menu.AppendAction(collapsePreviewText, _ => SetSelectionPreviews(false), (a) => DropdownMenuAction.Status.Normal);
-                    break;
+                    if (selectedNode.node.previewExpanded)
+                        collapsePreviewAction = DropdownMenuAction.Status.Normal;
+                    else
+                        expandPreviewAction = DropdownMenuAction.Status.Normal;
                 }
+
+                if (selectedNode.expanded)
+                    minimizeAction = DropdownMenuAction.Status.Normal;
+                else
+                    maximizeAction = DropdownMenuAction.Status.Normal;
             }
-            
-            string expandPreviewText = "Expand Previews";
-            foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
-            {
-                if (selectedNode.node.hasPreview && !selectedNode.node.previewExpanded)
-                {
-                    if (selection.Count == 1)
-                    {
-                        expandPreviewText = "Expand Preview";
-                    }
-                    evt.menu.AppendAction(expandPreviewText, _ => SetSelectionPreviews(true), (a) => DropdownMenuAction.Status.Normal);
-                    break;
-                }
-            }
+
+            evt.menu.AppendAction("View/Minimize", _ => SetExpansion(false), (a) => minimizeAction);
+            evt.menu.AppendAction("View/Maximize", _ => SetExpansion(true), (a) => maximizeAction);
+
+            evt.menu.AppendAction(expandPreviewText, _ => SetSelectionPreviews(true), (a) => expandPreviewAction);
+            evt.menu.AppendAction(collapsePreviewText, _ => SetSelectionPreviews(false), (a) => collapsePreviewAction);
 
             if (evt.target is BlackboardField)
             {
@@ -282,12 +289,21 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
+        void SetExpansion(bool state)
+        {
+            graph.owner.RegisterCompleteObjectUndo("Toggle Expansion");
+            foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
+            {
+                selectedNode.expanded = state;
+            }
+        }
+
         void SetSelectionPreviews(bool state)
         {
             graph.owner.RegisterCompleteObjectUndo("Toggle Preview Visibility");
             foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
             {
-                selectedNode.UpdatePreviewExpandedState(state);
+                selectedNode.node.previewExpanded = state;
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -163,14 +163,48 @@ namespace UnityEditor.ShaderGraph.Drawing
                     evt.menu.AppendAction("Open Sub Graph", OpenSubGraph, (a) => DropdownMenuAction.Status.Normal);
                 }
             }
-            else if (evt.target is BlackboardField)
+
+            string collapsePreviewText = "Collapse Previews";
+            foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
+            {
+                if (selectedNode.node.hasPreview && selectedNode.node.previewExpanded)
+                {
+                    if (selection.Count == 1)
+                    {
+                        collapsePreviewText = "Collapse Preview";
+                    }
+                    evt.menu.AppendAction(collapsePreviewText, _ => SetSelectionPreviews(false), (a) => DropdownMenuAction.Status.Normal);
+                    break;
+                }
+            }
+            
+            string expandPreviewText = "Expand Previews";
+            foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
+            {
+                if (selectedNode.node.hasPreview && !selectedNode.node.previewExpanded)
+                {
+                    if (selection.Count == 1)
+                    {
+                        expandPreviewText = "Expand Preview";
+                    }
+                    evt.menu.AppendAction(expandPreviewText, _ => SetSelectionPreviews(true), (a) => DropdownMenuAction.Status.Normal);
+                    break;
+                }
+            }
+
+            if (evt.target is BlackboardField)
             {
                 evt.menu.AppendAction("Delete", (e) => DeleteSelectionImplementation("Delete", AskUser.DontAskUser), (e) => canDeleteSelection ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
             }
             if (evt.target is MaterialGraphView)
             {
-                evt.menu.AppendAction("Collapse Previews", CollapsePreviews, (a) => DropdownMenuAction.Status.Normal);
-                evt.menu.AppendAction("Expand Previews", ExpandPreviews, (a) => DropdownMenuAction.Status.Normal);
+                foreach (AbstractMaterialNode node in graph.GetNodes<AbstractMaterialNode>())
+                {
+                    if (node.hasPreview && node.previewExpanded == true)
+                        evt.menu.AppendAction("Collapse All Previews", CollapsePreviews, (a) => DropdownMenuAction.Status.Normal);
+                    if (node.hasPreview && node.previewExpanded == false)
+                        evt.menu.AppendAction("Expand All Previews", ExpandPreviews, (a) => DropdownMenuAction.Status.Normal);
+                }
                 evt.menu.AppendSeparator();
             }
         }
@@ -245,6 +279,15 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     group.RemoveElement(node);
                 }
+            }
+        }
+
+        void SetSelectionPreviews(bool state)
+        {
+            graph.owner.RegisterCompleteObjectUndo("Toggle Preview Visibility");
+            foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
+            {
+                selectedNode.UpdatePreviewExpandedState(state);
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -435,7 +435,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        public void UpdatePreviewExpandedState(bool expanded)
+        void UpdatePreviewExpandedState(bool expanded)
         {
             node.previewExpanded = expanded;
             if (m_PreviewFiller == null)

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -97,7 +97,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     collapsePreviewButton.AddManipulator(new Clickable(() =>
                         {
                             node.owner.owner.RegisterCompleteObjectUndo("Collapse Preview");
-                            UpdatePreviewExpandedState(false);
+                            SetPreviewExpandedStateOnSelection(false);
                         }));
                     m_PreviewImage.Add(collapsePreviewButton);
                 }
@@ -121,13 +121,13 @@ namespace UnityEditor.ShaderGraph.Drawing
                     expandPreviewButton.AddManipulator(new Clickable(() =>
                         {
                             node.owner.owner.RegisterCompleteObjectUndo("Expand Preview");
-                            UpdatePreviewExpandedState(true);
+                            SetPreviewExpandedStateOnSelection(true);
                         }));
                     m_PreviewFiller.Add(expandPreviewButton);
                 }
                 contents.Add(m_PreviewFiller);
 
-                UpdatePreviewExpandedState(node.previewExpanded);
+                SetPreviewExpandedStateOnSelection(node.previewExpanded);
             }
 
             // Add port input container, which acts as a pixel cache for all port inputs
@@ -187,6 +187,12 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_SettingsButton.AddManipulator(new Clickable(() =>
                 {
                     UpdateSettingsExpandedState();
+                }));
+
+            //Override the base Node class's node-expansion button
+            m_CollapseButton.AddManipulator(new Clickable(() =>
+                {
+                    SetNodeExpandedStateOnSelection(!expanded);
                 }));
 
             if(m_Settings.childCount > 0)
@@ -410,7 +416,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_NodeSettingsView.Add(m_Settings);
         }
 
-
         void UpdateSettingsExpandedState()
         {
             m_ShowSettings = !m_ShowSettings;
@@ -418,9 +423,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             {
                 m_NodeSettingsView.Add(m_Settings);
                 m_NodeSettingsView.visible = true;
-                m_GraphView.ClearSelection();
-                m_GraphView.AddToSelection(this);
-
+                SetSelfSelected();
                 m_SettingsButton.AddToClassList("clicked");
                 RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
                 OnGeometryChanged(null);
@@ -432,6 +435,47 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_NodeSettingsView.visible = false;
                 m_SettingsButton.RemoveFromClassList("clicked");
                 UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            }
+        }
+
+
+        private void SetSelfSelected()
+        {
+            m_GraphView.ClearSelection();
+            m_GraphView.AddToSelection(this);
+        }
+
+        void SetNodeExpandedStateOnSelection(bool state)
+        {
+            if (!selected)
+            {
+                SetSelfSelected();
+                expanded = state;
+            }
+            else
+            {
+                if (m_GraphView is MaterialGraphView)
+                {
+                    var matGraphView = m_GraphView as MaterialGraphView;
+                    matGraphView.SetNodeExpandedOnSelection(state);
+                }
+            }
+        }
+
+        void SetPreviewExpandedStateOnSelection(bool state)
+        {
+            if (!selected)
+            {
+                SetSelfSelected();
+                UpdatePreviewExpandedState(state);
+            }
+            else
+            {
+                if(m_GraphView is MaterialGraphView)
+                {
+                    var matGraphView = m_GraphView as MaterialGraphView;
+                    matGraphView.SetPreviewExpandedOnSelection(state);
+                }
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -189,12 +189,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                     UpdateSettingsExpandedState();
                 }));
 
-            //Override the base Node class's node-expansion button
-            m_CollapseButton.AddManipulator(new Clickable(() =>
-                {
-                    SetNodeExpandedStateOnSelection(!expanded);
-                }));
-
             if(m_Settings.childCount > 0)
             {
                 m_ButtonContainer = new VisualElement { name = "button-container" };
@@ -431,7 +425,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             else
             {
                 m_Settings.RemoveFromHierarchy();
-
+                SetSelfSelected();
                 m_NodeSettingsView.visible = false;
                 m_SettingsButton.RemoveFromClassList("clicked");
                 UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -74,6 +74,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (m_ControlItems.childCount > 0)
                 contents.Add(controlsContainer);
 
+            // Node Base class toggles the 'expanded' variable already, this is on top of that call
+            m_CollapseButton.RegisterCallback<MouseUpEvent>(SetNodeExpandedStateOnSelection);
+
             if (node.hasPreview)
             {
                 // Add actual preview which floats on top of the node
@@ -439,19 +442,16 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_GraphView.AddToSelection(this);
         }
 
-        void SetNodeExpandedStateOnSelection(bool state)
+        void SetNodeExpandedStateOnSelection(MouseUpEvent evt)
         {
             if (!selected)
-            {
                 SetSelfSelected();
-                expanded = state;
-            }
             else
             {
                 if (m_GraphView is MaterialGraphView)
                 {
                     var matGraphView = m_GraphView as MaterialGraphView;
-                    matGraphView.SetNodeExpandedOnSelection(state);
+                    matGraphView.SetNodeExpandedOnSelection(expanded);
                 }
             }
         }

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -435,7 +435,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        void UpdatePreviewExpandedState(bool expanded)
+        public void UpdatePreviewExpandedState(bool expanded)
         {
             node.previewExpanded = expanded;
             if (m_PreviewFiller == null)

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -473,6 +473,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
+        public bool CanToggleExpanded()
+        {
+            return m_CollapseButton.enabledInHierarchy;
+        }
+
         void UpdatePreviewExpandedState(bool expanded)
         {
             node.previewExpanded = expanded;


### PR DESCRIPTION
### Purpose of this PR
Add contextual options to the right-click menu that can toggle all selected node's preview windows.
![MenuViewOptions](https://user-images.githubusercontent.com/50928697/58723880-02fa5400-8390-11e9-977d-79c9843fbda7.gif)

---
### Release Notes
N/A

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [x] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Ftoggle-previews&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Ftoggle-previews

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low

**Halo Effect**: None, Low, Medium, High? Low

---
### Comments to reviewers
N/A

