### PR TITLE
Material Quality Node support for HDRP

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Utilities/EditorMaterialQuality.cs
+++ b/com.unity.render-pipelines.core/Editor/Utilities/EditorMaterialQuality.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine.Rendering;
+using Utilities;
+
+namespace UnityEditor.Rendering.Utilities
+{
+    public static class EditorMaterialQualityUtilities
+    {
+        public static MaterialQuality GetMaterialQuality(this ShaderKeywordSet keywordSet)
+        {
+            var result = (MaterialQuality)0;
+            for (var i = 0; i < MaterialQualityUtilities.Keywords.Length; ++i)
+            {
+                if (keywordSet.IsEnabled(MaterialQualityUtilities.Keywords[i]))
+                    result |= (MaterialQuality) (1 << i);
+            }
+
+            return result;
+        }
+    }
+}

--- a/com.unity.render-pipelines.core/Editor/Utilities/EditorMaterialQuality.cs.meta
+++ b/com.unity.render-pipelines.core/Editor/Utilities/EditorMaterialQuality.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2475d4ff1fb90a64c828b1e6f47e671e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.core/Runtime/Utilities/MaterialQuality.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/MaterialQuality.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Utilities
+{
+    [Flags]
+    public enum MaterialQuality
+    {
+        Low = 1 << 0,
+        Medium = 1 << 1,
+        High = 1 << 2
+    }
+
+    public static class MaterialQualityUtilities
+    {
+        public static string[] KeywordNames =
+        {
+            "MATERIAL_QUALITY_LOW",
+            "MATERIAL_QUALITY_MEDIUM",
+            "MATERIAL_QUALITY_HIGH",
+        };
+
+        public static string[] EnumNames = Enum.GetNames(typeof(MaterialQuality));
+
+        public static ShaderKeyword[] Keywords =
+        {
+            new ShaderKeyword(KeywordNames[0]),
+            new ShaderKeyword(KeywordNames[1]),
+            new ShaderKeyword(KeywordNames[2]),
+        };
+
+        public static MaterialQuality GetHighestQuality(this MaterialQuality levels)
+        {
+            for (var i = Keywords.Length - 1; i >= 0; --i)
+            {
+                var level = (MaterialQuality) (1 << i);
+                if ((levels & level) != 0)
+                    return level;
+            }
+
+            return 0;
+        }
+
+        public static void SetGlobalShaderKeywords(this MaterialQuality level)
+        {
+            for (var i = 0; i < KeywordNames.Length; ++i)
+            {
+                if ((level & (MaterialQuality) (1 << i)) != 0)
+                    Shader.EnableKeyword(KeywordNames[i]);
+                else
+                    Shader.DisableKeyword(KeywordNames[i]);
+            }
+        }
+
+        public static int ToFirstIndex(this MaterialQuality level)
+        {
+            for (var i = 0; i < KeywordNames.Length; ++i)
+            {
+                if ((level & (MaterialQuality) (1 << i)) != 0)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        public static MaterialQuality FromIndex(int index) => (MaterialQuality) (1 << index);
+    }
+}

--- a/com.unity.render-pipelines.core/Runtime/Utilities/MaterialQuality.cs.meta
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/MaterialQuality.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14221b1c07bee064e8078151055512fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Call the End/Begin camera rendering callbacks for camera with customRender enabled
 - Changeg framesettings migration order of postprocess flags as a pr for reflection settings flags have been backported to 2019.2
 
+### Added
+- Support for Material Quality in Shader Graph
+- Material Quality support selection in HDRP Asset
+
 ## [7.0.1] - 2019-07-25
 
 ### Added

--- a/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPPreprocessShaders.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPPreprocessShaders.cs
@@ -15,6 +15,9 @@ namespace UnityEditor.Rendering.HighDefinition
 
         public override bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData)
         {
+            if (IsMaterialQualityVariantStripped(hdrpAsset, inputData))
+                return true;
+            
             // Strip every useless shadow configs
             var shadowInitParams = hdrpAsset.currentPlatformRenderPipelineSettings.hdShadowInitParams;
 

--- a/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPPreprocessShaders.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPPreprocessShaders.cs
@@ -13,11 +13,8 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         public CommonShaderPreprocessor() { }
 
-        public override bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData)
+        protected override bool DoShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData)
         {
-            if (IsMaterialQualityVariantStripped(hdrpAsset, inputData))
-                return true;
-            
             // Strip every useless shadow configs
             var shadowInitParams = hdrpAsset.currentPlatformRenderPipelineSettings.hdShadowInitParams;
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/AxF/AxFShaderPreprocessor.cs
@@ -7,7 +7,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         public AxFShaderPreprocessor() {}
 
-        public override bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData)
+        protected override bool DoShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData)
         {
             // Note: We know that all the rules of common stripper and Lit Stripper are apply, here we only need to do what is specific to AxF shader
             bool isForwardPass = snippet.passName == "ForwardOnly";

--- a/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using UnityEditor.Rendering;
+using UnityEditor.Rendering.Utilities;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.HighDefinition;
@@ -57,6 +59,23 @@ namespace UnityEditor.Rendering.HighDefinition
                 {HDShadowFilteringQuality.Medium, m_ShadowMedium},
                 {HDShadowFilteringQuality.High, m_ShadowHigh},
             };
