### PR TITLE
Grant internal access to ShaderGraph for future SpeedTree package

### DIFF
--- a/com.unity.shadergraph/Editor/AssemblyInfo.cs
+++ b/com.unity.shadergraph/Editor/AssemblyInfo.cs
@@ -3,3 +3,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Unity.ShaderGraph.Editor.Tests")]
 [assembly: InternalsVisibleTo("Unity.RenderPipelines.Lightweight.Editor")]
 [assembly: InternalsVisibleTo("Unity.RenderPipelines.HighDefinition.Editor")]
+[assembly: InternalsVisibleTo("Unity.SpeedTree.Editor")]


### PR DESCRIPTION
### Purpose of this PR
We are planning to move a lot of SpeedTree support into its own package, and since this will include some ShaderGraph nodes, the idea is to give that package access to ShaderGraph internals.

---
### Release Notes
This is basically just future-proofing for when the SpeedTree package actually exists.  There is an intention to backport to 2019.2 (and package v6.8?) as well, so that when the SpeedTree package is created, it will "just plain work"(tm) all the way back to 2019.2.

---
### Testing status
Other than verifying that nothing gets broken (which has been verified in editor, and also being checked in Katana), there's no need for further testing beyond that at this stage as the package in question does not yet exist.

---
### Overall Product Risks
**Technical Risk**: None... yet.
**Halo Effect**: None... again, yet.

---
### Comments to reviewers
Yes, I know I am putting this in a branch labeled terrain, but since it's such a minuscule change, I didn't feel the need to create a whole other branch just for this.  I'm just using a branch I'm anyway going to use for another separate PR.
