### PR TITLE
Minor color mode fix for precision inheritance

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Colors/PrecisionColors.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Colors/PrecisionColors.cs
@@ -19,5 +19,13 @@ namespace UnityEditor.ShaderGraph.Drawing.Colors
 
             return !string.IsNullOrEmpty(ussClass);
         }
+
+        public override void ClearColor(IShaderNodeView nodeView)
+        {
+            foreach (var type in ConcretePrecision.GetValues(typeof(ConcretePrecision)))
+            {
+                nodeView.colorElement.RemoveFromClassList(type.ToString());
+            }
+        }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
@@ -207,7 +207,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        public void HandleGraphChanges()
+        public bool HandleGraphChanges()
         {
             if (m_Graph.didActiveOutputNodeChange)
             {
@@ -248,6 +248,8 @@ namespace UnityEditor.ShaderGraph.Drawing
                     m_RefreshTimedNodes = true;
                 }
             }
+
+            return m_NodesToUpdate.Count > 0;
         }
 
         List<PreviewProperty> m_PreviewProperties = new List<PreviewProperty>();

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -454,7 +454,14 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         public void HandleGraphChanges()
         {
-            previewManager.HandleGraphChanges();
+            if(previewManager.HandleGraphChanges())
+            {
+                var nodeList = m_GraphView.Query<MaterialNodeView>().ToList();
+
+                m_ColorManager.SetNodesDirty(nodeList);
+                m_ColorManager.UpdateNodeViews(nodeList);
+            }
+
             previewManager.RenderPreviews();
             m_BlackboardProvider.HandleGraphChanges();
             m_GroupHashSet.Clear();


### PR DESCRIPTION
### Purpose of this PR
Exact same as https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3749
There was a bug that didn't populate node colors downstream when an edge was added or removed if the Color Mode was in **Precision**.
**Broken Version:**
![ColorModePrecisionBUG](https://user-images.githubusercontent.com/50928697/58597716-08d82400-822e-11e9-89d3-08fab076a590.gif)

**Fixed Version:**
![ColorModePrecision](https://user-images.githubusercontent.com/50928697/58597664-ddedd000-822d-11e9-8075-eac25e4a7ec4.gif)

---
### Release Notes
N/A

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [x] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Fcolor-mode-bug-fix&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fcolor-mode-bug-fix

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low

**Halo Effect**: None, Low, Medium, High? Low

---
### Comments to reviewers
N/A
