### PR TITLE
Added Default Settings panel in Project Preferences

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
@@ -1,0 +1,16 @@
+﻿VisualElement {}
+
+.h1 {
+    font-style: bold;
+    font-size: 16;
+    margin: 2 5 15 5;
+}
+
+/* ========= Quality Settings Panel =========  */
+
+.unity-quality-header-list {
+    margin: 5;
+    border-bottom: 1;
+    border-color: #1F1F1F;
+    flex: 1 0 0;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss
@@ -8,6 +8,24 @@
 
 /* ========= Quality Settings Panel =========  */
 
+HDRPAssetHeaderEntry {
+    flex-direction: row;
+    align-items: center;
+}
+
+.unity-quality-entry-tag {
+    border-bottom: 1;
+    border-top: 1;
+    border-right: 1;
+    border-left: 1;
+    border-top-left-radius: 2;
+    border-top-right-radius: 2;
+    border-bottom-left-radius: 2;
+    border-bottom-right-radius: 2;
+    margin: 0 2;
+    padding: 0 2;
+}
+
 .unity-quality-header-list {
     margin: 5;
     border-bottom: 1;

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4eb227ed39a6894e9c82f914beda9f3
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
@@ -1,0 +1,14 @@
+﻿.unity-list-view .odd {
+    background-color: #3f3f3f;
+}
+
+/* We need to override the selected value in this case */
+.unity-list-view .odd:selected {
+    background-color: #3e5f96;
+}
+
+/* ========= Quality Settings Panel =========  */
+
+.unity-quality-header-list {
+    border-color: #1F1F1F;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss
@@ -12,3 +12,7 @@
 .unity-quality-header-list {
     border-color: #1F1F1F;
 }
+
+.unity-quality-entry-tag {
+    border-color: #1F1F1F;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a81dc0e7a9f29b49966e9ea0c0cbca4
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
@@ -1,0 +1,14 @@
+﻿.unity-list-view .odd {
+    background-color: #bcbcbc;
+}
+
+/* We need to override the selected value in this case */
+.unity-list-view .odd:selected {
+    background-color: #3e5f96;
+}
+
+/* ========= Quality Settings Panel =========  */
+
+.unity-quality-header-list {
+    border-color: #999999;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss
@@ -12,3 +12,7 @@
 .unity-quality-header-list {
     border-color: #999999;
 }
+
+.unity-quality-entry-tag {
+    border-color: #999999;
+}

--- a/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0d0c9314cb60804cb977760a997071d
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDEditorUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDEditorUtils.cs
@@ -7,11 +7,39 @@ using UnityEditor.Rendering;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using UnityEditor.ShaderGraph;
+using UnityEngine.UIElements;
 
 namespace UnityEditor.Experimental.Rendering.HDPipeline
 {
     public class HDEditorUtils
     {
+        const string EditorStyleSheetPath =
+            @"Packages/com.unity.render-pipelines.high-definition/Editor/HDRPEditor.uss";
+        const string EditorStyleLightSheetPath =
+            @"Packages/com.unity.render-pipelines.high-definition/Editor/HDRPEditorLight.uss";
+        const string EditorStyleDarkSheetPath =
+            @"Packages/com.unity.render-pipelines.high-definition/Editor/HDRPEditorDark.uss";
+
+        private static (StyleSheet, StyleSheet, StyleSheet) m_StyleSheets = (null, null, null);
+
+        static (StyleSheet, StyleSheet, StyleSheet) SpecificStyleSheets
+            => (m_StyleSheets.Item1) != null ? m_StyleSheets : (m_StyleSheets = (
+                AssetDatabase.LoadAssetAtPath<StyleSheet>(EditorStyleSheetPath),
+                AssetDatabase.LoadAssetAtPath<StyleSheet>(EditorStyleLightSheetPath),
+                AssetDatabase.LoadAssetAtPath<StyleSheet>(EditorStyleDarkSheetPath)
+            ));
+
+        public static void AddStyleSheets(VisualElement element)
+        {
+            element.styleSheets.Add(SpecificStyleSheets.Item1);
+            element.styleSheets.Add(
+                EditorGUIUtility.isProSkin
+                ? SpecificStyleSheets.Item3
+                : SpecificStyleSheets.Item2
+            );
+        }
+
+
         static readonly Action<SerializedProperty, GUIContent> k_DefaultDrawer = (p, l) => EditorGUILayout.PropertyField(p, l);
 
         delegate void MaterialResetter(Material material);

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineEditor.cs
@@ -8,15 +8,23 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
     {
         SerializedHDRenderPipelineAsset m_SerializedHDRenderPipeline;
 
+        internal bool showInspector = true;
+
         void OnEnable()
         {
+#if QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE
+            showInspector = false;
+#endif
             m_SerializedHDRenderPipeline = new SerializedHDRenderPipelineAsset(serializedObject);
         }
 
         public override void OnInspectorGUI()
         {
+            if (!showInspector)
+                return;
+
             var serialized = m_SerializedHDRenderPipeline;
-            
+
             serialized.Update();
 
             HDRenderPipelineUI.Inspector.Draw(serialized, this);

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -59,7 +59,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         static HDRenderPipelineUI()
         {
             Inspector = CED.Group(
-                CED.Group(SupportedSettingsInfoSection),
+                //CED.Group(SupportedSettingsInfoSection),
                 FrameSettingsSection,
                 CED.FoldoutGroup(k_GeneralSectionTitle, Expandable.General, k_ExpandedState, Drawer_SectionGeneral),
                 CED.FoldoutGroup(k_RenderingSectionTitle, Expandable.Rendering, k_ExpandedState,
@@ -164,7 +164,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 serialized.SetEditorResource(editorResources);
             EditorGUI.showMixedValue = false;
 
-            EditorGUILayout.PropertyField(serialized.enableSRPBatcher, k_SRPBatcher);
+            //EditorGUILayout.PropertyField(serialized.enableSRPBatcher, k_SRPBatcher);
             EditorGUILayout.PropertyField(serialized.shaderVariantLogLevel, k_ShaderVariantLogLevel);
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs
@@ -1,0 +1,120 @@
+
+
+using System.Linq;
+using Object = UnityEngine.Object;
+#if QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor.Rendering;
+using UnityEngine;
+using UnityEngine.Assertions;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Experimental.Rendering.HDPipeline;
+using UnityEngine.Rendering;
+using UnityEngine.UIElements;
+
+namespace UnityEditor.Experimental.Rendering.HDPipeline
+{
+    public class DefaultSettingsPanelProvider
+    {
+        [SettingsProvider]
+        public static SettingsProvider CreateSettingsProvider()
+        {
+            return new SettingsProvider("Project/Default Settings/HDRP", SettingsScope.Project)
+            {
+                activateHandler = (searchContext, rootElement) =>
+                {
+                    HDEditorUtils.AddStyleSheets(rootElement);
+
+                    var panel = new DefaultSettingsPanel(searchContext);
+                    panel.style.flexGrow = 1;
+
+                    rootElement.Add(panel);
+                },
+                keywords = new [] { "default", "hdrp" }
+            };
+        }
+
+        class DefaultSettingsPanel : VisualElement
+        {
+            VolumeProfile m_DefaultVolumeProfile;
+            Editor m_Cached;
+
+
+            public DefaultSettingsPanel(string searchContext)
+            {
+                m_DefaultVolumeProfile = GetOrCreateDefaultVolumeProfile();
+
+                {
+                    var title = new Label
+                    {
+                        text = "Volume Components"
+                    };
+                    title.AddToClassList("h1");
+                    Add(title);
+                }
+                {
+                    var inspectorContainer = new IMGUIContainer(Draw_VolumeInspector);
+                    inspectorContainer.style.flexGrow = 1;
+                    inspectorContainer.style.flexDirection = FlexDirection.Row;
+                    Add(inspectorContainer);
+                }
+            }
+
+            void Draw_VolumeInspector()
+            {
+                Editor.CreateCachedEditor(m_DefaultVolumeProfile, Type.GetType("UnityEditor.Rendering.VolumeProfileEditor"), ref m_Cached);
+                m_Cached.OnInspectorGUI();
+            }
+
+            static string k_DefaultVolumeAssetPath =
+                $@"Packages/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/{DefaultSettings.defaultVolumeProfileFileStem}.asset";
+            static VolumeProfile GetOrCreateDefaultVolumeProfile()
+            {
+                // Search a VolumeProfile in the ResourceFolder with the name "DefaultSettingsVolumeProfile".
+                var selectedAsset = DefaultSettings.defaultVolumeProfile;
+
+                // Asset was found, we can return it.
+                if (selectedAsset != null && !selectedAsset.Equals(null))
+                    return selectedAsset;
+
+                // There is no default asset, so create one from the asset provided by the package.
+                var defaultAsset = AssetDatabase.LoadAssetAtPath<VolumeProfile>(k_DefaultVolumeAssetPath);
+                Assert.IsNotNull(defaultAsset, "Default Volume Profile asset is missing");
+
+                // Create resource folder if it is missing
+                var targetPath = $"Assets/Resources/{DefaultSettings.defaultVolumeProfileFileStem}.asset";
+                var parentPath = Path.GetDirectoryName(targetPath);
+                if (!Directory.Exists(parentPath))
+                    Directory.CreateDirectory(parentPath);
+
+                // Deep copy of the VolumeProfile
+                selectedAsset = Object.Instantiate(defaultAsset);
+                selectedAsset.name = defaultAsset.name;
+                AssetDatabase.CreateAsset(selectedAsset, targetPath);
+                AssetDatabase.SaveAssets();
+
+                AssetDatabase.StartAssetEditing();
+                using (ListPool<VolumeComponent>.Get(out var components))
+                {
+                    for (int i = 0, c = selectedAsset.components.Count; i < c ; ++i)
+                    {
+                        var componentClone = Object.Instantiate(selectedAsset.components[i]);
+                        componentClone.name = selectedAsset.components[i].name;
+                        components.Add(componentClone);
+                        AssetDatabase.AddObjectToAsset(componentClone, selectedAsset);
+                    }
+
+                    selectedAsset.components.Clear();
+                    selectedAsset.components.AddRange(components);
+                }
+                AssetDatabase.StopAssetEditing();
+
+                // Return the new default asset
+                return selectedAsset;
+            }
+        }
+    }
+}
+#endif

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs
@@ -64,6 +64,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             void Draw_VolumeInspector()
             {
+                if (m_DefaultVolumeProfile == null || m_DefaultVolumeProfile.Equals(null))
+                    m_DefaultVolumeProfile = GetOrCreateDefaultVolumeProfile();
+                
                 Editor.CreateCachedEditor(m_DefaultVolumeProfile, Type.GetType("UnityEditor.Rendering.VolumeProfileEditor"), ref m_Cached);
                 m_Cached.OnInspectorGUI();
             }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs
@@ -1,11 +1,10 @@
-
-
 using System.Linq;
 using Object = UnityEngine.Object;
-#if QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE
 using System;
 using System.Collections.Generic;
 using System.IO;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
 using UnityEditor.Rendering;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -66,8 +65,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 if (m_DefaultVolumeProfile == null || m_DefaultVolumeProfile.Equals(null))
                     m_DefaultVolumeProfile = GetOrCreateDefaultVolumeProfile();
-                
-                Editor.CreateCachedEditor(m_DefaultVolumeProfile, Type.GetType("UnityEditor.Rendering.VolumeProfileEditor"), ref m_Cached);
+
+                Editor.CreateCachedEditor(m_DefaultVolumeProfile,
+                    Type.GetType("UnityEditor.Rendering.VolumeProfileEditor"), ref m_Cached);
                 m_Cached.OnInspectorGUI();
             }
 
@@ -119,5 +119,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
     }
+
+    class PreProcessBuild : IPreprocessBuildWithReport
+    {
+        public int callbackOrder { get; }
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            // Create default settings volume profile if required
+            DefaultSettings.GetOrCreateDefaultVolume();
+        }
+    }
 }
-#endif

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/DefaultSettingsPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db026c2146a2e584293274deeb0232f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -1,7 +1,6 @@
-using System;
+#if QUALITY_SETTINGS_GET_RENDER_PIPELINE_AT_AVAILABLE
+
 using System.Collections.Generic;
-using System.Linq;
-using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.Experimental.Rendering.HDPipeline;
@@ -187,3 +186,4 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
     }
 }
+#endif

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -177,11 +177,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             void DrawInspector()
             {
                 var selected = m_HDRPAssetList.selectedIndex;
-                if (selected >= 0)
-                {
-                    Editor.CreateCachedEditor(m_HDRPAssets[selected].asset, typeof(HDRenderPipelineEditor), ref m_Cached);
-                    m_Cached.OnInspectorGUI();
-                }
+                if (selected < 0)
+                    return;
+
+                Editor.CreateCachedEditor(m_HDRPAssets[selected].asset, typeof(HDRenderPipelineEditor), ref m_Cached);
+                ((HDRenderPipelineEditor) m_Cached).showInspector = true;
+                m_Cached.OnInspectorGUI();
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering.HDPipeline;
+using UnityEngine.Rendering;
+using UnityEngine.UIElements;
+
+namespace UnityEditor.Experimental.Rendering.HDPipeline
+{
+    public class QualitySettingsPanel
+    {
+        [SettingsProvider]
+        public static SettingsProvider CreateSettingsProvider()
+        {
+            return new SettingsProvider("HDRP/Quality", SettingsScope.Project)
+            {
+                activateHandler = (searchContext, rootElement) =>
+                {
+                    HDEditorUtils.AddStyleSheets(rootElement);
+
+                    var panel = new QualitySettingsPanelVisualElement(searchContext);
+                    panel.style.flexGrow = 1;
+
+                    rootElement.Add(panel);
+                },
+                keywords = new [] { "quality", "hdrp" }
+            };
+        }
+
+        class HDRPAssetHeaderEntry : VisualElement
+        {
+            TextElement m_Element;
+
+            public HDRPAssetHeaderEntry()
+            {
+                m_Element = new Label();
+
+                m_Element.style.paddingLeft = 5;
+                m_Element.style.flexGrow = 1;
+                m_Element.style.flexDirection = FlexDirection.Row;
+                m_Element.style.unityTextAlign = TextAnchor.MiddleLeft;
+
+                Add(m_Element);
+            }
+
+            public void Bind(int index, HDRenderPipelineAsset asset)
+            {
+                m_Element.text = asset.name;
+
+                RemoveFromClassList("even");
+                RemoveFromClassList("odd");
+                AddToClassList((index & 1) == 1 ? "odd" : "even");
+            }
+        }
+
+        class QualitySettingsPanelVisualElement : VisualElement
+        {
+            HDRenderPipelineAsset[] m_HDRPAssets;
+            Label m_InspectorTitle;
+            ListView m_HDRPAssetList;
+            Editor m_Cached;
+
+            public QualitySettingsPanelVisualElement(string searchContext)
+            {
+                m_HDRPAssets = GraphicsSettings.allConfiguredRenderPipelines
+                    .OfType<HDRenderPipelineAsset>()
+                    .Distinct()
+                    .ToArray();
+
+                // title
+                var title = new Label()
+                {
+                    text = "Quality"
+                };
+                title.AddToClassList("h1");
+
+                // Header
+                var headerBox = new VisualElement();
+                headerBox.style.height = 200;
+
+                m_HDRPAssetList = new ListView()
+                {
+                    bindItem = (el, i) => ((HDRPAssetHeaderEntry)el).Bind(i, m_HDRPAssets[i]),
+                    itemHeight = (int)EditorGUIUtility.singleLineHeight,
+                    selectionType = SelectionType.Single,
+                    itemsSource = m_HDRPAssets,
+                    makeItem = () => new HDRPAssetHeaderEntry(),
+                };
+                m_HDRPAssetList.AddToClassList("unity-quality-header-list");
+                m_HDRPAssetList.onSelectionChanged += OnSelectionChanged;
+
+                headerBox.Add(m_HDRPAssetList);
+
+                m_InspectorTitle = new Label();
+                m_InspectorTitle.text = "No asset selected";
+                m_InspectorTitle.AddToClassList("h1");
+
+                // Inspector
+                var inspector = new IMGUIContainer(DrawInspector);
+                inspector.style.flexGrow = 1;
+                inspector.style.flexDirection = FlexDirection.Row;
+
+                var inspectorBox = new ScrollView();
+                inspectorBox.style.flexGrow = 1;
+                inspectorBox.style.flexDirection = FlexDirection.Row;
+                inspectorBox.contentContainer.Add(inspector);
+
+                Add(title);
+                Add(headerBox);
+                Add(m_InspectorTitle);
+                Add(inspectorBox);
+            }
+
+            void OnSelectionChanged(List<object> obj)
+            {
+                m_InspectorTitle.text = m_HDRPAssets[m_HDRPAssetList.selectedIndex].name;
+            }
+
+            void DrawInspector()
+            {
+                var selected = m_HDRPAssetList.selectedIndex;
+                if (selected >= 0)
+                {
+                    Editor.CreateCachedEditor(m_HDRPAssets[selected], typeof(HDRenderPipelineEditor), ref m_Cached);
+                    m_Cached.OnInspectorGUI();
+                }
+            }
+        }
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs
@@ -51,7 +51,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 if (asset.isDefault)
                     names = Enumerable.Repeat("default", 1).Union(names);
 
-                m_Element.text = $"{asset.asset.name} in {string.Join(",", names.ToArray())}";
+                m_Element.text = $"{asset.asset.name} in {string.Join(", ", names.ToArray())}";
 
                 RemoveFromClassList("even");
                 RemoveFromClassList("odd");
@@ -96,7 +96,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     if (index >= 0)
                         m_HDRPAssets[index].indices.Add(i);
                     else
-                        m_HDRPAssets.Add(new HDRPAssetLocations(false, hdrp2));
+                    {
+                        var loc = new HDRPAssetLocations(false, hdrp2);
+                        loc.indices.Add(i);
+                        m_HDRPAssets.Add(loc);
+                    }
+
                 }
 
                 // title

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/QualitySettingsPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfeb5d71e2791f547877bb12f65552ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/DefaultSettingsVolumeProfile.asset
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/DefaultSettingsVolumeProfile.asset
@@ -1,0 +1,554 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-9101703278119620515
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4910d90e50201484ba448b791a192696, type: 3}
+  m_Name: VolumetricLightingController
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  depthExtent:
+    m_OverrideState: 0
+    m_Value: 64
+    min: 0.1
+  sliceDistributionUniformity:
+    m_OverrideState: 0
+    m_Value: 0.75
+    min: 0
+    max: 1
+--- !u!114 &-1619875036018992408
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56b145d2b9ee1ac4f846968484e7485a, type: 3}
+  m_Name: ContactShadows
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  enable:
+    m_OverrideState: 1
+    m_Value: 0
+  length:
+    m_OverrideState: 1
+    m_Value: 0.11
+    min: 0
+    max: 1
+  opacity:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+    max: 1
+  distanceScaleFactor:
+    m_OverrideState: 1
+    m_Value: 0.47
+    min: 0
+    max: 1
+  maxDistance:
+    m_OverrideState: 0
+    m_Value: 50
+    min: 0
+  fadeDistance:
+    m_OverrideState: 0
+    m_Value: 5
+    min: 0
+  sampleCount:
+    m_OverrideState: 1
+    m_Value: 11
+    min: 4
+    max: 64
+--- !u!114 &-65731491752108837
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 598e2d32e2c7b0c418e030c3236d663a, type: 3}
+  m_Name: ChromaticAberration
+  m_EditorClassIdentifier: 
+  active: 0
+  m_AdvancedMode: 0
+  spectralLut:
+    m_OverrideState: 0
+    m_Value: {fileID: 0}
+  intensity:
+    m_OverrideState: 1
+    m_Value: 1
+    min: 0
+    max: 1
+  maxSamples:
+    m_OverrideState: 0
+    m_Value: 3
+    min: 3
+    max: 24
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: DefaultSettingsVolumeProfile
+  m_EditorClassIdentifier: 
+  components:
+  - {fileID: 114527594671542966}
+  - {fileID: 114339849572665496}
+  - {fileID: 114914201461855468}
+  - {fileID: 114698408567805600}
+  - {fileID: 9169818020052063708}
+  - {fileID: -65731491752108837}
+  - {fileID: 7913036788313345836}
+  - {fileID: 7144747380904203025}
+  - {fileID: -9101703278119620515}
+  - {fileID: -1619875036018992408}
+  - {fileID: 6663165335437035198}
+--- !u!114 &114339849572665496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d7593b3a9277ac4696b20006c21dde2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  skyType:
+    m_OverrideState: 1
+    m_Value: 2
+  skyAmbientMode:
+    m_OverrideState: 0
+    m_Value: 0
+  fogType:
+    m_OverrideState: 1
+    m_Value: 2
+--- !u!114 &114527594671542966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ddcec8a8eb2d684d833ac8f5d26aebd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  maxShadowDistance:
+    m_OverrideState: 1
+    m_Value: 150
+    min: 0
+  cascadeShadowSplitCount:
+    m_OverrideState: 1
+    m_Value: 4
+    min: 1
+    max: 4
+  cascadeShadowSplit0:
+    m_OverrideState: 1
+    m_Value: 0.06444056
+  cascadeShadowSplit1:
+    m_OverrideState: 1
+    m_Value: 0.23527981
+  cascadeShadowSplit2:
+    m_OverrideState: 1
+    m_Value: 0.46608394
+  cascadeShadowBorder0:
+    m_OverrideState: 1
+    m_Value: 0
+  cascadeShadowBorder1:
+    m_OverrideState: 1
+    m_Value: 0
+  cascadeShadowBorder2:
+    m_OverrideState: 1
+    m_Value: 0
+  cascadeShadowBorder3:
+    m_OverrideState: 1
+    m_Value: 0
+--- !u!114 &114698408567805600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2150ee00179b2f4418ea8b21a7e98eea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  colorMode:
+    m_OverrideState: 1
+    m_Value: 1
+  color:
+    m_OverrideState: 1
+    m_Value: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    hdr: 0
+    showAlpha: 1
+    showEyeDropper: 1
+  density:
+    m_OverrideState: 1
+    m_Value: 1
+    min: 0
+    max: 1
+  maxFogDistance:
+    m_OverrideState: 0
+    m_Value: 5000
+    min: 0
+  mipFogMaxMip:
+    m_OverrideState: 1
+    m_Value: 0.5
+    min: 0
+    max: 1
+  mipFogNear:
+    m_OverrideState: 1
+    m_Value: 0
+    min: 0
+  mipFogFar:
+    m_OverrideState: 1
+    m_Value: 1000
+    min: 0
+  fogDistance:
+    m_OverrideState: 1
+    m_Value: 200
+    min: 0
+  fogBaseHeight:
+    m_OverrideState: 1
+    m_Value: 0
+  fogHeightAttenuation:
+    m_OverrideState: 1
+    m_Value: 0.005
+    min: 0
+    max: 1
+--- !u!114 &114914201461855468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3df29e7cc05fbec4aa43e06ea875565d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  rotation:
+    m_OverrideState: 1
+    m_Value: 0
+    min: 0
+    max: 360
+  skyIntensityMode:
+    m_OverrideState: 0
+    m_Value: 0
+  exposure:
+    m_OverrideState: 1
+    m_Value: 1.25
+  multiplier:
+    m_OverrideState: 1
+    m_Value: 1
+    min: 0
+  upperHemisphereLuxValue:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+  desiredLuxValue:
+    m_OverrideState: 0
+    m_Value: 20000
+  updateMode:
+    m_OverrideState: 1
+    m_Value: 0
+  updatePeriod:
+    m_OverrideState: 1
+    m_Value: 0
+    min: 0
+  includeSunInBaking:
+    m_OverrideState: 0
+    m_Value: 0
+  sunSize:
+    m_OverrideState: 1
+    m_Value: 0.04
+    min: 0
+    max: 1
+  sunSizeConvergence:
+    m_OverrideState: 1
+    m_Value: 5
+    min: 1
+    max: 10
+  atmosphereThickness:
+    m_OverrideState: 1
+    m_Value: 0.5
+    min: 0
+    max: 5
+  skyTint:
+    m_OverrideState: 1
+    m_Value: {r: 1, g: 0.964728, b: 0.3537736, a: 1}
+    hdr: 0
+    showAlpha: 1
+    showEyeDropper: 1
+  groundColor:
+    m_OverrideState: 1
+    m_Value: {r: 0.59927905, g: 0.6172068, b: 0.6320754, a: 1}
+    hdr: 0
+    showAlpha: 1
+    showEyeDropper: 1
+  enableSunDisk:
+    m_OverrideState: 1
+    m_Value: 1
+--- !u!114 &6663165335437035198
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32b6af8f7ad32324cb6941c3290e5895, type: 3}
+  m_Name: MicroShadowing
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  enable:
+    m_OverrideState: 1
+    m_Value: 1
+  opacity:
+    m_OverrideState: 1
+    m_Value: 0.117
+    min: 0
+    max: 1
+--- !u!114 &7144747380904203025
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 24f077503be6ae942a1e1245dbd53ea9, type: 3}
+  m_Name: Bloom
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 1
+  intensity:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 1
+  scatter:
+    m_OverrideState: 0
+    m_Value: 0.7
+    min: 0
+    max: 1
+  tint:
+    m_OverrideState: 0
+    m_Value: {r: 1, g: 1, b: 1, a: 1}
+    hdr: 0
+    showAlpha: 0
+    showEyeDropper: 1
+  dirtTexture:
+    m_OverrideState: 0
+    m_Value: {fileID: 0}
+  dirtIntensity:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+  highQualityFiltering:
+    m_OverrideState: 0
+    m_Value: 1
+  resolution:
+    m_OverrideState: 1
+    m_Value: 2
+  prefilter:
+    m_OverrideState: 0
+    m_Value: 0
+  anamorphic:
+    m_OverrideState: 0
+    m_Value: 1
+--- !u!114 &7913036788313345836
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d08ce26990eb1a4a9177b860541e702, type: 3}
+  m_Name: Exposure
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  mode:
+    m_OverrideState: 1
+    m_Value: 0
+  meteringMode:
+    m_OverrideState: 0
+    m_Value: 2
+  luminanceSource:
+    m_OverrideState: 0
+    m_Value: 1
+  fixedExposure:
+    m_OverrideState: 1
+    m_Value: 0.4
+  compensation:
+    m_OverrideState: 0
+    m_Value: 14.97
+  limitMin:
+    m_OverrideState: 0
+    m_Value: -10
+  limitMax:
+    m_OverrideState: 0
+    m_Value: 20
+  curveMap:
+    m_OverrideState: 0
+    m_Value:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: -10
+        value: -10
+        inSlope: 0
+        outSlope: 1
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 20
+        value: 20
+        inSlope: 1
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  adaptationMode:
+    m_OverrideState: 0
+    m_Value: 1
+  adaptationSpeedDarkToLight:
+    m_OverrideState: 0
+    m_Value: 3
+    min: 0.001
+  adaptationSpeedLightToDark:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0.001
+--- !u!114 &8689955086501673153
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f086a068d4c5889438831b3ae9afc11c, type: 3}
+  m_Name: Tonemapping
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  mode:
+    m_OverrideState: 0
+    m_Value: 0
+  toeStrength:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 1
+  toeLength:
+    m_OverrideState: 0
+    m_Value: 0.5
+    min: 0
+    max: 1
+  shoulderStrength:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 1
+  shoulderLength:
+    m_OverrideState: 0
+    m_Value: 0.5
+    min: 0
+  shoulderAngle:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 1
+  gamma:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0.001
+--- !u!114 &9169818020052063708
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f086a068d4c5889438831b3ae9afc11c, type: 3}
+  m_Name: Tonemapping
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  mode:
+    m_OverrideState: 1
+    m_Value: 2
+  toeStrength:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 1
+  toeLength:
+    m_OverrideState: 0
+    m_Value: 0.5
+    min: 0
+    max: 1
+  shoulderStrength:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 1
+  shoulderLength:
+    m_OverrideState: 0
+    m_Value: 0.5
+    min: 0
+  shoulderAngle:
+    m_OverrideState: 0
+    m_Value: 0
+    min: 0
+    max: 1
+  gamma:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0.001

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/DefaultSettingsVolumeProfile.asset
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/DefaultSettingsVolumeProfile.asset
@@ -1,100 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-9101703278119620515
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4910d90e50201484ba448b791a192696, type: 3}
-  m_Name: VolumetricLightingController
-  m_EditorClassIdentifier: 
-  active: 1
-  m_AdvancedMode: 0
-  depthExtent:
-    m_OverrideState: 0
-    m_Value: 64
-    min: 0.1
-  sliceDistributionUniformity:
-    m_OverrideState: 0
-    m_Value: 0.75
-    min: 0
-    max: 1
---- !u!114 &-1619875036018992408
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 56b145d2b9ee1ac4f846968484e7485a, type: 3}
-  m_Name: ContactShadows
-  m_EditorClassIdentifier: 
-  active: 1
-  m_AdvancedMode: 0
-  enable:
-    m_OverrideState: 1
-    m_Value: 0
-  length:
-    m_OverrideState: 1
-    m_Value: 0.11
-    min: 0
-    max: 1
-  opacity:
-    m_OverrideState: 0
-    m_Value: 1
-    min: 0
-    max: 1
-  distanceScaleFactor:
-    m_OverrideState: 1
-    m_Value: 0.47
-    min: 0
-    max: 1
-  maxDistance:
-    m_OverrideState: 0
-    m_Value: 50
-    min: 0
-  fadeDistance:
-    m_OverrideState: 0
-    m_Value: 5
-    min: 0
-  sampleCount:
-    m_OverrideState: 1
-    m_Value: 11
-    min: 4
-    max: 64
---- !u!114 &-65731491752108837
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 598e2d32e2c7b0c418e030c3236d663a, type: 3}
-  m_Name: ChromaticAberration
-  m_EditorClassIdentifier: 
-  active: 0
-  m_AdvancedMode: 0
-  spectralLut:
-    m_OverrideState: 0
-    m_Value: {fileID: 0}
-  intensity:
-    m_OverrideState: 1
-    m_Value: 1
-    min: 0
-    max: 1
-  maxSamples:
-    m_OverrideState: 0
-    m_Value: 3
-    min: 3
-    max: 24
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -112,13 +17,6 @@ MonoBehaviour:
   - {fileID: 114339849572665496}
   - {fileID: 114914201461855468}
   - {fileID: 114698408567805600}
