### PR TITLE
fix menu order

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Debugging/DebugWindow.cs
+++ b/com.unity.render-pipelines.core/Editor/Debugging/DebugWindow.cs
@@ -126,7 +126,7 @@ namespace UnityEditor.Rendering
             s_TypeMapDirty = false;
         }
 
-        [MenuItem("Window/Render Pipeline/Render Pipeline Debug", priority = 0)] // 112 is hardcoded number given by the UxTeam to fit correctly in the Windows menu
+        [MenuItem("Window/Render Pipeline/Render Pipeline Debug", priority = 10005)] // 112 is hardcoded number given by the UxTeam to fit correctly in the Windows menu
         static void Init()
         {
             var window = GetWindow<DebugWindow>();

--- a/com.unity.render-pipelines.core/Editor/LookDev/LookDev.cs
+++ b/com.unity.render-pipelines.core/Editor/LookDev/LookDev.cs
@@ -93,7 +93,7 @@ namespace UnityEditor.Rendering.LookDev
         }
 
         /// <summary>open the LookDev window</summary>
-        [MenuItem("Window/Render Pipeline/Look Dev", false, 10000)]
+        [MenuItem("Window/Render Pipeline/Look Dev", false, 10200)]
         public static void Open()
         {
             s_ViewDisplayer = EditorWindow.GetWindow<DisplayWindow>();

--- a/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDRPWizard.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDRPWizard.cs
@@ -211,7 +211,7 @@ namespace UnityEditor.Rendering.HighDefinition
             RequestCloseAndRelaunchWithCurrentArguments = requestCloseAndRelaunchWithCurrentArgumentsLambda.Compile();
         }
 
-        [MenuItem("Window/Render Pipeline/HD Render Pipeline Wizard", priority = 5)]
+        [MenuItem("Window/Render Pipeline/HD Render Pipeline Wizard", priority = 10000)]
         static void OpenWindow()
         {
             GetWindow<HDWizard>("Render Pipeline Wizard");


### PR DESCRIPTION
### Purpose of this PR
Fix order in menu for Render Pipeline category
[note: issue introduced due to editor not rebuilding sub path position when inner element change... It is required to restart fully the editor to be sure where the subpath will land]

---
### Release Notes

---
### Testing status
**Katana Tests**: 
**Manual Tests**: 
**Automated Tests**: 
---
### Overall Product Risks
**Technical Risk**: None
**Halo Effect**: None

---
### Comments to reviewers
