### PR TITLE
Refactored SSS in preparation for RenderGraph implementation

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScattering.hlsl
@@ -70,7 +70,7 @@ struct SSSData
 #define SSSBufferType0 float4 // Must match GBufferType0 in deferred
 
 // SSSBuffer texture declaration
-TEXTURE2D_X(_SSSBufferTexture0);
+TEXTURE2D_X(_SSSBufferTexture);
 
 // Note: The SSS buffer used here is sRGB
 void EncodeIntoSSSBuffer(SSSData sssData, uint2 positionSS, out SSSBufferType0 outSSSBuffer0)
@@ -87,7 +87,7 @@ void DecodeFromSSSBuffer(float4 sssBuffer, uint2 positionSS, out SSSData sssData
 
 void DecodeFromSSSBuffer(uint2 positionSS, out SSSData sssData)
 {
-    float4 sssBuffer = LOAD_TEXTURE2D_X(_SSSBufferTexture0, positionSS);
+    float4 sssBuffer = LOAD_TEXTURE2D_X(_SSSBufferTexture, positionSS);
     DecodeFromSSSBuffer(sssBuffer, positionSS, sssData);
 }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
@@ -5,16 +5,13 @@ using System.Linq;
 
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
-    public class SubsurfaceScatteringManager
+    using RTHandle = RTHandleSystem.RTHandle;
+
+    public partial class HDRenderPipeline
     {
-        // Currently we only support SSSBuffer with one buffer. If the shader code change, it may require to update the shader manager
-        public const int k_MaxSSSBuffer = 1;
-
-        public int sssBufferCount { get { return k_MaxSSSBuffer; } }
-
-        RTHandleSystem.RTHandle[] m_ColorMRTs = new RTHandleSystem.RTHandle[k_MaxSSSBuffer];
-        RTHandleSystem.RTHandle[] m_ColorMSAAMRTs = new RTHandleSystem.RTHandle[k_MaxSSSBuffer];
-        bool[] m_ReuseGBufferMemory  = new bool[k_MaxSSSBuffer];
+        RTHandle m_SSSColor;
+        RTHandle m_SSSColorMSAA;
+        bool m_SSSReuseGBufferMemory;
 
         // Disney SSS Model
         ComputeShader m_SubsurfaceScatteringCS;
@@ -22,141 +19,121 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         int m_SubsurfaceScatteringKernelMSAA;
         Material m_CombineLightingPass;
 
-        RTHandleSystem.RTHandle m_HTile;
+        RTHandle m_SSSHTile;
         // End Disney SSS Model
 
         // Need an extra buffer on some platforms
-        RTHandleSystem.RTHandle m_CameraFilteringBuffer;
+        RTHandle m_SSSCameraFilteringBuffer;
 
         // This is use to be able to read stencil value in compute shader
-        Material m_CopyStencilForSplitLighting;
-
-        bool m_MSAASupport = false;
+        Material m_SSSCopyStencilForSplitLighting;
 
         // List of every diffusion profile data we need
-        Vector4[]                   thicknessRemaps;
-        Vector4[]                   shapeParams;
-        Vector4[]                   transmissionTintsAndFresnel0;
-        Vector4[]                   disabledTransmissionTintsAndFresnel0;
-        Vector4[]                   worldScales;
-        Vector4[]                   filterKernels;
-        float[]                     diffusionProfileHashes;
-        int[]                       diffusionProfileUpdate;
-        DiffusionProfileSettings[]  setDiffusionProfiles;
-        HDRenderPipelineAsset       hdAsset;
-        DiffusionProfileSettings    defaultDiffusionProfile;
-        int                         activeDiffusionProfileCount;
-        public uint                 texturingModeFlags;        // 1 bit/profile: 0 = PreAndPostScatter, 1 = PostScatter
-        public uint                 transmissionFlags;         // 1 bit/profile: 0 = regular, 1 = thin
+        Vector4[]                   m_SSSThicknessRemaps;
+        Vector4[]                   m_SSSShapeParams;
+        Vector4[]                   m_SSSTransmissionTintsAndFresnel0;
+        Vector4[]                   m_SSSDisabledTransmissionTintsAndFresnel0;
+        Vector4[]                   m_SSSWorldScales;
+        Vector4[]                   m_SSSFilterKernels;
+        float[]                     m_SSSDiffusionProfileHashes;
+        int[]                       m_SSSDiffusionProfileUpdate;
+        DiffusionProfileSettings[]  m_SSSSetDiffusionProfiles;
+        DiffusionProfileSettings    m_SSSDefaultDiffusionProfile;
+        int                         m_SSSActiveDiffusionProfileCount;
+        uint                        m_SSSTexturingModeFlags;        // 1 bit/profile: 0 = PreAndPostScatter, 1 = PostScatter
+        uint                        m_SSSTransmissionFlags;         // 1 bit/profile: 0 = regular, 1 = thin
 
-        public SubsurfaceScatteringManager()
+        public void InitSSSBuffers()
         {
-        }
-
-        public void InitSSSBuffers(GBufferManager gbufferManager, RenderPipelineSettings settings)
-        {
-            // Reset the msaa flag
-            m_MSAASupport = settings.supportMSAA;
+            RenderPipelineSettings settings = asset.currentPlatformRenderPipelineSettings;
 
             if (settings.supportedLitShaderMode == RenderPipelineSettings.SupportedLitShaderMode.ForwardOnly) //forward only
             {
                 // In case of full forward we must allocate the render target for forward SSS (or reuse one already existing)
                 // TODO: Provide a way to reuse a render target
-                m_ColorMRTs[0] = RTHandles.Alloc(Vector2.one, TextureXR.slices, colorFormat: GraphicsFormat.R8G8B8A8_SRGB, dimension: TextureXR.dimension, useDynamicScale: true, name: "SSSBuffer");
-                m_ReuseGBufferMemory [0] = false;
+                m_SSSColor = RTHandles.Alloc(Vector2.one, TextureXR.slices, colorFormat: GraphicsFormat.R8G8B8A8_SRGB, dimension: TextureXR.dimension, useDynamicScale: true, name: "SSSBuffer");
+                m_SSSReuseGBufferMemory = false;
             }
 
             // We need to allocate the texture if we are in forward or both in case one of the cameras is in enable forward only mode
-            if (m_MSAASupport)
+            if (settings.supportMSAA)
             {
-                 m_ColorMSAAMRTs[0] = RTHandles.Alloc(Vector2.one, TextureXR.slices, colorFormat: GraphicsFormat.R8G8B8A8_SRGB, dimension: TextureXR.dimension, enableMSAA: true, bindTextureMS: true, useDynamicScale: true, name: "SSSBufferMSAA");
+                 m_SSSColorMSAA = RTHandles.Alloc(Vector2.one, TextureXR.slices, colorFormat: GraphicsFormat.R8G8B8A8_SRGB, dimension: TextureXR.dimension, enableMSAA: true, bindTextureMS: true, useDynamicScale: true, name: "SSSBufferMSAA");
             }
 
             if ((settings.supportedLitShaderMode & RenderPipelineSettings.SupportedLitShaderMode.DeferredOnly) != 0) //deferred or both
             {
                 // In case of deferred, we must be in sync with SubsurfaceScattering.hlsl and lit.hlsl files and setup the correct buffers
-                m_ColorMRTs[0] = gbufferManager.GetSubsurfaceScatteringBuffer(0); // Note: This buffer must be sRGB (which is the case with Lit.shader)
-                m_ReuseGBufferMemory [0] = true;
+                m_SSSColor = m_GbufferManager.GetSubsurfaceScatteringBuffer(0); // Note: This buffer must be sRGB (which is the case with Lit.shader)
+                m_SSSReuseGBufferMemory = true;
             }
 
             if (NeedTemporarySubsurfaceBuffer() || settings.supportMSAA)
             {
                 // Caution: must be same format as m_CameraSssDiffuseLightingBuffer
-                m_CameraFilteringBuffer = RTHandles.Alloc(Vector2.one, TextureXR.slices, colorFormat: GraphicsFormat.B10G11R11_UFloatPack32, dimension: TextureXR.dimension, enableRandomWrite: true, useDynamicScale: true, name: "SSSCameraFiltering"); // Enable UAV
+                m_SSSCameraFilteringBuffer = RTHandles.Alloc(Vector2.one, TextureXR.slices, colorFormat: GraphicsFormat.B10G11R11_UFloatPack32, dimension: TextureXR.dimension, enableRandomWrite: true, useDynamicScale: true, name: "SSSCameraFiltering"); // Enable UAV
             }
 
             // We use 8x8 tiles in order to match the native GCN HTile as closely as possible.
-            m_HTile = RTHandles.Alloc(size => new Vector2Int((size.x + 7) / 8, (size.y + 7) / 8), TextureXR.slices, colorFormat: GraphicsFormat.R8_UNorm, dimension: TextureXR.dimension, enableRandomWrite: true, useDynamicScale: true, name: "SSSHtile"); // Enable UAV
+            m_SSSHTile = RTHandles.Alloc(size => new Vector2Int((size.x + 7) / 8, (size.y + 7) / 8), TextureXR.slices, colorFormat: GraphicsFormat.R8_UNorm, dimension: TextureXR.dimension, enableRandomWrite: true, useDynamicScale: true, name: "SSSHtile"); // Enable UAV
 
             // fill the list with the max number of diffusion profile so we dont have
             // the error: exceeds previous array size (5 vs 3). Cap to previous size.
-            thicknessRemaps = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
-            shapeParams = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
-            transmissionTintsAndFresnel0 = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
-            disabledTransmissionTintsAndFresnel0 = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
-            worldScales = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
-            filterKernels = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT * DiffusionProfileConstants.SSS_N_SAMPLES_NEAR_FIELD];
-            diffusionProfileHashes = new float[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
-            diffusionProfileUpdate = new int[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
-            setDiffusionProfiles = new DiffusionProfileSettings[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSThicknessRemaps = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSShapeParams = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSTransmissionTintsAndFresnel0 = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSDisabledTransmissionTintsAndFresnel0 = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSWorldScales = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSFilterKernels = new Vector4[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT * DiffusionProfileConstants.SSS_N_SAMPLES_NEAR_FIELD];
+            m_SSSDiffusionProfileHashes = new float[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSDiffusionProfileUpdate = new int[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
+            m_SSSSetDiffusionProfiles = new DiffusionProfileSettings[DiffusionProfileConstants.DIFFUSION_PROFILE_COUNT];
         }
 
-        public RTHandleSystem.RTHandle GetSSSBuffer(int index)
+        public RTHandle GetSSSBuffer()
         {
-            Debug.Assert(index < sssBufferCount);
-            return m_ColorMRTs[index];
+            return m_SSSColor;
         }
 
-        public RTHandleSystem.RTHandle GetSSSBufferMSAA(int index)
+        public RTHandle GetSSSBufferMSAA()
         {
-            Debug.Assert(index < sssBufferCount);
-            return m_ColorMSAAMRTs[index];
+            return m_SSSColorMSAA;
         }
 
-        public void Build(HDRenderPipelineAsset hdAsset)
+        public void InitializeSubsurfaceScattering()
         {
             // Disney SSS (compute + combine)
-            string kernelName = hdAsset.currentPlatformRenderPipelineSettings.increaseSssSampleCount ? "SubsurfaceScatteringHQ" : "SubsurfaceScatteringMQ";
-            string kernelNameMSAA = hdAsset.currentPlatformRenderPipelineSettings.increaseSssSampleCount ? "SubsurfaceScatteringHQ_MSAA" : "SubsurfaceScatteringMQ_MSAA";
-            m_SubsurfaceScatteringCS = hdAsset.renderPipelineResources.shaders.subsurfaceScatteringCS;
+            string kernelName = asset.currentPlatformRenderPipelineSettings.increaseSssSampleCount ? "SubsurfaceScatteringHQ" : "SubsurfaceScatteringMQ";
+            string kernelNameMSAA = asset.currentPlatformRenderPipelineSettings.increaseSssSampleCount ? "SubsurfaceScatteringHQ_MSAA" : "SubsurfaceScatteringMQ_MSAA";
+            m_SubsurfaceScatteringCS = asset.renderPipelineResources.shaders.subsurfaceScatteringCS;
             m_SubsurfaceScatteringKernel = m_SubsurfaceScatteringCS.FindKernel(kernelName);
             m_SubsurfaceScatteringKernelMSAA = m_SubsurfaceScatteringCS.FindKernel(kernelNameMSAA);
-            m_CombineLightingPass = CoreUtils.CreateEngineMaterial(hdAsset.renderPipelineResources.shaders.combineLightingPS);
+            m_CombineLightingPass = CoreUtils.CreateEngineMaterial(asset.renderPipelineResources.shaders.combineLightingPS);
             m_CombineLightingPass.SetInt(HDShaderIDs._StencilMask, (int)HDRenderPipeline.StencilBitMask.LightingMask);
 
-            m_CopyStencilForSplitLighting = CoreUtils.CreateEngineMaterial(hdAsset.renderPipelineResources.shaders.copyStencilBufferPS);
-            m_CopyStencilForSplitLighting.SetInt(HDShaderIDs._StencilRef, (int)StencilLightingUsage.SplitLighting);
-            m_CopyStencilForSplitLighting.SetInt(HDShaderIDs._StencilMask, (int)HDRenderPipeline.StencilBitMask.LightingMask);
+            m_SSSCopyStencilForSplitLighting = CoreUtils.CreateEngineMaterial(asset.renderPipelineResources.shaders.copyStencilBufferPS);
+            m_SSSCopyStencilForSplitLighting.SetInt(HDShaderIDs._StencilRef, (int)StencilLightingUsage.SplitLighting);
+            m_SSSCopyStencilForSplitLighting.SetInt(HDShaderIDs._StencilMask, (int)HDRenderPipeline.StencilBitMask.LightingMask);
 
-            this.hdAsset = hdAsset;
-            defaultDiffusionProfile = hdAsset.renderPipelineResources.assets.defaultDiffusionProfile;
+            m_SSSDefaultDiffusionProfile = asset.renderPipelineResources.assets.defaultDiffusionProfile;
         }
 
-        public void Cleanup()
+        public void CleanupSubsurfaceScattering()
         {
             CoreUtils.Destroy(m_CombineLightingPass);
-            CoreUtils.Destroy(m_CopyStencilForSplitLighting);
-
-            for (int i = 0; i < k_MaxSSSBuffer; ++i)
+            CoreUtils.Destroy(m_SSSCopyStencilForSplitLighting);
+            if (!m_SSSReuseGBufferMemory)
             {
-                if (!m_ReuseGBufferMemory [i])
-                {
-                    RTHandles.Release(m_ColorMRTs[i]);
+                RTHandles.Release(m_SSSColor);
                 }
-
-                if (m_MSAASupport)
-                {
-                    RTHandles.Release(m_ColorMSAAMRTs[i]);
-                }
+            RTHandles.Release(m_SSSColorMSAA);
+            RTHandles.Release(m_SSSCameraFilteringBuffer);
+            RTHandles.Release(m_SSSHTile);
             }
-
-            RTHandles.Release(m_CameraFilteringBuffer);
-            RTHandles.Release(m_HTile);
-        }
 
         void UpdateCurrentDiffusionProfileSettings()
         {
-            var currentDiffusionProfiles = hdAsset.diffusionProfileSettingsList;
+            var currentDiffusionProfiles = asset.diffusionProfileSettingsList;
             var diffusionProfileOverride = VolumeManager.instance.stack.GetComponent<DiffusionProfileOverride>();
 
             // If there is a diffusion profile volume override, we merge diffusion profiles that are overwritten
@@ -167,8 +144,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             // The first profile of the list is the default diffusion profile, used either when the diffusion profile
             // on the material isn't assigned or when the diffusion profile can't be displayed (too many on the frame)
-            SetDiffusionProfileAtIndex(defaultDiffusionProfile, 0);
-            diffusionProfileHashes[0] = DiffusionProfileConstants.DIFFUSION_PROFILE_NEUTRAL_ID;
+            SetDiffusionProfileAtIndex(m_SSSDefaultDiffusionProfile, 0);
+            m_SSSDiffusionProfileHashes[0] = DiffusionProfileConstants.DIFFUSION_PROFILE_NEUTRAL_ID;
 
             int i = 1;
             foreach (var v in currentDiffusionProfiles)
@@ -178,56 +155,56 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 SetDiffusionProfileAtIndex(v, i++);
             }
 
-            activeDiffusionProfileCount = i;
+            m_SSSActiveDiffusionProfileCount = i;
         }
 
         void SetDiffusionProfileAtIndex(DiffusionProfileSettings settings, int index)
         {
             // if the diffusion profile was already set and it haven't changed then there is nothing to upgrade
-            if (setDiffusionProfiles[index] == settings && diffusionProfileUpdate[index] == settings.updateCount)
+            if (m_SSSSetDiffusionProfiles[index] == settings && m_SSSDiffusionProfileUpdate[index] == settings.updateCount)
                 return;
 
             // if the settings have not yet been initialized
             if (settings.profile.filterKernelNearField == null)
                 return;
 
-            thicknessRemaps[index] = settings.thicknessRemaps;
-            shapeParams[index] = settings.shapeParams;
-            transmissionTintsAndFresnel0[index] = settings.transmissionTintsAndFresnel0;
-            disabledTransmissionTintsAndFresnel0[index] = settings.disabledTransmissionTintsAndFresnel0;
-            worldScales[index] = settings.worldScales;
+            m_SSSThicknessRemaps[index] = settings.thicknessRemaps;
+            m_SSSShapeParams[index] = settings.shapeParams;
+            m_SSSTransmissionTintsAndFresnel0[index] = settings.transmissionTintsAndFresnel0;
+            m_SSSDisabledTransmissionTintsAndFresnel0[index] = settings.disabledTransmissionTintsAndFresnel0;
+            m_SSSWorldScales[index] = settings.worldScales;
             for (int j = 0, n = DiffusionProfileConstants.SSS_N_SAMPLES_NEAR_FIELD; j < n; j++)
             {
-                filterKernels[n * index + j].x = settings.profile.filterKernelNearField[j].x;
-                filterKernels[n * index + j].y = settings.profile.filterKernelNearField[j].y;
+                m_SSSFilterKernels[n * index + j].x = settings.profile.filterKernelNearField[j].x;
+                m_SSSFilterKernels[n * index + j].y = settings.profile.filterKernelNearField[j].y;
 
                 if (j < DiffusionProfileConstants.SSS_N_SAMPLES_FAR_FIELD)
                 {
-                    filterKernels[n * index + j].z = settings.profile.filterKernelFarField[j].x;
-                    filterKernels[n * index + j].w = settings.profile.filterKernelFarField[j].y;
+                    m_SSSFilterKernels[n * index + j].z = settings.profile.filterKernelFarField[j].x;
+                    m_SSSFilterKernels[n * index + j].w = settings.profile.filterKernelFarField[j].y;
                 }
             }
-            diffusionProfileHashes[index] = HDShadowUtils.Asfloat(settings.profile.hash);
+            m_SSSDiffusionProfileHashes[index] = HDShadowUtils.Asfloat(settings.profile.hash);
 
             // Erase previous value (This need to be done here individually as in the SSS editor we edit individual component)
             uint mask = 1u << index;
-            texturingModeFlags &= ~mask;
-            transmissionFlags &= ~mask;
+            m_SSSTexturingModeFlags &= ~mask;
+            m_SSSTransmissionFlags &= ~mask;
 
-            texturingModeFlags |= (uint)settings.profile.texturingMode    << index;
-            transmissionFlags  |= (uint)settings.profile.transmissionMode << index;
+            m_SSSTexturingModeFlags |= (uint)settings.profile.texturingMode    << index;
+            m_SSSTransmissionFlags  |= (uint)settings.profile.transmissionMode << index;
 
-            setDiffusionProfiles[index] = settings;
-            diffusionProfileUpdate[index] = settings.updateCount;
+            m_SSSSetDiffusionProfiles[index] = settings;
+            m_SSSDiffusionProfileUpdate[index] = settings.updateCount;
         }
 
-        public void PushGlobalParams(HDCamera hdCamera, CommandBuffer cmd)
+        public void PushSubsurfaceScatteringGlobalParams(HDCamera hdCamera, CommandBuffer cmd)
         {
             UpdateCurrentDiffusionProfileSettings();
 
-            cmd.SetGlobalInt(HDShaderIDs._DiffusionProfileCount, activeDiffusionProfileCount);
+            cmd.SetGlobalInt(HDShaderIDs._DiffusionProfileCount, m_SSSActiveDiffusionProfileCount);
 
-            if (activeDiffusionProfileCount == 0)
+            if (m_SSSActiveDiffusionProfileCount == 0)
                 return ;
 
             // Broadcast SSS parameters to all shaders.
@@ -236,67 +213,134 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 // Warning: Unity is not able to losslessly transfer integers larger than 2^24 to the shader system.
                 // Therefore, we bitcast uint to float in C#, and bitcast back to uint in the shader.
-                uint texturingModeFlags = this.texturingModeFlags;
-                uint transmissionFlags = this.transmissionFlags;
+                uint texturingModeFlags = this.m_SSSTexturingModeFlags;
+                uint transmissionFlags = this.m_SSSTransmissionFlags;
                 cmd.SetGlobalFloat(HDShaderIDs._TexturingModeFlags, *(float*)&texturingModeFlags);
                 cmd.SetGlobalFloat(HDShaderIDs._TransmissionFlags, *(float*)&transmissionFlags);
             }
-            cmd.SetGlobalVectorArray(HDShaderIDs._ThicknessRemaps, thicknessRemaps);
-            cmd.SetGlobalVectorArray(HDShaderIDs._ShapeParams, shapeParams);
+            cmd.SetGlobalVectorArray(HDShaderIDs._ThicknessRemaps, m_SSSThicknessRemaps);
+            cmd.SetGlobalVectorArray(HDShaderIDs._ShapeParams, m_SSSShapeParams);
             // To disable transmission, we simply nullify the transmissionTint
-            cmd.SetGlobalVectorArray(HDShaderIDs._TransmissionTintsAndFresnel0, hdCamera.frameSettings.IsEnabled(FrameSettingsField.Transmission) ? transmissionTintsAndFresnel0 : disabledTransmissionTintsAndFresnel0);
-            cmd.SetGlobalVectorArray(HDShaderIDs._WorldScales, worldScales);
-            cmd.SetGlobalFloatArray(HDShaderIDs._DiffusionProfileHashTable, diffusionProfileHashes);
+            cmd.SetGlobalVectorArray(HDShaderIDs._TransmissionTintsAndFresnel0, hdCamera.frameSettings.IsEnabled(FrameSettingsField.Transmission) ? m_SSSTransmissionTintsAndFresnel0 : m_SSSDisabledTransmissionTintsAndFresnel0);
+            cmd.SetGlobalVectorArray(HDShaderIDs._WorldScales, m_SSSWorldScales);
+            cmd.SetGlobalFloatArray(HDShaderIDs._DiffusionProfileHashTable, m_SSSDiffusionProfileHashes);
         }
 
-        bool NeedTemporarySubsurfaceBuffer()
+        static bool NeedTemporarySubsurfaceBuffer()
         {
             // Caution: need to be in sync with SubsurfaceScattering.cs USE_INTERMEDIATE_BUFFER (Can't make a keyword as it is a compute shader)
             // Typed UAV loads from FORMAT_R16G16B16A16_FLOAT is an optional feature of Direct3D 11.
             // Most modern GPUs support it. We can avoid performing a costly copy in this case.
             // TODO: test/implement for other platforms.
-            return SystemInfo.graphicsDeviceType != GraphicsDeviceType.PlayStation4 &&
+            return (SystemInfo.graphicsDeviceType != GraphicsDeviceType.PlayStation4 &&
                 SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOne &&
-                SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOneD3D12;
+                SystemInfo.graphicsDeviceType != GraphicsDeviceType.XboxOneD3D12);
         }
 
-        // Combines specular lighting and diffuse lighting with subsurface scattering.
-        // In the case our frame is MSAA, for the moment given the fact that we do not have read/write access to the stencil buffer of the MSAA target; we need to keep this pass MSAA
-        // However, the compute can't output and MSAA target so we blend the non-MSAA target into the MSAA one.
-        public void SubsurfaceScatteringPass(HDCamera hdCamera, CommandBuffer cmd, RTHandleSystem.RTHandle colorBufferRT,
-        RTHandleSystem.RTHandle diffuseBufferRT, RTHandleSystem.RTHandle depthStencilBufferRT, RTHandleSystem.RTHandle depthTextureRT)
+        struct SubsurfaceScatteringParameters
+        {
+            public ComputeShader    subsurfaceScatteringCS;
+            public int              subsurfaceScatteringCSKernel;
+            public bool             needTemporaryBuffer;
+            public Material         copyStencilForSplitLighting;
+            public Material         combineLighting;
+            public uint             texturingModeFlags;
+            public int              numTilesX;
+            public int              numTilesY;
+            public int              numTilesZ;
+            public Vector4[]        worldScales;
+            public Vector4[]        filterKernels;
+            public Vector4[]        shapeParams;
+            public float[]          diffusionProfileHashes;
+
+        }
+
+        struct SubsurfaceScatteringResources
+        {
+            public RTHandle colorBuffer;
+            public RTHandle diffuseBuffer;
+            public RTHandle depthStencilBuffer;
+            public RTHandle depthTexture;
+
+            public RTHandle cameraFilteringBuffer;
+            public RTHandle hTileBuffer;
+            public RTHandle sssBuffer;
+        }
+
+        SubsurfaceScatteringParameters PrepareSubsurfaceScatteringParameters(HDCamera hdCamera)
+        {
+            var parameters = new SubsurfaceScatteringParameters();
+
+            parameters.subsurfaceScatteringCS = m_SubsurfaceScatteringCS;
+            parameters.subsurfaceScatteringCSKernel = hdCamera.frameSettings.IsEnabled(FrameSettingsField.MSAA) ? m_SubsurfaceScatteringKernelMSAA : m_SubsurfaceScatteringKernel;
+            parameters.needTemporaryBuffer = NeedTemporarySubsurfaceBuffer() || hdCamera.frameSettings.IsEnabled(FrameSettingsField.MSAA);
+            parameters.copyStencilForSplitLighting = m_SSSCopyStencilForSplitLighting;
+            parameters.combineLighting = m_CombineLightingPass;
+            parameters.texturingModeFlags = m_SSSTexturingModeFlags;
+            parameters.numTilesX = ((int)hdCamera.screenSize.x + 15) / 16;
+            parameters.numTilesY = ((int)hdCamera.screenSize.y + 15) / 16;
+            parameters.numTilesZ = hdCamera.viewCount;
+
+            parameters.worldScales = m_SSSWorldScales;
+            parameters.filterKernels = m_SSSFilterKernels;
+            parameters.shapeParams = m_SSSShapeParams;
+            parameters.diffusionProfileHashes = m_SSSDiffusionProfileHashes;
+
+            return parameters;
+        }
+
+        public void RenderSubsurfaceScattering(HDCamera hdCamera, CommandBuffer cmd, RTHandle colorBufferRT,
+            RTHandle diffuseBufferRT, RTHandle depthStencilBufferRT, RTHandle depthTextureRT)
         {
             if (!hdCamera.frameSettings.IsEnabled(FrameSettingsField.SubsurfaceScattering))
                 return;
 
-            // TODO: For MSAA, at least initially, we can only support Jimenez, because we can't
-            // create MSAA + UAV render targets.
-
             using (new ProfilingSample(cmd, "Subsurface Scattering", CustomSamplerId.SubsurfaceScattering.GetSampler()))
             {
+                var parameters = PrepareSubsurfaceScatteringParameters(hdCamera);
+                var resources = new SubsurfaceScatteringResources();
+                resources.colorBuffer = colorBufferRT;
+                resources.diffuseBuffer = diffuseBufferRT;
+                resources.depthStencilBuffer = depthStencilBufferRT;
+                resources.depthTexture = depthTextureRT;
+                resources.cameraFilteringBuffer = m_SSSCameraFilteringBuffer;
+                resources.hTileBuffer = m_SSSHTile;
+                resources.sssBuffer = m_SSSColor;
+
                 // For Jimenez we always need an extra buffer, for Disney it depends on platform
-                if (NeedTemporarySubsurfaceBuffer() || hdCamera.frameSettings.IsEnabled(FrameSettingsField.MSAA))
+                if (parameters.needTemporaryBuffer)
                 {
                     // Clear the SSS filtering target
                     using (new ProfilingSample(cmd, "Clear SSS filtering target", CustomSamplerId.ClearSSSFilteringTarget.GetSampler()))
                     {
-                        HDUtils.SetRenderTarget(cmd, m_CameraFilteringBuffer, ClearFlag.Color, Color.clear);
+                        HDUtils.SetRenderTarget(cmd, m_SSSCameraFilteringBuffer, ClearFlag.Color, Color.clear);
                     }
                 }
 
+                RenderSubsurfaceScattering(parameters, resources, cmd);
+                    }
+                }
+
+        // Combines specular lighting and diffuse lighting with subsurface scattering.
+        // In the case our frame is MSAA, for the moment given the fact that we do not have read/write access to the stencil buffer of the MSAA target; we need to keep this pass MSAA
+        // However, the compute can't output and MSAA target so we blend the non-MSAA target into the MSAA one.
+        static void RenderSubsurfaceScattering(in SubsurfaceScatteringParameters parameters, in SubsurfaceScatteringResources resources, CommandBuffer cmd)
+        {
+            // TODO: For MSAA, at least initially, we can only support Jimenez, because we can't
+            // create MSAA + UAV render targets.
                 using (new ProfilingSample(cmd, "HTile for SSS", CustomSamplerId.HTileForSSS.GetSampler()))
                 {
                     // Currently, Unity does not offer a way to access the GCN HTile even on PS4 and Xbox One.
                     // Therefore, it's computed in a pixel shader, and optimized to only contain the SSS bit.
 
                     // Clear the HTile texture. TODO: move this to ClearBuffers(). Clear operations must be batched!
-                    HDUtils.SetRenderTarget(cmd, m_HTile, ClearFlag.Color, Color.clear);
+                HDUtils.SetRenderTarget(cmd, resources.hTileBuffer, ClearFlag.Color, Color.clear);
 
-                    HDUtils.SetRenderTarget(cmd, depthStencilBufferRT); // No need for color buffer here
-                    cmd.SetRandomWriteTarget(1, m_HTile); // This need to be done AFTER SetRenderTarget
+                HDUtils.SetRenderTarget(cmd, resources.depthStencilBuffer); // No need for color buffer here
+                cmd.SetRandomWriteTarget(1, resources.hTileBuffer); // This need to be done AFTER SetRenderTarget
                     // Generate HTile for the split lighting stencil usage. Don't write into stencil texture (shaderPassId = 2)
                     // Use ShaderPassID 1 => "Pass 2 - Export HTILE for stencilRef to output"
-                    CoreUtils.DrawFullScreen(cmd, m_CopyStencilForSplitLighting, null, 2);
+                CoreUtils.DrawFullScreen(cmd, parameters.copyStencilForSplitLighting, null, 2);
                     cmd.ClearRandomWriteTargets();
                 }
 
@@ -304,49 +348,38 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 {
                     // Warning: Unity is not able to losslessly transfer integers larger than 2^24 to the shader system.
                     // Therefore, we bitcast uint to float in C#, and bitcast back to uint in the shader.
-                    uint texturingModeFlags = this.texturingModeFlags;
-                    cmd.SetComputeFloatParam(m_SubsurfaceScatteringCS, HDShaderIDs._TexturingModeFlags, *(float*)&texturingModeFlags);
+                uint textureingModeFlags = parameters.texturingModeFlags;
+                cmd.SetComputeFloatParam(parameters.subsurfaceScatteringCS, HDShaderIDs._TexturingModeFlags, *(float*)&textureingModeFlags);
                 }
 
-                cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._WorldScales,          worldScales);
-                cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._FilterKernels,        filterKernels);
-                cmd.SetComputeVectorArrayParam(m_SubsurfaceScatteringCS, HDShaderIDs._ShapeParams,          shapeParams);
-                cmd.SetComputeFloatParams(m_SubsurfaceScatteringCS, HDShaderIDs._DiffusionProfileHashTable, diffusionProfileHashes);
+            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._WorldScales,          parameters.worldScales);
+            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._FilterKernels,        parameters.filterKernels);
+            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._ShapeParams,          parameters.shapeParams);
+            cmd.SetComputeFloatParams(parameters.subsurfaceScatteringCS, HDShaderIDs._DiffusionProfileHashTable, parameters.diffusionProfileHashes);
 
