### PR TITLE
Fix normal from height node

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - The `Custom Function Node` now uses an object field to reference its source when using `File` mode.
+- Added a Strength input on the NormalFromHeight node and fix a NaN on it.
 
 ### Fixed
 - Fixed an error in `Custom Function Node` port naming.


### PR DESCRIPTION
### Purpose of this PR
+ Fix a NaN in the normal from height node code
+ Add a strength factor in the normal from height node

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=shadergraph%2Ffix%2Fnormal_from_height_node&automation-tools_branch=master&unity_branch=trunk)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

