### PR TITLE
Fix Custom Function node include file dependencies

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - New Shader Graph windows are now docked to either existing Shader Graph windows, or to the Scene View.
 
+### Fixed
+- Fixed various dependency tracking issues with Sub Graphs and HLSL include files from Custom Function Nodes.
+
 ## [7.0.0] - 2019-07-10
 ### Added
 - You can now use the `SHADERGRAPH_PREVIEW` keyword in `Custom Function Node` to generate different code for preview Shaders.

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New Shader Graph windows are now docked to either existing Shader Graph windows, or to the Scene View.
 
 ### Fixed
-- Fixed various dependency tracking issues with Sub Graphs and HLSL include files from Custom Function Nodes.
+- Fixed various dependency tracking issues with Sub Graphs and HLSL files from Custom Function Nodes.
 
 ## [7.0.0] - 2019-07-10
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -160,6 +160,17 @@ namespace UnityEditor.ShaderGraph
                         if(string.IsNullOrEmpty(path))
                             path = functionSource;
 
+                        string hash;
+                        try
+                        {
+                            hash = AssetDatabase.GetAssetDependencyHash(path).ToString();
+                        }
+                        catch
+                        {
+                            hash = "Failed to compute hash for include";
+                        }
+
+                        builder.AppendLine($"// {hash}");
                         builder.AppendLine($"#include \"{path}\"");
                     });
                     break;

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -296,6 +296,16 @@ namespace UnityEditor.ShaderGraph
             base.ValidateNode();
         }
 
+        public void Reload(HashSet<string> changedFileDependencies)
+        {
+            if (changedFileDependencies.Contains(m_FunctionSource))
+            {
+                owner.ClearErrorsForNode(this);
+                ValidateNode();
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
         public VisualElement CreateSettingsElement()
         {
             PropertySheet ps = new PropertySheet();

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/CustomFunctionNode.cs
@@ -39,7 +39,7 @@ namespace UnityEditor.ShaderGraph
             }
         }
         
-        readonly static string[] k_ValidExtensions = { ".hlsl", ".cginc" };
+        public static string[] s_ValidExtensions = { ".hlsl", ".cginc" };
         const string k_InvalidFileType = "Source file is not a valid file type. Valid file extensions are .hlsl and .cginc";
         const string k_MissingOutputSlot = "A Custom Function Node must have at least one output slot";
 
@@ -250,7 +250,7 @@ namespace UnityEditor.ShaderGraph
                     path = functionSource;
 
                 string extension = Path.GetExtension(path);
-                return k_ValidExtensions.Contains(extension);
+                return s_ValidExtensions.Contains(extension);
             }
         }
 
@@ -284,7 +284,7 @@ namespace UnityEditor.ShaderGraph
                     if(!string.IsNullOrEmpty(path))
                     {
                         string extension = path.Substring(path.LastIndexOf('.'));
-                        if(!k_ValidExtensions.Contains(extension))
+                        if(!s_ValidExtensions.Contains(extension))
                         {
                             owner.AddValidationError(tempId, k_InvalidFileType, ShaderCompilerMessageSeverity.Error);
                         }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/SubGraphNode.cs
@@ -230,9 +230,9 @@ namespace UnityEditor.ShaderGraph
             UpdateSlots();
         }
         
