### PR TITLE
Fix failing tests for Yamato

### DIFF
--- a/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/056_2D_Lights.png.meta
+++ b/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/056_2D_Lights.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e336211fa3edbe943be388a391343306
+guid: 172614691e42947488b71aab75141456
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/056_2D_Lights_Shader_Graph.png.meta
+++ b/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/056_2D_Lights_Shader_Graph.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5f1cd77e0e73c8044b0989d88cc7fca3
+guid: f4c1061f83fa57747a15ca6e28d7dfa2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/057_SpeedTree_V7.png.meta
+++ b/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsEditor/Direct3D11/057_SpeedTree_V7.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ae8a57cc62e835d40be9440c043f3c10
+guid: 06d73007f3d55c846b265938776b585f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsPlayer/Direct3D11/056_2D_Lights.png.meta
+++ b/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsPlayer/Direct3D11/056_2D_Lights.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e336211fa3edbe943be388a391343306
+guid: 01eab0c088629aa4797d0a5d5f38fa55
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsPlayer/Direct3D11/057_SpeedTree_V7.png.meta
+++ b/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsPlayer/Direct3D11/057_SpeedTree_V7.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ae8a57cc62e835d40be9440c043f3c10
+guid: e4fe4936864167443895fb18edea7fad
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsPlayer/Direct3D11/058_SpeedTree_V8.png.meta
+++ b/TestProjects/LWGraphicsTest/Assets/ReferenceImages/Linear/WindowsPlayer/Direct3D11/058_SpeedTree_V8.png.meta
@@ -1,12 +1,12 @@
 fileFormatVersion: 2
-guid: 9085ebc552bf7c74c91da2e1b8af0845
+guid: 968bd5f8671bde24d866fa131d499a55
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
   serializedVersion: 10
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 0
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -20,7 +20,7 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
-  isReadable: 1
+  isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   grayScaleToAlpha: 0
@@ -37,7 +37,7 @@ TextureImporter:
     wrapU: -1
     wrapV: -1
     wrapW: -1
-  nPOTScale: 0
+  nPOTScale: 1
   lightmap: 0
   compressionQuality: 50
   spriteMode: 0
@@ -63,7 +63,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 0
+    textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/TestProjects/LWGraphicsTest/Assets/Scenes/059_xr_LitShaderMaps.meta
+++ b/TestProjects/LWGraphicsTest/Assets/Scenes/059_xr_LitShaderMaps.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfa65dab5a610f840acb44f4a1904294
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.lightweight/Tests/Runtime/Light2DTests.cs
+++ b/com.unity.render-pipelines.lightweight/Tests/Runtime/Light2DTests.cs
@@ -96,28 +96,30 @@ namespace UnityEngine.Rendering.LWRP.Tests
             Assert.AreSame(light2, Light2DManager.lights[0][2]);
         }
 
-        [UnityTest]
-        public IEnumerator IsLightVisibleReturnsTrueIfInCameraView()
+        [Test]
+        public void IsLightVisibleReturnsTrueIfInCameraView()
         {
             var camera = m_TestObject1.AddComponent<Camera>();
             var light = m_TestObject2.AddComponent<Light2D>();
             light.transform.position = camera.transform.position;
             Light2D.SetupCulling(default(ScriptableRenderContext), camera);
 
-            yield return null;
+            // We can only verify the results after culling is done on this camera.
+            camera.Render();
 
             Assert.IsTrue(light.IsLightVisible(camera));
         }
 
-        [UnityTest]
-        public IEnumerator IsLightVisibleReturnsFalseIfNotInCameraView()
+        [Test]
+        public void IsLightVisibleReturnsFalseIfNotInCameraView()
         {
             var camera = m_TestObject1.AddComponent<Camera>();
             var light = m_TestObject2.AddComponent<Light2D>();
             light.transform.position = camera.transform.position + new Vector3(9999.0f, 0.0f, 0.0f);
             Light2D.SetupCulling(default(ScriptableRenderContext), camera);
 
-            yield return null;
+            // We can only verify the results after culling is done on this camera.
+            camera.Render();
 
             Assert.IsFalse(light.IsLightVisible(camera));
         }

--- a/com.unity.render-pipelines.lightweight/Tests/Runtime/RuntimeTests.cs
+++ b/com.unity.render-pipelines.lightweight/Tests/Runtime/RuntimeTests.cs
@@ -5,27 +5,41 @@ using UnityEngine;
 using UnityEngine.Rendering.LWRP;
 using UnityEngine.Rendering;
 
+[TestFixture]
 class RuntimeTests
 {
+    GameObject go;
+    Camera camera;
+    RenderPipelineAsset prevAsset;
+    LightweightRenderPipelineAsset asset;
+
+    [SetUp]
+    public void Setup()
+    {
+        go = new GameObject();
+        camera = go.AddComponent<Camera>();
+        prevAsset = GraphicsSettings.renderPipelineAsset;
+        asset = ScriptableObject.CreateInstance<LightweightRenderPipelineAsset>();
+    }
+
+    [TearDown]
+    public void Cleanup()
+    {
+        GraphicsSettings.renderPipelineAsset = prevAsset;
+        Object.DestroyImmediate(asset);
+        Object.DestroyImmediate(go);
+    }
+
     // When LWRP pipeline is active, lightsUseLinearIntensity must match active color space.
     [UnityTest]
     public IEnumerator PipelineHasCorrectColorSpace()
     {
-        GameObject go = new GameObject();
-        Camera camera = go.AddComponent<Camera>();
-        RenderPipelineAsset prevAsset = GraphicsSettings.renderPipelineAsset;
-
-        LightweightRenderPipelineAsset asset = ScriptableObject.CreateInstance<LightweightRenderPipelineAsset>();
         GraphicsSettings.renderPipelineAsset = asset;
         camera.Render();
         yield return null;
         
         Assert.AreEqual(QualitySettings.activeColorSpace == ColorSpace.Linear, GraphicsSettings.lightsUseLinearIntensity,
             "GraphicsSettings.lightsUseLinearIntensity must match active color space.");
-
-        GraphicsSettings.renderPipelineAsset = prevAsset;
-        ScriptableObject.DestroyImmediate(asset);
-        GameObject.DestroyImmediate(go);
     }
 
     // When switching to LWRP it sets "LightweightPipeline" as global shader tag.
@@ -33,10 +47,6 @@ class RuntimeTests
     [UnityTest]
     public IEnumerator PipelineSetsAndRestoreGlobalShaderTagCorrectly()
     {
-        GameObject go = new GameObject();
-        Camera camera = go.AddComponent<Camera>();
-        RenderPipelineAsset prevAsset = GraphicsSettings.renderPipelineAsset;
-        LightweightRenderPipelineAsset asset = ScriptableObject.CreateInstance<LightweightRenderPipelineAsset>();
         GraphicsSettings.renderPipelineAsset = asset;
         camera.Render();
         yield return null;
@@ -48,9 +58,5 @@ class RuntimeTests
         yield return null;
 
         Assert.AreEqual("", Shader.globalRenderPipeline, "Render Pipeline shader tag is not restored.");
-        GraphicsSettings.renderPipelineAsset = prevAsset;
-
-        ScriptableObject.DestroyImmediate(asset);
-        GameObject.DestroyImmediate(go);
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Fix failing tests for Yamato.

---
### Release Notes
N/A

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: 

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=2d%2Ftest-fix&unity_branch=trunk&automation-tools_branch=master&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/2d%252Ftest-fix

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
N/A
