### PR TITLE
XRSystem and UniversalRP XR SDK integration

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/ForwardRendererData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRendererData.cs
@@ -36,6 +36,9 @@ namespace UnityEngine.Rendering.Universal
             [Reload("Shaders/Utils/Blit.shader")]
             public Shader blitPS;
 
+            [Reload("Shaders/Utils/FastBlit.shader")]
+            public Shader fastBlitPS;
+
             [Reload("Shaders/Utils/CopyDepth.shader")]
             public Shader copyDepthPS;
 

--- a/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitXRPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/FinalBlitXRPass.cs
@@ -1,0 +1,86 @@
+namespace UnityEngine.Rendering.Universal
+{
+    /// <summary>
+    /// Copy the given color target to the current camera target
+    ///
+    /// You can use this pass to copy the result of rendering to
+    /// the camera target. The pass takes the screen viewport into
+    /// consideration.
+    /// </summary>
+    internal class FinalBlitXRPass : ScriptableRenderPass
+    {
+        const string m_ProfilerTag = "Final Blit XR Pass";
+        RenderTargetIdentifier m_Source;
+        RenderTargetIdentifier m_Dest;
+        RenderTextureDescriptor m_srcDesc;
+        RenderTextureDescriptor m_dstDesc;
+        int m_Targetslice;
+
+        Material m_BlitMaterial;
+
+        bool m_IsMobileOrSwitch;
+
+        public FinalBlitXRPass(RenderPassEvent evt, Material blitMaterial)
+        {
+            m_BlitMaterial = blitMaterial;
+            renderPassEvent = evt;
+        }
+
+        public void Setup(RenderTextureDescriptor srcDescriptor, RenderTargetIdentifier srcHandle, RenderTextureDescriptor dstDescriptor, RenderTargetIdentifier dstHandle, int targetslice)
+        {
+            m_Source = srcHandle;
+            m_Dest = dstHandle;
+            m_srcDesc = srcDescriptor;
+            m_dstDesc = dstDescriptor;
+            m_Targetslice = targetslice;
+
+            m_IsMobileOrSwitch = Application.isMobilePlatform || Application.platform == RuntimePlatform.Switch;
+        }
+
+        /// <inheritdoc/>
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            if (m_BlitMaterial == null)
+            {
+                Debug.LogErrorFormat("Missing {0}. {1} render pass will not execute. Check for missing reference in the renderer resources.", m_BlitMaterial, GetType().Name);
+                return;
+            }
+
+            // @thomas: TODO handles srgb. fetch from display subsystem.
+            bool requiresSRGBConvertion = false;
+
+            // @thomas: TODO handles color format
+            bool killAlpha = renderingData.killAlphaInFinalBlit;
+
+            CommandBuffer cmd = CommandBufferPool.Get(m_ProfilerTag);
+
+            if (requiresSRGBConvertion)
+                cmd.EnableShaderKeyword(ShaderKeywordStrings.LinearToSRGBConversion);
+            else
+                cmd.DisableShaderKeyword(ShaderKeywordStrings.LinearToSRGBConversion);
+
+            if (killAlpha)
+                cmd.EnableShaderKeyword(ShaderKeywordStrings.KillAlpha);
+            else
+                cmd.DisableShaderKeyword(ShaderKeywordStrings.KillAlpha);
+
+            {
+                cmd.SetGlobalTexture("_BlitTex", m_Source);
+
+                // xr flip!
+                cmd.SetGlobalVector("_BlitScaleBias", new Vector4(1,-1,0,1));
+
+                if (m_dstDesc.dimension == TextureDimension.Tex2DArray)
+                    cmd.SetRenderTarget(m_Dest, 0, CubemapFace.Unknown, m_Targetslice);
+                else
+                    cmd.SetRenderTarget(m_Dest, RenderBufferLoadAction.DontCare, RenderBufferStoreAction.Store);
+
+                // Emit 3 vertex draw with empty vbo and ibo. VS will generate full screen triangle
+                cmd.DrawProcedural(Matrix4x4.identity, m_BlitMaterial, 0, MeshTopology.Triangles, 3, 1);
+            }
+
+            context.ExecuteCommandBuffer(cmd);
+            CommandBufferPool.Release(cmd);
+        }
+    }
+}

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRendererData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRendererData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine.Scripting.APIUpdating;
 
@@ -41,7 +42,19 @@ namespace UnityEngine.Rendering.Universal
         protected virtual void OnEnable()
         {
             isInvalidated = true;
+#if UNITY_EDITOR
+            ResourceReloader.ReloadAllNullIn(this, UniversalRenderPipelineAsset.packagePath);
+#endif
         }
+
+        [Serializable, ReloadGroup]
+        public sealed class CommonShaderResources
+        {
+            [Reload("Shaders/Utils/XRMirrorView.shader")]
+            public Shader xrMirrorViewPS;
+        }
+
+        public CommonShaderResources commonShaders;
 
 #if UNITY_EDITOR
         internal virtual Material GetDefaultMaterial(DefaultMaterialType materialType)

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -38,6 +38,7 @@ namespace UnityEngine.Rendering.Universal
     {
         public Camera camera;
         public RenderTextureDescriptor cameraTargetDescriptor;
+        public XRPass xrPass;
         public float renderScale;
         public bool isSceneViewCamera;
         public bool isDefaultViewport;

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
@@ -5,7 +5,7 @@
 // To avoid allocating every frame, XRView is a struct and XRPass is pooled.
 
 #if UNITY_2019_3_OR_NEWER && ENABLE_VR
-#define USE_XR_SDK
+//#define USE_XR_SDK
 #endif
 
 using System;

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
@@ -172,56 +172,5 @@ namespace UnityEngine.Rendering.Universal
             // Validate memory limitations
             //Debug.Assert(views.Count <= TextureXR.kMaxSlices);
         }