-                int sssKernel = hdCamera.frameSettings.IsEnabled(FrameSettingsField.MSAA) ? m_SubsurfaceScatteringKernelMSAA : m_SubsurfaceScatteringKernel;
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._DepthTexture,       resources.depthTexture);
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._SSSHTile,           resources.hTileBuffer);
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._IrradianceSource,   resources.diffuseBuffer);
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._SSSBufferTexture,   resources.sssBuffer);
 
-                cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._DepthTexture,       depthTextureRT);
-                cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._SSSHTile,           m_HTile);
-                cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._IrradianceSource,   diffuseBufferRT);
-
-                for (int i = 0; i < sssBufferCount; ++i)
+            if (parameters.needTemporaryBuffer)
                 {
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._SSSBufferTexture[i], GetSSSBuffer(i));
-                }
+                cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._CameraFilteringBuffer, resources.cameraFilteringBuffer);
 
-                int numTilesX = ((int)hdCamera.screenSize.x + 15) / 16;
-                int numTilesY = ((int)hdCamera.screenSize.y + 15) / 16;
-                int numTilesZ = hdCamera.viewCount;
+                // Perform the SSS filtering pass
+                cmd.DispatchCompute(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, parameters.numTilesX, parameters.numTilesY, parameters.numTilesZ);
 
