### PR TITLE
Universal RP Asset and Renderer Refactor

### DIFF
--- a/TestProjects/UniversalGraphicsTest/Assets/Test/Runtime/CameraCallbackTests.cs
+++ b/TestProjects/UniversalGraphicsTest/Assets/Test/Runtime/CameraCallbackTests.cs
@@ -29,7 +29,7 @@ public class CameraCallbackTests : ScriptableRendererFeature
 
 	public override void Create()
 	{
-		ForwardRendererData data = UniversalRenderPipeline.asset.m_RendererData[0] as ForwardRendererData;
+		ForwardRendererData data = UniversalRenderPipeline.asset.m_RendererDataList[0] as ForwardRendererData;
 		if (data == null)
 			return;
 		var shader = data.shaders.samplingPS;

--- a/TestProjects/UniversalGraphicsTest/Assets/Test/Runtime/CameraCallbackTests.cs
+++ b/TestProjects/UniversalGraphicsTest/Assets/Test/Runtime/CameraCallbackTests.cs
@@ -29,7 +29,9 @@ public class CameraCallbackTests : ScriptableRendererFeature
 
 	public override void Create()
 	{
-		ForwardRendererData data = UniversalRenderPipeline.asset.m_RendererData as ForwardRendererData;
+		ForwardRendererData data = UniversalRenderPipeline.asset.m_RendererData[0] as ForwardRendererData;
+		if (data == null)
+			return;
 		var shader = data.shaders.samplingPS;
 		m_SamplingMaterial = CoreUtils.CreateEngineMaterial(shader);
 	}

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
@@ -138,7 +138,7 @@ namespace UnityEditor.Rendering.Universal
             m_PostProcessingSettingsFoldout = new SavedBool($"{target.GetType()}.PostProcessingSettingsFoldout", false);
             m_AdvancedSettingsFoldout = new SavedBool($"{target.GetType()}.AdvancedSettingsFoldout", false);
 
-            m_RendererDataProp = serializedObject.FindProperty("m_RendererData");
+            m_RendererDataProp = serializedObject.FindProperty("m_RendererDataList");
             m_DefaultRendererProp = serializedObject.FindProperty("m_DefaultRenderer");
             m_RendererDataList = new ReorderableList(serializedObject, m_RendererDataProp, false, true, true, true);
 

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
@@ -354,11 +354,14 @@ namespace UnityEditor.Rendering.Universal
 
         void DrawRendererListLayout(ReorderableList list, SerializedProperty prop)
         {
-            list.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) => {
+            list.drawElementCallback = (Rect rect, int index, bool isActive, bool isFocused) =>
+            {
+                rect.y += 2;
                 Rect indexRect = new Rect(rect.x, rect.y, 14, EditorGUIUtility.singleLineHeight);
                 EditorGUI.LabelField(indexRect, index.ToString());
                 Rect objRect = new Rect(rect.x + indexRect.width, rect.y, rect.width - 134, EditorGUIUtility.singleLineHeight);
                 EditorGUI.ObjectField(objRect, prop.GetArrayElementAtIndex(index), GUIContent.none);
+                
                 Rect defaultButton = new Rect(rect.width - 90, rect.y, 86, EditorGUIUtility.singleLineHeight);
                 var defaultRenderer = m_DefaultRendererProp.intValue;
                 GUI.enabled = index != defaultRenderer;
@@ -375,7 +378,7 @@ namespace UnityEditor.Rendering.Universal
                 }
             };
             
-            list.drawHeaderCallback = (Rect rect) => { EditorGUI.LabelField(rect, "Renderers"); };
+            list.drawHeaderCallback = (Rect rect) => { EditorGUI.LabelField(rect, "Renderers"); list.index = list.count - 1; };
 
             list.onCanRemoveCallback = li => { return li.count > 1; };
 
@@ -383,9 +386,22 @@ namespace UnityEditor.Rendering.Universal
 
             list.onRemoveCallback = li =>
             {
-                li.serializedProperty.DeleteArrayElementAtIndex(li.serializedProperty.arraySize - 1);
-                li.serializedProperty.arraySize--;
-                li.index = li.count - 1;
+                if (li.serializedProperty.arraySize - 1 != m_DefaultRendererProp.intValue)
+                {
+                    li.serializedProperty.DeleteArrayElementAtIndex(li.serializedProperty.arraySize - 1);
+                    li.serializedProperty.arraySize--;
+                    li.index = li.count - 1;
+                }
+                else if (li.serializedProperty.arraySize == 1)
+                {
+                    EditorUtility.DisplayDialog("Cannot remove last Renderer", "Removal of the Last Renderer is not allowed.",
+                        "Close");
+                }
+                else
+                {
+                    EditorUtility.DisplayDialog("Cannot remove Default Renderer", "Removal of the Default Renderer is not allowed. To remove, set another Renderer to be the new Default and then remove.",
+                        "Close");
+                }
             };
         }
     }

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineCameraEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineCameraEditor.cs
@@ -28,8 +28,7 @@ namespace UnityEditor.Rendering.Universal
             public static GUIContent allowMSAA = EditorGUIUtility.TrTextContent("MSAA", "Use Multi Sample Anti-Aliasing to reduce aliasing.");
             public static GUIContent allowHDR = EditorGUIUtility.TrTextContent("HDR", "High Dynamic Range gives you a wider range of light intensities, so your lighting looks more realistic. With it, you can still see details and experience less saturation even with bright light.", (Texture) null);
 
