### PR TITLE
Backport Now the static lighting sky will correctly take the default values for non-overridden properties (#4149)

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Volume/VolumeComponent.cs
+++ b/com.unity.render-pipelines.core/Runtime/Volume/VolumeComponent.cs
@@ -27,7 +27,7 @@ namespace UnityEngine.Rendering
 
         public string displayName { get; protected set; } = "";
 
-        internal ReadOnlyCollection<VolumeParameter> parameters { get; private set; }
+        public ReadOnlyCollection<VolumeParameter> parameters { get; private set; }
 
 #pragma warning disable 414
         [SerializeField]

--- a/com.unity.render-pipelines.core/Runtime/Volume/VolumeParameter.cs
+++ b/com.unity.render-pipelines.core/Runtime/Volume/VolumeParameter.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.Rendering
             return ((VolumeParameter<T>) this).value;
         }
 
-        internal abstract void SetValue(VolumeParameter parameter);
+        public abstract void SetValue(VolumeParameter parameter);
 
         // This is used in case you need to access fields/properties that can't be accessed in the
         // constructor of a ScriptableObject (VolumeParameter are generally declared and inited in
@@ -99,7 +99,7 @@ namespace UnityEngine.Rendering
             m_Value = x;
         }
 
-        internal override void SetValue(VolumeParameter parameter)
+        public override void SetValue(VolumeParameter parameter)
         {
             m_Value = parameter.GetValue<T>();
         }

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed PBR master node always opaque (wrong blend modes for forward pass)
 - Fixed alphaClip option in materials not updating the renderqueue.
 - Fixed PBR master node preview
+- Now the static lighting sky will correctly take the default values for non-overridden properties
 
 ## [6.9.0] - 2019-07-02
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/StaticLightingSky.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/StaticLightingSky.cs
@@ -5,14 +5,36 @@ using UnityEngine.Serialization;
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
     [ExecuteAlways]
-    public class StaticLightingSky : MonoBehaviour
+    class StaticLightingSky : MonoBehaviour
     {
         [SerializeField]
         VolumeProfile m_Profile;
         [SerializeField, FormerlySerializedAs("m_BakingSkyUniqueID")]
         int m_StaticLightingSkyUniqueID = 0;
+        int m_LastComputedHash;
 
-        public SkySettings skySettings { get; private set; }
+        // This one contain only property values from overridden properties in the original profile component
+        public SkySettings m_SkySettings;
+        public SkySettings m_SkySettingsFromProfile;
+
+        public SkySettings skySettings
+        {
+            get
+            {
+                GetSkyFromIDAndVolume(m_StaticLightingSkyUniqueID, m_Profile, out var skyFromProfile, out var skyType);
+                if (skyFromProfile != null)
+                {
+                    int newHash = skyFromProfile.GetHashCode();
+                    if (m_LastComputedHash != newHash)
+                        UpdateCurrentStaticLightingSky();
+                }
+                else
+                {
+                    Reset();
+                }
+                return m_SkySettings;
+            }
+        }
 
         List<SkySettings> m_VolumeSkyList = new List<SkySettings>();
 
@@ -48,29 +70,58 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
         }
 
-        void UpdateCurrentStaticLightingSky()
+        void GetSkyFromIDAndVolume(int skyUniqueID, VolumeProfile profile, out SkySettings skySetting, out System.Type skyType)
         {
-            skySettings = GetSkyFromIDAndVolume(m_StaticLightingSkyUniqueID, m_Profile);
-        }
-
-        SkySettings GetSkyFromIDAndVolume(int skyUniqueID, VolumeProfile profile)
-        {
+            skySetting = null;
+            skyType = typeof(SkySettings);
             if (profile != null && skyUniqueID != 0)
             {
                 m_VolumeSkyList.Clear();
-                if (m_Profile.TryGetAllSubclassOf<SkySettings>(typeof(SkySettings), m_VolumeSkyList))
+                if (profile.TryGetAllSubclassOf<SkySettings>(typeof(SkySettings), m_VolumeSkyList))
                 {
                     foreach (var sky in m_VolumeSkyList)
                     {
                         if (skyUniqueID == SkySettings.GetUniqueID(sky.GetType()))
                         {
-                            return sky;
+                            skyType = sky.GetType();
+                            skySetting = sky;
+                        }
                         }
                     }
                 }
             }
 
