### PR TITLE
Precomputed velocity

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - direct strenght properties in ambient occlusion now affect direct specular as well
 - Added a warning in the material UI when the diffusion profile assigned is not in the HDRP asset
-- Added support of Alembic velocity to various shaders
+- Added Alembic velocity support to various Shaders.
 
 ## [6.9.0] - 2019-07-02
 

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - direct strenght properties in ambient occlusion now affect direct specular as well
 - Added a warning in the material UI when the diffusion profile assigned is not in the HDRP asset
+- Added support of Alembic velocity to various shaders
 
 ## [6.9.0] - 2019-07-02
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFGUI.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             new SurfaceOptionUIBlock(MaterialUIBlock.Expandable.Base, features: SurfaceOptionUIBlock.Features.Unlit),
             new AxfSurfaceInputsUIBlock(MaterialUIBlock.Expandable.Input),
             new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing),
-            new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.AdditionalVelocity)
+            new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.AddPrecomputedVelocity)
         };
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
@@ -113,9 +113,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             material.SetInt(kStencilWriteMaskMV, stencilWriteMaskMV);
 
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFGUI.cs
@@ -27,6 +27,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             new SurfaceOptionUIBlock(MaterialUIBlock.Expandable.Base, features: SurfaceOptionUIBlock.Features.Unlit),
             new AxfSurfaceInputsUIBlock(MaterialUIBlock.Expandable.Input),
             new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing),
+            new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.AdditionalVelocity)
         };
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
@@ -110,6 +111,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             material.SetInt(kStencilWriteMaskDepth, stencilWriteMaskDepth);
             material.SetInt(kStencilRefMV, stencilRefMV);
             material.SetInt(kStencilWriteMaskMV, stencilWriteMaskMV);
+
+
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
         }
     }
 } // namespace UnityEditor

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
@@ -50,9 +50,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
             
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
 using System.Linq;
+using UnityEngine.Rendering;
 
 // Include material common properties names
 using static UnityEngine.Experimental.Rendering.HDPipeline.HDMaterialProperties;
@@ -48,6 +49,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
+
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
+            
         }
 
         protected override void SetupMaterialKeywordsAndPassInternal(Material material) => SetupMaterialKeywordsAndPass(material);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
@@ -335,6 +335,21 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
+        [SerializeField]
+        bool m_AddVelocityChange = false;
+
+        public ToggleData addVelocityChange
+        {
+           get { return new ToggleData(m_AddVelocityChange); }
+           set
+           {
+               if (m_AddVelocityChange == value.isOn)
+                   return;
+               m_AddVelocityChange = value.isOn;
+               Dirty(ModificationScope.Graph);
+           }
+        }
+
 
         [SerializeField]
         bool m_EnergyConservingSpecular = true;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
@@ -336,16 +336,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
-        bool m_AddVelocityChange = false;
+        bool m_AddPrecomputedVelocity = false;
 
-        public ToggleData addVelocityChange
+        public ToggleData addPrecomputedVelocity
         {
-           get { return new ToggleData(m_AddVelocityChange); }
+           get { return new ToggleData(m_AddPrecomputedVelocity); }
            set
            {
-               if (m_AddVelocityChange == value.isOn)
+               if (m_AddPrecomputedVelocity == value.isOn)
                    return;
-               m_AddVelocityChange = value.isOn;
+               m_AddPrecomputedVelocity = value.isOn;
                Dirty(ModificationScope.Graph);
            }
         }
@@ -733,14 +733,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 value = new Color(1.0f, 1.0f, 1.0f, 1.0f)
             });
 
-            //See SG-ADDITIONALVELOCITY-NOTE
-            if (addVelocityChange.isOn)
+
+            if (addPrecomputedVelocity.isOn)
             {
                 collector.AddShaderProperty(new BooleanShaderProperty
                 {
                     value = true,
                     hidden = true,
-                    overrideReferenceName = kAdditionalVelocityChange,
+                    overrideReferenceName = kAddPrecomputedVelocity,
                 });
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
@@ -733,6 +733,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 value = new Color(1.0f, 1.0f, 1.0f, 1.0f)
             });
 
+            //See SG-ADDITIONALVELOCITY-NOTE
+            if (addVelocityChange.isOn)
+            {
+                collector.AddShaderProperty(new BooleanShaderProperty
+                {
+                    value = true,
+                    hidden = true,
+                    overrideReferenceName = kAdditionalVelocityChange,
+                });
+            }
+
             // Add all shader properties required by the inspector
             HDSubShaderUtilities.AddStencilShaderProperties(collector, RequiresSplitLighting(), receiveSSR.isOn);
             HDSubShaderUtilities.AddBlendingStatesShaderProperties(

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
@@ -48,6 +48,7 @@ Pass
     $Specular.AA:                       #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
     $DisableDecals:                     #define _DISABLE_DECALS 1
     $DisableSSR:                        #define _DISABLE_SSR 1
+    $AdditionalVelocityChange:          #define _ADDITIONAL_VELOCITY_CHANGE
     $DepthOffset:                       #define _DEPTHOFFSET_ON 1
     $BlendMode.PreserveSpecular:        #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
@@ -48,7 +48,7 @@ Pass
     $Specular.AA:                       #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
     $DisableDecals:                     #define _DISABLE_DECALS 1
     $DisableSSR:                        #define _DISABLE_SSR 1
-    $AdditionalVelocityChange:          #define _ADDITIONAL_VELOCITY_CHANGE
+    $AddPrecomputedVelocity:            #define _ADD_PRECOMPUTED_VELOCITY
     $DepthOffset:                       #define _DEPTHOFFSET_ON 1
     $BlendMode.PreserveSpecular:        #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
@@ -214,12 +214,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
-            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            ps.Add(new PropertyRow(CreateLabel("Add Precomputed Velocity", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
                 {
-                    toggle.value = m_Node.addVelocityChange.isOn;
-                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                    toggle.value = m_Node.addPrecomputedVelocity.isOn;
+                    toggle.OnToggleChanged(ChangeAddPrecomputedVelocity);
                 });
             });
 
@@ -374,12 +374,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             m_Node.receiveSSR = td;
         }
 
-        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
-            ToggleData td = m_Node.addVelocityChange;
+            ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
-            m_Node.addVelocityChange = td;
+            m_Node.addPrecomputedVelocity = td;
         }
 
         void ChangeEnergyConservingSpecular(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
@@ -376,7 +376,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
 
         void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
-            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Precomputed Velocity");
             ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
             m_Node.addPrecomputedVelocity = td;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
@@ -214,6 +214,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
+            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            {
+                row.Add(new Toggle(), (toggle) =>
+                {
+                    toggle.value = m_Node.addVelocityChange.isOn;
+                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                });
+            });
+
             ps.Add(new PropertyRow(CreateLabel("Override Baked GI", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
@@ -363,6 +372,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             ToggleData td = m_Node.receiveSSR;
             td.isOn = evt.newValue;
             m_Node.receiveSSR = td;
+        }
+
+        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            ToggleData td = m_Node.addVelocityChange;
+            td.isOn = evt.newValue;
+            m_Node.addVelocityChange = td;
         }
 
         void ChangeEnergyConservingSpecular(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
@@ -368,9 +368,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 activeFields.Add("DisableSSR");
             }
 
-            if (masterNode.addVelocityChange.isOn)
+            if (masterNode.addPrecomputedVelocity.isOn)
             {
-                activeFields.Add("AdditionalVelocityChange");
+                activeFields.Add("AddPrecomputedVelocity");
             }
 
             if (masterNode.energyConservingSpecular.isOn)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
@@ -286,8 +286,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 HDSubShaderUtilities.SetStencilStateForForward(ref pass);
                 HDSubShaderUtilities.SetBlendModeForForward(ref pass);
 
-                pass.ExtraDefines.Remove("#ifndef DEBUG_DISPLAY\n#define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST\n#endif");                
-
+                pass.ExtraDefines.Remove("#ifndef DEBUG_DISPLAY\n#define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST\n#endif");
                 if (masterNode.surfaceType == SurfaceType.Opaque)
                 {
                     if (masterNode.alphaTest.isOn)
@@ -367,6 +366,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (!masterNode.receiveSSR.isOn)
             {
                 activeFields.Add("DisableSSR");
+            }
+
+            if (masterNode.addVelocityChange.isOn)
+            {
+                activeFields.Add("AdditionalVelocityChange");
             }
 
             if (masterNode.energyConservingSpecular.isOn)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSubShader.cs
@@ -287,6 +287,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 HDSubShaderUtilities.SetBlendModeForForward(ref pass);
 
                 pass.ExtraDefines.Remove("#ifndef DEBUG_DISPLAY\n#define SHADERPASS_FORWARD_BYPASS_ALPHA_TEST\n#endif");
+                
                 if (masterNode.surfaceType == SurfaceType.Opaque)
                 {
                     if (masterNode.alphaTest.isOn)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
+using UnityEngine.Rendering;
 
 // Include material common properties names
 using static UnityEngine.Experimental.Rendering.HDPipeline.HDMaterialProperties;
@@ -47,6 +48,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
+
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
         }
 
         protected override void SetupMaterialKeywordsAndPassInternal(Material material) => SetupMaterialKeywordsAndPass(material);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
@@ -49,9 +49,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
@@ -407,15 +407,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
-        bool m_AddVelocityChange = false;
-        public ToggleData addVelocityChange
+        bool m_AddPrecomputedVelocity = false;
+        public ToggleData addPrecomputedVelocity
         {
-            get { return new ToggleData(m_AddVelocityChange); }
+            get { return new ToggleData(m_AddPrecomputedVelocity); }
             set
             {
-                if (m_AddVelocityChange == value.isOn)
+                if (m_AddPrecomputedVelocity == value.isOn)
                     return;
-                m_AddVelocityChange = value.isOn;
+                m_AddPrecomputedVelocity = value.isOn;
                 Dirty(ModificationScope.Graph);
             }
         }
@@ -808,15 +808,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 hidden = true,
                 value = new Color(1.0f, 1.0f, 1.0f, 1.0f)
             });