-  - {fileID: 9169818020052063708}
-  - {fileID: -65731491752108837}
-  - {fileID: 7913036788313345836}
-  - {fileID: 7144747380904203025}
-  - {fileID: -9101703278119620515}
-  - {fileID: -1619875036018992408}
-  - {fileID: 6663165335437035198}
 --- !u!114 &114339849572665496
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -137,7 +35,7 @@ MonoBehaviour:
     m_OverrideState: 1
     m_Value: 2
   skyAmbientMode:
-    m_OverrideState: 0
+    m_OverrideState: 1
     m_Value: 0
   fogType:
     m_OverrideState: 1
@@ -158,7 +56,7 @@ MonoBehaviour:
   m_AdvancedMode: 0
   maxShadowDistance:
     m_OverrideState: 1
-    m_Value: 150
+    m_Value: 500
     min: 0
   cascadeShadowSplitCount:
     m_OverrideState: 1
@@ -167,13 +65,13 @@ MonoBehaviour:
     max: 4
   cascadeShadowSplit0:
     m_OverrideState: 1
-    m_Value: 0.06444056
+    m_Value: 0.05
   cascadeShadowSplit1:
     m_OverrideState: 1
-    m_Value: 0.23527981
+    m_Value: 0.15
   cascadeShadowSplit2:
     m_OverrideState: 1