-                if (NeedTemporarySubsurfaceBuffer() || hdCamera.frameSettings.IsEnabled(FrameSettingsField.MSAA))
-                {
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, sssKernel, HDShaderIDs._CameraFilteringBuffer, m_CameraFilteringBuffer);
+                parameters.combineLighting.SetTexture(HDShaderIDs._IrradianceSource, resources.cameraFilteringBuffer);
 
-                    // Perform the SSS filtering pass which fills 'm_CameraFilteringBufferRT'.
-                    cmd.DispatchCompute(m_SubsurfaceScatteringCS, sssKernel, numTilesX, numTilesY, numTilesZ);
-
-                    cmd.SetGlobalTexture(HDShaderIDs._IrradianceSource, m_CameraFilteringBuffer);  // Cannot set a RT on a material
-
-                    // Additively blend diffuse and specular lighting into 'm_CameraColorBufferRT'.
-                    HDUtils.DrawFullScreen(cmd, m_CombineLightingPass, colorBufferRT, depthStencilBufferRT);
+                // Additively blend diffuse and specular lighting into the color buffer.
+                HDUtils.DrawFullScreen(cmd, parameters.combineLighting, resources.colorBuffer);
                 }
                 else
                 {
-                    cmd.SetComputeTextureParam(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, HDShaderIDs._CameraColorTexture, colorBufferRT);
+                cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._CameraColorTexture, resources.colorBuffer);
 
                     // Perform the SSS filtering pass which performs an in-place update of 'colorBuffer'.
