### PR TITLE
Various fixes based on @vlad feedback about subgraph in Visual Effect Graph

### DIFF
--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXBlockController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXBlockController.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.VFX.UI
             m_ContextController = contextController;
             if (model is VFXSubgraphBlock)
             {
-                model.Invalidate(VFXModel.InvalidationCause.kSettingChanged); // Simulate a settings change in case the subgraph parameters has changed.
+                (model as VFXSubgraphBlock).RecreateCopy();
             }
         }
 

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXContextController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXContextController.cs
@@ -112,7 +112,7 @@ namespace UnityEditor.VFX.UI
             if (model is VFXSubgraphContext)
             {
                 SyncFlowAnchors();
-                model.ResyncSlots(false);
+                model.ResyncSlots(true);
             }
         }
 

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/Controllers/VFXDataAnchorController.cs
@@ -119,7 +119,7 @@ namespace UnityEditor.VFX.UI
             UpdateInfos();
             Profiler.EndSample();
 
-            sourceNode.DataEdgesMightHaveChanged();
+            sourceNode.DataEdgesMightHaveChanged();            
 
             Profiler.BeginSample("VFXDataAnchorController.NotifyChange");
             NotifyChange(AnyThing);

--- a/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXDataAnchor.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Elements/VFXDataAnchor.cs
@@ -197,6 +197,8 @@ namespace UnityEditor.VFX.UI
                 AddToClassList("hidden");
             }
 
+            UpdateCapColor();
+
 
             if (controller.direction == Direction.Output)
                 m_ConnectorText.text = controller.name;

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXNodeProvider.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXNodeProvider.cs
@@ -94,12 +94,17 @@ namespace UnityEditor.VFX.UI
 
                         if ( typeof(T) == typeof(VisualEffectSubgraphBlock))
                         {
-                            VFXBlockSubgraphContext blockContext = asset.GetResource().GetOrCreateGraph().children.OfType<VFXBlockSubgraphContext>().First();
+                            VFXBlockSubgraphContext blockContext = asset.GetResource().GetOrCreateGraph().children.OfType<VFXBlockSubgraphContext>().FirstOrDefault();
 
-                            item.additionalInfos = new AdditionalBlockInfo() { compatibleType = blockContext.compatibleContextType, compatibleData = blockContext.ownedType };
+                            if (blockContext != null)
+                            {
+                                item.additionalInfos = new AdditionalBlockInfo() { compatibleType = blockContext.compatibleContextType, compatibleData = blockContext.ownedType };
+                                m_Items.Add(item);
+                            }
                         }
+                        else
+                            m_Items.Add(item);
 
-                        m_Items.Add(item);
                     }
                 }
             }

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXPaste.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXPaste.cs
@@ -307,7 +307,7 @@ namespace UnityEditor.VFX.UI
 
             var slotContainer = model as IVFXSlotContainer;
             var inputSlots = slotContainer.inputSlots;