+        }
+
+        protected static bool IsMaterialQualityVariantStripped(HDRenderPipelineAsset hdrpAsset, ShaderCompilerData inputData)
+        {
+            if (IsMaterialQualityVariantStripped(hdrpAsset, inputData))
+                return true;
+
+            var shaderMaterialLevel = inputData.shaderKeywordSet.GetMaterialQuality();
+            // if there are material quality defines in this shader
+            // and they don't match the material quality accepted by the hdrp asset
+            if (shaderMaterialLevel != 0 && (hdrpAsset.materialQualityLevels & shaderMaterialLevel) == 0)
+            {
+                // then strip this variant
+                return true;
+            }
+
+            return false;
         }
 
         public abstract bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
@@ -61,6 +61,14 @@ namespace UnityEditor.Rendering.HighDefinition
             };
         }
 
+        public bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet,
+            ShaderCompilerData inputData)
+        {
+            return IsMaterialQualityVariantStripped(hdrpAsset, inputData) || DoShadersStripper(hdrpAsset, shader, snippet, inputData);
+        }
+
+        protected abstract bool DoShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData);
+
         protected static bool IsMaterialQualityVariantStripped(HDRenderPipelineAsset hdrpAsset, ShaderCompilerData inputData)
         {
             var shaderMaterialLevel = inputData.shaderKeywordSet.GetMaterialQuality();
@@ -74,7 +82,5 @@ namespace UnityEditor.Rendering.HighDefinition
 
             return false;
         }
