### PR TITLE
Fix issue with wrong opaque blending for after postprocess

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed invalid capture direction when rendering planar reflection probes
 - Fixed Decal HTILE optimization with platform not supporting texture atomatic (Disable it)
 - Fixed a crash in the build when the contact shadows are disabled
+- Fixed issue with wrong opaque blending settings for After Postprocess
 
 ### Changed
 - Optimization: Reduce the group size of the deferred lighting pass from 16x16 to 8x8

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
@@ -67,6 +67,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 material.SetOverrideTag("RenderType", alphaTestEnable ? "TransparentCutout" : "");
                 material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
                 material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                // We also setup the alpha blend mode in case we used after postprocess
+                material.SetInt("_AlphaSrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                material.SetInt("_AlphaDstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
                 material.SetInt(kZWrite, 1);
             }
             else

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
@@ -67,12 +67,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 material.SetOverrideTag("RenderType", alphaTestEnable ? "TransparentCutout" : "");
                 material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
                 material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                // We also setup the alpha blend mode in case we used after postprocess
-                if (HDRenderQueue.k_RenderQueue_AfterPostProcessOpaque.Contains(material.renderQueue))
-                {
-                    material.SetInt("_AlphaSrcBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                    material.SetInt("_AlphaDstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                }
+                // Caution:  we need to setup One for src and Zero for Dst for all element as users could switch from transparent to Opaque and keep remaining value.
+                // Unity will disable Blending based on these default value.
+                // Note that for after postprocess we setup 0 in opacity inside the shaders, so we correctly end with 0 in opacity for the compositing pass
+                material.SetInt("_AlphaSrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                material.SetInt("_AlphaDstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
                 material.SetInt(kZWrite, 1);
             }
             else

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
@@ -68,8 +68,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
                 material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
                 // We also setup the alpha blend mode in case we used after postprocess
-                material.SetInt("_AlphaSrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-                material.SetInt("_AlphaDstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                if (HDRenderQueue.k_RenderQueue_AfterPostProcessOpaque.Contains(material.renderQueue))
+                {
+                    material.SetInt("_AlphaSrcBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                    material.SetInt("_AlphaDstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                }
                 material.SetInt(kZWrite, 1);
             }
             else


### PR DESCRIPTION
### Purpose of this PR
Fix issue with wrong opaque blending for after postprocess

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix-after-postprocess&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