-                    cmd.DispatchCompute(m_SubsurfaceScatteringCS, m_SubsurfaceScatteringKernel, numTilesX, numTilesY, numTilesZ);
-                }
+                cmd.DispatchCompute(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, parameters.numTilesX, parameters.numTilesY, parameters.numTilesZ);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SubsurfaceScattering/SubsurfaceScatteringManager.cs
@@ -318,8 +318,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
 
                 RenderSubsurfaceScattering(parameters, resources, cmd);
-                    }
-                }
+            }
+        }
 
         // Combines specular lighting and diffuse lighting with subsurface scattering.
         // In the case our frame is MSAA, for the moment given the fact that we do not have read/write access to the stencil buffer of the MSAA target; we need to keep this pass MSAA
@@ -328,42 +328,42 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             // TODO: For MSAA, at least initially, we can only support Jimenez, because we can't
             // create MSAA + UAV render targets.
-                using (new ProfilingSample(cmd, "HTile for SSS", CustomSamplerId.HTileForSSS.GetSampler()))
-                {
-                    // Currently, Unity does not offer a way to access the GCN HTile even on PS4 and Xbox One.
-                    // Therefore, it's computed in a pixel shader, and optimized to only contain the SSS bit.
+            using (new ProfilingSample(cmd, "HTile for SSS", CustomSamplerId.HTileForSSS.GetSampler()))
+            {
+                // Currently, Unity does not offer a way to access the GCN HTile even on PS4 and Xbox One.
+                // Therefore, it's computed in a pixel shader, and optimized to only contain the SSS bit.
 
-                    // Clear the HTile texture. TODO: move this to ClearBuffers(). Clear operations must be batched!
+                // Clear the HTile texture. TODO: move this to ClearBuffers(). Clear operations must be batched!
                 HDUtils.SetRenderTarget(cmd, resources.hTileBuffer, ClearFlag.Color, Color.clear);
 
                 HDUtils.SetRenderTarget(cmd, resources.depthStencilBuffer); // No need for color buffer here
                 cmd.SetRandomWriteTarget(1, resources.hTileBuffer); // This need to be done AFTER SetRenderTarget
-                    // Generate HTile for the split lighting stencil usage. Don't write into stencil texture (shaderPassId = 2)
-                    // Use ShaderPassID 1 => "Pass 2 - Export HTILE for stencilRef to output"
+                // Generate HTile for the split lighting stencil usage. Don't write into stencil texture (shaderPassId = 2)
+                // Use ShaderPassID 1 => "Pass 2 - Export HTILE for stencilRef to output"
                 CoreUtils.DrawFullScreen(cmd, parameters.copyStencilForSplitLighting, null, 2);
-                    cmd.ClearRandomWriteTargets();
-                }
+                cmd.ClearRandomWriteTargets();
+            }
 
