### PR TITLE
Fix locale for migration tests

### DIFF
--- a/com.unity.render-pipelines.high-definition/Tests/Editor/HDAdditionalReflectionData.MigrationTests.cs
+++ b/com.unity.render-pipelines.high-definition/Tests/Editor/HDAdditionalReflectionData.MigrationTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using UnityEditor.Rendering.TestFramework;
+using System;
 
 namespace UnityEngine.Rendering.HighDefinition.Tests
 {
@@ -144,7 +145,7 @@ namespace UnityEngine.Rendering.HighDefinition.Tests
             }
 
             string GeneratePrefabYAML(LegacyProbeData legacyProbeData)
-                => $@"%YAML 1.1
+                => FormattableString.Invariant($@"%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &3102262843427888416
 GameObject:
@@ -343,7 +344,7 @@ MonoBehaviour:
   priority: 0
   blendDistance: 0
   weight: 1
-  sharedProfile: {{fileID: 11400000, guid: cc8be05cdf24e1748a0d99d50a681853, type: 2}}";
+  sharedProfile: {{fileID: 11400000, guid: cc8be05cdf24e1748a0d99d50a681853, type: 2}}");
         }
 
         public class MigrateFromLegacyProbe
@@ -508,7 +509,7 @@ MonoBehaviour:
             }
 
             string GeneratePrefabYAML(LegacyProbeData legacyProbeData)
-                => $@"%YAML 1.1
+                => FormattableString.Invariant($@"%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &4579176910221717176
 GameObject:
@@ -574,7 +575,7 @@ ReflectionProbe:
   m_UseOcclusionCulling: {(legacyProbeData.useOcclusionCulling ? 1 : 0)}
   m_Importance: {legacyProbeData.importance}
   m_CustomBakedTexture: {{fileID: 0}}
-";
+");
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Tests/Editor/PlanarReflectionProbe.MigrationTests.cs
+++ b/com.unity.render-pipelines.high-definition/Tests/Editor/PlanarReflectionProbe.MigrationTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using UnityEditor.Rendering.TestFramework;
+using System;
 
 namespace UnityEngine.Rendering.HighDefinition.Tests
 {
@@ -152,7 +153,7 @@ namespace UnityEngine.Rendering.HighDefinition.Tests
             }
 
             string GeneratePrefabYAML(LegacyProbeData legacyProbeData)
-                => $@"%YAML 1.1
+                => FormattableString.Invariant($@"%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &6171638715142251291
 GameObject:
@@ -298,7 +299,7 @@ MonoBehaviour:
   m_ObsoleteOverrideFieldOfView: 0
   m_ObsoleteFieldOfViewOverride: 90
   m_ObsoleteCaptureNearPlane: 0.3
-  m_ObsoleteCaptureFarPlane: 1000";
+  m_ObsoleteCaptureFarPlane: 1000");
         }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Tests/Editor/TestFramework/YAMLUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Tests/Editor/TestFramework/YAMLUtilities.cs
@@ -1,11 +1,12 @@
 using UnityEngine;
+using System;
 
 namespace UnityEditor.Rendering.TestFramework
 {
     static class YAMLUtilities
     {
-        public static string ToYAML(this Quaternion v) => $"{{x: {v.x}, y: {v.y}, z: {v.z}, w: {v.w}}}";
-        public static string ToYAML(this Vector3 v) => $"{{x: {v.x}, y: {v.y}, z: {v.z}}}";
-        public static string ToYAML(this Color v) => $"{{r: {v.r}, g: {v.g}, b: {v.b}, a: {v.a}}}";
+        public static string ToYAML(this Quaternion v) => FormattableString.Invariant($"{{x: {v.x}, y: {v.y}, z: {v.z}, w: {v.w}}}");
+        public static string ToYAML(this Vector3 v) => FormattableString.Invariant($"{{x: {v.x}, y: {v.y}, z: {v.z}}}");
+        public static string ToYAML(this Color v) => FormattableString.Invariant($"{{r: {v.r}, g: {v.g}, b: {v.b}, a: {v.a}}}");
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Fixed invalid locale (FR-fr) when generating text prefab for migration tests.

---
### Testing status
**Katana Tests**: -

**Automated Tests**: Runned locally migration tests

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