-
-            //See SG-ADDITIONALVELOCITY-NOTE
-            if (addVelocityChange.isOn)
+            
+            if (addPrecomputedVelocity.isOn)
             {
                 collector.AddShaderProperty(new BooleanShaderProperty
                 {
                     value = true,
                     hidden = true,
-                    overrideReferenceName = kAdditionalVelocityChange,
+                    overrideReferenceName = kAddPrecomputedVelocity,
                 });
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
@@ -809,6 +809,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 value = new Color(1.0f, 1.0f, 1.0f, 1.0f)
             });
 
+            //See SG-ADDITIONALVELOCITY-NOTE
+            if (addVelocityChange.isOn)
+            {
+                collector.AddShaderProperty(new BooleanShaderProperty
+                {
+                    value = true,
+                    hidden = true,
+                    overrideReferenceName = kAdditionalVelocityChange,
+                });
+            }
+
             // Add all shader properties required by the inspector
             HDSubShaderUtilities.AddStencilShaderProperties(collector, false, receiveSSR.isOn);
             HDSubShaderUtilities.AddBlendingStatesShaderProperties(

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
@@ -407,6 +407,20 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
+        bool m_AddVelocityChange = false;
+        public ToggleData addVelocityChange
+        {
+            get { return new ToggleData(m_AddVelocityChange); }
+            set
+            {
+                if (m_AddVelocityChange == value.isOn)
+                    return;
+                m_AddVelocityChange = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
         bool m_UseLightFacingNormal = false;
         public ToggleData useLightFacingNormal
         {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -45,7 +45,7 @@ Pass
     $Specular.AA:                       #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
     $DisableDecals:                     #define _DISABLE_DECALS 1
     $DisableSSR:                        #define _DISABLE_SSR 1
-    $AdditionalVelocityChange:          #define _ADDITIONAL_VELOCITY_CHANGE   
+    $AddPrecomputedVelocity:            #define _ADD_PRECOMPUTED_VELOCITY   
     $TransparentWritesMotionVec:        #define _WRITE_TRANSPARENT_MOTION_VECTOR 1
     $DepthOffset:                       #define _DEPTHOFFSET_ON 1
     $UseLightFacingNormal:              #define _USE_LIGHT_FACING_NORMAL 1

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -45,6 +45,7 @@ Pass
     $Specular.AA:                       #define _ENABLE_GEOMETRIC_SPECULAR_AA 1
     $DisableDecals:                     #define _DISABLE_DECALS 1
     $DisableSSR:                        #define _DISABLE_SSR 1
+    $AdditionalVelocityChange:          #define _ADDITIONAL_VELOCITY_CHANGE   
     $TransparentWritesMotionVec:        #define _WRITE_TRANSPARENT_MOTION_VECTOR 1
     $DepthOffset:                       #define _DEPTHOFFSET_ON 1
     $UseLightFacingNormal:              #define _USE_LIGHT_FACING_NORMAL 1

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
@@ -194,6 +194,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
+            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            {
+                row.Add(new Toggle(), (toggle) =>
+                {
+                    toggle.value = m_Node.addVelocityChange.isOn;
+                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                });
+            });
+
             ps.Add(new PropertyRow(CreateLabel("Geometric Specular AA", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
@@ -361,6 +370,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             ToggleData td = m_Node.receiveSSR;
             td.isOn = evt.newValue;
             m_Node.receiveSSR = td;
+        }
+
+        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            ToggleData td = m_Node.addVelocityChange;
+            td.isOn = evt.newValue;
+            m_Node.addVelocityChange = td;
         }
 
         void ChangeUseLightFacingNormal(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
@@ -194,12 +194,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
-            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            ps.Add(new PropertyRow(CreateLabel("Add Precomputed Velocity", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
                 {
-                    toggle.value = m_Node.addVelocityChange.isOn;
-                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                    toggle.value = m_Node.addPrecomputedVelocity.isOn;
+                    toggle.OnToggleChanged(ChangeAddPrecomputedVelocity);
                 });
             });
 
@@ -372,12 +372,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             m_Node.receiveSSR = td;
         }
 
-        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
-            ToggleData td = m_Node.addVelocityChange;
+            ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
-            m_Node.addVelocityChange = td;
+            m_Node.addPrecomputedVelocity = td;
         }
 
         void ChangeUseLightFacingNormal(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
@@ -374,7 +374,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
 
         void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
-            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Precomputed Velocity");
             ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
             m_Node.addPrecomputedVelocity = td;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
@@ -518,6 +518,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 activeFields.Add("DisableSSR");
             }
+       
+            if (masterNode.addVelocityChange.isOn)
+            {
+                activeFields.Add("AdditionalVelocityChange");
+            }
 
             if (masterNode.specularAA.isOn && pass.PixelShaderUsesSlot(HairMasterNode.SpecularAAThresholdSlotId) && pass.PixelShaderUsesSlot(HairMasterNode.SpecularAAScreenSpaceVarianceSlotId))
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSubShader.cs
@@ -519,9 +519,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 activeFields.Add("DisableSSR");
             }
        
-            if (masterNode.addVelocityChange.isOn)
+            if (masterNode.addPrecomputedVelocity.isOn)
             {
-                activeFields.Add("AdditionalVelocityChange");
+                activeFields.Add("AddPrecomputedVelocity");
             }
 
             if (masterNode.specularAA.isOn && pass.PixelShaderUsesSlot(HairMasterNode.SpecularAAThresholdSlotId) && pass.PixelShaderUsesSlot(HairMasterNode.SpecularAAScreenSpaceVarianceSlotId))

--- a/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitGUI.cs
@@ -170,6 +170,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             SetupLayersMappingKeywords(material);
             BaseLitGUI.SetupStencil(material, material.GetInt(kReceivesSSR) != 0, material.GetMaterialId() == MaterialId.LitSSS);
 
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
+
             for (int i = 0; i < kMaxLayerCount; ++i)
             {
                 NormalMapSpace normalMapSpace = ((NormalMapSpace)material.GetFloat(kNormalMapSpace + i));

--- a/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitGUI.cs
@@ -170,9 +170,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             SetupLayersMappingKeywords(material);
             BaseLitGUI.SetupStencil(material, material.GetInt(kReceivesSSR) != 0, material.GetMaterialId() == MaterialId.LitSSS);
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
 
             for (int i = 0; i < kMaxLayerCount; ++i)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitGUI.cs
@@ -209,6 +209,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 CoreUtils.SetKeyword(material, "_REFRACTION_SPHERE", (refractionModelValue == ScreenSpaceRefraction.RefractionModel.Sphere) && canHaveRefraction);
                 CoreUtils.SetKeyword(material, "_TRANSMITTANCECOLORMAP", material.GetTexture(kTransmittanceColorMap) && canHaveRefraction);
             }
+
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
         }
     }
 } // namespace UnityEditor

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitGUI.cs
@@ -210,9 +210,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 CoreUtils.SetKeyword(material, "_TRANSMITTANCECOLORMAP", material.GetTexture(kTransmittanceColorMap) && canHaveRefraction);
             }
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
+using UnityEngine.Rendering;
 
 // Include material common properties names
 using static UnityEngine.Experimental.Rendering.HDPipeline.HDMaterialProperties;