-            return null;
+        void UpdateCurrentStaticLightingSky()
+        {
+            // First, grab the sky settings of the right type in the profile.
+            CoreUtils.Destroy(m_SkySettings);
+            m_SkySettings = null;
+            m_LastComputedHash = 0;
+            GetSkyFromIDAndVolume(m_StaticLightingSkyUniqueID, m_Profile, out m_SkySettingsFromProfile, out var skyType);
+
+            if (m_SkySettingsFromProfile != null)
+            {
+                // The static lighting sky is a Volume Component that lives outside of the volume system (we just grab a component from a profile)
+                // As such, it may contain values that are not actually overridden
+                // For example, user overrides a value, change it, and disable overrides. In this case the volume still contains the old overridden value
+                // In this case, we want to use values only if they are still overridden, so we create a volume component with default values and then copy the overridden values from the profile.
+
+                // Create an instance with default values
+                m_SkySettings = (SkySettings)ScriptableObject.CreateInstance(skyType);
+                var newSkyParameters = m_SkySettings.parameters;
+                var profileSkyParameters = m_SkySettingsFromProfile.parameters;
+                int parameterCount = m_SkySettings.parameters.Count;
+                // Copy overridden parameters.
+                for (int i  = 0; i < parameterCount; ++i)
+                {
+                    if (profileSkyParameters[i].overrideState == true)
+                    {
+                        newSkyParameters[i].SetValue(profileSkyParameters[i]);
+                    }
+        }
+
+                m_LastComputedHash = m_SkySettingsFromProfile.GetHashCode();
+            }
         }
 
         // All actions done in this method are because Editor won't go through setters so we need to manually check consistency of our data.
@@ -87,9 +138,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             // If we detect that the profile has changed, we need to reset the static lighting sky.
             // We have to do that manually because PropertyField won't go through setters.
-            if (profile != null && skySettings != null)
+            if (profile != null && m_SkySettingsFromProfile != null)
             {
-                if (!profile.components.Find(x => x == skySettings))
+                if (!profile.components.Find(x => x == m_SkySettingsFromProfile))
                 {
                     m_StaticLightingSkyUniqueID = 0;
                 }
@@ -101,13 +152,22 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         void OnEnable()
         {
             UpdateCurrentStaticLightingSky();
-            SkyManager.RegisterStaticLightingSky(this);
+                SkyManager.RegisterStaticLightingSky(this);
         }
 
         void OnDisable()
         {
-            SkyManager.UnRegisterStaticLightingSky(this);
-            skySettings = null;
+                SkyManager.UnRegisterStaticLightingSky(this);
+
+            Reset();
+        }
+
+        void Reset()
+        {
+            CoreUtils.Destroy(m_SkySettings);
+            m_SkySettings = null;
+            m_SkySettingsFromProfile = null;
+            m_LastComputedHash = 0;
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/StaticLightingSky.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/StaticLightingSky.cs
@@ -5,7 +5,7 @@ using UnityEngine.Serialization;
 namespace UnityEngine.Experimental.Rendering.HDPipeline
 {
     [ExecuteAlways]
-    class StaticLightingSky : MonoBehaviour
+    public class StaticLightingSky : MonoBehaviour
     {
         [SerializeField]
         VolumeProfile m_Profile;

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/StaticLightingSky.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/StaticLightingSky.cs
@@ -111,14 +111,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 var newSkyParameters = m_SkySettings.parameters;
                 var profileSkyParameters = m_SkySettingsFromProfile.parameters;
                 int parameterCount = m_SkySettings.parameters.Count;
+
+                // Seems to inexplicably happen sometimes on domain reload.
+                if (profileSkyParameters == null)
+                {
+                    return;
+                }
+
                 // Copy overridden parameters.
-                for (int i  = 0; i < parameterCount; ++i)
+                for (int i = 0; i < parameterCount; ++i)
                 {
                     if (profileSkyParameters[i].overrideState == true)
                     {
                         newSkyParameters[i].SetValue(profileSkyParameters[i]);
                     }
-        }
+                }
 
                 m_LastComputedHash = m_SkySettingsFromProfile.GetHashCode();
             }
@@ -152,13 +159,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         void OnEnable()
         {
             UpdateCurrentStaticLightingSky();
-                SkyManager.RegisterStaticLightingSky(this);
+            SkyManager.RegisterStaticLightingSky(this);
         }
 
         void OnDisable()
         {
-                SkyManager.UnRegisterStaticLightingSky(this);
-
+            SkyManager.UnRegisterStaticLightingSky(this);
             Reset();
         }
 


### PR DESCRIPTION
### Purpose of this PR
Backport Now the static lighting sky will correctly take the default values for non-overridden properties (#4149)

---
### Testing status
**Katana Tests**: [Running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=backport-static-sky-fix&automation-tools_branch=master&unity_branch=2019.2%2Fstaging)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
