### PR TITLE
fix issue with isolated ABV test package

### DIFF
--- a/com.unity.render-pipelines.high-definition-config/package.json
+++ b/com.unity.render-pipelines.high-definition-config/package.json
@@ -5,5 +5,7 @@
     "unity": "2019.3",
     "unityRelease": "0a10",
     "displayName": "High Definition RP Config",
-	"dependencies": {}
+    "dependencies": {
+        "com.unity.render-pipelines.core": "7.1.1"
+    }
 }

--- a/com.unity.render-pipelines.high-definition/Tests/Editor/DocumentationTests.cs
+++ b/com.unity.render-pipelines.high-definition/Tests/Editor/DocumentationTests.cs
@@ -1,5 +1,8 @@
 using NUnit.Framework;
-using DocumentationTestLibrary = UnityEditor.Rendering.Tests.DocumentationTests;
+using System.Collections.Generic;
+using UnityEngine.Networking;
+using System.Linq;
+using UnityEngine;
 
 namespace UnityEditor.Rendering.HighDefinition.Tests
 {
@@ -8,8 +11,26 @@ namespace UnityEditor.Rendering.HighDefinition.Tests
         [Test]
         public void AllDocumentationLinksAccessible()
         {
-            foreach (var url in DocumentationTestLibrary.GetDocumentationURLsForAssembly(typeof(UnityEngine.Rendering.HighDefinition.Documentation).Assembly))
-                DocumentationTestLibrary.IsLinkValid(url);
+            foreach (var url in GetDocumentationURLsForAssembly(typeof(UnityEngine.Rendering.HighDefinition.Documentation).Assembly))
+                IsLinkValid(url);
         }
+
+        public static void IsLinkValid(string url, bool shouldExist = true)
+        {
+            using (UnityWebRequest webRequest = UnityWebRequest.Get(url))
+            {
+                var asyncOp = webRequest.SendWebRequest();
+                while (!webRequest.isDone)
+                    new WaitForEndOfFrame();
+                Assert.IsTrue((webRequest.isNetworkError || webRequest.isHttpError) ^ shouldExist, $"{url}\n{webRequest.error}");
+            }
+        }
+
+        public static IEnumerable<string> GetDocumentationURLsForAssembly(System.Reflection.Assembly assembly)
+            => TypeCache
+                .GetTypesWithAttribute<HelpURLAttribute>()
+                .Where(x => x.Assembly == assembly)
+                .Select(x => (x.GetCustomAttributes(typeof(HelpURLAttribute), false).First() as HelpURLAttribute).URL)
+                .Distinct();
     }
 }


### PR DESCRIPTION
### Purpose of this PR
This fix issue with ABV isolated package test

---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