-            for (int i = 0; i < node.inputSlots.Length; ++i)
+            for (int i = 0; i < node.inputSlots.Length && i< inputSlots.Count; ++i)
             {
                 if (inputSlots[i].name == node.inputSlots[i].name)
                 {

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
@@ -165,6 +165,11 @@ namespace UnityEditor.VFX.UI
         {
             foreach (var edge in dataEdges.Where(t => t.Value.input == anchor || t.Value.output == anchor).ToArray())
             {
+                if (edge.Value.input == anchor)
+                    edge.Value.output.Disconnect(edge.Value);
+                else
+                    edge.Value.input.Disconnect(edge.Value);
+
                 RemoveElement(edge.Value);
                 dataEdges.Remove(edge.Key);
             }

--- a/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
+++ b/com.unity.visualeffectgraph/Editor/GraphView/Views/VFXView.cs
@@ -1711,14 +1711,25 @@ namespace UnityEditor.VFX.UI
             else
             {
                 var references = DragAndDrop.objectReferences.OfType<VisualEffectAsset>().Cast<VisualEffectObject>().Concat(DragAndDrop.objectReferences.OfType<VisualEffectSubgraphOperator>());
+                VisualEffectObject draggedObject = references.FirstOrDefault();
+                bool isOperator = draggedObject is VisualEffectSubgraphOperator;
 
-                if (references.Count() > 0 && (!controller.model.isSubgraph || !references.Any(t => t.GetResource().GetOrCreateGraph().subgraphDependencies.Contains(controller.model.subgraph) || t.GetResource() == controller.model)))
+                if (draggedObject != null && draggedObject != controller.model.visualEffectObject)
                 {
-                    DragAndDrop.visualMode = DragAndDropVisualMode.Link;
-                    e.StopPropagation();
+                    var draggedObjectDependencies = draggedObject.GetResource().GetOrCreateGraph().subgraphDependencies;
+                    bool vfxIntovfx = !isOperator && !controller.model.isSubgraph && !draggedObjectDependencies.Contains(controller.model.subgraph); // dropping a vfx into a vfx
+                    bool operatorIntovfx = isOperator && !controller.model.isSubgraph; //dropping an operator into a vfx
+                    bool operatorIntoOperator = isOperator && controller.model.visualEffectObject is VisualEffectSubgraphOperator && !draggedObjectDependencies.Contains(controller.model.visualEffectObject); //dropping an operator into a vfx
+                    if (vfxIntovfx || operatorIntovfx || operatorIntoOperator)
+                    {
+                        DragAndDrop.visualMode = DragAndDropVisualMode.Link;
+                        e.StopPropagation();
+                    }
+                    return;
                 }
+
                 var droppedBlocks = DragAndDrop.objectReferences.OfType<VisualEffectSubgraphBlock>();
-                if (droppedBlocks.Count() > 0 && (!controller.model.isSubgraph || !references.Any(t => t.GetResource().GetOrCreateGraph().subgraphDependencies.Contains(controller.model.subgraph) || t.GetResource() == controller.model)))
+                if (droppedBlocks.Count() > 0 && !controller.model.isSubgraph )
                 {
                     DragAndDrop.visualMode = DragAndDropVisualMode.Link;
                     e.StopPropagation();
@@ -1750,33 +1761,44 @@ namespace UnityEditor.VFX.UI
                 DragAndDrop.AcceptDrag();
                 var references = DragAndDrop.objectReferences.OfType<VisualEffectAsset>().Cast<VisualEffectObject>().Concat(DragAndDrop.objectReferences.OfType<VisualEffectSubgraphOperator>());
 
-                if (references.Count() > 0 && (!controller.model.isSubgraph || !references.Any(t => t.GetResource().GetOrCreateGraph().subgraphDependencies.Contains(controller.model.subgraph) || t.GetResource() == controller.model)))
+                VisualEffectObject draggedObject = references.FirstOrDefault();
+                bool isOperator = draggedObject is VisualEffectSubgraphOperator;
+
+                if (draggedObject != null && draggedObject != controller.model.visualEffectObject)
                 {
-                    Vector2 mousePosition = contentViewContainer.WorldToLocal(e.mousePosition);
-                    VFXModel newModel = (references.First() is VisualEffectAsset) ? VFXSubgraphContext.CreateInstance<VFXSubgraphContext>() as VFXModel : VFXSubgraphOperator.CreateInstance<VFXSubgraphOperator>() as VFXModel;
+                    var draggedObjectDependencies = draggedObject.GetResource().GetOrCreateGraph().subgraphDependencies;
+                    bool vfxIntovfx = !isOperator && !controller.model.isSubgraph && !draggedObjectDependencies.Contains(controller.model.subgraph); // dropping a vfx into a vfx
+                    bool operatorIntovfx = isOperator && !controller.model.isSubgraph; //dropping an operator into a vfx
+                    bool operatorIntoOperator = isOperator && controller.model.visualEffectObject is VisualEffectSubgraphOperator && !draggedObjectDependencies.Contains(controller.model.visualEffectObject); //dropping an operator into a vfx
+                    if (vfxIntovfx || operatorIntovfx || operatorIntoOperator)
+                    {
+                        Vector2 mousePosition = contentViewContainer.WorldToLocal(e.mousePosition);
+                        VFXModel newModel = (references.First() is VisualEffectAsset) ? VFXSubgraphContext.CreateInstance<VFXSubgraphContext>() as VFXModel : VFXSubgraphOperator.CreateInstance<VFXSubgraphOperator>() as VFXModel;
 
-                    controller.AddVFXModel(mousePosition, newModel);
+                        controller.AddVFXModel(mousePosition, newModel);
 
-                    newModel.SetSettingValue("m_Subgraph", references.First());
+                        newModel.SetSettingValue("m_Subgraph", references.First());
 
-                    //TODO add to picked groupnode
-                    e.StopPropagation();
+                        //TODO add to picked groupnode
+                        e.StopPropagation();
+                    }
                 }
-                else
+                else if (!controller.model.isSubgraph) //can't drag a vfx subgraph block in a subgraph operator or a subgraph block
                 {
                     var droppedBlocks = DragAndDrop.objectReferences.OfType<VisualEffectSubgraphBlock>();
-                    if(droppedBlocks.Count() > 0 && (!controller.model.isSubgraph || !references.Any(t => t.GetResource().GetOrCreateGraph().subgraphDependencies.Contains(controller.model.subgraph) || t.GetResource() == controller.model)))
+                    VisualEffectSubgraphBlock droppedBlock = droppedBlocks.FirstOrDefault();
+                    if (droppedBlock != null)
                     {
                         Vector2 mousePosition = contentViewContainer.WorldToLocal(e.mousePosition);
 
                         VFXContextType contextKind = droppedBlocks.First().GetResource().GetOrCreateGraph().children.OfType<VFXBlockSubgraphContext>().First().compatibleContextType;
-                        VFXModelDescriptor<VFXContext> contextType = VFXLibrary.GetContexts().First(t=>t.modelType == typeof(VFXBasicInitialize));
-                        if((contextKind & VFXContextType.Update) == VFXContextType.Update)
+                        VFXModelDescriptor<VFXContext> contextType = VFXLibrary.GetContexts().First(t => t.modelType == typeof(VFXBasicInitialize));
+                        if ((contextKind & VFXContextType.Update) == VFXContextType.Update)
                             contextType = VFXLibrary.GetContexts().First(t => t.modelType == typeof(VFXBasicUpdate));
                         else if ((contextKind & VFXContextType.Spawner) == VFXContextType.Spawner)
                             contextType = VFXLibrary.GetContexts().First(t => t.modelType == typeof(VFXBasicSpawner));
                         else if ((contextKind & VFXContextType.Output) == VFXContextType.Output)
-                            contextType = VFXLibrary.GetContexts().First(t => t.modelType == typeof(VFXMeshOutput));
+                            contextType = VFXLibrary.GetContexts().First(t => t.modelType == typeof(VFXPlanarPrimitiveOutput) && t.model.taskType == VFXTaskType.ParticleQuadOutput);
 
                         VFXContext ctx = controller.AddVFXContext(mousePosition, contextType);
 

--- a/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
@@ -203,7 +203,9 @@ namespace UnityEditor.VFX
                 VFXGraph subGraph = m_Subgraph.GetResource().GetOrCreateGraph();
                 VFXBlockSubgraphContext blockContext = subGraph.children.OfType<VFXBlockSubgraphContext>().First();
                 VFXContext parent = GetParent();
-                if (parent == null || blockContext == null )
+                if (parent == null )
+                    return true;
+                if (blockContext == null)
                     return false;
 
                 return (blockContext.compatibleContextType & parent.contextType) == parent.contextType;

--- a/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
@@ -49,10 +49,14 @@ namespace UnityEditor.VFX
 
                     foreach (var param in GetParameters(t => InputPredicate(t)))
                     {
+                        List<VFXPropertyAttribute> attributes = new List<VFXPropertyAttribute>();
                         if (!string.IsNullOrEmpty(param.tooltip))
-                            yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip)), param.value);
-                        else
-                            yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName), param.value);
+                            attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip));
+
+                        if( param.hasRange)
+                            attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kRange, (float)VFXConverter.ConvertTo(param.m_Min.Get(), typeof(float)), (float)VFXConverter.ConvertTo(param.m_Max.Get(), typeof(float))));
+
+                        yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, attributes.ToArray()), param.value);
                     }
                 }
             }