@@ -47,6 +48,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
+
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
         }
 
         protected override void SetupMaterialKeywordsAndPassInternal(Material material) => SetupMaterialKeywordsAndPass(material);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
@@ -49,9 +49,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -518,6 +518,20 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
+        bool m_AddVelocityChange = false;
+        public ToggleData addVelocityChange
+        {
+            get { return new ToggleData(m_AddVelocityChange); }
+            set
+            {
+                if (m_AddVelocityChange == value.isOn)
+                    return;
+                m_AddVelocityChange = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
         bool m_EnergyConservingSpecular = true;
 
         public ToggleData energyConservingSpecular

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -518,15 +518,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
-        bool m_AddVelocityChange = false;
-        public ToggleData addVelocityChange
+        bool m_AddPrecomputedVelocity = false;
+        public ToggleData addPrecomputedVelocity
         {
-            get { return new ToggleData(m_AddVelocityChange); }
+            get { return new ToggleData(m_AddPrecomputedVelocity); }
             set
             {
-                if (m_AddVelocityChange == value.isOn)
+                if (m_AddPrecomputedVelocity == value.isOn)
                     return;
-                m_AddVelocityChange = value.isOn;
+                m_AddPrecomputedVelocity = value.isOn;
                 Dirty(ModificationScope.Graph);
             }
         }
@@ -998,15 +998,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 hidden = true,
                 value = (int)renderingPass,
             });
-
-            //See SG-ADDITIONALVELOCITY-NOTE
-            if (addVelocityChange.isOn)
+            
+            if (addPrecomputedVelocity.isOn)
             {
                 collector.AddShaderProperty(new BooleanShaderProperty
                 {
                     value = true,
                     hidden = true,
-                    overrideReferenceName = kAdditionalVelocityChange,
+                    overrideReferenceName = kAddPrecomputedVelocity,
                 });
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -999,6 +999,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 value = (int)renderingPass,
             });
 
+            //See SG-ADDITIONALVELOCITY-NOTE
+            if (addVelocityChange.isOn)
+            {
+                collector.AddShaderProperty(new BooleanShaderProperty
+                {
+                    value = true,
+                    hidden = true,
+                    overrideReferenceName = kAdditionalVelocityChange,
+                });
+            }
+
             // Add all shader properties required by the inspector
             HDSubShaderUtilities.AddStencilShaderProperties(collector, RequiresSplitLighting(), receiveSSR.isOn);
             HDSubShaderUtilities.AddBlendingStatesShaderProperties(

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
@@ -52,6 +52,7 @@ Pass
     $RefractionSphere:                   #define _REFRACTION_SPHERE 1
     $DisableDecals:                      #define _DISABLE_DECALS 1
     $DisableSSR:                         #define _DISABLE_SSR 1
+    $AdditionalVelocityChange:           #define _ADDITIONAL_VELOCITY_CHANGE
     $TransparentWritesMotionVec:         #define _WRITE_TRANSPARENT_MOTION_VECTOR 1
     $DepthOffset:                        #define _DEPTHOFFSET_ON 1
     $BlendMode.PreserveSpecular:        #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
@@ -52,7 +52,7 @@ Pass
     $RefractionSphere:                   #define _REFRACTION_SPHERE 1
     $DisableDecals:                      #define _DISABLE_DECALS 1
     $DisableSSR:                         #define _DISABLE_SSR 1
-    $AdditionalVelocityChange:           #define _ADDITIONAL_VELOCITY_CHANGE
+    $AddPrecomputedVelocity:             #define _ADD_PRECOMPUTED_VELOCITY
     $TransparentWritesMotionVec:         #define _WRITE_TRANSPARENT_MOTION_VECTOR 1
     $DepthOffset:                        #define _DEPTHOFFSET_ON 1
     $BlendMode.PreserveSpecular:        #define _BLENDMODE_PRESERVE_SPECULAR_LIGHTING 1

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
@@ -330,12 +330,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
-            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            ps.Add(new PropertyRow(CreateLabel("Add Precomputed Velocity", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
                 {
-                    toggle.value = m_Node.addVelocityChange.isOn;
-                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                    toggle.value = m_Node.addPrecomputedVelocity.isOn;
+                    toggle.OnToggleChanged(ChangeAddPrecomputedVelocity);
                 });
             });
 
@@ -596,12 +596,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             m_Node.receiveSSR = td;
         }
         
-        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
-            ToggleData td = m_Node.addVelocityChange;
+            ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
-            m_Node.addVelocityChange = td;
+            m_Node.addPrecomputedVelocity = td;
         }
 
         void ChangeSpecularAA(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
@@ -330,6 +330,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
+            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            {
+                row.Add(new Toggle(), (toggle) =>
+                {
+                    toggle.value = m_Node.addVelocityChange.isOn;
+                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                });
+            });
+
             ps.Add(new PropertyRow(CreateLabel("Geometric Specular AA", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
@@ -585,6 +594,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             ToggleData td = m_Node.receiveSSR;
             td.isOn = evt.newValue;
             m_Node.receiveSSR = td;
+        }
+        
+        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            ToggleData td = m_Node.addVelocityChange;
+            td.isOn = evt.newValue;
+            m_Node.addVelocityChange = td;
         }
 
         void ChangeSpecularAA(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
@@ -598,7 +598,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
         
         void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
-            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Precomputed Velocity");
             ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
             m_Node.addPrecomputedVelocity = td;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
@@ -877,9 +877,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 activeFields.Add("DisableSSR");
             }
             
-            if (masterNode.addVelocityChange.isOn)
+            if (masterNode.addPrecomputedVelocity.isOn)
             {
-                activeFields.Add("AdditionalVelocityChange");
+                activeFields.Add("AddPrecomputedVelocity");
             }
 
             if (masterNode.specularAA.isOn && pass.PixelShaderUsesSlot(HDLitMasterNode.SpecularAAThresholdSlotId) && pass.PixelShaderUsesSlot(HDLitMasterNode.SpecularAAScreenSpaceVarianceSlotId))

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSubShader.cs
@@ -876,7 +876,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             {
                 activeFields.Add("DisableSSR");
             }
-
+            
+            if (masterNode.addVelocityChange.isOn)
+            {
+                activeFields.Add("AdditionalVelocityChange");
+            }
 
             if (masterNode.specularAA.isOn && pass.PixelShaderUsesSlot(HDLitMasterNode.SpecularAAThresholdSlotId) && pass.PixelShaderUsesSlot(HDLitMasterNode.SpecularAAScreenSpaceVarianceSlotId))
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.HDPipeline;
+using UnityEngine.Rendering;
 
 // Include material common properties names
 using static UnityEngine.Experimental.Rendering.HDPipeline.HDMaterialProperties;
@@ -47,6 +48,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool receiveSSR = material.HasProperty(kReceivesSSR) ? material.GetInt(kReceivesSSR) != 0 : false;
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
+
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
         }
 
         protected override void SetupMaterialKeywordsAndPassInternal(Material material) => SetupMaterialKeywordsAndPass(material);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
@@ -49,9 +49,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool useSplitLighting = material.HasProperty(kUseSplitLighting) ? material.GetInt(kUseSplitLighting) != 0: false;
             BaseLitGUI.SetupStencil(material, receiveSSR, useSplitLighting);
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
@@ -582,6 +582,20 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
+        bool m_AddVelocityChange = false;
+        public ToggleData addVelocityChange
+        {
+            get { return new ToggleData(m_AddVelocityChange); }
+            set
+            {
+                if (m_AddVelocityChange == value.isOn)
+                    return;
+                m_AddVelocityChange = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
         bool m_GeometricSpecularAA;
 
         public ToggleData geometricSpecularAA

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
@@ -1255,6 +1255,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 value = new Color(1.0f, 1.0f, 1.0f, 1.0f)
             });
 
