### PR TITLE
Add ParticleSystem Shader Samples

### DIFF
--- a/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/.sample.json
+++ b/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/.sample.json
@@ -1,0 +1,5 @@
+{
+    "displayName":"Particle System Shader Samples",
+    "description": "Adds Particle System Shader samples to your project. Open the SampleScene to see examples of various lit and unlit particle effects.",
+    "createSeparatePackage": false
+}

--- a/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/ParticleSystemShaderSamples.unitypackage
+++ b/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/ParticleSystemShaderSamples.unitypackage
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23b6add3aab1526d1279f029cb78a088f03eb79283532ea1641d0bfc132f282e
-size 223548
+oid sha256:0b5dc677f6f051a0cbb4ec89da2e6f4551d40a6b0197eac9640b7b9249381aee
+size 380472

--- a/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/ParticleSystemShaderSamples.unitypackage
+++ b/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/ParticleSystemShaderSamples.unitypackage
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23b6add3aab1526d1279f029cb78a088f03eb79283532ea1641d0bfc132f282e
+size 223548

--- a/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/ParticleSystemShaderSamples.unitypackage.meta
+++ b/com.unity.render-pipelines.high-definition/Samples~/ParticleSystemShaderSamples/ParticleSystemShaderSamples.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f5309c277e2a5bb46a3b5f40da42af25
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -33,6 +33,11 @@
         "displayName" : "Procedural Sky",
         "description" : "Adds the deprecated procedural sky of HDRP.",
         "path" : "Samples~/ProceduralSky"
+    },
+	{
+        "displayName" : "Particle System Shader Samples",
+        "description" : "Adds Particle System Shader samples to your project. Open the SampleScene to see examples of various lit and unlit particle effects.",
+        "path" : "Samples~/ParticleSystemShaderSamples"
     }
     ]
 }


### PR DESCRIPTION
### Purpose of this PR

Adds a sample to HDRP containing a selection of Shader Graphs for use with the Particle System.
Recreates core functionality from the old Standard Particle Shaders in the built-in renderer.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- Create empty HDRP project
- Open Package Manager window
- Import Particle System Shaders Sample
- Open SampleScene scene
- Enter Play Mode
- Observe each system and check it exhibits the desired functionality based on its assigned material/shader.

**Automated Tests**:  n/a

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.