--- a/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
@@ -87,10 +87,13 @@ namespace UnityEditor.VFX
         {
             get
             {
-                foreach( var block in m_SubBlocks)
+                if (m_SubBlocks != null)
                 {
-                    foreach (var attribute in block.attributes)
-                        yield return attribute;
+                    foreach (var block in m_SubBlocks)
+                    {
+                        foreach (var attribute in block.attributes)
+                            yield return attribute;
+                    }
                 }
             }
         }

--- a/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
@@ -33,15 +33,27 @@ namespace UnityEditor.VFX
         protected override IEnumerable<VFXPropertyWithValue> inputProperties
         {
             get {
-                if(m_SubChildren == null && subgraph != null) // if the subasset exists but the subchildren has not been recreated yet, return the existing slots
-                    Debug.LogError("input Properties called before OnEnable in Subgraph block");
 
-                foreach ( var param in GetParameters(t=> InputPredicate(t)))
+                if(m_isInOnEnable) // Recreate copy cannot be called in OnEnable because the subgraph my not have been enabled itself so in OnEnable send back the previous input properties
                 {
-                    if (!string.IsNullOrEmpty(param.tooltip))
-                        yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip)), param.value);
-                    else
-                        yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName), param.value);
+                    if (subgraph != null)
+                    {
+                        foreach (var inputSlot in inputSlots)
+                            yield return new VFXPropertyWithValue(inputSlot.property, inputSlot.value);
+                    }
+                }
+                else
+                {
+                    if (m_SubChildren == null && subgraph != null) // if the subasset exists but the subchildren has not been recreated yet, return the existing slots
+                        RecreateCopy();
+
+                    foreach (var param in GetParameters(t => InputPredicate(t)))
+                    {
+                        if (!string.IsNullOrEmpty(param.tooltip))
+                            yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip)), param.value);
+                        else
+                            yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName), param.value);
+                    }
                 }
             }
         }
