### PR TITLE
Fix checkout of files with Preforce

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDBakedReflectionSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDBakedReflectionSystem.cs
@@ -218,10 +218,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                     var bakedTexturePath = HDBakingUtilities.GetBakedTextureFilePath(probe);
                     HDBakingUtilities.CreateParentDirectoryIfMissing(bakedTexturePath);
-                    if (Provider.isActive && File.Exists(bakedTexturePath))
-                    {
-                        Checkout(bakedTexturePath, CheckoutMode.Both);
-                    }
+                    Checkout(bakedTexturePath);
                     // Checkout will make those file writeable, but this is not immediate,
                     // so we retries when this fails.
                     if (!HDEditorUtils.CopyFileWithRetryOnUnauthorizedAccess(cacheFile, bakedTexturePath))
@@ -481,6 +478,14 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             AssetDatabase.StopAssetEditing();
         }
 
+        static void Checkout(string targetFile)
+        {
+            if (Provider.isActive
+                && HDEditorUtils.IsAssetPath(targetFile)
+                && Provider.GetAssetByPath(targetFile) != null)
+                Provider.Checkout(targetFile, CheckoutMode.Both);
+        }
+
         internal static void AssignRenderData(HDProbe probe, string bakedTexturePath)
         {
             switch (probe.settings.type)
@@ -519,8 +524,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             (uint)StaticEditorFlags.ReflectionProbeStatic
                         );
                         HDBakingUtilities.CreateParentDirectoryIfMissing(targetFile);
-                        if (Provider.isActive && HDEditorUtils.IsAssetPath(targetFile))
-                            Checkout(targetFile, CheckoutMode.Both);
+                        Checkout(targetFile);
                         HDTextureUtilities.WriteTextureFileToDisk(cubeRT, targetFile);
                         break;
                     }
@@ -539,13 +543,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             out var cameraSettings, out var cameraPositionSettings
                         );
                         HDBakingUtilities.CreateParentDirectoryIfMissing(targetFile);
-                        if (Provider.isActive && HDEditorUtils.IsAssetPath(targetFile))
-                            Checkout(targetFile, CheckoutMode.Both);
+                        Checkout(targetFile);
                         HDTextureUtilities.WriteTextureFileToDisk(planarRT, targetFile);
                         var renderData = new HDProbe.RenderData(cameraSettings, cameraPositionSettings);
                         var targetRenderDataFile = targetFile + ".renderData";
-                        if (Provider.isActive && HDEditorUtils.IsAssetPath(targetRenderDataFile))
-                            Checkout(targetRenderDataFile, CheckoutMode.Both);
+                        Checkout(targetRenderDataFile);
                         HDBakingUtilities.TrySerializeToDisk(renderData, targetRenderDataFile);
                         break;
                     }


### PR DESCRIPTION
### Purpose of this PR
[Fix case 1152419 - 
[A2] "ArgumentNullException: Value cannot be null" errors thrown when baking HD reflection probes and using Perforce integration](https://fogbugz.unity3d.com/f/cases/1152419/)

---
### Release Notes
Fix case 1152419 - 
[A2] "ArgumentNullException: Value cannot be null" errors thrown when baking HD reflection probes and using Perforce integration

---
### Testing status
**Katana Tests**: [ABV Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2FPerforceBakeReflection&automation-tools_branch=master&unity_branch=trunk&sort=1-asc)

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: -

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None

---
### Comments to reviewers