-            public static GUIContent rendererType = EditorGUIUtility.TrTextContent("Renderer Type", "Controls which renderer this camera uses.");
-            public static GUIContent rendererData = EditorGUIUtility.TrTextContent("Renderer Data", "Required by a custom Renderer. If none is assigned this camera uses the one assigned in the Pipeline Settings.");
+            public static GUIContent rendererType = EditorGUIUtility.TrTextContent("Renderer", "Controls which renderer this camera uses.");
 
             public static GUIContent volumeLayerMask = EditorGUIUtility.TrTextContent("Volume Mask", "This camera will only be affected by volumes in the selected scene-layers.");
             public static GUIContent volumeTrigger = EditorGUIUtility.TrTextContent("Volume Trigger", "A transform that will act as a trigger for volume blending. If none is set, the camera itself will act as a trigger.");
@@ -40,17 +39,12 @@ namespace UnityEditor.Rendering.Universal
             public static GUIContent stopNaN = EditorGUIUtility.TrTextContent("Stop NaN", "Automatically replaces NaN/Inf in shaders by a black pixel to avoid breaking some effects. This will affect performances and should only be used if you experience NaN issues that you can't fix. Has no effect on GLES2 platforms.");
             public static GUIContent dithering = EditorGUIUtility.TrTextContent("Dithering", "Applies 8-bit dithering to the final render to reduce color banding.");
 
-            public readonly GUIContent[] renderingPathOptions = { EditorGUIUtility.TrTextContent("Forward") };
             public readonly string hdrDisabledWarning = "HDR rendering is disabled in the Universal Render Pipeline asset.";
             public readonly string mssaDisabledWarning = "Anti-aliasing is disabled in the Universal Render Pipeline asset.";
+            
+            public static readonly string missingRendererWarning = "The currently selected Renderer is missing form the Universal Render Pipeline asset.";
+            public static readonly string noRendererError = "There are no valid Renderers available on the Universal Render Pipeline asset.";
 