@@ -62,10 +74,12 @@ namespace UnityEditor.VFX
             return m_SubChildren.OfType<VFXParameter>().Where(t => predicate(t)).OrderBy(t => t.order);
         }
 
+        bool m_isInOnEnable;
         private new void OnEnable()
         {
-            RecreateCopy();
+            m_isInOnEnable = true;
             base.OnEnable();
+            m_isInOnEnable = false;
         }
 
         void SubChildrenOnInvalidate(VFXModel model, InvalidationCause cause)
@@ -185,7 +199,14 @@ namespace UnityEditor.VFX
             {
                 if (m_Subgraph == null)
                     return true;
-                return (m_Subgraph.GetResource().GetOrCreateGraph().children.OfType<VFXBlockSubgraphContext>().First().compatibleContextType & GetParent().contextType) == GetParent().contextType;
+
+                VFXGraph subGraph = m_Subgraph.GetResource().GetOrCreateGraph();
+                VFXBlockSubgraphContext blockContext = subGraph.children.OfType<VFXBlockSubgraphContext>().First();
+                VFXContext parent = GetParent();
+                if (parent == null || blockContext == null )
+                    return false;
+
+                return (blockContext.compatibleContextType & parent.contextType) == parent.contextType;
             }
         }
 

--- a/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Blocks/VFXSubgraphBlock.cs
@@ -49,14 +49,7 @@ namespace UnityEditor.VFX
 
                     foreach (var param in GetParameters(t => InputPredicate(t)))
                     {
-                        List<VFXPropertyAttribute> attributes = new List<VFXPropertyAttribute>();
-                        if (!string.IsNullOrEmpty(param.tooltip))
-                            attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip));
-
-                        if( param.hasRange)
-                            attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kRange, (float)VFXConverter.ConvertTo(param.m_Min.Get(), typeof(float)), (float)VFXConverter.ConvertTo(param.m_Max.Get(), typeof(float))));
-
-                        yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, attributes.ToArray()), param.value);
+                        yield return VFXSubgraphUtility.GetPropertyFromInputParameter(param);
                     }
                 }
             }

