### PR TITLE
Fix shadergraph material pass setup not called

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed material albedo affecting the lux meter
 - Fixed XR SDK mirror view blit, cleanup some XRTODO and removed XRDebug.cs
 - Fixed culling for volumetrics with XR single-pass rendering
+- Fix shadergraph material pass setup not called
 
 ### Changed
 - RenderQueue for Opaque now start at Background instead of Geometry.

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
@@ -43,6 +43,7 @@ namespace UnityEditor.Rendering.HighDefinition
             SynchronizeShaderGraphProperties(material);
 
             BaseLitGUI.SetupBaseLitKeywords(material);
+            BaseLitGUI.SetupBaseLitMaterialPass(material);
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
@@ -43,6 +43,7 @@ namespace UnityEditor.Rendering.HighDefinition
             SynchronizeShaderGraphProperties(material);
 
             BaseLitGUI.SetupBaseLitKeywords(material);
+            BaseLitGUI.SetupBaseLitMaterialPass(material);
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
@@ -41,7 +41,9 @@ namespace UnityEditor.Rendering.HighDefinition
         public static void SetupMaterialKeywordsAndPass(Material material)
         {
             SynchronizeShaderGraphProperties(material);
+
             BaseLitGUI.SetupBaseLitKeywords(material);
+            BaseLitGUI.SetupBaseLitMaterialPass(material);
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
@@ -43,6 +43,7 @@ namespace UnityEditor.Rendering.HighDefinition
             SynchronizeShaderGraphProperties(material);
 
             BaseLitGUI.SetupBaseLitKeywords(material);
+            BaseLitGUI.SetupBaseLitMaterialPass(material);
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);


### PR DESCRIPTION
### Purpose of this PR
Fix ShaderGraph material pass setup not called

This fixes the `Back Then From Rendering` option in ShaderGraph affecting opaque materials (they were rendered with the two passes).

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix%2Fshadergraph_setup_pass&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