-    m_Value: 0.46608394
+    m_Value: 0.3
   cascadeShadowBorder0:
     m_OverrideState: 1
     m_Value: 0
@@ -215,7 +113,7 @@ MonoBehaviour:
     min: 0
     max: 1
   maxFogDistance:
-    m_OverrideState: 0
+    m_OverrideState: 1
     m_Value: 5000
     min: 0
   mipFogMaxMip:
@@ -240,7 +138,7 @@ MonoBehaviour:
     m_Value: 0
   fogHeightAttenuation:
     m_OverrideState: 1
-    m_Value: 0.005
+    m_Value: 0.2
     min: 0
     max: 1
 --- !u!114 &114914201461855468
@@ -301,167 +199,24 @@ MonoBehaviour:
     max: 10
   atmosphereThickness:
     m_OverrideState: 1
-    m_Value: 0.5
+    m_Value: 1
     min: 0
     max: 5
   skyTint:
     m_OverrideState: 1
-    m_Value: {r: 1, g: 0.964728, b: 0.3537736, a: 1}
+    m_Value: {r: 0.5, g: 0.5, b: 0.5, a: 1}
     hdr: 0
     showAlpha: 1
     showEyeDropper: 1
   groundColor:
     m_OverrideState: 1
-    m_Value: {r: 0.59927905, g: 0.6172068, b: 0.6320754, a: 1}
+    m_Value: {r: 0.369, g: 0.349, b: 0.341, a: 1}
     hdr: 0
     showAlpha: 1
     showEyeDropper: 1
   enableSunDisk:
     m_OverrideState: 1
     m_Value: 1
