### PR TITLE
Fix for decals showing blurry low res mip when using texture mip map streaming

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added custom BaseShaderPreprocessor in HDEditorUtils.GetBaseShaderPreprocessorList()
 - Fixed compile issue when USE_XR_SDK is not defined
 - Fixed procedural sky sun disk intensity for high directional light intensities
+- Fixed Decal mip level when using texture mip map streaming to avoid dropping to lowest permitted mip (now loading all mips)
 
 ### Changed
 - Optimization: Reduce the group size of the deferred lighting pass from 16x16 to 8x8

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalSystem.cs
@@ -838,9 +838,31 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 Array.Copy(value.resultIndices, m_ResultIndices, m_NumResults);
             }
         }
+		
+		void SetupMipStreamingSettings(Texture texture, bool allMips)
+		{
+			if (texture)
+			{
+				if (texture.dimension == UnityEngine.Rendering.TextureDimension.Tex2D)
+				{
+					Texture2D tex2D = (texture as Texture2D);
+					if (allMips)
+						tex2D.requestedMipmapLevel = 0;
+					else
+						tex2D.ClearRequestedMipmapLevel();
+				}
+			}
+		}
 
         DecalHandle AddDecal(Matrix4x4 localToWorld, Quaternion rotation, Matrix4x4 sizeOffset, float drawDistance, float fadeScale, Vector4 uvScaleBias, bool affectsTransparency, Material material, int layerMask, float fadeFactor)
         {
+			if (material != null)
+			{
+				SetupMipStreamingSettings(material.GetTexture("_BaseColorMap"), true);
+				SetupMipStreamingSettings(material.GetTexture("_NormalMap"), true);
+				SetupMipStreamingSettings(material.GetTexture("_MaskMap"), true);
+			}
+				
             DecalSet decalSet = null;
             int key = material != null ? material.GetInstanceID() : kNullMaterialIndex;
             if (!m_DecalSets.TryGetValue(key, out decalSet))


### PR DESCRIPTION
### Purpose of this PR
Fix for decals showing blurry low res mip when using texture mip map streaming
With this fix decals pick the highest mip for streaming rather than defaulting to lowest permitted mip
(due to nothing calculating the required mip level).

Bug report. 
https://fogbugz.unity3d.com/f/cases/1140772/
Note this had a PR to fix it with Unity code but that needs to be reverted due to side effects.

The following PR will undo the above bug fix, so an alternative fix is needed in the Decal system to prevent a regression
https://ono.unity3d.com/unity/unity/pull-request/88212/_/core/graphics/texture-streaming-preload-fix

---
### Release Notes
Fixed decal rendering when texture mip map streaming is enabled.

---
### Testing status
**Katana Tests**: 
Launched Katana
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=decals-texture-streaming-fix&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

**Manual Tests**: What did you do?
- Created a decal with texture containing mips and set to streaming.
- Enabled texture streaming and set max mip level reduction high (to 7)
- Prior to this fix the texture was limited to a low mip so looks blurry.
- With this fix all the mips are loaded and is no longer blurry.
There is also a test in the bug report listed above.

**Automated Tests**: 
- Nothing added

---
### Overall Product Risks
**Technical Risk**: Low, 
**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