-                unsafe
-                {
-                    // Warning: Unity is not able to losslessly transfer integers larger than 2^24 to the shader system.
-                    // Therefore, we bitcast uint to float in C#, and bitcast back to uint in the shader.
+            unsafe
+            {
+                // Warning: Unity is not able to losslessly transfer integers larger than 2^24 to the shader system.
+                // Therefore, we bitcast uint to float in C#, and bitcast back to uint in the shader.
                 uint textureingModeFlags = parameters.texturingModeFlags;
                 cmd.SetComputeFloatParam(parameters.subsurfaceScatteringCS, HDShaderIDs._TexturingModeFlags, *(float*)&textureingModeFlags);
-                }
+            }
 
-            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._WorldScales,          parameters.worldScales);
-            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._FilterKernels,        parameters.filterKernels);
-            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._ShapeParams,          parameters.shapeParams);
+            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._WorldScales, parameters.worldScales);
+            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._FilterKernels, parameters.filterKernels);
+            cmd.SetComputeVectorArrayParam(parameters.subsurfaceScatteringCS, HDShaderIDs._ShapeParams, parameters.shapeParams);
             cmd.SetComputeFloatParams(parameters.subsurfaceScatteringCS, HDShaderIDs._DiffusionProfileHashTable, parameters.diffusionProfileHashes);
 
