### PR TITLE
Fix for OSX incorrect blit material texture dimension in ExecuteCaptureAction

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -872,7 +872,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // Since recorder does not know about this, we need to send a texture of the right size.
             cmd.GetTemporaryRT(m_RecorderTempRT, actualWidth, actualHeight, 0, FilterMode.Point, input.rt.graphicsFormat);
 
-            var blitMaterial = HDUtils.GetBlitMaterial(TextureDimension.Tex2DArray);
+            var blitMaterial = HDUtils.GetBlitMaterial(input.rt.dimension);
 
             var rtHandleScale = RTHandles.rtHandleProperties.rtHandleScale;
             Vector2 viewportScale = new Vector2(rtHandleScale.x, rtHandleScale.y);


### PR DESCRIPTION
### Purpose of this PR
This PR fixes an issue introduced by the following commit on d55189c623e8162786c614f0981d4417dce4884a on OSX

Inside the HDCamera.cs ExecuteCaptureAction method. The BlitMaterial source dimension was set to TextureDimension.Tex2DArray to fix a problem on windows but OSX (Metal) still uses TextureDimension.Tex2D

This pr instead correctly query the input RenderTexture.dimension to set the blit material source  accordingly.


---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [N/A] Checked new UI names with UX convention
- [N/A ] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- [N/A] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

Locally tested with Unity Recorder 2.0.1-preview.1 Option Target Camera Main Camera now works
on both Windows and Mac

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/hdrp%252Ffix-executecaptureaction-incorrect-blit-source-on-mac/.yamato%252Fupm-ci-hdrp.yml%2523HDRP_Windows64_playmode_trunk

https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=hdrp%2Ffix-executecaptureaction-incorrect-blit-source-on-mac&automation-tools_branch=master&unity_branch=trunk&sort=1-asc
Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low


