### PR TITLE
Added HDRP Quality Settings in Project Preference Window

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
@@ -1,0 +1,16 @@
+﻿VisualElement {}
+
+.h1 {
+    font-style: bold;
+    font-size: 16;
+    margin: 2 5 15 5;
+}
+
+/* ========= Quality Settings Panel =========  */
+
+.unity-quality-header-list {
+    margin: 5;
+    border-bottom: 1;
+    border-color: #1F1F1F;
+    flex: 1 0 0;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
@@ -8,6 +8,24 @@
 
 /* ========= Quality Settings Panel =========  */
 
+HDRPAssetHeaderEntry {
+    flex-direction: row;
+    align-items: center;
+}
+
+.unity-quality-entry-tag {
+    border-bottom: 1;
+    border-top: 1;
+    border-right: 1;
+    border-left: 1;
+    border-top-left-radius: 2;
+    border-top-right-radius: 2;
+    border-bottom-left-radius: 2;
+    border-bottom-right-radius: 2;
+    margin: 0 2;
+    padding: 0 2;
+}
+
 .unity-quality-header-list {
     margin: 5;
     border-bottom: 1;

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4eb227ed39a6894e9c82f914beda9f3
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
@@ -1,0 +1,14 @@
+﻿.unity-list-view .odd {
+    background-color: #3f3f3f;
+}
+
+/* We need to override the selected value in this case */
+.unity-list-view .odd:selected {
+    background-color: #3e5f96;
+}
+
+/* ========= Quality Settings Panel =========  */
+
+.unity-quality-header-list {
+    border-color: #1F1F1F;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
@@ -12,3 +12,7 @@
 .unity-quality-header-list {
     border-color: #1F1F1F;
 }
+
+.unity-quality-entry-tag {
+    border-color: #1F1F1F;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a81dc0e7a9f29b49966e9ea0c0cbca4
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
@@ -1,0 +1,14 @@
+﻿.unity-list-view .odd {
+    background-color: #bcbcbc;
+}
+
+/* We need to override the selected value in this case */
+.unity-list-view .odd:selected {
+    background-color: #3e5f96;
+}
+
+/* ========= Quality Settings Panel =========  */
+
+.unity-quality-header-list {
+    border-color: #999999;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
@@ -12,3 +12,7 @@
 .unity-quality-header-list {
     border-color: #999999;
 }
+
+.unity-quality-entry-tag {
+    border-color: #999999;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0d0c9314cb60804cb977760a997071d
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDEditorUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDEditorUtils.cs
@@ -7,11 +7,39 @@ using UnityEditor.Rendering;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEditor.ShaderGraph;
+using UnityEngine.UIElements;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class HDEditorUtils
     {
+        const string EditorStyleSheetPath =
+            @"Packages/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss";
+        const string EditorStyleLightSheetPath =
+            @"Packages/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss";
+        const string EditorStyleDarkSheetPath =
+            @"Packages/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss";
+
+        private static (StyleSheet, StyleSheet, StyleSheet) m_StyleSheets = (null, null, null);
+
+        static (StyleSheet, StyleSheet, StyleSheet) SpecificStyleSheets
+            => (m_StyleSheets.Item1) != null ? m_StyleSheets : (m_StyleSheets = (
+                AssetDatabase.LoadAssetAtPath<StyleSheet>(EditorStyleSheetPath),
+                AssetDatabase.LoadAssetAtPath<StyleSheet>(EditorStyleLightSheetPath),
+                AssetDatabase.LoadAssetAtPath<StyleSheet>(EditorStyleDarkSheetPath)
+            ));
+
+        public static void AddStyleSheets(VisualElement element)
+        {
+            element.styleSheets.Add(SpecificStyleSheets.Item1);
+            element.styleSheets.Add(
+                EditorGUIUtility.isProSkin
+                ? SpecificStyleSheets.Item3
+                : SpecificStyleSheets.Item2
+            );
+        }
+
+
         static readonly Action<SerializedProperty, GUIContent> k_DefaultDrawer = (p, l) => EditorGUILayout.PropertyField(p, l);
 
         delegate void MaterialResetter(Material material);

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineEditor.cs
@@ -8,15 +8,23 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
     {
         SerializedHDRenderPipelineAsset m_SerializedHDRenderPipeline;
 
+        internal bool showInspector = true;
+
         void OnEnable()
         {
+#if QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE
+            showInspector = false;
+#endif
             m_SerializedHDRenderPipeline = new SerializedHDRenderPipelineAsset(serializedObject);
         }
 
         public override void OnInspectorGUI()
         {
+            if (!showInspector)
+                return;
+
             var serialized = m_SerializedHDRenderPipeline;
-            
+
             serialized.Update();
 
             HDRenderPipelineUI.Inspector.Draw(serialized, this);

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -59,7 +59,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         static HDRenderPipelineUI()
         {
             Inspector = CED.Group(
-                CED.Group(SupportedSettingsInfoSection),
+                //CED.Group(SupportedSettingsInfoSection),
                 FrameSettingsSection,
                 CED.FoldoutGroup(k_GeneralSectionTitle, Expandable.General, k_ExpandedState, Drawer_SectionGeneral),
                 CED.FoldoutGroup(k_RenderingSectionTitle, Expandable.Rendering, k_ExpandedState,
@@ -164,7 +164,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 serialized.SetEditorResource(editorResources);
             EditorGUI.showMixedValue = false;
 
-            EditorGUILayout.PropertyField(serialized.enableSRPBatcher, k_SRPBatcher);
+            //EditorGUILayout.PropertyField(serialized.enableSRPBatcher, k_SRPBatcher);
             EditorGUILayout.PropertyField(serialized.shaderVariantLogLevel, k_ShaderVariantLogLevel);
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -1,7 +1,6 @@
-using System;
+#if QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE
+
 using System.Collections.Generic;
-using System.Linq;
-using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Experimental.Rendering.HDPipeline;
@@ -187,3 +186,4 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
     }
 }
+#endif

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -177,11 +177,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             void DrawInspector()
             {
                 var selected = m_HDRPAssetList.selectedIndex;
-                if (selected >= 0)
-                {
-                    Editor.CreateCachedEditor(m_HDRPAssets[selected].asset, typeof(HDRenderPipelineEditor), ref m_Cached);
-                    m_Cached.OnInspectorGUI();
-                }
+                if (selected < 0)
+                    return;
+
+                Editor.CreateCachedEditor(m_HDRPAssets[selected].asset, typeof(HDRenderPipelineEditor), ref m_Cached);
+                ((HDRenderPipelineEditor) m_Cached).showInspector = true;
+                m_Cached.OnInspectorGUI();
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering.HDPipeline;
+using UnityEngine.Rendering;
+using UnityEngine.UIElements;
+
+namespace UnityEditor.Experimental.Rendering.HDPipeline
+{
+    public class QualitySettingsPanel
+    {
+        [SettingsProvider]
+        public static SettingsProvider CreateSettingsProvider()
+        {
+            return new SettingsProvider("HDRP/Quality", SettingsScope.Project)
+            {
+                activateHandler = (searchContext, rootElement) =>
+                {
+                    HDEditorUtils.AddStyleSheets(rootElement);
+
+                    var panel = new QualitySettingsPanelVisualElement(searchContext);
+                    panel.style.flexGrow = 1;
+
+                    rootElement.Add(panel);
+                },
+                keywords = new [] { "quality", "hdrp" }
+            };
+        }
+
+        class HDRPAssetHeaderEntry : VisualElement
+        {
+            TextElement m_Element;
+
+            public HDRPAssetHeaderEntry()
+            {
+                m_Element = new Label();
+
+                m_Element.style.paddingLeft = 5;
+                m_Element.style.flexGrow = 1;
+                m_Element.style.flexDirection = FlexDirection.Row;
+                m_Element.style.unityTextAlign = TextAnchor.MiddleLeft;
+
+                Add(m_Element);
+            }
+
+            public void Bind(int index, HDRenderPipelineAsset asset)
+            {
+                m_Element.text = asset.name;
+
+                RemoveFromClassList("even");
+                RemoveFromClassList("odd");
+                AddToClassList((index & 1) == 1 ? "odd" : "even");
+            }
+        }
+
+        class QualitySettingsPanelVisualElement : VisualElement
+        {
+            HDRenderPipelineAsset[] m_HDRPAssets;
+            Label m_InspectorTitle;
+            ListView m_HDRPAssetList;
+            Editor m_Cached;
+
+            public QualitySettingsPanelVisualElement(string searchContext)
+            {
+                m_HDRPAssets = GraphicsSettings.allConfiguredRenderPipelines
+                    .OfType<HDRenderPipelineAsset>()
+                    .Distinct()
+                    .ToArray();
+
+                // title
+                var title = new Label()
+                {
+                    text = "Quality"
+                };
+                title.AddToClassList("h1");
+
+                // Header
+                var headerBox = new VisualElement();
+                headerBox.style.height = 200;
+
+                m_HDRPAssetList = new ListView()
+                {
+                    bindItem = (el, i) => ((HDRPAssetHeaderEntry)el).Bind(i, m_HDRPAssets[i]),
+                    itemHeight = (int)EditorGUIUtility.singleLineHeight,
+                    selectionType = SelectionType.Single,
+                    itemsSource = m_HDRPAssets,
+                    makeItem = () => new HDRPAssetHeaderEntry(),
+                };
+                m_HDRPAssetList.AddToClassList("unity-quality-header-list");
+                m_HDRPAssetList.onSelectionChanged += OnSelectionChanged;
+
+                headerBox.Add(m_HDRPAssetList);
+
+                m_InspectorTitle = new Label();
+                m_InspectorTitle.text = "No asset selected";
+                m_InspectorTitle.AddToClassList("h1");
+
+                // Inspector
+                var inspector = new IMGUIContainer(DrawInspector);
+                inspector.style.flexGrow = 1;
+                inspector.style.flexDirection = FlexDirection.Row;
+
+                var inspectorBox = new ScrollView();
+                inspectorBox.style.flexGrow = 1;
+                inspectorBox.style.flexDirection = FlexDirection.Row;
+                inspectorBox.contentContainer.Add(inspector);
+
+                Add(title);
+                Add(headerBox);
+                Add(m_InspectorTitle);
+                Add(inspectorBox);
+            }
+
+            void OnSelectionChanged(List<object> obj)
+            {
+                m_InspectorTitle.text = m_HDRPAssets[m_HDRPAssetList.selectedIndex].name;
+            }
+
+            void DrawInspector()
+            {
+                var selected = m_HDRPAssetList.selectedIndex;
+                if (selected >= 0)
+                {
+                    Editor.CreateCachedEditor(m_HDRPAssets[selected], typeof(HDRenderPipelineEditor), ref m_Cached);
+                    m_Cached.OnInspectorGUI();
+                }
+            }
+        }
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -51,7 +51,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 if (asset.isDefault)
                     names = Enumerable.Repeat("default", 1).Union(names);
 
-                m_Element.text = $"{asset.asset.name} in {string.Join(",", names.ToArray())}";
+                m_Element.text = $"{asset.asset.name} in {string.Join(", ", names.ToArray())}";
 
                 RemoveFromClassList("even");
                 RemoveFromClassList("odd");
@@ -96,7 +96,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     if (index >= 0)
                         m_HDRPAssets[index].indices.Add(i);
                     else
-                        m_HDRPAssets.Add(new HDRPAssetLocations(false, hdrp2));
+                    {
+                        var loc = new HDRPAssetLocations(false, hdrp2);
+                        loc.indices.Add(i);
+                        m_HDRPAssets.Add(loc);
+                    }
+
                 }
 
                 // title

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfeb5d71e2791f547877bb12f65552ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
- Added HDRP Quality Settings in Project Preference Window
- Removed SRP Batcher field in General section of HDRP Asset inspector
- Added feature gate `QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE`
- Inspector of HDRP Asset is hidden

This is a single place to edit all assigned HDRP assets in the quality settings and graphic settings.

![Capture](https://user-images.githubusercontent.com/1635937/59507816-72059b80-8eac-11e9-9982-a2f84a86a0b1.PNG)

---
### Release Notes
- Added HDRP Quality Settings in Project Preference Window
- Removed SRP Batcher field in General section of HDRP Asset inspector
- Added feature gate `QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE`
- Inspector of HDRP Asset is hidden

---
### Testing status
**Katana Tests**: -

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: -

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