+            //See SG-ADDITIONALVELOCITY-NOTE
+            if (addVelocityChange.isOn)
+            {
+                collector.AddShaderProperty(new BooleanShaderProperty
+                {
+                    value = true,
+                    hidden = true,
+                    overrideReferenceName = kAdditionalVelocityChange,
+                });
+            }
+
             // Add all shader properties required by the inspector
             HDSubShaderUtilities.AddStencilShaderProperties(collector, RequiresSplitLighting(), receiveSSR.isOn);
             HDSubShaderUtilities.AddBlendingStatesShaderProperties(

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
@@ -582,15 +582,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
-        bool m_AddVelocityChange = false;
-        public ToggleData addVelocityChange
+        bool m_AddPrecomputedVelocity = false;
+        public ToggleData addPrecomputedVelocity
         {
-            get { return new ToggleData(m_AddVelocityChange); }
+            get { return new ToggleData(m_AddPrecomputedVelocity); }
             set
             {
-                if (m_AddVelocityChange == value.isOn)
+                if (m_AddPrecomputedVelocity == value.isOn)
                     return;
-                m_AddVelocityChange = value.isOn;
+                m_AddPrecomputedVelocity = value.isOn;
                 Dirty(ModificationScope.Graph);
             }
         }
@@ -1254,15 +1254,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 hidden = true,
                 value = new Color(1.0f, 1.0f, 1.0f, 1.0f)
             });
-
-            //See SG-ADDITIONALVELOCITY-NOTE
-            if (addVelocityChange.isOn)
+            
+            if (addPrecomputedVelocity.isOn)
             {
                 collector.AddShaderProperty(new BooleanShaderProperty
                 {
                     value = true,
                     hidden = true,
-                    overrideReferenceName = kAdditionalVelocityChange,
+                    overrideReferenceName = kAddPrecomputedVelocity,
                 });
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
@@ -97,7 +97,7 @@ Pass
     // Decals:
     // DisableSSR:
     // $SpecularOcclusion:
-    // AdditionalVelocityChange:
+    // AddPrecomputedVelocity:
 
     //
     // Original shader keywords reference:
@@ -147,7 +147,7 @@ Pass
 
     $DisableDecals:                                      #define _DISABLE_DECALS
     $DisableSSR:                                         #define _DISABLE_SSR
-    $AdditionalVelocityChange:                           #define _ADDITIONAL_VELOCITY_CHANGE
+    $AddPrecomputedVelocity:                             #define _ADD_PRECOMPUTED_VELOCITY
     // StackLit shader_features:
 
     $SpecularOcclusion:                                  #define _ENABLESPECULAROCCLUSION // main enable

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
@@ -97,6 +97,7 @@ Pass
     // Decals:
     // DisableSSR:
     // $SpecularOcclusion:
+    // AdditionalVelocityChange:
 
     //
     // Original shader keywords reference:
@@ -146,7 +147,7 @@ Pass
 
     $DisableDecals:                                      #define _DISABLE_DECALS
     $DisableSSR:                                         #define _DISABLE_SSR
-
+    $AdditionalVelocityChange:                           #define _ADDITIONAL_VELOCITY_CHANGE
     // StackLit shader_features:
 
     $SpecularOcclusion:                                  #define _ENABLESPECULAROCCLUSION // main enable

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
@@ -184,6 +184,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             //  
             //  receiveDecals
             //  receiveSSR
+            //  addVelocityChange
             //  geometricSpecularAA
             //  specularOcclusion
             //  
@@ -333,6 +334,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 {
                     toggle.value = m_Node.receiveSSR.isOn;
                     toggle.OnToggleChanged(ChangeReceiveSSR);
+                });
+            });
+
+            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            {
+                row.Add(new Toggle(), (toggle) =>
+                {
+                    toggle.value = m_Node.addVelocityChange.isOn;
+                    toggle.OnToggleChanged(ChangeAddVelocityChange);
                 });
             });
 
@@ -630,6 +640,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             ToggleData td = m_Node.receiveSSR;
             td.isOn = evt.newValue;
             m_Node.receiveSSR = td;
+        }
+
+        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            ToggleData td = m_Node.addVelocityChange;
+            td.isOn = evt.newValue;
+            m_Node.addVelocityChange = td;
         }
 
         void ChangeGeometricSpecularAA(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
@@ -644,7 +644,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
 
         void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
-            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Precomputed Velocity");
             ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
             m_Node.addPrecomputedVelocity = td;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
@@ -184,7 +184,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             //  
             //  receiveDecals
             //  receiveSSR
-            //  addVelocityChange
+            //  addPrecomputedVelocity
             //  geometricSpecularAA
             //  specularOcclusion
             //  
@@ -337,12 +337,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
-            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            ps.Add(new PropertyRow(CreateLabel("Add Precomputed Velocity", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
                 {
-                    toggle.value = m_Node.addVelocityChange.isOn;
-                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                    toggle.value = m_Node.addPrecomputedVelocity.isOn;
+                    toggle.OnToggleChanged(ChangeAddPrecomputedVelocity);
                 });
             });
 
@@ -642,12 +642,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             m_Node.receiveSSR = td;
         }
 
-        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
-            ToggleData td = m_Node.addVelocityChange;
+            ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
-            m_Node.addVelocityChange = td;
+            m_Node.addPrecomputedVelocity = td;
         }
 
         void ChangeGeometricSpecularAA(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
@@ -723,6 +723,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 activeFields.Add("DisableSSR");
             }
 
+            if (masterNode.addVelocityChange.isOn)
+            {
+                activeFields.Add("AdditionalVelocityChange");
+            }
+
             // Note here we combine an "enable"-like predicate and the $SurfaceDescription.(slotname) predicate
             // into a single $GeometricSpecularAA pedicate.
             //

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSubShader.cs
@@ -723,9 +723,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 activeFields.Add("DisableSSR");
             }
 
-            if (masterNode.addVelocityChange.isOn)
+            if (masterNode.addPrecomputedVelocity.isOn)
             {
-                activeFields.Add("AdditionalVelocityChange");
+                activeFields.Add("AddPrecomputedVelocity");
             }
 
             // Note here we combine an "enable"-like predicate and the $SurfaceDescription.(slotname) predicate

--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/AdvancedOptionsUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/AdvancedOptionsUIBlock.cs
@@ -13,6 +13,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             None                = 0,
             Instancing          = 1 << 0,
             SpecularOcclusion   = 1 << 1,
+            AdditionalVelocity  = 1 << 2,
             All                 = ~0
         }
 
@@ -20,10 +21,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             public const string header = "Advanced Options";
             public static GUIContent enableSpecularOcclusionText = new GUIContent("Specular Occlusion From Bent Normal", "Requires cosine weighted bent normal and cosine weighted ambient occlusion. Specular occlusion for Reflection Probe");
+            public static GUIContent additionalVelocityChangeText = new GUIContent("Additional Velocity Changes", "Requires additional per vertex velocity info");
         }
 
         protected MaterialProperty enableSpecularOcclusion = null;
+        protected MaterialProperty additionalVelocityChange = null;
         protected const string kEnableSpecularOcclusion = "_EnableSpecularOcclusion";
+        protected const string kAdditionalVelocityChange = HDMaterialProperties.kAdditionalVelocityChange;
 
         Expandable  m_ExpandableBit;
         Features    m_Features;
@@ -37,6 +41,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public override void LoadMaterialProperties()
         {
             enableSpecularOcclusion = FindProperty(kEnableSpecularOcclusion);
+            additionalVelocityChange = FindProperty(kAdditionalVelocityChange);
         }
 
         public override void OnGUI()
@@ -54,6 +59,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 materialEditor.EnableInstancingField();
             if ((m_Features & Features.SpecularOcclusion) != 0)
                 materialEditor.ShaderProperty(enableSpecularOcclusion, Styles.enableSpecularOcclusionText);
+            if ((m_Features & Features.AdditionalVelocity) != 0)
+            {
+                if ( additionalVelocityChange != null)
+                    materialEditor.ShaderProperty(additionalVelocityChange, Styles.additionalVelocityChangeText);
+            }
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/AdvancedOptionsUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/AdvancedOptionsUIBlock.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             None                = 0,
             Instancing          = 1 << 0,
             SpecularOcclusion   = 1 << 1,
