### PR TITLE
Disable the compilation of the first variant of the shadergraph…

### DIFF
--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -73,7 +73,7 @@ Shader ""Hidden/GraphErrorShader2""
             string path = ctx.assetPath;
             var sourceAssetDependencyPaths = new List<string>();
             var text = GetShaderText(path, out configuredTextures, sourceAssetDependencyPaths, out var graph);
-            var shader = ShaderUtil.CreateShaderAsset(text);
+            var shader = ShaderUtil.CreateShaderAsset(text, false);
 
             if (graph != null && graph.messageManager.nodeMessagesChanged)
             {


### PR DESCRIPTION
### Purpose of this PR
Disable the compilation of the first variant of the shadergraph on import

---
### Testing status
**Yamato Tests**
:https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/shadergraph%252Ffix%252Fdisable_first_variant_compilation_import

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low