---- !u!114 &6663165335437035198
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 32b6af8f7ad32324cb6941c3290e5895, type: 3}
-  m_Name: MicroShadowing
-  m_EditorClassIdentifier: 
-  active: 1
-  m_AdvancedMode: 0
-  enable:
-    m_OverrideState: 1
-    m_Value: 1
-  opacity:
-    m_OverrideState: 1
-    m_Value: 0.117
-    min: 0
-    max: 1
---- !u!114 &7144747380904203025
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 24f077503be6ae942a1e1245dbd53ea9, type: 3}
-  m_Name: Bloom
-  m_EditorClassIdentifier: 
-  active: 1
-  m_AdvancedMode: 1
-  intensity:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 1
-  scatter:
-    m_OverrideState: 0
-    m_Value: 0.7
-    min: 0
-    max: 1
-  tint:
-    m_OverrideState: 0
-    m_Value: {r: 1, g: 1, b: 1, a: 1}
-    hdr: 0
-    showAlpha: 0
-    showEyeDropper: 1
-  dirtTexture:
-    m_OverrideState: 0
-    m_Value: {fileID: 0}
-  dirtIntensity:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-  highQualityFiltering:
-    m_OverrideState: 0
-    m_Value: 1
-  resolution:
-    m_OverrideState: 1
-    m_Value: 2
-  prefilter:
-    m_OverrideState: 0
-    m_Value: 0
-  anamorphic:
-    m_OverrideState: 0
-    m_Value: 1
---- !u!114 &7913036788313345836
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2d08ce26990eb1a4a9177b860541e702, type: 3}
-  m_Name: Exposure
-  m_EditorClassIdentifier: 
-  active: 1
-  m_AdvancedMode: 0
-  mode:
-    m_OverrideState: 1
-    m_Value: 0
-  meteringMode:
-    m_OverrideState: 0
-    m_Value: 2
-  luminanceSource:
-    m_OverrideState: 0
-    m_Value: 1
-  fixedExposure:
-    m_OverrideState: 1
-    m_Value: 0.4
-  compensation:
-    m_OverrideState: 0
-    m_Value: 14.97
-  limitMin:
-    m_OverrideState: 0
-    m_Value: -10
-  limitMax:
-    m_OverrideState: 0
-    m_Value: 20
-  curveMap:
-    m_OverrideState: 0
-    m_Value:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: -10
-        value: -10
-        inSlope: 0
-        outSlope: 1
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      - serializedVersion: 3
-        time: 20
-        value: 20
-        inSlope: 1
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-  adaptationMode:
-    m_OverrideState: 0
-    m_Value: 1
-  adaptationSpeedDarkToLight:
-    m_OverrideState: 0
-    m_Value: 3
-    min: 0.001
-  adaptationSpeedLightToDark:
-    m_OverrideState: 0
-    m_Value: 1
-    min: 0.001
 --- !u!114 &8689955086501673153
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -479,51 +234,6 @@ MonoBehaviour:
   mode:
     m_OverrideState: 0
     m_Value: 0
