### PR TITLE
Fix emission node exposure weight label

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
@@ -64,7 +64,7 @@ namespace UnityEditor.Rendering.HighDefinition
         const int kEmissionExposureWeightInputSlotId = 3;
         const string kEmissionOutputSlotName = "Output";
         const string kEmissionColorInputSlotName = "Color";
-        const string kEmissionExpositionWeightInputSlotName = "ExpositionWeight";
+        const string kEmissionExpositionWeightInputSlotName = "Exposure Weight";
         const string kEmissionIntensityInputSlotName = "Intensity";
 
         public override bool hasPreview { get { return false; } }


### PR DESCRIPTION
### Purpose of this PR
Fix typo in Exposure node:
"ExpositionWeight" -> "Exposure Weight"

---
### Release Notes

---
### Testing status
**Katana Tests**: 

**Manual Tests**: What did you do?
- [x] Checked new UI names with UX convention

**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: None
**Halo Effect**: None

---
### Comments to reviewers
