### PR TITLE
[Shader Graph] Removing failure from UIElements

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Inspector/MasterPreviewView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/MasterPreviewView.cs
@@ -72,7 +72,6 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector
 
         public MasterPreviewView(PreviewManager previewManager, GraphData graph)
         {
-            cacheAsBitmap = true;
             style.overflow = Overflow.Hidden;
             m_PreviewManager = previewManager;
             m_Graph = graph;


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
One line removal to fix failure due to `cacheasBitmap`
---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.
Last entry on Changelog also describes this fix, so no new entry added
---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally


**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch): Yamato green 
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fuielements-failure/.yamato%252Fupm-ci-shadergraph.yml%2523ShaderGraph_Windows64_editmode_trunk/194964/job

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? low 

**Halo Effect**: None, Low, Medium, High? low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