-            AdditionalVelocity  = 1 << 2,
+            AddPrecomputedVelocity  = 1 << 2,
             All                 = ~0
         }
 
@@ -21,13 +21,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         {
             public const string header = "Advanced Options";
             public static GUIContent enableSpecularOcclusionText = new GUIContent("Specular Occlusion From Bent Normal", "Requires cosine weighted bent normal and cosine weighted ambient occlusion. Specular occlusion for Reflection Probe");
-            public static GUIContent additionalVelocityChangeText = new GUIContent("Additional Velocity Changes", "Requires additional per vertex velocity info");
+            public static GUIContent addPrecomputedVelocityText = new GUIContent("Add Precomputed Velocity", "Requires additional per vertex velocity info");
         }
 
         protected MaterialProperty enableSpecularOcclusion = null;
-        protected MaterialProperty additionalVelocityChange = null;
+        protected MaterialProperty addPrecomputedVelocity = null;
         protected const string kEnableSpecularOcclusion = "_EnableSpecularOcclusion";
-        protected const string kAdditionalVelocityChange = HDMaterialProperties.kAdditionalVelocityChange;
+        protected const string kAddPrecomputedVelocity = HDMaterialProperties.kAddPrecomputedVelocity;
 
         Expandable  m_ExpandableBit;
         Features    m_Features;
@@ -41,7 +41,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         public override void LoadMaterialProperties()
         {
             enableSpecularOcclusion = FindProperty(kEnableSpecularOcclusion);
-            additionalVelocityChange = FindProperty(kAdditionalVelocityChange);
+            addPrecomputedVelocity = FindProperty(kAddPrecomputedVelocity);
         }
 
         public override void OnGUI()
@@ -59,10 +59,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 materialEditor.EnableInstancingField();
             if ((m_Features & Features.SpecularOcclusion) != 0)
                 materialEditor.ShaderProperty(enableSpecularOcclusion, Styles.enableSpecularOcclusionText);
-            if ((m_Features & Features.AdditionalVelocity) != 0)
+            if ((m_Features & Features.AddPrecomputedVelocity) != 0)
             {
-                if ( additionalVelocityChange != null)
-                    materialEditor.ShaderProperty(additionalVelocityChange, Styles.additionalVelocityChangeText);
+                if ( addPrecomputedVelocity != null)
+                    materialEditor.ShaderProperty(addPrecomputedVelocity, Styles.addPrecomputedVelocityText);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/ShaderGraphUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/ShaderGraphUIBlock.cs
@@ -148,6 +148,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
+        // Track additional velocity state. See SG-ADDITIONALVELOCITY-NOTE
+        bool m_AdditionalVelocityChange = false;
+
         void DrawMotionVectorToggle()
         {
             // I absolutely don't know what this is meant to do
@@ -166,6 +169,20 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool enabled = materials[0].GetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr);
             EditorGUI.BeginChangeCheck();
             enabled = EditorGUILayout.Toggle("Motion Vector For Vertex Animation", enabled);
+
+            // SG-ADDITIONALVELOCITY-NOTE:
+            // We would like to automatically enable the motion vector pass (handled on material UI side)
+            // in case we have additional velocity change enabled in a graph. Due to serialization of material, changing
+            // a value in between shadergraph compilations would have no effect on a material, so we instead
+            // inform the motion vector UI via the existence of the property at all and query against that.
+            bool hasAdditionalVelocityChange = materials[0].HasProperty(kAdditionalVelocityChange);
+            if (m_AdditionalVelocityChange != hasAdditionalVelocityChange)
+            {
+                enabled |= hasAdditionalVelocityChange;
+                m_AdditionalVelocityChange = hasAdditionalVelocityChange;
+                GUI.changed = true;
+            }
+
             if (EditorGUI.EndChangeCheck())
             {
                 foreach (var material in materials)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/ShaderGraphUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/ShaderGraphUIBlock.cs
@@ -170,7 +170,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             enabled = EditorGUILayout.Toggle("Motion Vector For Vertex Animation", enabled);
             
             // We would like to automatically enable the motion vector pass (handled on material UI side)
-            // in case we have additional velocity change enabled in a graph. Due to serialization of material, changing
+            // in case we have add precomputed velocity enabled in a graph. Due to serialization of material, changing
             // a value in between shadergraph compilations would have no effect on a material, so we instead
             // inform the motion vector UI via the existence of the property at all and query against that.
             bool hasPrecomputedVelocity = materials[0].HasProperty(kAddPrecomputedVelocity);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/ShaderGraphUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/ShaderGraphUIBlock.cs
@@ -147,9 +147,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 materialEditor.LightmapEmissionFlagsProperty(MaterialEditor.kMiniTextureFieldLabelIndentLevel, true, true);
             }
         }
-
-        // Track additional velocity state. See SG-ADDITIONALVELOCITY-NOTE
-        bool m_AdditionalVelocityChange = false;
+        
+        bool m_AddPrecomputedVelocity = false;
 
         void DrawMotionVectorToggle()
         {
@@ -169,17 +168,16 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             bool enabled = materials[0].GetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr);
             EditorGUI.BeginChangeCheck();
             enabled = EditorGUILayout.Toggle("Motion Vector For Vertex Animation", enabled);
-
-            // SG-ADDITIONALVELOCITY-NOTE:
+            
             // We would like to automatically enable the motion vector pass (handled on material UI side)
             // in case we have additional velocity change enabled in a graph. Due to serialization of material, changing
             // a value in between shadergraph compilations would have no effect on a material, so we instead
             // inform the motion vector UI via the existence of the property at all and query against that.
-            bool hasAdditionalVelocityChange = materials[0].HasProperty(kAdditionalVelocityChange);
-            if (m_AdditionalVelocityChange != hasAdditionalVelocityChange)
+            bool hasPrecomputedVelocity = materials[0].HasProperty(kAddPrecomputedVelocity);
+            if (m_AddPrecomputedVelocity != hasPrecomputedVelocity)
             {
-                enabled |= hasAdditionalVelocityChange;
-                m_AdditionalVelocityChange = hasAdditionalVelocityChange;
+                enabled |= hasPrecomputedVelocity;
+                m_AddPrecomputedVelocity = hasPrecomputedVelocity;
                 GUI.changed = true;
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
@@ -314,14 +314,22 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             // Shader graphs materials have their own management of motion vector pass in the material inspector
             if (!material.shader.IsShaderGraph())
             {
+                //In the case of additional velocity data we will enable the motion vector pass.
+                bool additionalVelocityEnabled = false;
+                if (material.HasProperty(kAdditionalVelocityChange))
+                {
+                    additionalVelocityEnabled = material.GetInt(kAdditionalVelocityChange) != 0;
+                }
+
                 // We don't have any vertex animation for lit/unlit vector, so we
                 // setup motion vector pass to false. Remind that in HDRP this
                 // doesn't disable motion vector, it just mean that the material
                 // don't do any vertex deformation but we can still have
                 // skinning / morph target
-                material.SetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr,
-             		                     material.GetInt(kAdditionalVelocityChange) !=0);
-            }
+                material.SetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr, additionalVelocityEnabled);
+
+             }
+
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
@@ -315,10 +315,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (!material.shader.IsShaderGraph())
             {
                 //In the case of additional velocity data we will enable the motion vector pass.
-                bool additionalVelocityEnabled = false;
-                if (material.HasProperty(kAdditionalVelocityChange))
+                bool addPrecomputedVelocity = false;
+                if (material.HasProperty(kAddPrecomputedVelocity))
                 {
-                    additionalVelocityEnabled = material.GetInt(kAdditionalVelocityChange) != 0;
+                    addPrecomputedVelocity = material.GetInt(kAddPrecomputedVelocity) != 0;
                 }
 
                 // We don't have any vertex animation for lit/unlit vector, so we
@@ -326,9 +326,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 // doesn't disable motion vector, it just mean that the material
                 // don't do any vertex deformation but we can still have
                 // skinning / morph target
-                material.SetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr, additionalVelocityEnabled);
-
-             }
+                material.SetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr, addPrecomputedVelocity);
+            }
 
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
@@ -319,7 +319,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 // doesn't disable motion vector, it just mean that the material
                 // don't do any vertex deformation but we can still have
                 // skinning / morph target