-        public void Reload(HashSet<string> changedSubGraphs)
+        public void Reload(HashSet<string> changedFileDependencies)
         {
-            if (changedSubGraphs.Contains(asset.assetGuid) || asset.descendents.Any(changedSubGraphs.Contains))
+            if (changedFileDependencies.Contains(asset.assetGuid) || asset.descendents.Any(changedFileDependencies.Contains))
             {
                 m_SubGraph = null;
                 UpdateSlots();

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -29,7 +29,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         bool m_HasError;
 
         [NonSerialized]
-        HashSet<string> m_ChangedSubGraphs = new HashSet<string>();
+        HashSet<string> m_ChangedFileDependencies = new HashSet<string>();
 
         ColorSpace m_ColorSpace;
         RenderPipelineAsset m_RenderPipelineAsset;
@@ -145,14 +145,18 @@ namespace UnityEditor.ShaderGraph.Drawing
                     graphObject.Validate();
                 }
 
-                if (m_ChangedSubGraphs.Count > 0 && graphObject != null && graphObject.graph != null)
+                if (m_ChangedFileDependencies.Count > 0 && graphObject != null && graphObject.graph != null)
                 {
                     foreach (var subGraphNode in graphObject.graph.GetNodes<SubGraphNode>())
                     {
-                        subGraphNode.Reload(m_ChangedSubGraphs);
+                        subGraphNode.Reload(m_ChangedFileDependencies);
+                    }
+                    foreach (var customFunctionNode in graphObject.graph.GetNodes<CustomFunctionNode>())
+                    {
+                        customFunctionNode.Reload(m_ChangedFileDependencies);
                     }
 
-                    m_ChangedSubGraphs.Clear();
+                    m_ChangedFileDependencies.Clear();
                 }
 
                 if (graphObject.wasUndoRedoPerformed)
@@ -175,11 +179,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        public void ReloadSubGraphsOnNextUpdate(List<string> subGraphs)
+        public void ReloadSubGraphsOnNextUpdate(List<string> changedFiles)
         {
-            foreach (var subGraph in subGraphs)
+            foreach (var changedFile in changedFiles)
             {
-                m_ChangedSubGraphs.Add(subGraph);
+                m_ChangedFileDependencies.Add(changedFile);
             }
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
@@ -400,9 +400,23 @@ namespace UnityEditor.ShaderGraph.Drawing
             // Check for shaders that finished compiling and set them to redraw
             foreach (var renderData in m_RenderDatas)
             {
-                if (renderData != null && renderData.shaderData.isCompiling &&
-                    ShaderUtil.IsPassCompiled(renderData.shaderData.mat, 0))
+                if (renderData != null && renderData.shaderData.isCompiling)
                 {
+                    var isCompiled = true;
+                    for (var i = 0; i < renderData.shaderData.mat.passCount; i++)
+                    {
+                        if (!ShaderUtil.IsPassCompiled(renderData.shaderData.mat, i))
+                        {
+                            isCompiled = false;
+                            break;
+                        }
+                    }
+
+                    if (!isCompiled)
+                    {
+                        continue;
+                    }
+
                     renderData.shaderData.isCompiling = false;
                     CheckForErrors(renderData.shaderData);
                     m_NodesToDraw.Add(renderData.shaderData.node);
@@ -441,18 +455,22 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
                 ShaderUtil.ClearCachedData(renderData.shaderData.shader);
                 // Always explicitly use pass 0 for preview shaders
-                BeginCompile(renderData, results.shader, 0);
+                BeginCompile(renderData, results.shader);
             }
 
             ShaderUtil.allowAsyncCompilation = wasAsyncAllowed;
             m_NodesToUpdate.Clear();
         }
 
-        void BeginCompile(PreviewRenderData renderData, string shaderStr, int shaderPass)
+        void BeginCompile(PreviewRenderData renderData, string shaderStr)
         {
             var shaderData = renderData.shaderData;
+            ShaderUtil.ClearCachedData(shaderData.shader);
             ShaderUtil.UpdateShaderAsset(shaderData.shader, shaderStr, false);
-            ShaderUtil.CompilePass(shaderData.mat, shaderPass);
+            for (var i = 0; i < shaderData.mat.passCount; i++)
+            {
+                ShaderUtil.CompilePass(shaderData.mat, i);
+            }
             shaderData.isCompiling = true;
             renderData.NotifyPreviewChanged();
         }
@@ -551,7 +569,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 ShaderUtil.ClearCachedData(shaderData.shader);
             }
 
-            BeginCompile(masterRenderData, shaderData.shaderString, masterNode.GetActiveSubShader()?.GetPreviewPassIndex() ?? 0);
+            BeginCompile(masterRenderData, shaderData.shaderString);
         }
 
         void DestroyRenderData(PreviewRenderData renderData)

