### PR TITLE
Universal RP Minor Fixes

### DIFF
--- a/TestProjects/UniversalGraphicsTest/Packages/manifest.json
+++ b/TestProjects/UniversalGraphicsTest/Packages/manifest.json
@@ -19,7 +19,6 @@
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.1.0",
     "com.unity.ugui": "1.0.0",
-    "com.unity.xr.legacyinputhelpers": "2.0.4",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/BokehDepthOfField.shader
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/BokehDepthOfField.shader
@@ -127,7 +127,7 @@ Shader "Hidden/Universal Render Pipeline/BokehDepthOfField"
             return half4(avg, coc);
         }
 
-        void Accumulate(float4 samp0, float2 uv, float2 disp, inout float4 farAcc, inout float4 nearAcc)
+        void Accumulate(float4 samp0, float2 uv, float2 disp, inout half4 farAcc, inout half4 nearAcc)
         {
             float dist = length(disp);
 


### PR DESCRIPTION
### Purpose of this PR
Fixes issues when attempting to run the Universal RP tests on platforms.

---
### Release Notes
Accumulate in BokehDepthOfField takes a float4 for in/out, but FragBlur expects to provide it half4 and the function itself processes the relevant values as half4. This fixes it.

There's no need for the XR Legacy Input Helpers in the Universal Test Project, so I've removed it from the manifest.

---
### Testing status
Testing locally on my machine and against target hardware is fine in 2019.3.

---
### Overall Product Risks
**Technical Risk**: Low.

**Halo Effect**: Low.