-            public static GUIContent[] displayedRendererTypeOverride =
-            {
-                new GUIContent("Custom"),
-                new GUIContent("Use Pipeline Settings"),
-            };
-
-            public static int[] rendererTypeOptions = Enum.GetValues(typeof(RendererOverrideOption)).Cast<int>().ToArray();
             public static GUIContent[] cameraBackgroundType =
             {
                 new GUIContent("Skybox"),
@@ -123,7 +117,6 @@ namespace UnityEditor.Rendering.Universal
         SerializedProperty m_AdditionalCameraDataRenderDepthProp;
         SerializedProperty m_AdditionalCameraDataRenderOpaqueProp;
         SerializedProperty m_AdditionalCameraDataRendererProp;
-        SerializedProperty m_AdditionalCameraDataRendererDataProp;
         SerializedProperty m_AdditionalCameraDataVolumeLayerMask;
         SerializedProperty m_AdditionalCameraDataVolumeTrigger;
         SerializedProperty m_AdditionalCameraDataRenderPostProcessing;
@@ -172,8 +165,7 @@ namespace UnityEditor.Rendering.Universal
             m_AdditionalCameraDataRenderShadowsProp = m_AdditionalCameraDataSO.FindProperty("m_RenderShadows");
             m_AdditionalCameraDataRenderDepthProp = m_AdditionalCameraDataSO.FindProperty("m_RequiresDepthTextureOption");
             m_AdditionalCameraDataRenderOpaqueProp = m_AdditionalCameraDataSO.FindProperty("m_RequiresOpaqueTextureOption");
-            m_AdditionalCameraDataRendererProp = m_AdditionalCameraDataSO.FindProperty("m_RendererOverrideOption");
-            m_AdditionalCameraDataRendererDataProp = m_AdditionalCameraDataSO.FindProperty("m_RendererData");
+            m_AdditionalCameraDataRendererProp = m_AdditionalCameraDataSO.FindProperty("m_RendererIndex");
             m_AdditionalCameraDataVolumeLayerMask = m_AdditionalCameraDataSO.FindProperty("m_VolumeLayerMask");
             m_AdditionalCameraDataVolumeTrigger = m_AdditionalCameraDataSO.FindProperty("m_VolumeTrigger");
             m_AdditionalCameraDataRenderPostProcessing = m_AdditionalCameraDataSO.FindProperty("m_RenderPostProcessing");
@@ -321,7 +313,7 @@ namespace UnityEditor.Rendering.Universal
             bool selectedValueShadows;
             CameraOverrideOption selectedDepthOption;
             CameraOverrideOption selectedOpaqueOption;
-            RendererOverrideOption selectedRendererOption;
+            int selectedRendererOption;
             LayerMask selectedVolumeLayerMask;
             Transform selectedVolumeTrigger;
             bool selectedRenderPostProcessing;
@@ -335,7 +327,7 @@ namespace UnityEditor.Rendering.Universal
                 selectedValueShadows = true;
                 selectedDepthOption = CameraOverrideOption.UsePipelineSettings;
                 selectedOpaqueOption = CameraOverrideOption.UsePipelineSettings;
-                selectedRendererOption = RendererOverrideOption.UsePipelineSettings;
+                selectedRendererOption = -1;
                 selectedVolumeLayerMask = 1; // "Default"
                 selectedVolumeTrigger = null;
                 selectedRenderPostProcessing = false;
@@ -350,7 +342,7 @@ namespace UnityEditor.Rendering.Universal
                 selectedValueShadows = m_AdditionalCameraData.renderShadows;
                 selectedDepthOption = (CameraOverrideOption)m_AdditionalCameraDataRenderDepthProp.intValue;
                 selectedOpaqueOption =(CameraOverrideOption)m_AdditionalCameraDataRenderOpaqueProp.intValue;
-                selectedRendererOption = (RendererOverrideOption) m_AdditionalCameraDataRendererProp.intValue;
+                selectedRendererOption = m_AdditionalCameraDataRendererProp.intValue;
                 selectedVolumeLayerMask = m_AdditionalCameraDataVolumeLayerMask.intValue;
                 selectedVolumeTrigger = (Transform)m_AdditionalCameraDataVolumeTrigger.objectReferenceValue;
                 selectedRenderPostProcessing = m_AdditionalCameraDataRenderPostProcessing.boolValue;
@@ -362,18 +354,18 @@ namespace UnityEditor.Rendering.Universal
 
             hasChanged |= DrawLayerMask(m_AdditionalCameraDataVolumeLayerMask, ref selectedVolumeLayerMask, Styles.volumeLayerMask);
             hasChanged |= DrawObjectField(m_AdditionalCameraDataVolumeTrigger, ref selectedVolumeTrigger, Styles.volumeTrigger);
-            hasChanged |= DrawIntPopup(m_AdditionalCameraDataRendererProp, ref selectedRendererOption, Styles.rendererType, Styles.displayedRendererTypeOverride, Styles.rendererTypeOptions);
-
-            if (selectedRendererOption == RendererOverrideOption.Custom && m_AdditionalCameraDataSO != null)
+            
+            hasChanged |= DrawBasicIntPopup(m_AdditionalCameraDataRendererProp, ref selectedRendererOption, Styles.rendererType, UniversalRenderPipeline.asset.rendererDisplayList,
+                UniversalRenderPipeline.asset.rendererIndexList);
+            if (!UniversalRenderPipeline.asset.ValidateRendererDataList())
             {
-                EditorGUI.indentLevel++;
-                EditorGUI.BeginChangeCheck();
-                EditorGUILayout.PropertyField(m_AdditionalCameraDataRendererDataProp, Styles.rendererData);
-                if (EditorGUI.EndChangeCheck())
-                    hasChanged = true;
-                EditorGUI.indentLevel--;
+                EditorGUILayout.HelpBox(Styles.noRendererError, MessageType.Error);
             }
-
+            else if (!UniversalRenderPipeline.asset.ValidateRendererData(selectedRendererOption))
+            {
+                EditorGUILayout.HelpBox(Styles.missingRendererWarning, MessageType.Warning);
+            }
+            
             // TODO: Fix this for lw/postfx
             bool defaultDrawOfDepthTextureUI = true;
             if (defaultDrawOfDepthTextureUI)
@@ -480,6 +472,20 @@ namespace UnityEditor.Rendering.Universal
 
             EditorGUI.BeginChangeCheck();
             value = (T)(object)EditorGUI.IntPopup(controlRect, style, (int)(object)value, optionNames, optionValues);
+            if (EditorGUI.EndChangeCheck())
+                hasChanged = true;
+
+            EndProperty();
+            return hasChanged;
+        }
+        
+        bool DrawBasicIntPopup(SerializedProperty prop, ref int value, GUIContent style, GUIContent[] optionNames, int[] optionValues)
+        {
+            bool hasChanged = false;
+            var controlRect = BeginProperty(prop, style);
+
+            EditorGUI.BeginChangeCheck();
+            value = EditorGUI.IntPopup(controlRect, style, value, optionNames, optionValues);
             if (EditorGUI.EndChangeCheck())
                 hasChanged = true;
 

--- a/com.unity.render-pipelines.universal/Runtime/Data/PostProcessData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/PostProcessData.cs
@@ -22,7 +22,7 @@ namespace UnityEngine.Rendering.Universal
             }
         }
 
