### PR TITLE
Added extension API for custom keyword nodes

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Graphs/ShaderKeyword.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ShaderKeyword.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace UnityEditor.ShaderGraph
 {
     [Serializable]
-    struct ShaderKeywordEntry
+    internal struct ShaderKeywordEntry
     {
         public int id;
         public string displayName;

--- a/com.unity.shadergraph/Editor/Data/Util/KeywordUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/KeywordUtil.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine;
 
 namespace UnityEditor.ShaderGraph
@@ -22,6 +23,9 @@ namespace UnityEditor.ShaderGraph
                 new ShaderKeywordEntry(3, "Low", "LOW"),
             },
         };
+
+        [CustomKeywordNodeProvider]
+        public static IEnumerable<ShaderKeyword> BuiltinShaderKeywords() => Enumerable.Repeat(QualityKeyword, 1);
     }
 
     static class KeywordUtil

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -221,7 +221,8 @@ namespace UnityEditor.ShaderGraph.Drawing
             gm.AddItem(new GUIContent($"{path}/Boolean"), false, () => AddInputRow(new ShaderKeyword(ShaderKeywordType.Boolean), true));
             gm.AddItem(new GUIContent($"{path}/Enum"), false, () => AddInputRow(new ShaderKeyword(ShaderKeywordType.Enum), true));
             gm.AddSeparator($"{path}/");
-            AddBuiltinKeyword(gm, BuiltinKeyword.QualityKeyword, path);
+            foreach (var shaderKeyword in BlackboardCustomKeywordNode.GetAllShaderKeyword())
+                AddBuiltinKeyword(gm, shaderKeyword, path);
         }
 
         void AddBuiltinKeyword(GenericMenu gm, ShaderKeyword keyword, string path)

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/IBlackboardCustomKeywordNodeProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/IBlackboardCustomKeywordNodeProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UnityEditor.ShaderGraph.Drawing
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    class CustomKeywordNodeProviderAttribute : Attribute
+    {
+        public int order { get; private set; }
+
+        public CustomKeywordNodeProviderAttribute(int order = 0) => this.order = order;
+    }
+
+    static class BlackboardCustomKeywordNode
+    {
+        public static IEnumerable<ShaderKeyword> GetAllShaderKeyword()
+            => TypeCache.GetMethodsWithAttribute<CustomKeywordNodeProviderAttribute>()
+                .Where(method => method.IsStatic && method.ReturnType == typeof(IEnumerable<ShaderKeyword>))
+                .OrderBy(method => method.GetCustomAttributes(typeof(CustomKeywordNodeProviderAttribute), false)
+                    .Cast<CustomKeywordNodeProviderAttribute>().First().order)
+                .SelectMany(method =>
+                    (IEnumerable<ShaderKeyword>) method.Invoke(null, new object[0] { })
+                );
+    }
+}

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/IBlackboardCustomKeywordNodeProvider.cs.meta
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/IBlackboardCustomKeywordNodeProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c9d769f1b8c48746bca5318ac6d2dfb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR
In HDRP, we need to add a specific keyword node for raytracing.
To do it properly, we need an API to add our specific node in the ShaderGraph available keyword nodes.

This can be done by writing a method that provides shader keywords, the `QualityKeyword` was updated to use this path as well.

Example usage:
```
static class BuiltinKeyword
    {
        public static ShaderKeyword QualityKeyword = new ShaderKeyword(ShaderKeywordType.Enum, false)
        {
            displayName = "Material Quality",
            overrideReferenceName = "MATERIAL_QUALITY",
            isEditable = false,
            keywordDefinition = ShaderKeywordDefinition.ShaderFeature,
            keywordScope = ShaderKeywordScope.Global,
            entries = new List<ShaderKeywordEntry>()
            {
                new ShaderKeywordEntry(1, "High", "HIGH"),
                new ShaderKeywordEntry(2, "Medium", "MEDIUM"),
                new ShaderKeywordEntry(3, "Low", "LOW"),
            },
        };

        [CustomKeywordNodeProvider]
        public static IEnumerable<ShaderKeyword> BuiltinShaderKeywords() => Enumerable.Repeat(QualityKeyword, 1);
    }
```

---
### Testing status
**Katana Tests**: -

**Automated Tests**: -

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