-                material.SetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr, false);
+                material.SetShaderPassEnabled(HDShaderPassNames.s_MotionVectorsStr,
+             		                     material.GetInt(kAdditionalVelocityChange) !=0);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
@@ -270,6 +270,21 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
         }
 
+        [SerializeField]
+        bool m_AddVelocityChange = false;
+        public ToggleData addVelocityChange
+        {
+            get { return new ToggleData(m_AddVelocityChange); }
+            set
+            {
+                if (m_AddVelocityChange == value.isOn)
+                    return;
+                m_AddVelocityChange = value.isOn;
+                UpdateNodeAfterDeserialization();
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
         public HDUnlitMasterNode()
         {
             UpdateNodeAfterDeserialization();

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
@@ -271,15 +271,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         }
 
         [SerializeField]
-        bool m_AddVelocityChange = false;
-        public ToggleData addVelocityChange
+        bool m_AddPrecomputedVelocity = false;
+        public ToggleData addPrecomputedVelocity
         {
-            get { return new ToggleData(m_AddVelocityChange); }
+            get { return new ToggleData(m_AddPrecomputedVelocity); }
             set
             {
-                if (m_AddVelocityChange == value.isOn)
+                if (m_AddPrecomputedVelocity == value.isOn)
                     return;
-                m_AddVelocityChange = value.isOn;
+                m_AddPrecomputedVelocity = value.isOn;
                 UpdateNodeAfterDeserialization();
                 Dirty(ModificationScope.Graph);
             }
@@ -390,13 +390,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             });
 
             //See SG-ADDITIONALVELOCITY-NOTE
-            if (addVelocityChange.isOn)
+            if (addPrecomputedVelocity.isOn)
             {
                 collector.AddShaderProperty(new BooleanShaderProperty
                 {
                     value  = true,
                     hidden = true,
-                    overrideReferenceName = kAdditionalVelocityChange,
+                    overrideReferenceName = kAddPrecomputedVelocity,
                 });
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
@@ -389,6 +389,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 value = (int)renderingPass,
             });
 
+            //See SG-ADDITIONALVELOCITY-NOTE
+            if (addVelocityChange.isOn)
+            {
+                collector.AddShaderProperty(new BooleanShaderProperty
+                {
+                    value  = true,
+                    hidden = true,
+                    overrideReferenceName = kAdditionalVelocityChange,
+                });
+            }
+
             // Add all shader properties required by the inspector
             HDSubShaderUtilities.AddStencilShaderProperties(collector, false, false);
             HDSubShaderUtilities.AddBlendingStatesShaderProperties(

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
@@ -35,7 +35,8 @@ Pass
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
 
     $AlphaFog:                           #define _ENABLE_FOG_ON_TRANSPARENT 1
-
+    $AdditionalVelocityChange:           #define _ADDITIONAL_VELOCITY_CHANGE
+   
     //enable GPU instancing support
     #pragma multi_compile_instancing
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
@@ -35,7 +35,7 @@ Pass
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
 
     $AlphaFog:                           #define _ENABLE_FOG_ON_TRANSPARENT 1
-    $AdditionalVelocityChange:           #define _ADDITIONAL_VELOCITY_CHANGE
+    $AddPrecomputedVelocity:            #define _ADD_PRECOMPUTED_VELOCITY
    
     //enable GPU instancing support
     #pragma multi_compile_instancing

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
@@ -262,7 +262,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
 
         void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
-            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Precomputed Velocity");
             ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
             m_Node.addPrecomputedVelocity = td;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
@@ -208,6 +208,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
+            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            {
+                row.Add(new Toggle(), (toggle) =>
+                {
+                    toggle.value = m_Node.addVelocityChange.isOn;
+                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                });
+            });
+
             Add(ps);
         }
 
@@ -249,6 +258,14 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             ToggleData td = m_Node.transparencyFog;
             td.isOn = evt.newValue;
             m_Node.transparencyFog = td;
+        }
+
+        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
+            ToggleData td = m_Node.addVelocityChange;
+            td.isOn = evt.newValue;
+            m_Node.addVelocityChange = td;
         }
 
         void ChangeRenderingPass(ChangeEvent<HDRenderQueue.RenderQueueType> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
@@ -208,12 +208,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
                 });
             });
 
-            ps.Add(new PropertyRow(CreateLabel("Additional Velocity Change", indentLevel)), (row) =>
+            ps.Add(new PropertyRow(CreateLabel("Add Precomputed Velocity", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
                 {
-                    toggle.value = m_Node.addVelocityChange.isOn;
-                    toggle.OnToggleChanged(ChangeAddVelocityChange);
+                    toggle.value = m_Node.addPrecomputedVelocity.isOn;
+                    toggle.OnToggleChanged(ChangeAddPrecomputedVelocity);
                 });
             });
 
@@ -260,12 +260,12 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline.Drawing
             m_Node.transparencyFog = td;
         }
 
-        void ChangeAddVelocityChange(ChangeEvent<bool> evt)
+        void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)
         {
             m_Node.owner.owner.RegisterCompleteObjectUndo("Add Velocity Change");
-            ToggleData td = m_Node.addVelocityChange;
+            ToggleData td = m_Node.addPrecomputedVelocity;
             td.isOn = evt.newValue;
-            m_Node.addVelocityChange = td;
+            m_Node.addPrecomputedVelocity = td;
         }
 
         void ChangeRenderingPass(ChangeEvent<HDRenderQueue.RenderQueueType> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
@@ -306,9 +306,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
 
-            if (masterNode.addVelocityChange.isOn)
+            if (masterNode.addPrecomputedVelocity.isOn)
             {
-                activeFields.Add("AdditionalVelocityChange");
+                activeFields.Add("AddPrecomputedVelocity");
             }
 
             return activeFields;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSubShader.cs
@@ -306,6 +306,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 }
             }
 
+            if (masterNode.addVelocityChange.isOn)
+            {
+                activeFields.Add("AdditionalVelocityChange");
+            }
+
             return activeFields;
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitPass.template
@@ -33,6 +33,7 @@ Pass
     $BlendMode.Alpha:                    #define _BLENDMODE_ALPHA 1
     $BlendMode.Add:                      #define _BLENDMODE_ADD 1
     $BlendMode.Premultiply:              #define _BLENDMODE_PRE_MULTIPLY 1
+    $AdditionalVelocityChange:           #define _ADDITIONAL_VELOCITY_CHANGE
     //-------------------------------------------------------------------------------------
     // End Variant Definitions
     //-------------------------------------------------------------------------------------

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitPass.template
@@ -33,7 +33,7 @@ Pass
     $BlendMode.Alpha:                    #define _BLENDMODE_ALPHA 1
     $BlendMode.Add:                      #define _BLENDMODE_ADD 1
     $BlendMode.Premultiply:              #define _BLENDMODE_PRE_MULTIPLY 1
-    $AdditionalVelocityChange:           #define _ADDITIONAL_VELOCITY_CHANGE
+    $AddPrecomputedVelocity:             #define _ADD_PRECOMPUTED_VELOCITY
     //-------------------------------------------------------------------------------------
     // End Variant Definitions
     //-------------------------------------------------------------------------------------

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitSubShader.cs
@@ -360,6 +360,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 // opaque-only defines
             }
 
+            if (masterNode.addVelocityChange.isOn)
+            {
+                activeFields.Add("AdditionalVelocityChange");
+            }
+
             return activeFields;
         }
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitSubShader.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/UnlitSubShader.cs
@@ -360,9 +360,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 // opaque-only defines
             }
 
-            if (masterNode.addVelocityChange.isOn)
+            if (masterNode.addPrecomputedVelocity.isOn)
             {
-                activeFields.Add("AdditionalVelocityChange");
+                activeFields.Add("AddPrecomputedVelocity");
             }
 
             return activeFields;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitGUI.cs
@@ -18,7 +18,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             new UnlitSurfaceInputsUIBlock(MaterialUIBlock.Expandable.Input),
             new TransparencyUIBlock(MaterialUIBlock.Expandable.Transparency),
             new EmissionUIBlock(MaterialUIBlock.Expandable.Emissive),
