### PR TITLE
Lw/update post processing version

### DIFF
--- a/TestProjects/PostProcessing/Packages/manifest.json
+++ b/TestProjects/PostProcessing/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "com.unity.postprocessing": "2.1.6",
+        "com.unity.postprocessing": "2.1.7",
         "com.unity.testframework.graphics": "file:../../../com.unity.testframework.graphics",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.assetbundle": "1.0.0",

--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Replaced beginCameraRendering callbacks by non obsolete implementation in Light2D
 - Updated `ScriptableRendererFeature` and `ScriptableRenderPass` API docs.
 - Shader type Real translates to FP16 precision on Nintendo Switch.
+- Updated Post Processing package version from 2.1.6 > 2.1.7
 
 ### Fixed
 - Fixed a case where built-in Shader time values could be out of sync with actual time. [case 1142495](https://fogbugz.unity3d.com/f/cases/1142495/)

--- a/com.unity.render-pipelines.lightweight/package.json
+++ b/com.unity.render-pipelines.lightweight/package.json
@@ -6,7 +6,7 @@
 	"unityRelease": "0a3",
     "displayName": "Lightweight RP",
     "dependencies": {
-        "com.unity.postprocessing": "2.1.6",
+        "com.unity.postprocessing": "2.1.7",
         "com.unity.render-pipelines.core": "7.0.0",
         "com.unity.shadergraph": "7.0.0"
     },


### PR DESCRIPTION
### Purpose of this PR
Updated Post Processing to latest version

---
### Release Notes
Post Processing 2.1.6 > 2.1.7

---
### Testing status
**Katana Tests**: Running
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lw%2Fupdate-post-processing-version&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] C# and shader warnings (supress shader cache to see them)

**Automated Tests**: N/A

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.