-
-        internal void StartLegacyStereo(Camera camera, CommandBuffer cmd, ScriptableRenderContext renderContext)
-        {
-            if (enabled)
-            {
-                // Required for some legacy shaders (text for example)
-                cmd.SetViewProjectionMatrices(GetViewMatrix(), GetProjMatrix());
-
-                if (camera.stereoEnabled)
-                {
-                    // Reset scissor and viewport for C++ stereo code
-                    cmd.DisableScissorRect();
-                    cmd.SetViewport(camera.pixelRect);
-
-                    renderContext.ExecuteCommandBuffer(cmd);
-                    cmd.Clear();
-
-                    if (legacyMultipassEnabled)
-                        renderContext.StartMultiEye(camera, legacyMultipassEye);
-                    else
-                        renderContext.StartMultiEye(camera);
-                }
-            }
-        }
-
-        internal void StopLegacyStereo(Camera camera, CommandBuffer cmd, ScriptableRenderContext renderContext)
-        {
-            if (enabled && camera.stereoEnabled)
-            {
-                renderContext.ExecuteCommandBuffer(cmd);
-                cmd.Clear();
-                renderContext.StopMultiEye(camera);
-            }
-        }
-
-        internal void EndCamera(Camera camera, ScriptableRenderContext renderContext, CommandBuffer cmd, XRSystem system)
-        {
-            if (!enabled)
-                return;
-
-            {
-                renderContext.ExecuteCommandBuffer(cmd);
-                cmd.Clear();
-
-                // Pushes to XR headset and/or display mirror
-                if (legacyMultipassEnabled)
-                    renderContext.StereoEndRender(camera, legacyMultipassEye, legacyMultipassEye == 1);
-                else
-                    renderContext.StereoEndRender(camera);
-            }
-        }
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
@@ -5,7 +5,7 @@
 // To avoid allocating every frame, XRView is a struct and XRPass is pooled.
 
 #if UNITY_2019_3_OR_NEWER && ENABLE_VR
-//#define USE_XR_SDK
+#define USE_XR_SDK
 #endif
 
 using System;
@@ -90,6 +90,9 @@ namespace UnityEngine.Rendering.Universal
         // Legacy multipass support
         internal int  legacyMultipassEye      { get => (int)views[0].legacyStereoEye; }
         internal bool legacyMultipassEnabled  { get => enabled && !instancingEnabled && legacyMultipassEye >= 0; }
+
+        //XRTODO: refactor this logic
+        public bool isMirrorView = false;
 
         internal static XRPass Create(int multipassId, RenderTexture rt = null)
         {

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
@@ -59,6 +59,12 @@ namespace UnityEngine.Rendering.Universal
 #endif
     }
 
