### PR TITLE
[ShaderGraph] n* Styling Fixes

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When you change a Sub Graph, Shader Graph windows now correctly reload.
 - When you save a Shader Graph, all other Shader Graph windows no longer re-compile their preview Shaders.
 - Shader Graph UI now draws with correct styling for 2019.3.
+- When deleting edge connections to nodes with a preview error, input ports no longer draw in the wrong position.
 
 ## [6.7.0-preview] - 2019-05-16
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an error that occured when creating a Sub Graph from a selection containing a Group Node.
 - When you change a Sub Graph, Shader Graph windows now correctly reload.
 - When you save a Shader Graph, all other Shader Graph windows no longer re-compile their preview Shaders.
+- Shader Graph UI now draws with correct styling for 2019.3.
 
 ## [6.7.0-preview] - 2019-05-16
 ### Added

--- a/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumMaskControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumMaskControl.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
 
     class ChannelEnumMaskControlView : VisualElement, AbstractMaterialNodeModificationListener
     {
-        GUIContent m_Label;
+        string m_Label;
         AbstractMaterialNode m_Node;
         PropertyInfo m_PropertyInfo;
         IMGUIContainer m_Container;
@@ -41,14 +41,17 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
             m_SlotId = slotId;
             //if (!propertyInfo.PropertyType.IsEnum)
             //throw new ArgumentException("Property must be an enum.", "propertyInfo");
-            m_Label = new GUIContent(label ?? ObjectNames.NicifyVariableName(propertyInfo.Name));
+            m_Label = label;
             m_Container = new IMGUIContainer(OnGUIHandler);
             Add(m_Container);
         }
 
         void OnGUIHandler()
         {
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(m_Label);
             UpdatePopup();
+            GUILayout.EndHorizontal();
         }
 
         public void OnNodeModified(ModificationScope scope)
@@ -67,7 +70,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
                 string[] popupEntries = new string[channelCount];
                 for (int i = 0; i < popupEntries.Length; i++)
                     popupEntries[i] = enumEntryNames[i];
-                value = EditorGUILayout.MaskField(m_Label, value, popupEntries);
+                value = EditorGUILayout.MaskField("", value, popupEntries, GUILayout.Width(80f));
 
                 if (changeCheckScope.changed)
                 {

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -585,6 +585,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     portInputView = new PortInputView(port.slot) { style = { position = Position.Absolute } };
                     m_PortInputContainer.Add(portInputView);
+                    SetPortInputPosition(port, portInputView);
                 }
                 
                 port.RegisterCallback<GeometryChangedEvent>(UpdatePortInput);

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
@@ -11,8 +11,10 @@ ChannelEnumControlView > .unity-popup-field {
 }
 
 ChannelEnumControlView > Label {
-    width: 100px;
+    max-width: 100px;
+    width: 50px;
     margin-left: 8px;
     margin-right: 8px;
     -unity-text-align : middle-left;
+    flex-grow: 1;
 }

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
@@ -4,7 +4,6 @@ ChannelEnumControlView {
 
 ChannelEnumControlView > .unity-popup-field {
     width: 76px;
-    flex: 0;
     margin-left: 0;
     margin-right: 8px;
     margin-top: 4px;

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelMixerControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelMixerControlView.uss
@@ -20,9 +20,13 @@ ChannelMixerControlView > #buttonPanel {
 
 ChannelMixerControlView > #buttonPanel > Button {
     flex-grow: 1;
-    margin-left: 0;
-    margin-right: 0;
+    margin-left: 1;
+    margin-right: 1;
     align-items: center;
+    border-left-width: 0;
+    border-top-width: 0;
+    border-right-width: 0;
+    border-bottom-width: 1;
 }
 
 ChannelMixerControlView > #buttonPanel > Button > Label {

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/EnumControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/EnumControlView.uss
@@ -1,24 +1,24 @@
 EnumControlView {
     flex-direction: row;
     align-items: center;
+    margin-left: 8px;
+    margin-right: 5px;
 }
 
 .unity-base-field {
     width: 80px;
-	flex:1;
     margin-top: 4px;
     margin-bottom: 4px;
 }
 
 .unity-base-field__input {
-	flex:1;
 	margin-left: 0;
-    margin-right: 8px;
 }
 
 EnumControlView > Label {
-    width: 94px;
+    max-width: 94px;
+    width: 30px;
     -unity-text-align: middle-left;
-    margin-left: 8px;
+    flex-grow: 1;
     margin-right: 8px;
 }

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/EnumConversionControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/EnumConversionControlView.uss
@@ -1,7 +1,7 @@
 EnumConversionControlView {
     flex-direction: row;
-    padding-left: 8px;
-    padding-right: 8px;
+    padding-left: 5px;
+    padding-right: 5px;
     padding-top: 4px;
     padding-bottom: 4px;
 }

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/SliderControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/SliderControlView.uss
@@ -15,7 +15,6 @@ SliderControlView > #SliderPanel {
 .unity-slider .unity-base-field__input {
     margin-left: 0;
     margin-right: 0;
-    flex-direction: row;
     flex-grow: 1;
     min-width: 164px;
     overflow:visible;

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ToggleControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ToggleControlView.uss
@@ -9,6 +9,7 @@ ToggleControlView > #togglePanel > Label {
     margin-left: 8px;
     margin-right: 8px;
     -unity-text-align : middle-left;
+    flex-grow:1;
 }
 
 .unity-toggle{


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Fixing styling errors that emerged with 2019.3 + FogBugz 1155501 input ports becoming misalignment.
Styling issues:
Before:
![image](https://user-images.githubusercontent.com/39529353/59311271-c404b200-8c5d-11e9-98f3-22053bc2f31a.png)

After:
![image](https://user-images.githubusercontent.com/39529353/59311330-ed254280-8c5d-11e9-8170-b7585d59493b.png)

Bug Case:
![InputAlignmentBug](https://user-images.githubusercontent.com/39529353/59524723-7a98aa80-8e89-11e9-8dca-2d86cdbe63c3.gif)


---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.
Mostly touches USS files, with one c# control file for `ChannelMaskControl`.
One line fix in `MaterialNodeView.cs`.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)
n/a 
Launch Katana
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=sg%2Fnstar-fixes&unity_branch=trunk&automation-tools_branch=master&sort=1-asc

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low, touches USS files

**Halo Effect**: None, Low, Medium, High? Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