-        [MenuItem("Assets/Create/Rendering/Universal Render Pipeline/Post-process Data", priority = CoreUtils.assetCreateMenuPriority1)]
+        [MenuItem("Assets/Create/Rendering/Universal Render Pipeline/Post-process Data", priority = 500)]
         static void CreatePostProcessData()
         {
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, CreateInstance<CreatePostProcessDataAsset>(), "CustomPostProcessData.asset", null, null);

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRendererData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRendererData.cs
@@ -59,6 +59,8 @@ namespace UnityEngine.Rendering.Universal
 
         protected override ScriptableRenderer Create()
         {
+            m_DefaultStencilState = new StencilStateData();
+            
 #if UNITY_EDITOR
             if (!Application.isPlaying)
             {

--- a/com.unity.render-pipelines.universal/Runtime/UniversalAdditionalCameraData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalAdditionalCameraData.cs
@@ -19,6 +19,7 @@ namespace UnityEngine.Rendering.Universal
         UsePipelineSettings,
     }
 
+    //[Obsolete("Renderer override is no longer used, renderers are referenced by index on the pipeline asset.")]
     [MovedFrom("UnityEngine.Rendering.LWRP")] public enum RendererOverrideOption
     {
         Custom,
@@ -57,10 +58,8 @@ namespace UnityEngine.Rendering.Universal
         [Tooltip("If enabled opaque color texture will render for this camera and bound as _CameraOpaqueTexture.")]
         [SerializeField]
         CameraOverrideOption m_RequiresOpaqueTextureOption = CameraOverrideOption.UsePipelineSettings;
-
-        [SerializeField] RendererOverrideOption m_RendererOverrideOption = RendererOverrideOption.UsePipelineSettings;
-        [SerializeField] ScriptableRendererData m_RendererData = null;
-        ScriptableRenderer m_Renderer = null;
+        
+        [SerializeField] int m_RendererIndex = -1;
 
         [SerializeField] LayerMask m_VolumeLayerMask = 1; // "Default"
         [SerializeField] Transform m_VolumeTrigger = null;
@@ -136,16 +135,7 @@ namespace UnityEngine.Rendering.Universal
 
         public ScriptableRenderer scriptableRenderer
         {
-            get
-            {
-                if (m_RendererOverrideOption == RendererOverrideOption.UsePipelineSettings || m_RendererData == null)
-                    return UniversalRenderPipeline.asset.scriptableRenderer;
-
-                if (m_RendererData.isInvalidated || m_Renderer == null)
-                    m_Renderer = m_RendererData.InternalCreateRenderer();
-
-                return m_Renderer;
-            }
+            get => UniversalRenderPipeline.asset.GetRenderer(m_RendererIndex);
         }
 
         public LayerMask volumeLayerMask

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -97,6 +97,12 @@ namespace UnityEngine.Rendering.Universal
             }
         }
 