--- a/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
@@ -454,7 +454,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                     continue;
                 }
                 ShaderUtil.ClearCachedData(renderData.shaderData.shader);
-                // Always explicitly use pass 0 for preview shaders
                 BeginCompile(renderData, results.shader);
             }
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
@@ -52,19 +52,12 @@ namespace UnityEditor.ShaderGraph
             if (anyShaders)
                 UpdateAfterAssetChange(movedAssets);
             
-            var changedSubGraphs = movedAssets.Union(importedAssets)
-                .Where(x => x.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase))
+            var changedFiles = movedAssets.Union(importedAssets)
+                .Where(x => x.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase)
+                || CustomFunctionNode.s_ValidExtensions.Contains(Path.GetExtension(x)))
                 .Select(AssetDatabase.AssetPathToGUID)
                 .Distinct()
                 .ToList();
-
-            var changedIncludes =  movedAssets.Union(importedAssets)
-                .Select(AssetDatabase.AssetPathToGUID)
-                .Where(x => x.EndsWith("hlsl", StringComparison.InvariantCultureIgnoreCase))
-                .Distinct()
-                .ToList();
-
-            var changedFiles = changedSubGraphs.Union(changedIncludes).ToList();
 
             if (changedFiles.Count > 0)
             {

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
@@ -58,12 +58,20 @@ namespace UnityEditor.ShaderGraph
                 .Distinct()
                 .ToList();
 
-            if (changedSubGraphs.Count > 0)
+            var changedIncludes =  movedAssets.Union(importedAssets)
+                .Select(AssetDatabase.AssetPathToGUID)
+                .Where(x => x.EndsWith("hlsl", StringComparison.InvariantCultureIgnoreCase))
+                .Distinct()
+                .ToList();
+
+            var changedFiles = changedSubGraphs.Union(changedIncludes).ToList();
+
+            if (changedFiles.Count > 0)
             {
                 var windows = Resources.FindObjectsOfTypeAll<MaterialGraphEditWindow>();
                 foreach (var window in windows)
                 {
-                    window.ReloadSubGraphsOnNextUpdate(changedSubGraphs);
+                    window.ReloadSubGraphsOnNextUpdate(changedFiles);
                 }
             }
         }

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -229,7 +229,9 @@ namespace UnityEditor.ShaderGraph
         {
             if (!dependencyMap.ContainsKey(assetPath))
             {
-                MinimalGraphData.GetDependencyPaths(assetPath, dependencies);
+                if(assetPath.EndsWith(Extension))
+                    MinimalGraphData.GetDependencyPaths(assetPath, dependencies);
+                
                 var dependencyPaths = dependencyMap[assetPath] = dependencies.ToArray();
                 dependencies.Clear();
                 foreach (var dependencyPath in dependencyPaths)


### PR DESCRIPTION
### Purpose of this PR
An issues in the Sub Graph dependency tracking system lead to exceptions when handling HLSL include files. This has now been resolved, as well as adding more robust dependency tracking for updates on those files.

Fixes the following FB cases:
- Nested Sub Graphs can fail test for port connections when using GetSlotValue
https://fogbugz.unity3d.com/f/cases/1151533/
- Subgraph import error with assetdatase v2
https://fogbugz.unity3d.com/f/cases/1164768/
- Changing hlsl code that Custom Function Node points to does not update previews inside Graph View.
https://fogbugz.unity3d.com/f/cases/1167027/
- Breaking hlsl code that Custom Function Node points to does not update CFN.
https://fogbugz.unity3d.com/f/cases/1167028/

---
### Release Notes
Changelog

---
### Testing status
**Katana Tests**: Running

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup? 
N/A

Any test projects to go with this to help reviewers? 
N/A

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High? Medium - Sub graph import change, always risky

**Halo Effect**: None, Low, Medium, High? - Low only on import step

---
### Comments to reviewers
N/A
