### PR TITLE
Fix error in spot light UI post light scripting API

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/SerializedHDLight.cs
@@ -131,8 +131,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                     minFilterSize = o.Find("m_MinFilterSize"),
                     areaLightCookie = o.Find("m_AreaLightCookie"),
                     areaLightShadowCone = o.Find("m_AreaLightShadowCone"),
-                    useCustomSpotLightShadowCone = o.Find("useCustomSpotLightShadowCone"),
-                    customSpotLightShadowCone = o.Find("customSpotLightShadowCone"),
+                    useCustomSpotLightShadowCone = o.Find("m_UseCustomSpotLightShadowCone"),
+                    customSpotLightShadowCone = o.Find("m_CustomSpotLightShadowCone"),
                     useScreenSpaceShadows = o.Find("m_UseScreenSpaceShadows"),
                     interactsWithSky = o.Find("m_InteractsWithSky"),
 #if ENABLE_RAYTRACING

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -1921,6 +1921,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             data.shadowPrecision = shadowPrecision;
             data.shadowUpdateMode = shadowUpdateMode;
 
+            data.m_UseCustomSpotLightShadowCone = useCustomSpotLightShadowCone;
+            data.m_CustomSpotLightShadowCone = customSpotLightShadowCone;
+
 #if UNITY_EDITOR
             data.timelineWorkaround = timelineWorkaround;
 #endif


### PR DESCRIPTION
After the light scripting api the custom cone fields changed name, but the serialization code was still searching for the old ones. 

This fixes issues with the advanced settings in the spot light UI. 