### PR TITLE
fix ExecuteCaptureAction incorrect blit material source

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -872,7 +872,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // Since recorder does not know about this, we need to send a texture of the right size.
             cmd.GetTemporaryRT(m_RecorderTempRT, actualWidth, actualHeight, 0, FilterMode.Point, input.rt.graphicsFormat);
 
-            var blitMaterial = HDUtils.GetBlitMaterial(TextureDimension.Tex2D);
+            var blitMaterial = HDUtils.GetBlitMaterial(TextureDimension.Tex2DArray);
 
             var rtHandleScale = RTHandles.rtHandleProperties.rtHandleScale;
             Vector2 viewportScale = new Vector2(rtHandleScale.x, rtHandleScale.y);


### PR DESCRIPTION
### Purpose of this PR
This pr fixes an issue in HDCamera.cs ExecuteCaptureAction.
The blit material texture dimension used to copy the final pass to a temp render target is incorrectly set to Tex2D. Since version 2019.2 the source is now a Tex2DArray.
 
The ExecuteCaptureAction is used by the recorder which is broken without this fix.

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [N/A] Checked new UI names with UX convention
- [N/A ] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- [N/A ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the pathes)
- Other: 
Locally tested with Unity Recorder 2.0.1-preview.1 Option Target Camera Main Camera now works

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/hdrp%252Ffix-executecaptureactions-incorrect-blit-source/.yamato%252Fupm-ci-hdrp.yml%2523All_HDRP/172975/job

Any test projects to go with this to help reviewers?
Please validate with unity recorder 2.0.1-preview.1
---
### Overall Product Risks
**Technical Risk**: Low,

**Halo Effect**:Low