--- a/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphContext.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphContext.cs
@@ -6,7 +6,8 @@ using UnityEngine.Experimental.VFX;
 using UnityEditor.Experimental.VFX;
 
 namespace UnityEditor.VFX
-{   
+{
+
     class VFXSubgraphContext : VFXContext
     {
         public const string triggerEventName = "Trigger";
@@ -42,9 +43,7 @@ namespace UnityEditor.VFX
                 }
 
                 foreach ( var param in GetParameters(t=> InputPredicate(t)))
-                {
-                    yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName));
-                }
+                    yield return VFXSubgraphUtility.GetPropertyFromInputParameter(param);
             }
         }
 

--- a/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphContext.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphContext.cs
@@ -22,8 +22,23 @@ namespace UnityEditor.VFX
             get { return m_Subgraph; }
         }
 
+        public static void CallOnGraphChanged(VFXGraph graph)
+        {
+            if (OnGraphChanged != null)
+                OnGraphChanged(graph);
+        }
+
+        static Action<VFXGraph> OnGraphChanged; 
+
         public VFXSubgraphContext():base(VFXContextType.Subgraph, VFXDataType.SpawnEvent, VFXDataType.None)
         {
+            OnGraphChanged += GraphParameterChanged;
+        }
+
+        void GraphParameterChanged(VFXGraph graph)
+        {
+            if (m_Subgraph == graph.GetResource().asset && GetParent() != null)
+                RecreateCopy();
         }
 
         public const int s_MaxInputFlow = 5;
@@ -89,6 +104,7 @@ namespace UnityEditor.VFX
         private void OnDisable()
         {
             DetachFromOriginal();
+            OnGraphChanged -= GraphParameterChanged;
         }
 
 

--- a/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphOperator.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphOperator.cs
@@ -67,10 +67,14 @@ namespace UnityEditor.VFX
             get {
                 foreach (var param in GetParameters(t => VFXSubgraphUtility.InputPredicate(t)))
                 {
-                    if( ! string.IsNullOrEmpty(param.tooltip))
-                        yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip,param.tooltip)),param.value);
-                    else
-                        yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName ),param.value);
+                    List<VFXPropertyAttribute> attributes = new List<VFXPropertyAttribute>();
+                    if (!string.IsNullOrEmpty(param.tooltip))
+                        attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip));
+
+                    if (param.hasRange)
+                        attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kRange, (float)VFXConverter.ConvertTo(param.m_Min.Get(), typeof(float)), (float)VFXConverter.ConvertTo(param.m_Max.Get(), typeof(float))));
+
+                    yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, attributes.ToArray()), param.value);
                 }
             }
         }

--- a/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphOperator.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphOperator.cs
@@ -30,6 +30,18 @@ namespace UnityEditor.VFX
 
             return cptSlot;
         }
+        public static VFXPropertyWithValue GetPropertyFromInputParameter(VFXParameter param)
+        {
+            List<VFXPropertyAttribute> attributes = new List<VFXPropertyAttribute>();
+            if (!string.IsNullOrEmpty(param.tooltip))
+                attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip));
+
+            if (param.hasRange)
+                attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kRange, (float)VFXConverter.ConvertTo(param.m_Min.Get(), typeof(float)), (float)VFXConverter.ConvertTo(param.m_Max.Get(), typeof(float))));
+
+            return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, attributes.ToArray()), param.value);
+        }
+
         public static bool InputPredicate(VFXParameter param)
         {
             return param.exposed && !param.isOutput;
@@ -67,14 +79,7 @@ namespace UnityEditor.VFX
             get {
                 foreach (var param in GetParameters(t => VFXSubgraphUtility.InputPredicate(t)))
                 {
-                    List<VFXPropertyAttribute> attributes = new List<VFXPropertyAttribute>();
-                    if (!string.IsNullOrEmpty(param.tooltip))
-                        attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kTooltip, param.tooltip));
-
-                    if (param.hasRange)
-                        attributes.Add(new VFXPropertyAttribute(VFXPropertyAttribute.Type.kRange, (float)VFXConverter.ConvertTo(param.m_Min.Get(), typeof(float)), (float)VFXConverter.ConvertTo(param.m_Max.Get(), typeof(float))));
-
-                    yield return new VFXPropertyWithValue(new VFXProperty(param.type, param.exposedName, attributes.ToArray()), param.value);
+                    yield return VFXSubgraphUtility.GetPropertyFromInputParameter(param);
                 }
             }
         }

