### PR TITLE
 Don't kill alpha when rendering to renderTextures.

### DIFF
--- a/com.unity.render-pipelines.lightweight/CHANGELOG.md
+++ b/com.unity.render-pipelines.lightweight/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added missing page for 2D Lights in LWRP.
 - Fixed warnings for unsupported shadow map formats for GLES2 API.
 - Disabled shadows for devices that do not support shadow maps or depth textures.
+- LWRP now preserves alpha when rendering to render textures. [case 1156134](https://issuetracker.unity3d.com/issues/lwrp-camera-with-target-render-texture-does-not-respect-transparent-background-color-in-windows-standalone-build)
 
 ## [6.7.0] - 2019-05-16
 ### Added

--- a/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
+++ b/com.unity.render-pipelines.lightweight/Runtime/LightweightRenderPipeline.cs
@@ -322,7 +322,7 @@ namespace UnityEngine.Rendering.LWRP
             bool platformNeedsToKillAlpha = Application.platform == RuntimePlatform.IPhonePlayer ||
                 Application.platform == RuntimePlatform.Android ||
                 Application.platform == RuntimePlatform.tvOS;
-            renderingData.killAlphaInFinalBlit = !Graphics.preserveFramebufferAlpha && platformNeedsToKillAlpha;
+            renderingData.killAlphaInFinalBlit = cameraData.camera.targetTexture == null && !Graphics.preserveFramebufferAlpha && platformNeedsToKillAlpha;
         }
 
         static void InitializeShadowData(LightweightRenderPipelineAsset settings, NativeArray<VisibleLight> visibleLights, bool mainLightCastShadows, bool additionalLightsCastShadows, out ShadowData shadowData)


### PR DESCRIPTION
### Purpose of this PR
 don't kill alpha when rendering to render textures
 https://fogbugz.unity3d.com/f/cases/1156134

---
### Release Notes


---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=lw/dont-killalpha-rendertexture&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