+        // Internal max count for how many ScriptableRendererData can be added to a single Universal RP asset
+        internal static int maxScriptableRenderers
+        {
+            get => 8;
+        }
+
         public static UniversalRenderPipelineAsset asset
         {
             get

--- a/com.unity.render-pipelines.universal/Tests/Editor/EditorTests.cs
+++ b/com.unity.render-pipelines.universal/Tests/Editor/EditorTests.cs
@@ -18,9 +18,12 @@ class EditorTests
 
         try
         {
-            UniversalRenderPipelineAsset asset = UniversalRenderPipelineAsset.Create();
+            ForwardRendererData data = ScriptableObject.CreateInstance<ForwardRendererData>();
+            UniversalRenderPipelineAsset asset =
+                UniversalRenderPipelineAsset.Create(data);
             LogAssert.NoUnexpectedReceived();
             ScriptableObject.DestroyImmediate(asset);
+            ScriptableObject.DestroyImmediate(data);
         }
         // Makes sure the render pipeline is restored in case of a NullReference exception.
         finally
@@ -63,7 +66,9 @@ class EditorTests
     [Test]
     public void ValidateNewAssetResources()
     {
-        UniversalRenderPipelineAsset asset = UniversalRenderPipelineAsset.Create();
+        ForwardRendererData data = ScriptableObject.CreateInstance<ForwardRendererData>();
+        UniversalRenderPipelineAsset asset =
+            UniversalRenderPipelineAsset.Create(data);
         Assert.AreNotEqual(null, asset.defaultMaterial);
         Assert.AreNotEqual(null, asset.defaultParticleMaterial);
         Assert.AreNotEqual(null, asset.defaultLineMaterial);
@@ -79,6 +84,7 @@ class EditorTests
         Assert.AreNotEqual(null, asset.m_EditorResourcesAsset, "Editor Resources should be initialized when creating a new pipeline.");
         Assert.AreNotEqual(null, asset.m_RendererData, "A default renderer data should be created when creating a new pipeline.");
         ScriptableObject.DestroyImmediate(asset);
+        ScriptableObject.DestroyImmediate(data);
     }
 
     // When changing LWRP settings, all settings should be valid.
@@ -86,7 +92,9 @@ class EditorTests
     public void ValidateAssetSettings()
     {
         // Create a new asset and validate invalid settings
-        UniversalRenderPipelineAsset asset = UniversalRenderPipelineAsset.Create();
+        ForwardRendererData data = ScriptableObject.CreateInstance<ForwardRendererData>();
+        UniversalRenderPipelineAsset asset =
+            UniversalRenderPipelineAsset.Create(data);
         if (asset != null)
         {
             asset.shadowDistance = -1.0f;
@@ -117,5 +125,6 @@ class EditorTests
             Assert.LessOrEqual(asset.maxAdditionalLightsCount, UniversalRenderPipeline.maxPerObjectLights);
         }
         ScriptableObject.DestroyImmediate(asset);
+        ScriptableObject.DestroyImmediate(data);
     }
 }

