### PR TITLE
Fix for Low res transparency depth buffer not rendering on PS4

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a crash in the build when the contact shadows are disabled
 - Fixed camera rendering callbacks order (endCameraRendering was being called before the actual rendering)
 - Fixed issue with wrong opaque blending settings for After Postprocess
+- Fixed issue with Low resolution transparency on PS4
 
 ### Changed
 - Optimization: Reduce the group size of the deferred lighting pass from 16x16 to 8x8

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/DownsampleDepth.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/DownsampleDepth.shader
@@ -74,7 +74,7 @@ Shader "Hidden/HDRP/DownsampleDepth"
 
         Pass
         {
-            ZWrite On ZTest Off Blend Off Cull Off
+            ZWrite On Blend Off Cull Off ZTest Always
 
             HLSLPROGRAM
                 #pragma vertex Vert


### PR DESCRIPTION
As in the title, the previous state was fine on DirectX platforms (xbox + PC), but not on PS4 apparently. This fixes it. 

Without this fix, low res transparency is broken on PS4.