### PR TITLE
Fix exception with graph without resource.

### DIFF
--- a/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphContext.cs
+++ b/com.unity.visualeffectgraph/Editor/Models/Operators/VFXSubgraphContext.cs
@@ -32,12 +32,13 @@ namespace UnityEditor.VFX
 
         public VFXSubgraphContext():base(VFXContextType.Subgraph, VFXDataType.SpawnEvent, VFXDataType.None)
         {
-            OnGraphChanged += GraphParameterChanged;
+            
         }
 
         void GraphParameterChanged(VFXGraph graph)
         {
-            if (m_Subgraph == graph.GetResource().asset && GetParent() != null)
+            VisualEffectAsset asset = graph != null && graph.GetResource() != null ? graph.GetResource().asset : null;
+            if (m_Subgraph == asset && GetParent() != null)
                 RecreateCopy();
         }
 
@@ -92,6 +93,8 @@ namespace UnityEditor.VFX
         private new void OnEnable()
         {
             base.OnEnable();
+
+            OnGraphChanged += GraphParameterChanged;
             RecreateCopy();
         }
 


### PR DESCRIPTION


### Purpose of this PR
Fix vfx tests that use a VFXGraph without an attached VisualEffectResource.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [X] Opened test project + Run graphic tests locally
- [n/a] Built a player
- [n/a] Checked new UI names with UX convention
- [n/a] Tested UI multi-edition + Undo/Redo
- [X] C# and shader warnings (supress shader cache to see them)
- [n/a] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
