### PR TITLE
 Removed cbuffer for shader vars that don't need to be in cbuffers.

### DIFF
--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Input.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Input.hlsl
@@ -30,17 +30,12 @@ struct InputData
 //                      Constant Buffers                                     //
 ///////////////////////////////////////////////////////////////////////////////
 
-CBUFFER_START(_PerFrame)
 half4 _GlossyEnvironmentColor;
 half4 _SubtractiveShadowColor;
-CBUFFER_END
 
-CBUFFER_START(_PerCamera)
 float4x4 _InvCameraViewProj;
 float4 _ScaledScreenParams;
-CBUFFER_END
 
-CBUFFER_START(_LightBuffer)
 float4 _MainLightPosition;
 half4 _MainLightColor;
 
@@ -50,7 +45,6 @@ half4 _AdditionalLightsColor[MAX_VISIBLE_LIGHTS];
 half4 _AdditionalLightsAttenuation[MAX_VISIBLE_LIGHTS];
 half4 _AdditionalLightsSpotDir[MAX_VISIBLE_LIGHTS];
 half4 _AdditionalLightsOcclusionProbes[MAX_VISIBLE_LIGHTS];
-CBUFFER_END
 
 #define UNITY_MATRIX_M     unity_ObjectToWorld
 #define UNITY_MATRIX_I_M   unity_WorldToObject

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/Shadows.hlsl
@@ -24,7 +24,6 @@ SAMPLER_CMP(sampler_MainLightShadowmapTexture);
 TEXTURE2D_SHADOW(_AdditionalLightsShadowmapTexture);
 SAMPLER_CMP(sampler_AdditionalLightsShadowmapTexture);
 
-CBUFFER_START(_MainLightShadowBuffer)
 // Last cascade is initialized with a no-op matrix. It always transforms
 // shadow coord to half3(0, 0, NEAR_PLANE). We use this trick to avoid
 // branching since ComputeCascadeIndex can return cascade index = MAX_SHADOW_CASCADES
@@ -40,9 +39,7 @@ half4       _MainLightShadowOffset2;
 half4       _MainLightShadowOffset3;
 half4       _MainLightShadowData;    // (x: shadowStrength)
 float4      _MainLightShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
-CBUFFER_END
 
-CBUFFER_START(_AdditionalLightsShadowBuffer)
 float4x4    _AdditionalLightsWorldToShadow[MAX_VISIBLE_LIGHTS];
 half        _AdditionalShadowStrength[MAX_VISIBLE_LIGHTS];
 half4       _AdditionalShadowOffset0;
@@ -50,7 +47,6 @@ half4       _AdditionalShadowOffset1;
 half4       _AdditionalShadowOffset2;
 half4       _AdditionalShadowOffset3;
 float4      _AdditionalShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
-CBUFFER_END
 
 float4 _ShadowBias; // x: depth bias, y: normal bias
 

--- a/com.unity.render-pipelines.lightweight/ShaderLibrary/UnityInput.hlsl
+++ b/com.unity.render-pipelines.lightweight/ShaderLibrary/UnityInput.hlsl
@@ -32,7 +32,8 @@
 
 // ----------------------------------------------------------------------------
 
-CBUFFER_START(UnityPerCamera)
+// CBUFFER(Per-Camera) set currently in SetupCameraProperties
+// TODO: Need to remove SetupCameraProperties and make LWRP set these.
 // Time (t = time since current level load) values from Unity
 float4 _Time; // (t/20, t, t*2, t*3)
 float4 _SinTime; // sin(t/8), sin(t/4), sin(t/2), sin(t)
@@ -72,10 +73,9 @@ float4 _ZBufferParams;
 // z = unused
 // w = 1.0 if camera is ortho, 0.0 if perspective
 float4 unity_OrthoParams;
-CBUFFER_END
 
-
-CBUFFER_START(UnityPerCameraRare)
+// CBUFFER (UnityPerCameraRare) set currently in SetupCameraProperties
+// TODO: Need to remove SetupCameraProperties and make LWRP set these.
 float4 unity_CameraWorldClipPlanes[6];
 
 #if !defined(USING_STEREO_MATRICES)
@@ -87,7 +87,6 @@ float4x4 unity_CameraInvProjection;
 float4x4 unity_WorldToCamera;
 float4x4 unity_CameraToWorld;
 #endif
-CBUFFER_END
 
 // ----------------------------------------------------------------------------
 
@@ -175,13 +174,14 @@ int unity_StereoEyeIndex;
 GLOBAL_CBUFFER_END
 #endif
 
+// TODO: Check if this works. Seems if it should work it should be set as a feature block in UnityPerDrawRare
 CBUFFER_START(UnityPerDrawRare)
 float4x4 glstate_matrix_transpose_modelview0;
 CBUFFER_END
 
 // ----------------------------------------------------------------------------
 
-CBUFFER_START(UnityPerFrame)
+// CBUFFER (UnityPerFrame) - Set currently in multiple places RenderSettings, Camera
 real4 glstate_lightmodel_ambient;
 real4 unity_AmbientSky;
 real4 unity_AmbientEquator;
@@ -200,7 +200,6 @@ int unity_StereoEyeIndex;
 #endif
 
 real4 unity_ShadowColor;
-CBUFFER_END
 
 // ----------------------------------------------------------------------------
 
@@ -222,7 +221,7 @@ TEXTURE2D(unity_ShadowMask);
 // TODO: all affine matrices should be 3x4.
 // TODO: sort these vars by the frequency of use (descending), and put commonly used vars together.
 // Note: please use UNITY_MATRIX_X macros instead of referencing matrix variables directly.
-CBUFFER_START(UnityPerPass)
+// CBUFFER (UnityPerPass) - Couldn't find where these are set
 float4x4 _PrevViewProjMatrix;
 float4x4 _ViewProjMatrix;
 float4x4 _NonJitteredViewProjMatrix;
@@ -234,7 +233,6 @@ float4x4 _InvProjMatrix;
 float4   _InvProjParam;
 float4   _ScreenSize;       // {w, h, 1/w, 1/h}
 float4   _FrustumPlanes[6]; // {(a, b, c) = N, d = -dot(N, P)} [L, R, T, B, N, F]
-CBUFFER_END
 
 float4x4 OptimizeProjectionMatrix(float4x4 M)
 {

--- a/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitInput.hlsl
+++ b/com.unity.render-pipelines.lightweight/Shaders/Terrain/TerrainLitInput.hlsl
@@ -5,13 +5,11 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/CommonMaterial.hlsl"
 #include "Packages/com.unity.render-pipelines.lightweight/ShaderLibrary/SurfaceInput.hlsl"
 
-CBUFFER_START(_Terrain)
 half _Metallic0, _Metallic1, _Metallic2, _Metallic3;
 half _Smoothness0, _Smoothness1, _Smoothness2, _Smoothness3;
 
 float4 _Control_ST;
 half4 _Splat0_ST, _Splat1_ST, _Splat2_ST, _Splat3_ST;
-CBUFFER_END
 
 TEXTURE2D(_Control);    SAMPLER(sampler_Control);
 TEXTURE2D(_Splat0);     SAMPLER(sampler_Splat0);


### PR DESCRIPTION
### Purpose of this PR
 Remove CBUFFER when not needed. This PR doesn't change the cbuffers that affect SRP Batcher.
 - In GLES cbuffers will turn into UBO which is slower in some gfx devices. 
 - Also, when not declaring vars in cbuffers, they will be stripped away from shader and the remaining ones will be put into a global cbuffer.
---
### Release Notes


---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lw/bugfix/case-1157313&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