-            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._DepthTexture,       resources.depthTexture);
-            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._SSSHTile,           resources.hTileBuffer);
-            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._IrradianceSource,   resources.diffuseBuffer);
-            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._SSSBufferTexture,   resources.sssBuffer);
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._DepthTexture, resources.depthTexture);
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._SSSHTile, resources.hTileBuffer);
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._IrradianceSource, resources.diffuseBuffer);
+            cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._SSSBufferTexture, resources.sssBuffer);
 
             if (parameters.needTemporaryBuffer)
-                {
+            {
                 cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._CameraFilteringBuffer, resources.cameraFilteringBuffer);
 
                 // Perform the SSS filtering pass
@@ -373,12 +373,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 // Additively blend diffuse and specular lighting into the color buffer.
                 HDUtils.DrawFullScreen(cmd, parameters.combineLighting, resources.colorBuffer);
-                }
-                else
-                {
+            }
+            else
+            {
                 cmd.SetComputeTextureParam(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, HDShaderIDs._CameraColorTexture, resources.colorBuffer);
 
-                    // Perform the SSS filtering pass which performs an in-place update of 'colorBuffer'.
+                // Perform the SSS filtering pass which performs an in-place update of 'colorBuffer'.
                 cmd.DispatchCompute(parameters.subsurfaceScatteringCS, parameters.subsurfaceScatteringCSKernel, parameters.numTilesX, parameters.numTilesY, parameters.numTilesZ);
             }
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -331,14 +331,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             Shader.PropertyToID("_DBufferTexture3")
         };
 