-  toeStrength:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 1
-  toeLength:
-    m_OverrideState: 0
-    m_Value: 0.5
-    min: 0
-    max: 1
-  shoulderStrength:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 1
-  shoulderLength:
-    m_OverrideState: 0
-    m_Value: 0.5
-    min: 0
-  shoulderAngle:
-    m_OverrideState: 0
-    m_Value: 0
-    min: 0
-    max: 1
-  gamma:
-    m_OverrideState: 0
-    m_Value: 1
-    min: 0.001
---- !u!114 &9169818020052063708
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f086a068d4c5889438831b3ae9afc11c, type: 3}
-  m_Name: Tonemapping
-  m_EditorClassIdentifier: 
-  active: 1
-  m_AdvancedMode: 0
-  mode:
-    m_OverrideState: 1
-    m_Value: 2
   toeStrength:
     m_OverrideState: 0
     m_Value: 0

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/DefaultSettingsVolumeProfile.asset.meta
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/DefaultSettingsVolumeProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3043edc9d9a47704fad99f10fea80a08
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -930,6 +930,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (!m_ValidAPI || cameras.Length == 0)
                 return;
 
+            DefaultSettings.GetOrCreateDefaultVolume();
+
             UnityEngine.Rendering.RenderPipeline.BeginFrameRendering(renderContext, cameras);
 
             // Check if we can speed up FrameSettings process by skiping history

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/DefaultSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/DefaultSettings.cs
@@ -1,0 +1,11 @@
+using UnityEngine.Rendering;
+
+namespace UnityEngine.Experimental.Rendering.HDPipeline
+{
+    public class DefaultSettings
+    {
+        public const string defaultVolumeProfileFileStem = "DefaultSettingsVolumeProfile";
+
+        public static VolumeProfile defaultVolumeProfile => Resources.Load<VolumeProfile>(defaultVolumeProfileFileStem);
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/DefaultSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/DefaultSettings.cs
@@ -4,8 +4,47 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
     public class DefaultSettings
     {
+        static DefaultSettings()
+        {
+#if UNITY_EDITOR
+            UnityEditor.AssemblyReloadEvents.beforeAssemblyReload += () =>
+            {
+                if (s_DefaultVolume != null && !s_DefaultVolume.Equals(null))
+                {
+                    Object.Destroy(s_DefaultVolume.gameObject);
+                    s_DefaultVolume = null;
+                }
+            };
+#endif
+        }
+
+        private static Volume s_DefaultVolume = null;
+
         public const string defaultVolumeProfileFileStem = "DefaultSettingsVolumeProfile";
 
         public static VolumeProfile defaultVolumeProfile => Resources.Load<VolumeProfile>(defaultVolumeProfileFileStem);
+
+        public static Volume GetOrCreateDefaultVolume()
+        {
+            if (s_DefaultVolume == null || s_DefaultVolume.Equals(null))
+            {
+                var go = new GameObject("Default Volume") { hideFlags = HideFlags.HideAndDontSave };
+                s_DefaultVolume = go.AddComponent<Volume>();
+                s_DefaultVolume.isGlobal = true;
+                s_DefaultVolume.priority = float.MinValue;
+                s_DefaultVolume.profile = DefaultSettings.defaultVolumeProfile;
+            }
+            if (
+                // In case the asset was deleted or the reference removed
+                s_DefaultVolume.profile == null || s_DefaultVolume.profile.Equals(null)
+                #if UNITY_EDITOR
+                // In case the serialization recreated an empty volume profile
+                || !UnityEditor.AssetDatabase.Contains(s_DefaultVolume.profile)
+                #endif
+            )
+                s_DefaultVolume.profile = DefaultSettings.defaultVolumeProfile;
+
+            return s_DefaultVolume;
+        }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/DefaultSettings.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/DefaultSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d770677777c38da4cbaf858cf85fef60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

IMPORTANT: requires [Quality Settings PR](https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3841)

Define a way to setup the default settings in the editor and query them at runtime. Currently, only a default volume profile is supported.

In the editor, a `Default Settings` panel is added under "Project Preferences/Default Settings/HDRP".
This is the place to configure the default volume profile that will be used.

A `VolumeProfile` will be added in the project under the folder `Resources`.

![image](https://user-images.githubusercontent.com/1635937/59606774-4257cd00-9112-11e9-978a-079a58f38f6d.png)

---
### Release Notes
- Added Default Settings panel in Project Preferences
- Added a `DefaultSettings` API to query the default settings at runtime
- Create the default `VolumeProfile` in the editor when opening the `Default Settings` panel in the editor, if it is missing
- Create the default `VolumeProfile` in the editor when building a player, if it is missing
- Query the default settings at the begining of all rendering.

---
### Testing status
**Katana Tests**: [ABV Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FDefaultSettings&automation-tools_branch=master&unity_branch=trunk&sort=1-asc)

**Manual Tests**:
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: 
---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Medium (all volume settings are impacted)

---
### Comments to reviewers