-            new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing),
+            new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing | AdvancedOptionsUIBlock.Features.AdditionalVelocity),
         };
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
@@ -76,6 +76,11 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             material.SetInt(kStencilWriteMaskMV, stencilWriteMaskMV);
             material.SetInt(kStencilRefDistortionVec, (int)HDRenderPipeline.StencilBitMask.DistortionVectors);
             material.SetInt(kStencilWriteMaskDistortionVec, (int)HDRenderPipeline.StencilBitMask.DistortionVectors);
+
+            if (material.HasProperty(kAdditionalVelocityChange))
+            {
+                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+            }
         }
     }
 } // namespace UnityEditor

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitGUI.cs
@@ -18,7 +18,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             new UnlitSurfaceInputsUIBlock(MaterialUIBlock.Expandable.Input),
             new TransparencyUIBlock(MaterialUIBlock.Expandable.Transparency),
             new EmissionUIBlock(MaterialUIBlock.Expandable.Emissive),
-            new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing | AdvancedOptionsUIBlock.Features.AdditionalVelocity),
+            new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing | AdvancedOptionsUIBlock.Features.AddPrecomputedVelocity),
         };
 
         public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
@@ -77,9 +77,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             material.SetInt(kStencilRefDistortionVec, (int)HDRenderPipeline.StencilBitMask.DistortionVectors);
             material.SetInt(kStencilWriteMaskDistortionVec, (int)HDRenderPipeline.StencilBitMask.DistortionVectors);
 
-            if (material.HasProperty(kAdditionalVelocityChange))
+            if (material.HasProperty(kAddPrecomputedVelocity))
             {
-                CoreUtils.SetKeyword(material, "_ADDITIONAL_VELOCITY_CHANGE", material.GetInt(kAdditionalVelocityChange) != 0);
+                CoreUtils.SetKeyword(material, "_ADD_PRECOMPUTED_VELOCITY", material.GetInt(kAddPrecomputedVelocity) != 0);
             }
         }
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.shader
@@ -110,6 +110,7 @@ Shader "HDRP/AxF"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
+        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -127,6 +128,7 @@ Shader "HDRP/AxF"
 
     #pragma shader_feature _DISABLE_DECALS
     #pragma shader_feature _DISABLE_SSR
+    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
 
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.shader
@@ -110,7 +110,7 @@ Shader "HDRP/AxF"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -128,7 +128,7 @@ Shader "HDRP/AxF"
 
     #pragma shader_feature _DISABLE_DECALS
     #pragma shader_feature _DISABLE_SSR
-    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
+    #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
 
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/AxF/AxF.shader
@@ -110,7 +110,7 @@ Shader "HDRP/AxF"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -364,7 +364,7 @@ Shader "HDRP/LayeredLit"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -434,7 +434,7 @@ Shader "HDRP/LayeredLit"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
-    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
+    #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -364,6 +364,7 @@ Shader "HDRP/LayeredLit"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
+        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -433,6 +434,7 @@ Shader "HDRP/LayeredLit"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
+    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -364,7 +364,7 @@ Shader "HDRP/LayeredLit"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -374,6 +374,7 @@ Shader "HDRP/LayeredLitTessellation"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
+        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -444,6 +445,7 @@ Shader "HDRP/LayeredLitTessellation"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
+    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -374,7 +374,7 @@ Shader "HDRP/LayeredLitTessellation"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -445,7 +445,7 @@ Shader "HDRP/LayeredLitTessellation"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
-    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
+    #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -374,7 +374,7 @@ Shader "HDRP/LayeredLitTessellation"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -220,7 +220,8 @@ Shader "HDRP/Lit"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-
+        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        
         [HideInInspector] _DiffusionProfile("Obsolete, kept for migration purpose", Int) = 0
         [HideInInspector] _DiffusionProfileAsset("Diffusion Profile Asset", Vector) = (0, 0, 0, 0)
         [HideInInspector] _DiffusionProfileHash("Diffusion Profile Hash", Float) = 0
@@ -266,6 +267,7 @@ Shader "HDRP/Lit"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
+    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -220,7 +220,7 @@ Shader "HDRP/Lit"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
         
         [HideInInspector] _DiffusionProfile("Obsolete, kept for migration purpose", Int) = 0
         [HideInInspector] _DiffusionProfileAsset("Diffusion Profile Asset", Vector) = (0, 0, 0, 0)
@@ -267,7 +267,7 @@ Shader "HDRP/Lit"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
-    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
+    #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -220,7 +220,7 @@ Shader "HDRP/Lit"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
         
         [HideInInspector] _DiffusionProfile("Obsolete, kept for migration purpose", Int) = 0
         [HideInInspector] _DiffusionProfileAsset("Diffusion Profile Asset", Vector) = (0, 0, 0, 0)

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -231,7 +231,7 @@ Shader "HDRP/LitTessellation"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -275,7 +275,7 @@ Shader "HDRP/LitTessellation"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
-    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
+    #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -231,6 +231,7 @@ Shader "HDRP/LitTessellation"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
+        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -274,6 +275,7 @@ Shader "HDRP/LitTessellation"
 
     #pragma shader_feature_local _DISABLE_DECALS
     #pragma shader_feature_local _DISABLE_SSR
