### PR TITLE
Fixed frustum culling for 2D shape light falloff offset

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/2D/Light2DShape.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Light2DShape.cs
@@ -41,9 +41,12 @@ namespace UnityEngine.Experimental.Rendering.Universal
         BoundingSphere GetShapeLightBoundingSphere()
         {
             BoundingSphere boundingSphere;
-
-            Vector3 maximum = transform.TransformPoint(m_LocalBounds.max);
-            Vector3 minimum = transform.TransformPoint(m_LocalBounds.min);
+            
+            Vector3 maxBound = Vector3.Max(m_LocalBounds.max, m_LocalBounds.max + (Vector3)m_ShapeLightFalloffOffset);
+            Vector3 minBound = Vector3.Min(m_LocalBounds.min, m_LocalBounds.min + (Vector3)m_ShapeLightFalloffOffset);
+            
+            Vector3 maximum = transform.TransformPoint(maxBound);
+            Vector3 minimum = transform.TransformPoint(minBound);
             Vector3 center = 0.5f * (maximum + minimum);
             float radius = Vector3.Magnitude(maximum - center);
 


### PR DESCRIPTION
Fixed the boundary sphere calculated for the 2d shape lights. This sphere now takes into account the falloff offset that controls the light direction.
This fixes invalid frustum culling when only the falloff is in view.

### Purpose of this PR
This pull request will fix issues with 2d shape lights being culled too early.

---
### Release Notes
Fixed frustum culling on 2d shape lights with falloff offsets.

**Manual Tests**
- [x] Run graphic tests locally

---
### Overall Product Risks
**Technical Risk**: Low