--- a/com.unity.render-pipelines.universal/Tests/Editor/EditorTests.cs
+++ b/com.unity.render-pipelines.universal/Tests/Editor/EditorTests.cs
@@ -82,7 +82,7 @@ class EditorTests
         Assert.AreEqual(null, asset.default2DMaterial);
 
         Assert.AreNotEqual(null, asset.m_EditorResourcesAsset, "Editor Resources should be initialized when creating a new pipeline.");
-        Assert.AreNotEqual(null, asset.m_RendererData, "A default renderer data should be created when creating a new pipeline.");
+        Assert.AreNotEqual(null, asset.m_RendererDataList, "A default renderer data should be created when creating a new pipeline.");
         ScriptableObject.DestroyImmediate(asset);
         ScriptableObject.DestroyImmediate(data);
     }


### PR DESCRIPTION
### Purpose of this PR
The workflow for using custom Renderers was a bit unintuitive and also lead to it being hard to keep track of what was assigned to cameras in scene, this made it also hard at build time to know exactly what renderer and what settings were needed as we would have had to traverse every scene and prefab to check if they had custom renderers assign.

The Pipeline Asset now contains a list of all the renderers you wish to use in your project, this currently will be upgraded from previous assets but creating a forward renderer if type was ForwardRenderer, if the type was Custom, it will just insert the custom data into the first entry on the list.
![Screenshot 2019-08-09 at 09 40 44](https://user-images.githubusercontent.com/9811576/62860501-a78a0200-bd00-11e9-8d97-c0722d41ce8a.png)
Here you can see an Object slot for the ScriptableRendererData, there is also a Default button to set which renderer is classed as the one any new camera will use. The Cog button is a shortcut to the renderer asset.

The Camera now uses a dropdown to select which renderer to use, this is stored as a int and has safety fallbacks if the requested renderer no longer appears.
![Screenshot 2019-08-09 at 09 42 03](https://user-images.githubusercontent.com/9811576/62861335-69421200-bd03-11e9-8215-e004ffd175fd.png)
![Screenshot 2019-08-09 at 09 42 31](https://user-images.githubusercontent.com/9811576/62861371-8f67b200-bd03-11e9-830f-cefbfa83c7ff.png)

---
### Release Notes
TODO - Need to voice this out well as there could potentially be some minor manual upgrading required.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: TODO

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=universal%2Fasset-renderer-refactor&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/universal%252Fasset-renderer-refactor

---
### Overall Product Risks
**Technical Risk**: High - Changes to how renderers are loaded and stored, this can break rendering in both editor and builds.

**Halo Effect**: Low - Affects Universal RP Renderer logic.

---
### Comments to reviewers
Notes for the reviewers you have assigned.