+    public enum XRPassType
+    {
+        XRPassDrawScene = 0,
+        XRPassMirrorViewBlit = 1
+    }
+
     public class XRPass
     {
         readonly List<XRView> views = new List<XRView>(2);
@@ -91,8 +97,7 @@ namespace UnityEngine.Rendering.Universal
         internal int  legacyMultipassEye      { get => (int)views[0].legacyStereoEye; }
         internal bool legacyMultipassEnabled  { get => enabled && !instancingEnabled && legacyMultipassEye >= 0; }
 
-        //XRTODO: refactor this logic
-        public bool isMirrorView = false;
+        public XRPassType xrPassType = XRPassType.XRPassDrawScene;
 
         internal static XRPass Create(int multipassId, RenderTexture rt = null)
         {
@@ -114,7 +119,6 @@ namespace UnityEngine.Rendering.Universal
             }
             
             passInfo.xrSdkEnabled = false;
-
             return passInfo;
         }
 

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs
@@ -1,0 +1,220 @@
+// This file contain the two main data structures controlled by the XRSystem.
+// XRView contains the parameters required to render (proj and view matrices, viewport, etc)
+// XRPass holds the render target information and a list of XRView.
+// When a pass has 2+ views, hardware instancing will be active.
+// To avoid allocating every frame, XRView is a struct and XRPass is pooled.
+
+#if UNITY_2019_3_OR_NEWER && ENABLE_VR
+//#define USE_XR_SDK
+#endif
+
+using System;
+using System.Collections.Generic;
+using UnityEngine.Rendering;
+#if USE_XR_SDK
+using UnityEngine.Experimental.XR;
+#endif
+
+namespace UnityEngine.Rendering.Universal
+{
+    internal struct XRView
+    {
+        internal readonly Matrix4x4 projMatrix;
+        internal readonly Matrix4x4 viewMatrix;
+        internal readonly Rect viewport;
+        internal readonly Mesh occlusionMesh;
+        internal readonly int depthSlice;
+        internal readonly Camera.StereoscopicEye legacyStereoEye;
+
+        internal XRView(Camera camera, Camera.StereoscopicEye eye)
+        {
+            projMatrix = camera.GetStereoProjectionMatrix(eye);
+            viewMatrix = camera.GetStereoViewMatrix(eye);
+            viewport = camera.pixelRect;
+            occlusionMesh = null;
+            legacyStereoEye = eye;
+            depthSlice = 0;
+        }
+
+        internal XRView(Matrix4x4 proj, Matrix4x4 view, Rect vp)
+        {
+            projMatrix = proj;
+            viewMatrix = view;
+            viewport = vp;
+            occlusionMesh = null;
+            legacyStereoEye = (Camera.StereoscopicEye)(-1);
+            depthSlice = 0;
+        }
+
+#if USE_XR_SDK
+        internal XRView(XRDisplaySubsystem.XRRenderParameter renderParameter)
+        {
+            projMatrix = renderParameter.projection;
+            viewMatrix = renderParameter.view;
+            viewport = renderParameter.viewport;
+            occlusionMesh = renderParameter.occlusionMesh;
+            legacyStereoEye = (Camera.StereoscopicEye)(-1);
+            depthSlice = renderParameter.textureArraySlice;
+        }
+#endif
+    }
+
+    public class XRPass
+    {
+        readonly List<XRView> views = new List<XRView>(2);
+
+        internal bool enabled      { get => views.Count > 0; }
+        internal bool xrSdkEnabled { get; private set; }
+
+        internal int multipassId    { get; private set; }
+        internal int multiparamId   { get; set; }
+
+        internal int cullingPassId  { get; private set; }
+
+        // Ability to specify where to render the pass
+        internal RenderTargetIdentifier  renderTarget     { get; private set; }
+        internal RenderTextureDescriptor renderTargetDesc { get; private set; }
+        static RenderTargetIdentifier    invalidRT = -1;
+        internal bool                    renderTargetValid { get => renderTarget != invalidRT; }
+
+        // Access to view information
+        internal Matrix4x4 GetProjMatrix(int viewIndex = 0) { return views[viewIndex].projMatrix; }
+        internal Matrix4x4 GetViewMatrix(int viewIndex = 0) { return views[viewIndex].viewMatrix; }
+        internal Rect GetViewport(int viewIndex = 0)        { return views[viewIndex].viewport; }
+        internal int GetDepthSlice(int viewIndex = 0) { return views[viewIndex].depthSlice; }
+
+        // Instanced views support (instanced draw calls or multiview extension)
+        internal int viewCount { get => views.Count; }
+        internal bool instancingEnabled { get => viewCount > 1; }
+
+        // Legacy multipass support
+        internal int  legacyMultipassEye      { get => (int)views[0].legacyStereoEye; }
+        internal bool legacyMultipassEnabled  { get => enabled && !instancingEnabled && legacyMultipassEye >= 0; }
+
+        internal static XRPass Create(int multipassId, RenderTexture rt = null)
+        {
+            XRPass passInfo = GenericPool<XRPass>.Get();
+
+            passInfo.multipassId = multipassId;
+            passInfo.cullingPassId = multipassId;
+            passInfo.views.Clear();
+
+            if (rt != null)
+            {
+                passInfo.renderTarget = new RenderTargetIdentifier(rt);
+                passInfo.renderTargetDesc = rt.descriptor;
+            }
+            else
+            {
+                passInfo.renderTarget = invalidRT;
+                passInfo.renderTargetDesc = default;
+            }
+            
+            passInfo.xrSdkEnabled = false;
+
+            return passInfo;
+        }
+
+        internal void AddView(Camera camera, Camera.StereoscopicEye eye)
+        {
+            AddViewInternal(new XRView(camera, eye));
+        }
+
+        internal void AddView(Matrix4x4 proj, Matrix4x4 view, Rect vp)
+        {
+            AddViewInternal(new XRView(proj, view, vp));
+        }
+
+#if USE_XR_SDK
+        internal static XRPass Create(XRDisplaySubsystem.XRRenderPass xrRenderPass)
+        {
+            XRPass passInfo = GenericPool<XRPass>.Get();
+
+            passInfo.multipassId = xrRenderPass.renderPassIndex;
+
+            passInfo.cullingPassId = xrRenderPass.cullingPassIndex;
+            passInfo.views.Clear();
+            passInfo.renderTarget = xrRenderPass.renderTarget;
+            passInfo.renderTargetDesc = xrRenderPass.renderTargetDesc;
+            passInfo.xrSdkEnabled = true;
+
+            Debug.Assert(passInfo.renderTargetValid, "Invalid render target from XRDisplaySubsystem!");
+
+            return passInfo;
+        }
+
+        ~XRPass()
+        {
+
+        }
+
+        internal void AddView(XRDisplaySubsystem.XRRenderParameter xrSdkRenderParameter)
+        {
+            AddViewInternal(new XRView(xrSdkRenderParameter));
+        }
+#endif
+        internal static void Release(XRPass xrPass)
+        {
+            GenericPool<XRPass>.Release(xrPass);
+        }
+
+        internal void AddViewInternal(XRView xrView)
+        {
+            views.Add(xrView);
+
+            // Validate memory limitations
+            //Debug.Assert(views.Count <= TextureXR.kMaxSlices);
+        }
+
+        internal void StartLegacyStereo(Camera camera, CommandBuffer cmd, ScriptableRenderContext renderContext)
+        {
+            if (enabled)
+            {
+                // Required for some legacy shaders (text for example)
+                cmd.SetViewProjectionMatrices(GetViewMatrix(), GetProjMatrix());
+
+                if (camera.stereoEnabled)
+                {
+                    // Reset scissor and viewport for C++ stereo code
+                    cmd.DisableScissorRect();
+                    cmd.SetViewport(camera.pixelRect);
+
+                    renderContext.ExecuteCommandBuffer(cmd);
+                    cmd.Clear();
+
+                    if (legacyMultipassEnabled)
+                        renderContext.StartMultiEye(camera, legacyMultipassEye);
+                    else
+                        renderContext.StartMultiEye(camera);
+                }
+            }
+        }
+
+        internal void StopLegacyStereo(Camera camera, CommandBuffer cmd, ScriptableRenderContext renderContext)
+        {
+            if (enabled && camera.stereoEnabled)
+            {
+                renderContext.ExecuteCommandBuffer(cmd);
+                cmd.Clear();
+                renderContext.StopMultiEye(camera);
+            }
+        }
+
+        internal void EndCamera(Camera camera, ScriptableRenderContext renderContext, CommandBuffer cmd, XRSystem system)
+        {
+            if (!enabled)
+                return;
+
+            {
+                renderContext.ExecuteCommandBuffer(cmd);
+                cmd.Clear();
+
+                // Pushes to XR headset and/or display mirror
+                if (legacyMultipassEnabled)
+                    renderContext.StereoEndRender(camera, legacyMultipassEye, legacyMultipassEye == 1);
+                else
+                    renderContext.StereoEndRender(camera);
+            }
+        }
+    }
+}

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs.meta
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97f1d69cf0aca3f48aeb38c8edbed669
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
@@ -44,8 +44,10 @@ namespace UnityEngine.Rendering.Universal
         internal XRSystem(Shader xrMirrorViewPS)
         {
             RefreshXrSdk();
-
-            mirrorViewMaterial = CoreUtils.CreateEngineMaterial(xrMirrorViewPS);
+            if (xrMirrorViewPS != null)
+            {
+                mirrorViewMaterial = CoreUtils.CreateEngineMaterial(xrMirrorViewPS);
+            }
         }
 
         internal List<(Camera, XRPass)> SetupFrame(Camera[] cameras)