-
-        public abstract bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData);
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
@@ -63,9 +63,6 @@ namespace UnityEditor.Rendering.HighDefinition
 
         protected static bool IsMaterialQualityVariantStripped(HDRenderPipelineAsset hdrpAsset, ShaderCompilerData inputData)
         {
-            if (IsMaterialQualityVariantStripped(hdrpAsset, inputData))
-                return true;
-
             var shaderMaterialLevel = inputData.shaderKeywordSet.GetMaterialQuality();
             // if there are material quality defines in this shader
             // and they don't match the material quality accepted by the hdrp asset

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitShaderPreprocessor.cs
@@ -8,7 +8,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         public LitShaderPreprocessor() {}
 
-        public override bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData)
+        protected override bool DoShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData)
         {
             // CAUTION: Pass Name and Lightmode name must match in master node and .shader.
             // HDRP use LightMode to do drawRenderer and pass name is use here for stripping!

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.Skin.cs
@@ -33,6 +33,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
         static readonly GUIContent k_DefaultFrameSettingsContent = EditorGUIUtility.TrTextContent("Default Frame Settings For");
 
+        static readonly GUIContent k_CurrentMaterialQualityLevelContent = EditorGUIUtility.TrTextContent("Current Material Quality Level", "");
         static readonly GUIContent k_RenderPipelineResourcesContent = EditorGUIUtility.TrTextContent("Render Pipeline Resources", "Set of resources that need to be loaded when creating stand alone");
         static readonly GUIContent k_RenderPipelineRayTracingResourcesContent = EditorGUIUtility.TrTextContent("Render Pipeline Ray Tracing Resources", "Set of resources that need to be loaded when using ray tracing");
         static readonly GUIContent k_RenderPipelineEditorResourcesContent = EditorGUIUtility.TrTextContent("Render Pipeline Editor Resources", "Set of resources that need to be loaded for working in editor");

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.HighDefinition;
 using System.Text;
+using Utilities;
 using static UnityEngine.Rendering.HighDefinition.RenderPipelineSettings;
 
 namespace UnityEditor.Rendering.HighDefinition
@@ -602,6 +603,10 @@ namespace UnityEditor.Rendering.HighDefinition
 
         static void Drawer_SectionMaterialUnsorted(SerializedHDRenderPipelineAsset serialized, Editor owner)
         {
+            EditorGUILayout.PropertyField(serialized.materialQualityLevels);
+            var v = EditorGUILayout.EnumPopup(k_CurrentMaterialQualityLevelContent, (MaterialQuality) serialized.currentMaterialQualityLevel.intValue);
+            serialized.currentMaterialQualityLevel.intValue = (int)(object)v;
+            
             EditorGUILayout.PropertyField(serialized.renderPipelineSettings.supportDistortion, k_SupportDistortion);
 
             EditorGUILayout.PropertyField(serialized.renderPipelineSettings.supportSubsurfaceScattering, k_SupportedSSSContent);

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
@@ -8,6 +8,8 @@ namespace UnityEditor.Rendering.HighDefinition
         public SerializedObject serializedObject;
 
         public SerializedProperty renderPipelineResources;
+        public SerializedProperty currentMaterialQualityLevel;
+        public SerializedProperty materialQualityLevels;
         public SerializedProperty renderPipelineRayTracingResources;
         public SerializedProperty diffusionProfileSettingsList; 
         public SerializedProperty allowShaderVariantStripping;
@@ -45,6 +47,9 @@ namespace UnityEditor.Rendering.HighDefinition
         public SerializedHDRenderPipelineAsset(SerializedObject serializedObject)
         {
             this.serializedObject = serializedObject;
+
+            currentMaterialQualityLevel = serializedObject.FindProperty("m_CurrentMaterialQualityLevel");
+            materialQualityLevels = serializedObject.Find((HDRenderPipelineAsset s) => s.materialQualityLevels);
 
             renderPipelineResources = serializedObject.FindProperty("m_RenderPipelineResources");
             renderPipelineRayTracingResources = serializedObject.FindProperty("m_RenderPipelineRayTracingResources");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using UnityEngine.Experimental.GlobalIllumination;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Experimental.Rendering.RenderGraphModule;
+using Utilities;
 
 namespace UnityEngine.Rendering.HighDefinition
 {
@@ -1015,6 +1016,9 @@ namespace UnityEngine.Rendering.HighDefinition
         {
             if (!m_ValidAPI || cameras.Length == 0)
                 return;
+            
+            // Set the quality level for this rendering
+            asset.currentMaterialQualityLevel.SetGlobalShaderKeywords();
 
             GetOrCreateDefaultVolume();
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine.Serialization;
+using Utilities;
 
 namespace UnityEngine.Rendering.HighDefinition
 {
@@ -157,6 +158,31 @@ namespace UnityEngine.Rendering.HighDefinition
         internal bool enableSRPBatcher = true;
         [SerializeField]
         internal ShaderVariantLogLevel shaderVariantLogLevel = ShaderVariantLogLevel.Disabled;
+
+        public MaterialQuality materialQualityLevels = (MaterialQuality)(-1);
+
+        [SerializeField]
+        private MaterialQuality m_CurrentMaterialQualityLevel = MaterialQuality.High;
+
+        public MaterialQuality currentMaterialQualityLevel
+        {
+            get
+            {
+                if ((m_CurrentMaterialQualityLevel & materialQualityLevels) != m_CurrentMaterialQualityLevel)
+                {
+                    // Current quality level is not supported,
+                    // Pick the highest one
+                    var highest = materialQualityLevels.GetHighestQuality();
+                    if (highest == 0)
+                        // If none are available, still pick the lowest one
+                        highest = MaterialQuality.Low;
+
+                    return highest;
+                }
+
+                return m_CurrentMaterialQualityLevel;
+            }
+        }
 
         [SerializeField]
         [Obsolete("Use diffusionProfileSettingsList instead")]


### PR DESCRIPTION
### Purpose of this PR
Support Material Quality in Shader Graph shaders in HDRP

---
### Release Notes
Support Material Quality in Shader Graph shaders in HDRP

---
### Testing status
**Katana Tests**: -

**Automated Tests**: -

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
@JulienIgnace-Unity look at the stripper code if you are ok with the changes.