--- a/com.unity.visualeffectgraph/Editor/Models/Parameters/VFXParameter.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Parameters/VFXParameter.cs
@@ -58,6 +58,7 @@ namespace UnityEditor.VFX
                     {
                         var newSlot = VFXSlot.Create(new VFXProperty(outputSlots[0].property.type, "i"), VFXSlot.Direction.kInput);
                         newSlot.value = outputSlots[0].value;
+                        outputSlots[0].UnlinkAll(true);
                         RemoveSlot(outputSlots[0]);
                         AddSlot(newSlot);
 
@@ -73,6 +74,7 @@ namespace UnityEditor.VFX
                     {
                         var newSlot = VFXSlot.Create(new VFXProperty(inputSlots[0].property.type, "o"), VFXSlot.Direction.kOutput);
                         newSlot.value = inputSlots[0].value;
+                        inputSlots[0].UnlinkAll(true);
                         RemoveSlot(inputSlots[0]);
                         AddSlot(newSlot);
                         m_ExprSlots = outputSlots[0].GetVFXValueTypeSlots().ToArray();

--- a/com.unity.visualeffectgraph/Editor/Models/VFXGraph.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/VFXGraph.cs
@@ -405,6 +405,13 @@ namespace UnityEditor.VFX
             if (cause == VFXModel.InvalidationCause.kStructureChanged)
             {
                 UpdateSubAssets();
+                if( model == this)
+                    VFXSubgraphContext.CallOnGraphChanged(this);
+            }
+
+            if( cause == VFXModel.InvalidationCause.kSettingChanged && model is VFXParameter)
+            {
+                VFXSubgraphContext.CallOnGraphChanged(this);
             }
 
             if (cause != VFXModel.InvalidationCause.kExpressionInvalidated &&

--- a/com.unity.visualeffectgraph/Editor/Models/VFXGraph.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/VFXGraph.cs
@@ -626,6 +626,12 @@ namespace UnityEditor.VFX
                     m_ExpressionGraphDirty = false;
                 m_ExpressionValuesDirty = false;    
             }
+            else if(m_ExpressionGraphDirty && !preventRecompilation)
+            {
+                BuildSubgraphDependencies();
+                RecurseSubgraphRecreateCopy(this);
+                m_ExpressionGraphDirty = false;
+            }
             if(!preventDependencyRecompilation && m_DependentDirty)
             {
                 if (m_DependentDirty)


### PR DESCRIPTION
### Purpose of this PR
- Fix drag and drop of vfx into vfx, as well a forbid drag and drop of block into subgraph.
- Make sure dependencies are updated on subgraph as well.
- Fix can't call RecreateCopy in VFXSubgraphBlock.OnEnable because the sugraph might not have been OnEnabled yet.
- prevent error when undoing a subgraphblock deletion
- fix nodeprovider when a subgraphblock is invalid
- fix for subgraph block paste.
- When an anchor is removed, notify the other anchor from the links.
- Add range support for subgraph slots.
- factorize input property code from all subgraphs.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [X] Opened test project + Run graphic tests locally
- [n/a] Built a player
- [n/a] Checked new UI names with UX convention
- [X] Tested UI multi-edition + Undo/Redo
- [X] C# and shader warnings (supress shader cache to see them)
- [n/a] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=vfx%2Ffix%2Fvarious-subgraph&automation-tools_branch=master&unity_branch=trunk&sort=1-asc
katana 💚 
Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Medium : some of the fixes are deep.
**Halo Effect**: None, Low, Medium, High?
Low : mostly about subgraphs. Not much side effects expected.
---
### Comments to reviewers
Notes for the reviewers you have assigned.
