### PR TITLE
Use medium as default for shadows in deferred

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Replace ComputeMicroShadowing by GetAmbientOcclusionForMicroShadowing
 - Rename WorldToTangent to TangentToWorld as it was incorrectly named
 - Remove SunDisk and Sun Halo size from directional light
+- Change default for shadow quality in Deferred to Medium 
 
 
 ## [6.7.0-preview] - 2019-05-16

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAlgorithms.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowAlgorithms.hlsl
@@ -8,7 +8,7 @@
 
 // We can't use multi_compile for compute shaders so we force the shadow algorithm
 #if (SHADERPASS == SHADERPASS_DEFERRED_LIGHTING || SHADERPASS == SHADERPASS_VOLUMETRIC_LIGHTING || SHADERPASS == SHADERPASS_VOLUME_VOXELIZATION)
-#define SHADOW_LOW 
+#define SHADOW_MEDIUM 
 #endif
 
 #ifdef SHADOW_LOW
@@ -275,7 +275,7 @@ float EvalShadow_PunctualDepth(HDShadowData sd, Texture2D tex, SamplerComparison
     // We need to do the check on min/max coordinates because if the shadow spot angle is smaller than the actual cone, then we could have artifacts due to the clamp sampler.
     float2 maxCoord = (sd.shadowMapSize.xy - 0.5f) * _ShadowAtlasSize.zw + sd.atlasOffset;
     float2 minCoord = sd.atlasOffset;
-    return any(posTC > maxCoord || posTC < minCoord) ? 1.0f : PUNCTUAL_FILTER_ALGORITHM(sd, positionSS, posTC, sampleBias, tex, samp);
+    return any(posTC.xy > maxCoord || posTC.xy < minCoord) ? 1.0f : PUNCTUAL_FILTER_ALGORITHM(sd, positionSS, posTC, sampleBias, tex, samp);
 }
 
 //

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowManager.cs
@@ -157,7 +157,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             directionalShadowsDepthBits = k_DefaultShadowMapDepthBits,
             punctualLightShadowAtlas    = HDShadowAtlasInitParams.GetDefault(),
             areaLightShadowAtlas        = HDShadowAtlasInitParams.GetDefault(),
-			shadowQuality               = HDShadowQuality.Low,
+			shadowQuality               = HDShadowQuality.Medium,
             supportScreenSpaceShadows   = false,
             maxScreenSpaceShadows       = 2,
         };

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Shadow/HDShadowUtils.cs
@@ -24,9 +24,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (hdAsset == null)
                 return 1;
 
-            // Currently only PCF 3x3 is used for deferred rendering so if we're in deferred return 3
+            // Currently we force MEDIUM on deferred, so PCF 5x5 is used.
             if (camera.frameSettings.litShaderMode == LitShaderMode.Deferred)
-                return 3;
+                return 5;
 
             switch (hdAsset.currentPlatformRenderPipelineSettings.hdShadowInitParams.shadowQuality)
             {


### PR DESCRIPTION
As in the title... 


... Although I just realized this will require to take visual tests all over again... Maybe worth merging after the bias one as that will change the same tests. 