+    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
     #pragma shader_feature_local _ENABLE_GEOMETRIC_SPECULAR_AA
 
     // Keyword for transparent

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -231,7 +231,7 @@ Shader "HDRP/LitTessellation"
 
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
@@ -45,6 +45,7 @@ Shader "HDRP/TerrainLit"
 
         [HideInInspector] [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [HideInInspector] [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
+        [HideInInspector] [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -67,6 +68,7 @@ Shader "HDRP/TerrainLit"
     //#pragma shader_feature _ _LAYER_MAPPING_PLANAR3 _LAYER_MAPPING_TRIPLANAR3
 
     #pragma shader_feature_local _DISABLE_DECALS
+    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
 
     //enable GPU instancing support
     #pragma multi_compile_instancing

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
@@ -45,7 +45,7 @@ Shader "HDRP/TerrainLit"
 
         [HideInInspector] [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [HideInInspector] [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [HideInInspector] [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        [HideInInspector] [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE
@@ -68,7 +68,7 @@ Shader "HDRP/TerrainLit"
     //#pragma shader_feature _ _LAYER_MAPPING_PLANAR3 _LAYER_MAPPING_TRIPLANAR3
 
     #pragma shader_feature_local _DISABLE_DECALS
-    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
+    #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
 
     //enable GPU instancing support
     #pragma multi_compile_instancing

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLit.shader
@@ -45,7 +45,7 @@ Shader "HDRP/TerrainLit"
 
         [HideInInspector] [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [HideInInspector] [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
-        [HideInInspector] [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
+        [HideInInspector] [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
     }
 
     HLSLINCLUDE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
@@ -69,7 +69,7 @@ Shader "HDRP/Unlit"
         [HideInInspector] _StencilRefMV("_StencilRefMV", Int) = 128 // StencilBitMask.ObjectMotionVectors
         [HideInInspector] _StencilWriteMaskMV("_StencilWriteMaskMV", Int) = 128 // StencilBitMask.ObjectMotionVectors
 
-        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
 
         // Distortion vector pass
         [HideInInspector] _StencilRefDistortionVec("_StencilRefDistortionVec", Int) = 64 // StencilBitMask.DistortionVectors

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
@@ -68,6 +68,9 @@ Shader "HDRP/Unlit"
         // Motion vector pass
         [HideInInspector] _StencilRefMV("_StencilRefMV", Int) = 128 // StencilBitMask.ObjectMotionVectors
         [HideInInspector] _StencilWriteMaskMV("_StencilWriteMaskMV", Int) = 128 // StencilBitMask.ObjectMotionVectors
+
+        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+
         // Distortion vector pass
         [HideInInspector] _StencilRefDistortionVec("_StencilRefDistortionVec", Int) = 64 // StencilBitMask.DistortionVectors
         [HideInInspector] _StencilWriteMaskDistortionVec("_StencilWriteMaskDistortionVec", Int) = 64 // StencilBitMask.DistortionVectors
@@ -106,7 +109,7 @@ Shader "HDRP/Unlit"
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature_local _ENABLE_FOG_ON_TRANSPARENT
-
+    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
     //enable GPU instancing support
     #pragma multi_compile_instancing
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.shader
@@ -69,7 +69,7 @@ Shader "HDRP/Unlit"
         [HideInInspector] _StencilRefMV("_StencilRefMV", Int) = 128 // StencilBitMask.ObjectMotionVectors
         [HideInInspector] _StencilWriteMaskMV("_StencilWriteMaskMV", Int) = 128 // StencilBitMask.ObjectMotionVectors
 
-        [ToggleUI] _AddVelocityChange("EnableAdditionalVelocity", Float) = 0.0
+        [ToggleUI] _AddPrecomputedVelocity("EnableAdditionalVelocity", Float) = 0.0
 
         // Distortion vector pass
         [HideInInspector] _StencilRefDistortionVec("_StencilRefDistortionVec", Int) = 64 // StencilBitMask.DistortionVectors
@@ -109,7 +109,7 @@ Shader "HDRP/Unlit"
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature_local _ENABLE_FOG_ON_TRANSPARENT
-    #pragma shader_feature_local _ADDITIONAL_VELOCITY_CHANGE
+    #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
     //enable GPU instancing support
     #pragma multi_compile_instancing
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -749,6 +749,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public const string kEnableDecals = "_SupportDecals";
         public const string kSupportDecals = kEnableDecals;
         public const string kEnableSSR = "_ReceivesSSR";
+        public const string kAdditionalVelocityChange = "_AddVelocityChange";
 
         public const string kLayerCount = "_LayerCount";
         

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -749,7 +749,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         public const string kEnableDecals = "_SupportDecals";
         public const string kSupportDecals = kEnableDecals;
         public const string kEnableSSR = "_ReceivesSSR";
-        public const string kAdditionalVelocityChange = "_AddVelocityChange";
+        public const string kAddPrecomputedVelocity = "_AddPrecomputedVelocity";
 
         public const string kLayerCount = "_LayerCount";
         

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/MotionVectorVertexShaderCommon.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/MotionVectorVertexShaderCommon.hlsl
@@ -126,7 +126,7 @@ PackedVaryingsType MotionVectorVS(inout VaryingsType varyingsType, AttributesMes
         bool hasDeformation = unity_MotionVectorsParams.x > 0.0; // Skin or morph target
         float3 effectivePositionOS = (hasDeformation ? inputPass.previousPositionOS : inputMesh.positionOS);
  #if defined(_ADD_PRECOMPUTED_VELOCITY)
-         effectivePositionOS -= inputPass.alembicVelocity; // <= this line
+         effectivePositionOS -= inputPass.alembicVelocity;
  #endif
         
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/MotionVectorVertexShaderCommon.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/MotionVectorVertexShaderCommon.hlsl
@@ -5,6 +5,9 @@
 struct AttributesPass
 {
     float3 previousPositionOS : TEXCOORD4; // Contain previous transform position (in case of skinning for example)
+#if defined (_ADDITIONAL_VELOCITY_CHANGE)
+     float3 alembicVelocity    : TEXCOORD5; // Additional Velocity changes (Alembic computes velocities on runtime side).
+ #endif
 };
 
 struct VaryingsPassToPS
@@ -121,16 +124,19 @@ PackedVaryingsType MotionVectorVS(inout VaryingsType varyingsType, AttributesMes
     else
     {
         bool hasDeformation = unity_MotionVectorsParams.x > 0.0; // Skin or morph target
+        float3 effectivePositionOS = (hasDeformation ? inputPass.previousPositionOS : inputMesh.positionOS);
+ #if defined(_ADDITIONAL_VELOCITY_CHANGE)
+         effectivePositionOS -= inputPass.alembicVelocity; // <= this line
+ #endif
+        
 
     // Need to apply any vertex animation to the previous worldspace position, if we want it to show up in the motion vector buffer
 #if defined(HAVE_MESH_MODIFICATION)
         AttributesMesh previousMesh = inputMesh;
-        if (hasDeformation)
-            previousMesh.positionOS = inputPass.previousPositionOS;
-        previousMesh = ApplyMeshModification(previousMesh, _LastTimeParameters.xyz);
+        previousMesh.positionOS = effectivePositionOS ;
         float3 previousPositionRWS = TransformPreviousObjectToWorld(previousMesh.positionOS);
 #else
-        float3 previousPositionRWS = TransformPreviousObjectToWorld(hasDeformation ? inputPass.previousPositionOS : inputMesh.positionOS);
+        float3 previousPositionRWS = TransformPreviousObjectToWorld(effectivePositionOS);
 #endif
 
 #ifdef ATTRIBUTES_NEED_NORMAL

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/MotionVectorVertexShaderCommon.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/MotionVectorVertexShaderCommon.hlsl
@@ -5,8 +5,8 @@
 struct AttributesPass
 {
     float3 previousPositionOS : TEXCOORD4; // Contain previous transform position (in case of skinning for example)
-#if defined (_ADDITIONAL_VELOCITY_CHANGE)
-     float3 alembicVelocity    : TEXCOORD5; // Additional Velocity changes (Alembic computes velocities on runtime side).
+#if defined (_ADD_PRECOMPUTED_VELOCITY)
+     float3 alembicVelocity    : TEXCOORD5; // Add Precomputed Velocity (Alembic computes velocities on runtime side).
  #endif
 };
 
@@ -125,7 +125,7 @@ PackedVaryingsType MotionVectorVS(inout VaryingsType varyingsType, AttributesMes
     {
         bool hasDeformation = unity_MotionVectorsParams.x > 0.0; // Skin or morph target
         float3 effectivePositionOS = (hasDeformation ? inputPass.previousPositionOS : inputMesh.positionOS);
- #if defined(_ADDITIONAL_VELOCITY_CHANGE)
+ #if defined(_ADD_PRECOMPUTED_VELOCITY)
          effectivePositionOS -= inputPass.alembicVelocity; // <= this line
  #endif
         

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - You can no longer directly connect slots with invalid types. When the graph detects that situation, it now doesn't break and gives an error instead.
 - Fixed an error that previously occurred when you used `Sampler State` input ports on Sub Graphs.
 - Fixed various dependency tracking issues with Sub Graphs and HLSL files from Custom Function Nodes.
+- Added support of Alembic velocity to various shaders
 
 ## [6.9.0] - 2019-07-02
 

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
@@ -71,15 +71,15 @@ namespace UnityEditor.ShaderGraph
         }
 
         [SerializeField]
-        bool m_AddVelocityChange = false;
-        public ToggleData addVelocityChange
+        bool m_AddPrecomputedVelocity = false;
+        public ToggleData addPrecomputedVelocity
         {
-            get { return new ToggleData(m_AddVelocityChange); }
+            get { return new ToggleData(m_AddPrecomputedVelocity); }
             set
             {
-                if (m_AddVelocityChange == value.isOn)
+                if (m_AddPrecomputedVelocity == value.isOn)
                     return;
-                m_AddVelocityChange = value.isOn;
+                m_AddPrecomputedVelocity = value.isOn;
                 Dirty(ModificationScope.Graph);
             }
         }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
@@ -70,6 +70,20 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
+        [SerializeField]
+        bool m_AddVelocityChange = false;
+        public ToggleData addVelocityChange
+        {
+            get { return new ToggleData(m_AddVelocityChange); }
+            set
+            {
+                if (m_AddVelocityChange == value.isOn)
+                    return;
+                m_AddVelocityChange = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+        
         public UnlitMasterNode()
         {
             UpdateNodeAfterDeserialization();


### PR DESCRIPTION
### Purpose of this PR
Backport of https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3981 , https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3996
The option was renamed to **Add Precomputed Velocity** as discussed with @sebastienlagarde 

---
### Release Notes
Add option to have Additional PrecomputedVelocity (Useful for Alembic)

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?
Katana is green: https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=precomputedVelocity&automation-tools_branch=master&unity_branch=2019.2%2Fstaging&sort=4-asc
Yamato has failing tests:

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
Playmode tests on HDRP_Tests fail on my machine for a ton of strange reasons (no base image to compare with, etc). The release/2019.2 branch fails itself on my setup.
- [x] Built a player
- [x] Checked new UI names with UX convention
- [x] Tested UI multi-edition + Undo/Redo
- [x] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 
-Built shader Graph material based on lit, checked motion vectors work. Used regular a few regular materials and they look the same as before, and motion vectors work
-Built standalone OSX app

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Medium
New feature, disabled by default

**Halo Effect**:Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.