-        public static readonly int[] _SSSBufferTexture =
-        {
-            Shader.PropertyToID("_SSSBufferTexture0"),
-            Shader.PropertyToID("_SSSBufferTexture1"),
-            Shader.PropertyToID("_SSSBufferTexture2"),
-            Shader.PropertyToID("_SSSBufferTexture3"),
-        };
-
+        public static readonly int _SSSBufferTexture = Shader.PropertyToID("_SSSBufferTexture");
         public static readonly int _NormalBufferTexture = Shader.PropertyToID("_NormalBufferTexture");
 
         public static readonly int _EnableSSRefraction = Shader.PropertyToID("_EnableSSRefraction");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Utility/HDUtils.cs
@@ -259,7 +259,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.DrawProcedural(Matrix4x4.identity, GetBlitMaterial(source.dimension), bilinear ? 3 : 2, MeshTopology.Quads, 4, 1, s_PropertyBlock);
         }
 
-        public static void BlitTexture(CommandBuffer cmd, RTHandleSystem.RTHandle source, RTHandleSystem.RTHandle destination, Vector4 scaleBias, float mipLevel, bool bilinear)
+        public static void BlitTexture(CommandBuffer cmd, RTHandleSystem.RTHandle source, Vector4 scaleBias, float mipLevel, bool bilinear)
         {
             s_PropertyBlock.SetTexture(HDShaderIDs._BlitTexture, source);
             s_PropertyBlock.SetVector(HDShaderIDs._BlitScaleBias, scaleBias);
@@ -276,7 +276,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             Vector2 viewportScale = new Vector2(source.rtHandleProperties.rtHandleScale.x, source.rtHandleProperties.rtHandleScale.y);
             // Will set the correct camera viewport as well.
             SetRenderTarget(cmd, destination);
-            BlitTexture(cmd, source, destination, viewportScale, mipLevel, bilinear);
+            BlitTexture(cmd, source, viewportScale, mipLevel, bilinear);
         }
 
 