@@ -99,7 +101,15 @@ namespace UnityEngine.Rendering.Universal
         internal void RenderMirrorView(CommandBuffer cmd)
         {
 #if USE_XR_SDK
+            // Validate states
+            {
+                Debug.Assert(mirrorViewMaterial != null, "mirrorViewMaterial was not initialized!");
+            }
+
             if (display == null)
+                return;
+
+            if(mirrorViewMaterial == null)
                 return;
 
             using (new ProfilingSample(cmd, "XR Mirror View"))

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
@@ -3,7 +3,7 @@
 // - or the 'legacy' C++ stereo rendering path and XRSettings (will be removed in 2020.1)
 
 #if UNITY_2019_3_OR_NEWER && ENABLE_VR
-#define USE_XR_SDK
+//#define USE_XR_SDK
 #endif
 
 using System;

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
@@ -216,16 +216,16 @@ namespace UnityEngine.Rendering.Universal
                         renderPass.GetRenderParameter(camera, renderParamIndex, out var renderParam);
 
                         var xrPass = XRPass.Create(renderPass);
-                        xrPass.isMirrorView = false;
                         xrPass.AddView(renderParam);
                         xrPass.multiparamId = renderParamIndex;
+                        xrPass.xrPassType = XRPassType.XRPassDrawScene;
                         AddPassToFrame(camera, xrPass);
                     }
                 }
             }
             {
                 XRPass xrPass = GenericPool<XRPass>.Get();
-                xrPass.isMirrorView = true;
+                xrPass.xrPassType = XRPassType.XRPassMirrorViewBlit;
                 AddPassToFrame(camera, xrPass);
             }
 #endif

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
@@ -1,0 +1,282 @@
+// XRSystem is where information about XR views and passes are read from 2 exclusive sources:
+// - XRDisplaySubsystem from the XR SDK
+// - or the 'legacy' C++ stereo rendering path and XRSettings (will be removed in 2020.1)
+
+#if UNITY_2019_3_OR_NEWER && ENABLE_VR
+//#define USE_XR_SDK
+#endif
+
+using System;
+using System.Collections.Generic;
+using UnityEngine.Rendering;
+#if USE_XR_SDK
+using UnityEngine.Experimental.XR;
+#endif
+
+namespace UnityEngine.Rendering.Universal
+{
+    public partial class XRSystem
+    {
+        // Valid empty pass when a camera is not using XR
+        public readonly XRPass emptyPass = new XRPass();
+
+        // Bool that tells if xrsdk is available.
+        public bool xrSdkEnabled { get; private set; }
+
+        // Store active passes and avoid allocating memory every frames
+        List<(Camera, XRPass)> framePasses = new List<(Camera, XRPass)>();
+
+#if USE_XR_SDK
+        List<XRDisplaySubsystem> displayList = new List<XRDisplaySubsystem>();
+        XRDisplaySubsystem display = null;
+#endif
+
+        // Blit shader for the mirror view
+        Material mirrorViewMaterial;
+        MaterialPropertyBlock mirrorViewMaterialProperty = new MaterialPropertyBlock();
+
+        // Shader property id
+        public static readonly int _BlitScaleBias = Shader.PropertyToID("_BlitScaleBias");
+        public static readonly int _BlitScaleBiasRt = Shader.PropertyToID("_BlitScaleBiasRt");
+        public static readonly int _BlitTexArraySlice = Shader.PropertyToID("_BlitTexArraySlice");
+        public static readonly int _BlitTexture = Shader.PropertyToID("_BlitTexture");
+
+        internal XRSystem(Shader xrMirrorViewPS)
+        {
+            RefreshXrSdk();
+
+            mirrorViewMaterial = CoreUtils.CreateEngineMaterial(xrMirrorViewPS);
+        }
+
+        internal List<(Camera, XRPass)> SetupFrame(Camera[] cameras)
+        {
+            bool xrSdkActive = RefreshXrSdk();
+            xrSdkEnabled = xrSdkActive;
+
+            // Validate state
+            {
+                Debug.Assert(framePasses.Count == 0, "XRSystem.ReleaseFrame() was not called!");
+
+                if (XRGraphics.enabled)
+                {
+                    Debug.Assert(XRGraphics.stereoRenderingMode != XRGraphics.StereoRenderingMode.SinglePass, "single-pass (double-wide) is not compatible with HDRP.");
+                    Debug.Assert(!xrSdkActive, "The legacy C++ stereo rendering path must be disabled with XR SDK! Go to Project Settings --> Player --> XR Settings");
+                }
+            }
+            
+            foreach (var camera in cameras)
+            {
+                if (camera == null)
+                    continue;
+
+                // Read XR SDK or legacy settings
+                bool xrEnabled = xrSdkActive || (camera.stereoEnabled && XRGraphics.enabled);
+
+                // Enable XR layout only for gameview camera
+                // XRTODO: support render to texture
+                bool xrSupported = camera.cameraType == CameraType.Game && camera.targetTexture == null;
+
+                if (xrEnabled && xrSupported)
+                {
+                    if (xrSdkActive)
+                    {
+                        CreateLayoutFromXrSdk(camera);
+                    }
+                    else
+                    {
+                        CreateLayoutLegacyStereo(camera);
+                    }
+                }
+                else
+                {
+                    AddPassToFrame(camera, emptyPass);
+                }
+            }
+
+            return framePasses;
+        }
+
+        internal void RenderMirrorView(CommandBuffer cmd)
+        {
+#if USE_XR_SDK
+            if (display == null)
+                return;
+
+            using (new ProfilingSample(cmd, "XR Mirror View"))
+            {
+                cmd.SetRenderTarget(BuiltinRenderTextureType.CameraTarget);
+
+                // Null represents backbuffer as render texture
+                if (display.GetMirrorViewBlitDesc(null, out var blitDesc))
+                {
+                    if (blitDesc.nativeBlitAvailable)
+                    {
+                        display.AddGraphicsThreadMirrorViewBlit(cmd, blitDesc.nativeBlitInvalidStates);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < blitDesc.blitParamsCount; ++i)
+                        {
+
+                            blitDesc.GetBlitParameter(i, out var blitParam);
+                            cmd.DisableShaderKeyword(ShaderKeywordStrings.LinearToSRGBConversion);
+                            cmd.DisableShaderKeyword(ShaderKeywordStrings.KillAlpha);
+
+                            Vector4 scaleBias = new Vector4(blitParam.srcRect.width, blitParam.srcRect.height, blitParam.srcRect.x, blitParam.srcRect.y);
+                            Vector4 scaleBiasRT = new Vector4(blitParam.destRect.width, blitParam.destRect.height, blitParam.destRect.x, blitParam.destRect.y);
+
+                            mirrorViewMaterialProperty.SetTexture(_BlitTexture, blitParam.srcTex);
+                            mirrorViewMaterialProperty.SetVector(_BlitScaleBias, scaleBias);
+                            mirrorViewMaterialProperty.SetVector(_BlitScaleBiasRt, scaleBiasRT);
+                            mirrorViewMaterialProperty.SetInt(_BlitTexArraySlice, blitParam.srcTexArraySlice);
+
+                            int shaderPass = (blitParam.srcTex.dimension == TextureDimension.Tex2DArray) ? 1 : 0;
+
+                            // Draw full screen quad using VS
+                            cmd.DrawProcedural(Matrix4x4.identity, mirrorViewMaterial, shaderPass, MeshTopology.Quads, 4, 1, mirrorViewMaterialProperty);
+                        }
+                    }
+                }
+                else
+                {
+                    // Display subsystem is not ready for the mirror view yet, clear color to black for now.
+                    cmd.ClearRenderTarget(true, true, Color.black);
+                }
+            }
+#endif
+        }
+
+        bool RefreshXrSdk()
+        {
+            //TextureXR.maxViews = (XRGraphics.stereoRenderingMode == XRGraphics.StereoRenderingMode.SinglePassInstanced) ? 2 : 1;
+
+#if USE_XR_SDK
+            SubsystemManager.GetInstances(displayList);
+
+            // XRTODO: bind cameras to XR displays (only display 0 is used for now)
+            if (displayList.Count > 0)
+            {
+                display = displayList[0];
+                display.disableLegacyRenderer = true;
+
+                // XRTODO: handle more than 2 instanced views
+                //TextureXR.maxViews = 2;
+
+                return true;
+            }
+            else
+            {
+                display = null;
+            }
+#endif
+
+            return false;
+        }
+
+        void CreateLayoutLegacyStereo(Camera camera)
+        {
+            if (XRGraphics.stereoRenderingMode == XRGraphics.StereoRenderingMode.MultiPass)
+            {
+                for (int passIndex = 0; passIndex < 2; ++passIndex)
+                {
+                    var xrPass = XRPass.Create(passIndex);
+                    xrPass.AddView(camera, (Camera.StereoscopicEye)passIndex);
+
+                    AddPassToFrame(camera, xrPass);
+                }
+            }
+            else
+            {
+                var xrPass = XRPass.Create(multipassId: 0);
+
+                for (int viewIndex = 0; viewIndex < 2; ++viewIndex)
+                {
+                    xrPass.AddView(camera, (Camera.StereoscopicEye)viewIndex);
+                }
+
+               AddPassToFrame(camera, xrPass);
+            }
+        }
+
+        void CreateLayoutFromXrSdk(Camera camera)
+        {
+#if USE_XR_SDK
+            for (int renderPassIndex = 0; renderPassIndex < display.GetRenderPassCount(); ++renderPassIndex)
+            {
+                display.GetRenderPass(renderPassIndex, out var renderPass);
+
+                if (CanUseInstancing(camera, renderPass))
+                {
+                    // XRTODO: instanced views support with XR SDK
+                }
+                else
+                {
+                    for (int renderParamIndex = 0; renderParamIndex < renderPass.GetRenderParameterCount(); ++renderParamIndex)
+                    {
+                        renderPass.GetRenderParameter(camera, renderParamIndex, out var renderParam);
+
+                        var xrPass = XRPass.Create(renderPass);
+                        xrPass.AddView(renderParam);
+                        xrPass.multiparamId = renderParamIndex;
+                        AddPassToFrame(camera, xrPass);
+                    }
+                }
+            }
+#endif
+        }
+
+        internal bool GetCullingParameters(Camera camera, XRPass xrPass, out ScriptableCullingParameters cullingParams)
+        {
+#if USE_XR_SDK
+            if (display != null)
+            {
+                display.GetCullingParameters(camera, xrPass.cullingPassId, out cullingParams);
+            }
+            else
+#endif
+            {
+                if (!camera.TryGetCullingParameters(camera.stereoEnabled, out cullingParams))
+                    return false;
+            }
+
+            return true;
+        }
+
+        internal void ClearAll()
+        {
+            framePasses = null;
+
+#if USE_XR_SDK
+            displayList = null;
+            display = null;
+#endif
+        }
+
+        internal void ReleaseFrame()
+        {
+            foreach ((Camera _, XRPass xrPass) in framePasses)
+            {
+                if (xrPass != emptyPass)
+                    XRPass.Release(xrPass);
+            }
+
+            framePasses.Clear();
+        }
+
+        internal void AddPassToFrame(Camera camera, XRPass xrPass)
+        {
+            framePasses.Add((camera, xrPass));
+        }
+
+#if USE_XR_SDK
+        bool CanUseInstancing(Camera camera, XRDisplaySubsystem.XRRenderPass renderPass)
+        {
+            // XRTODO: instanced views support with XR SDK
+            return false;
+
+            // check viewCount > 1, valid texture array format and valid slice index
+            // limit to 2 for now (until code fully fixed)
+        }
+#endif
+    }
+}

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs
@@ -3,7 +3,7 @@
 // - or the 'legacy' C++ stereo rendering path and XRSettings (will be removed in 2020.1)
 
 #if UNITY_2019_3_OR_NEWER && ENABLE_VR
