### PR TITLE
IL2CPP Support Fix

### DIFF
--- a/com.unity.testframework.graphics/Tests/Runtime/FailedImageMessageTests.cs
+++ b/com.unity.testframework.graphics/Tests/Runtime/FailedImageMessageTests.cs
@@ -15,6 +15,7 @@ namespace UnityEngine.TestTools.Graphics.Tests
             AssertAreEqual(deserialized, message);
         }
 
+#if UNITY_MONO // IL2CPP does not support attributes with object arguments that are array types.
         [TestCase(null, null, null, null, null)]
         [TestCase("", "", new byte[0], new byte[0], new byte[0])]
         [TestCase("Foo", "Bar", new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, null, null)]
@@ -36,6 +37,7 @@ namespace UnityEngine.TestTools.Graphics.Tests
 
             AssertAreEqual(deserialized, message);
         }
+#endif
 
         private static void AssertAreEqual(FailedImageMessage deserialized, FailedImageMessage message)
         {


### PR DESCRIPTION
### Purpose of this PR
Builds using IL2CPP fail because it does not support attributes with object arguments that are array types, as used in SerializationRoundtrip_AllFieldsAreSerializedAndDeserialized.

---
### Release Notes
- Added #define directives to FailedImageMessageTests to enable IL2CPP support at build time

---
### Testing status
Running tests against my target hardware worked locally.

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
