### PR TITLE
Changed AOVRequestDataCollection API to public

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestDataCollection.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestDataCollection.cs
@@ -11,7 +11,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // Owned
         private List<AOVRequestData> m_AOVRequestData;
 
-        internal AOVRequestDataCollection(List<AOVRequestData> aovRequestData)
+        /// <summary>Build a new collection from requests.</summary>
+        /// <param name="aovRequestData">Requests to include in the collection.</param>
+        public AOVRequestDataCollection(List<AOVRequestData> aovRequestData)
             // Transfer ownership of the list
             => m_AOVRequestData = aovRequestData;
 


### PR DESCRIPTION
### Purpose of this PR
Changed AOVRequestDataCollection API to public

---
### Testing status
**Katana Tests**:-

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
