### PR TITLE
Clamp the area light size for scripting API when we change the light type

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - RenderQueue for Opaque now start at Background instead of Geometry.
+- Clamp the area light size for scripting API when we change the light type
 
 ## [7.0.0] - 2019-07-17
 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
@@ -793,10 +793,13 @@ namespace UnityEditor.Rendering.HighDefinition
                     // TODO: Currently if we use Area type as it is offline light in legacy, the light will not exist at runtime
                     //m_BaseData.type.enumValueIndex = (int)LightType.Rectangle;
                     // In case of change, think to update InitDefaultHDAdditionalLightData()
+                    
                     serialized.settings.lightType.enumValueIndex = (int)LightType.Point;
                     serialized.serializedLightData.lightTypeExtent.enumValueIndex = (int)LightTypeExtent.Rectangle;
                     if (serialized.settings.isRealtime)
                         serialized.settings.shadowsType.enumValueIndex = (int)LightShadows.None;
+                    serialized.serializedLightData.shapeWidth.floatValue = Mathf.Max(serialized.serializedLightData.shapeWidth.floatValue, k_MinLightSize);
+                    serialized.serializedLightData.shapeHeight.floatValue = Mathf.Max(serialized.serializedLightData.shapeHeight.floatValue, k_MinLightSize);
                     break;
                 case LightShape.Tube:
                     // TODO: Currently if we use Area type as it is offline light in legacy, the light will not exist at runtime
@@ -805,6 +808,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     serialized.settings.lightType.enumValueIndex = (int)LightType.Point;
                     serialized.serializedLightData.lightTypeExtent.enumValueIndex = (int)LightTypeExtent.Tube;
                     serialized.settings.shadowsType.enumValueIndex = (int)LightShadows.None;
+                    serialized.serializedLightData.shapeWidth.floatValue = Mathf.Max(serialized.serializedLightData.shapeWidth.floatValue, k_MinLightSize);
                     break;
                 case (LightShape)(-1):
                     // don't do anything, this is just to handle multi selection

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.cs
@@ -482,7 +482,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 if (m_ShapeWidth == value)
                     return;
 
-                if (lightTypeExtent == LightTypeExtent.Rectangle)
+                if (IsAreaLight(m_LightTypeExtent))
                     m_ShapeWidth = Mathf.Clamp(value, k_MinAreaWidth, float.MaxValue);
                 else
                     m_ShapeWidth = Mathf.Clamp(value, 0, float.MaxValue);
@@ -504,7 +504,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 if (m_ShapeHeight == value)
                     return;
 
-                if (lightTypeExtent == LightTypeExtent.Rectangle)
+                if (IsAreaLight(m_LightTypeExtent))
                     m_ShapeHeight = Mathf.Clamp(value, k_MinAreaWidth, float.MaxValue);
                 else
                     m_ShapeHeight = Mathf.Clamp(value, 0, float.MaxValue);
@@ -2284,11 +2284,20 @@ namespace UnityEngine.Rendering.HighDefinition
             }
         }
 
+        void UpdateShapeSize()
+        {
+            // Force to clamp the shape if we changed the type of the light
+            shapeWidth = m_ShapeWidth;
+            shapeHeight = m_ShapeHeight;
+        }
+
         /// <summary>
         /// Synchronize all the HD Additional Light values with the Light component.
         /// </summary>
         public void UpdateAllLightValues()
         {
+            UpdateShapeSize();
+
             // Update light intensity
             UpdateLightIntensity();
 


### PR DESCRIPTION
### Purpose of this PR
Fix a bug when setting an area light size <= 0 when a light is not Area and then switch the type to area.

FB: https://fogbugz.unity3d.com/f/cases/1171878

---
### Testing status
**Katana Tests**: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=HDRP%2Ffix%2Flight_size_script_clamp&automation-tools_branch=master&unity_branch=trunk

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
