### PR TITLE
Reset debug views on teardown

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
@@ -714,7 +714,6 @@ namespace UnityEngine.Rendering
 
         public static void ForceSceneLightingEnable()
         {
-            // Determine whether the "No Scene Lighting" checkbox is checked for the current view.
             foreach (UnityEditor.SceneView sv in UnityEditor.SceneView.sceneViews)
             {
                 sv.sceneLighting = true;

--- a/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/CoreUtils.cs
@@ -712,6 +712,15 @@ namespace UnityEngine.Rendering
             return disabled;
         }
 
+        public static void ForceSceneLightingEnable()
+        {
+            // Determine whether the "No Scene Lighting" checkbox is checked for the current view.
+            foreach (UnityEditor.SceneView sv in UnityEditor.SceneView.sceneViews)
+            {
+                sv.sceneLighting = true;
+            }
+        }
+
 #if UNITY_EDITOR
         static Func<List<UnityEditor.MaterialEditor>> materialEditors;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -826,6 +826,11 @@ namespace UnityEngine.Rendering.HighDefinition
             }
 
             CameraCaptureBridge.enabled = false;
+
+            // Disable all debug views
+            DebugManager.instance.Reset();
+            // Reset the scene lighting button
+            CoreUtils.ForceSceneLightingEnable();
         }
 
 


### PR DESCRIPTION
As in the title, this also fixes the issue with the sky and matcap left on when closing 