-//#define USE_XR_SDK
+#define USE_XR_SDK
 #endif
 
 using System;
@@ -216,11 +216,17 @@ namespace UnityEngine.Rendering.Universal
                         renderPass.GetRenderParameter(camera, renderParamIndex, out var renderParam);
 
                         var xrPass = XRPass.Create(renderPass);
+                        xrPass.isMirrorView = false;
                         xrPass.AddView(renderParam);
                         xrPass.multiparamId = renderParamIndex;
                         AddPassToFrame(camera, xrPass);
                     }
                 }
+            }
+            {
+                XRPass xrPass = GenericPool<XRPass>.Get();
+                xrPass.isMirrorView = true;
+                AddPassToFrame(camera, xrPass);
             }
 #endif
         }

--- a/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs.meta
+++ b/com.unity.render-pipelines.universal/Runtime/XR/XRSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2552a2eb9b5299040a8a6277cda85147
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/Shaders/Utils/FastBlit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/FastBlit.shader
@@ -1,0 +1,67 @@
+Shader "Hidden/Universal Render Pipeline/FastBlit"
+{
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline"}
+        LOD 100
+
+        Pass
+        {
+            Name "FastBlit"
+            ZTest Always
+            ZWrite Off
+            Cull Off
+
+            HLSLPROGRAM
+            // Required to compile gles 2.0 with standard srp library
+            #pragma prefer_hlslcc gles
+            #pragma exclude_renderers d3d11_9x
+            #pragma vertex Vertex
+            #pragma fragment Fragment
+
+            #pragma multi_compile _ _LINEAR_TO_SRGB_CONVERSION
+            #pragma multi_compile _ _KILL_ALPHA
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #ifdef _LINEAR_TO_SRGB_CONVERSION
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+            #endif
+
+            struct Attributes
+            {
+                uint   vertexID     : SV_VertexID;
+            };
+
+            struct Varyings
+            {
+                half4 positionCS    : SV_POSITION;
+                half2 uv            : TEXCOORD0;
+            };
+
+            TEXTURE2D(_BlitTex);
+            SAMPLER(sampler_BlitTex);
+            uniform float4 _BlitScaleBias;
+
+            Varyings Vertex(Attributes input)
+            {
+                Varyings output;
+                output.positionCS = GetFullScreenTriangleVertexPosition(input.vertexID);
+                output.uv = GetFullScreenTriangleTexCoord(input.vertexID) * _BlitScaleBias.xy + _BlitScaleBias.zw;;
+                return output;
+            }
+
+            half4 Fragment(Varyings input) : SV_Target
+            {
+                half4 col = SAMPLE_TEXTURE2D(_BlitTex, sampler_BlitTex, input.uv);
+                #ifdef _LINEAR_TO_SRGB_CONVERSION
+                col = LinearToSRGB(col);
+                #endif
+                #ifdef _KILL_ALPHA
+                col.a = 1.0;
+                #endif
+                return col;
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/com.unity.render-pipelines.universal/Shaders/Utils/TextureXR.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/TextureXR.hlsl
@@ -1,0 +1,118 @@
+#ifndef UNITY_TEXTUREXR_INCLUDED
+#define UNITY_TEXTUREXR_INCLUDED
+
+// single-pass instancing is the default VR method for HDRP
+// multi-pass is working but not recommended due to lower performance
+// multi-view is not yet supported
+// single-pass doule-wide is deprecated
+
+// XRTODO: refactor this with UnityInstancing.hlsl and sync with LWRP
+// XRTODO: update supported platforms based on Unity version (for required C++ fixes)
+
+// XRTODO: consolidate with TextureXR.cs
+#define XR_MAX_VIEWS 2
+
+// Must be in sync with C# with property useTexArray in TextureXR.cs
+#if (defined(SHADER_API_D3D11) && !defined(SHADER_API_XBOXONE)) || defined(SHADER_API_PSSL) || defined(SHADER_API_VULKAN)
+    #define UNITY_TEXTURE2D_X_ARRAY_SUPPORTED
+#endif
+
+// Validate supported platforms
+#if defined(STEREO_INSTANCING_ON) && !defined(UNITY_TEXTURE2D_X_ARRAY_SUPPORTED)
+    #error Single-pass stereo instancing is not supported on this platform (see UNITY_TEXTURE2D_X_ARRAY_SUPPORTED).
+#endif
+
+#if defined(UNITY_SINGLE_PASS_STEREO)
+    #error Single-pass (double-wide) is not compatible with HDRP.
+#endif
+
+// Control if TEXTURE2D_X macros will expand to texture arrays
+#if defined(UNITY_TEXTURE2D_X_ARRAY_SUPPORTED) && !defined(DISABLE_TEXTURE2D_X_ARRAY)
+    #define USE_TEXTURE2D_X_AS_ARRAY
+#endif
+
+// Early defines for single-pass stereo instancing
+#if defined(STEREO_INSTANCING_ON) && defined(UNITY_TEXTURE2D_X_ARRAY_SUPPORTED)
+    #define UNITY_STEREO_INSTANCING_ENABLED
+#endif
+
+// Workaround for lack of multi compile in compute shaders
+#if defined(SHADER_STAGE_COMPUTE) && defined(UNITY_TEXTURE2D_X_ARRAY_SUPPORTED)
+    #define UNITY_STEREO_INSTANCING_ENABLED
+#endif
+
+// Define to override default rendering matrices (used mostly in ShaderVariables.hlsl)
+#if defined(UNITY_STEREO_INSTANCING_ENABLED)
+    #define USING_STEREO_MATRICES
+#endif
+
+// Helper macros to handle XR instancing with Texture2DArray
+// With single-pass stereo instancing, unity_StereoEyeIndex is used to select the eye in the current context.
+// Otherwise, the index is statically set to 0
+#if defined(USE_TEXTURE2D_X_AS_ARRAY)
+
+    // Only single-pass stereo instancing used array indexing
+    #if defined(UNITY_STEREO_INSTANCING_ENABLED)
+        #define SLICE_ARRAY_INDEX   unity_StereoEyeIndex
+    #else
+        #define SLICE_ARRAY_INDEX  0
+    #endif
+
+    #define TEXTURE2D_X                                                      TEXTURE2D_ARRAY
+    #define TEXTURE2D_X_PARAM                                                TEXTURE2D_ARRAY_PARAM
+    #define TEXTURE2D_X_ARGS                                                 TEXTURE2D_ARRAY_ARGS
+    #define TEXTURE2D_X_HALF                                                 TEXTURE2D_ARRAY_HALF
+    #define TEXTURE2D_X_FLOAT                                                TEXTURE2D_ARRAY_FLOAT
+    #define TEXTURE2D_X_UINT(textureName)                                    Texture2DArray<uint> textureName
+    #define TEXTURE2D_X_MSAA(type, textureName)                              Texture2DMSArray<type> textureName
+
+    #define RW_TEXTURE2D_X(type, textureName)                                RW_TEXTURE2D_ARRAY(type, textureName)
+    #define COORD_TEXTURE2D_X(pixelCoord)                                    uint3(pixelCoord, SLICE_ARRAY_INDEX)
+    #define LOAD_TEXTURE2D_X(textureName, unCoord2)                          LOAD_TEXTURE2D_ARRAY(textureName, unCoord2, SLICE_ARRAY_INDEX)
+    #define LOAD_TEXTURE2D_X_MSAA(textureName, unCoord2, sampleIndex)        LOAD_TEXTURE2D_ARRAY_MSAA(textureName, unCoord2, SLICE_ARRAY_INDEX, sampleIndex)
+    #define LOAD_TEXTURE2D_X_LOD(textureName, unCoord2, lod)                 LOAD_TEXTURE2D_ARRAY_LOD(textureName, unCoord2, SLICE_ARRAY_INDEX, lod)
+    #define SAMPLE_TEXTURE2D_X(textureName, samplerName, coord2)             SAMPLE_TEXTURE2D_ARRAY(textureName, samplerName, coord2, SLICE_ARRAY_INDEX)
+    #define SAMPLE_TEXTURE2D_X_LOD(textureName, samplerName, coord2, lod)    SAMPLE_TEXTURE2D_ARRAY_LOD(textureName, samplerName, coord2, SLICE_ARRAY_INDEX, lod)
+    #define GATHER_TEXTURE2D_X(textureName, samplerName, coord2)             GATHER_TEXTURE2D_ARRAY(textureName, samplerName, coord2, SLICE_ARRAY_INDEX)
+    #define GATHER_RED_TEXTURE2D_X(textureName, samplerName, coord2)         GATHER_RED_TEXTURE2D(textureName, samplerName, float3(coord2, SLICE_ARRAY_INDEX))
+    #define GATHER_GREEN_TEXTURE2D_X(textureName, samplerName, coord2)       GATHER_GREEN_TEXTURE2D(textureName, samplerName, float3(coord2, SLICE_ARRAY_INDEX))
+#else
+    #define SLICE_ARRAY_INDEX                                                0
+
+    #define TEXTURE2D_X                                                      TEXTURE2D
+    #define TEXTURE2D_X_PARAM                                                TEXTURE2D_PARAM
+    #define TEXTURE2D_X_ARGS                                                 TEXTURE2D_ARGS
+    #define TEXTURE2D_X_HALF                                                 TEXTURE2D_HALF
+    #define TEXTURE2D_X_FLOAT                                                TEXTURE2D_FLOAT
+    #define TEXTURE2D_X_UINT(textureName)                                    Texture2D<uint> textureName
+    #define TEXTURE2D_X_MSAA(type, textureName)                              Texture2DMS<type> textureName
+
+    #define RW_TEXTURE2D_X                                                   RW_TEXTURE2D
+    #define COORD_TEXTURE2D_X(pixelCoord)                                    pixelCoord
+    #define LOAD_TEXTURE2D_X                                                 LOAD_TEXTURE2D
+    #define LOAD_TEXTURE2D_X_MSAA                                            LOAD_TEXTURE2D_MSAA
+    #define LOAD_TEXTURE2D_X_LOD                                             LOAD_TEXTURE2D_LOD
+    #define SAMPLE_TEXTURE2D_X                                               SAMPLE_TEXTURE2D
+    #define SAMPLE_TEXTURE2D_X_LOD                                           SAMPLE_TEXTURE2D_LOD
+    #define GATHER_TEXTURE2D_X                                               GATHER_TEXTURE2D
+    #define GATHER_RED_TEXTURE2D_X                                           GATHER_RED_TEXTURE2D
+    #define GATHER_GREEN_TEXTURE2D_X                                         GATHER_GREEN_TEXTURE2D
+#endif
+
+// see Unity\Shaders\Includes\UnityShaderVariables.cginc for impl used by the C++ renderer
+#if defined(USING_STEREO_MATRICES) && defined(UNITY_STEREO_INSTANCING_ENABLED)
+    static uint unity_StereoEyeIndex;
+#else
+    #define unity_StereoEyeIndex 0
+#endif
+
+// Helper macro to assign eye index during compute pass (usually from SV_DispatchThreadID)
+#if defined(SHADER_STAGE_COMPUTE)
+    #if defined(UNITY_STEREO_INSTANCING_ENABLED)
+        #define UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(eyeIndex) unity_StereoEyeIndex = eyeIndex;
+    #else
+        #define UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX(eyeIndex)
+    #endif
+#endif
+
+#endif // UNITY_TEXTUREXR_INCLUDED

--- a/com.unity.render-pipelines.universal/Shaders/Utils/TextureXR.hlsl.meta
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/TextureXR.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 996bbbff5bb3aab449da48e9092e4b48
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/Shaders/Utils/XRMirrorView.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/XRMirrorView.shader
@@ -14,7 +14,7 @@ Shader "Hidden/HDRP/XRMirrorView"
                 #pragma fragment FragBilinear
 
                 #define DISABLE_TEXTURE2D_X_ARRAY
-				#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+				#include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/TextureXR.hlsl"
 				
 				TEXTURE2D_X(_BlitTexture);
 				float4 FragBilinear(Varyings input) : SV_Target
@@ -38,7 +38,7 @@ Shader "Hidden/HDRP/XRMirrorView"
                 #pragma fragment FragBilinear
 				
 				#undef DISABLE_TEXTURE2D_X_ARRAY
-				#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+				#include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/TextureXR.hlsl"
 				
 				TEXTURE2D_X(_BlitTexture);
 				float4 FragBilinear(Varyings input) : SV_Target

--- a/com.unity.render-pipelines.universal/Shaders/Utils/XRMirrorView.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/XRMirrorView.shader
@@ -1,0 +1,90 @@
+Shader "Hidden/HDRP/XRMirrorView"
+{
+    SubShader
+    {
+        Tags{ "RenderPipeline" = "LightweightPipeline" }
+
+        // 0: TEXTURE2D
+        Pass
+        {
+            ZWrite Off ZTest Always Blend Off Cull Off
+
+            HLSLPROGRAM
+                #pragma vertex VertQuad
+                #pragma fragment FragBilinear
+
+                #define DISABLE_TEXTURE2D_X_ARRAY
+				#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+				
+				TEXTURE2D_X(_BlitTexture);
+				float4 FragBilinear(Varyings input) : SV_Target
+				{
+				#if defined(USE_TEXTURE2D_X_AS_ARRAY)
+					return SAMPLE_TEXTURE2D_ARRAY(_BlitTexture, sampler_LinearClamp, input.texcoord.xy, _BlitTexArraySlice);
+				#else
+					return SAMPLE_TEXTURE2D(_BlitTexture, sampler_LinearClamp, input.texcoord.xy);
+				#endif
+				}
+            ENDHLSL
+        }
+
+        // 1: TEXTURE2D_ARRAY
+        Pass
+        {
+            ZWrite Off ZTest Always Blend Off Cull Off
+
+            HLSLPROGRAM
+                #pragma vertex VertQuad
+                #pragma fragment FragBilinear
+				
+				#undef DISABLE_TEXTURE2D_X_ARRAY
+				#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+				
+				TEXTURE2D_X(_BlitTexture);
+				float4 FragBilinear(Varyings input) : SV_Target
+				{
+				#if defined(USE_TEXTURE2D_X_AS_ARRAY)
+					return SAMPLE_TEXTURE2D_ARRAY(_BlitTexture, sampler_LinearClamp, input.texcoord.xy, _BlitTexArraySlice);
+				#else
+					return SAMPLE_TEXTURE2D(_BlitTexture, sampler_LinearClamp, input.texcoord.xy);
+				#endif
+				}
+            ENDHLSL
+        }
+		
+		HLSLINCLUDE
+
+        #pragma target 4.5
+        #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+        #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+
+        SamplerState sampler_LinearClamp;
+        uniform float4 _BlitScaleBias;
+        uniform float4 _BlitScaleBiasRt;
+        uniform uint _BlitTexArraySlice;
+
+        struct Attributes
+        {
+            uint vertexID : SV_VertexID;
+        };
+
+        struct Varyings
+        {
+            float4 positionCS : SV_POSITION;
+            float2 texcoord   : TEXCOORD0;
+        };
+
+        Varyings VertQuad(Attributes input)
+        {
+            Varyings output;
+            output.positionCS = GetQuadVertexPosition(input.vertexID) * float4(_BlitScaleBiasRt.x, _BlitScaleBiasRt.y, 1, 1) + float4(_BlitScaleBiasRt.z, _BlitScaleBiasRt.w, 0, 0);
+            output.positionCS.xy = output.positionCS.xy * float2(2.0f, -2.0f) + float2(-1.0f, 1.0f); //convert to -1..1
+            output.texcoord = GetQuadTexCoord(input.vertexID) * _BlitScaleBias.xy + _BlitScaleBias.zw;
+            return output;
+        }
+
+		ENDHLSL
+    }
+
+    Fallback Off
+}

--- a/com.unity.render-pipelines.universal/Shaders/Utils/XRMirrorView.shader.meta
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/XRMirrorView.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 033ac7a87a2117047a5140bce689efb8
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/Tests/Editor/XRSystemTests.cs
+++ b/com.unity.render-pipelines.universal/Tests/Editor/XRSystemTests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using UnityEngine.TestTools.Constraints;
+using Is = UnityEngine.TestTools.Constraints.Is;
+
+namespace UnityEngine.Rendering.Universal.Tests
+{
+    class XRSystemTests
+    {
+        XRSystem xrSystem;
+        Camera[] cameras;
+
+        // Simulate multiple frames with many cameras, passes and views
+        const int k_FrameCount = 90;
+        const int k_CameraCount = 3;
+        const int k_PassCount = 4;
+        const int k_ViewCount = 2;
+
+        [SetUp]
+        public void SetUp()
+        {
+            xrSystem = new XRSystem(null);
+            TextureXR.maxViews = k_ViewCount;
+            cameras = new Camera[k_CameraCount];
+            for (int cameraIndex = 0; cameraIndex < k_CameraCount; ++cameraIndex)
+            {
+                var cameraGameObject = new GameObject();
+                cameras[cameraIndex] = cameraGameObject.AddComponent<Camera>();
+            }
+
+            SimulateOneFrame();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            xrSystem = null;
+            cameras = null;
+        }
+
+        public void SimulateOneFrame()
+        {
+            foreach (var camera in cameras)
+            {
+                for (int passIndex = 0; passIndex < k_PassCount; ++passIndex)
+                {
+                    var xrPass = XRPass.Create(passIndex);
+
+                    for (int viewIndex = 0; viewIndex < k_ViewCount; ++viewIndex)
+                    {
+                        xrPass.AddViewInternal(new XRView());
+                    }
+
+                    xrSystem.AddPassToFrame(camera, xrPass);
+                }
+            }
+
+            xrSystem.ReleaseFrame();
+        }
+
+        [Test]
+        public void ZeroGCMemoryPerFrame()
+        {
+            for (int i = 0; i < k_FrameCount; ++i)
+            {
+                Assert.That(() => SimulateOneFrame(), Is.Not.AllocatingGCMemory());
+            }
+        }
+    }
+}

--- a/com.unity.render-pipelines.universal/Tests/Editor/XRSystemTests.cs.meta
+++ b/com.unity.render-pipelines.universal/Tests/Editor/XRSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5dcdb8572b8a1d43903f36f2ae6debb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
This PR contains the groundwork for Pure XRSDK integration. The whole system is disabled for now due to the reason projection, view and render target logic is not implemented yet.

- Added XRSDK System in UniversalRP (system is disabled until the projection matrix, view matrix, and render targets are hooked up with UniversalRP's render logic)
** see XRSystem.cs and XRPass.cs
- Added finalXRBlit in ForwardRenderer to support final blit to eye texture (this is disabled until XR System is enabled)
** see ForwardRenderer.cs
- Added XRSDK mirrorView support (this is disabled until XR system is enabled)
** see UniversalRenderPipeline.cs
---
### Release Notes
- None

---
### Testing status
**Katana Tests**: Running

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally

**Automated Tests**: 
- added XRSystemTests.ZeroGCMemoryPerFrame as unit test to validate we're not allocating garbage each frame

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
This PR is trying to match HDRP's XRSDK implementation as close as possible. 
HDRP's XRSDK PR: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3393