### PR TITLE
[Shader Graph] Fix Small Bugs

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [7.1.0] - 2019-XX-XX
 ### Changed
 - New Shader Graph windows are now docked to either existing Shader Graph windows, or to the Scene View.
+- `Normal Reconstruct Z` node is now compatible with both fragment and vertex stages. 
+- `Position` node now draws the correct label for **Absolute World**. 
 
 ## [7.0.0] - 2019-07-10
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalReconstructZNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalReconstructZNode.cs
@@ -18,7 +18,7 @@ namespace UnityEditor.ShaderGraph
 
         static string NormalReconstructZ(
             [Slot(0, Binding.None)] Vector2 In,
-            [Slot(2, Binding.None, ShaderStageCapability.Fragment)] out Vector3 Out)
+            [Slot(2, Binding.None, ShaderStageCapability.All)] out Vector3 Out)
         {
             Out = Vector3.zero;
             return

--- a/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalReconstructZNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Artistic/Normal/NormalReconstructZNode.cs
@@ -18,7 +18,7 @@ namespace UnityEditor.ShaderGraph
 
         static string NormalReconstructZ(
             [Slot(0, Binding.None)] Vector2 In,
-            [Slot(2, Binding.None, ShaderStageCapability.All)] out Vector3 Out)
+            [Slot(2, Binding.None)] out Vector3 Out)
         {
             Out = Vector3.zero;
             return

--- a/com.unity.shadergraph/Editor/Data/Nodes/GeometryNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/GeometryNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
 using UnityEditor.Graphing;
@@ -19,7 +20,7 @@ namespace UnityEditor.ShaderGraph
         {
             get 
             {
-                var names = validSpaces.Select(cs => cs.ToString()).ToArray();
+                var names = validSpaces.Select(cs => cs.ToString().PascalToLabel()).ToArray();
                 return new PopupList(names, (int)m_Space);
             }
             set

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/PositionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/PositionNode.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -39,7 +41,7 @@ namespace UnityEditor.ShaderGraph
         {
             if (from == 0 && to == 1 && space == CoordinateSpace.World)
             {
-                var names = validSpaces.Select(cs => cs.ToString()).ToArray();
+                var names = validSpaces.Select(cs => cs.ToString().PascalToLabel()).ToArray();
                 spacePopup = new PopupList(names, (int)CoordinateSpace.AbsoluteWorld);
             }
         }

--- a/com.unity.shadergraph/Editor/Data/Util/TextUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/TextUtil.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.RegularExpressions;
+
+namespace UnityEditor.ShaderGraph
+{
+    public static class TextUtil
+    {
+        public static string PascalToLabel(this string pascalString)
+        {
+            return Regex.Replace(pascalString, "(\\B[A-Z])", " $1");
+        }
+    }
+}


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
1) Fix Case 1155476 - `Normal Reconstruct Z` node doesn't work in vertex stage.
2. Fix Case 1164355 - Space Node to have a space between Absolute & World

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.
1. 

![image](https://user-images.githubusercontent.com/39529353/61250310-3b6dab80-a70c-11e9-9df9-276863fef18c.png)

2. 
Before: 
![image](https://user-images.githubusercontent.com/39529353/61250127-c7cb9e80-a70b-11e9-9b7c-535b5d6765a8.png)

After:
![image](https://user-images.githubusercontent.com/39529353/61250116-c13d2700-a70b-11e9-900b-0980b80ba0ea.png)

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] Checked new UI names with UX convention
- [x] C# and shader warnings (supress shader cache to see them)
- [x] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Low

**Halo Effect**: None, Low, Medium, High? Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
Added new util for text to clean display names.