@@ -285,7 +285,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             // Will set the correct camera viewport as well.
             SetRenderTarget(cmd, destination);
-            BlitTexture(cmd, source, destination, scaleBias, mipLevel, bilinear);
+            BlitTexture(cmd, source, scaleBias, mipLevel, bilinear);
         }
 
         public static void BlitCameraTexture(CommandBuffer cmd, RTHandleSystem.RTHandle source, RTHandleSystem.RTHandle destination, Rect destViewport, float mipLevel = 0.0f, bool bilinear = false)
@@ -293,7 +293,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             Vector2 viewportScale = new Vector2(source.rtHandleProperties.rtHandleScale.x, source.rtHandleProperties.rtHandleScale.y);
             SetRenderTarget(cmd, destination);
             cmd.SetViewport(destViewport);
-            BlitTexture(cmd, source, destination, viewportScale, mipLevel, bilinear);
+            BlitTexture(cmd, source, viewportScale, mipLevel, bilinear);
         }
 
         // These method should be used to render full screen triangles sampling auto-scaling RTs.


### PR DESCRIPTION
### Purpose of this PR
- Removed the abstraction for mutliple SSS buffers
- Made SSS manager partial to HDRP class
- SSS rendering functions are now static functions
- Refactored final blit as well.

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Frendergraph-refacto-sss&automation-tools_branch=master&sort=1-asc)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
