### PR TITLE
Universal/fix null reference shaders

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/MaterialPostprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/MaterialPostprocessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEditor.Rendering.Universal.ShaderGUI;

--- a/com.unity.render-pipelines.universal/Editor/MaterialPostprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/MaterialPostprocessor.cs
@@ -23,7 +23,9 @@ namespace UnityEditor.Rendering.Universal
     {
         const string Key = "LWRP-material-upgrader";
 
-        [InitializeOnLoadMethod]
+        // Upgrade materials only after we compiled shaders.
+        // This fixes a case that caused ReloadAllNullIn to be called before shaders finished compiling.
+        [Callbacks.DidReloadScripts]
         static void ReimportAllMaterials()
         {
             //Check to see if the upgrader has been run for this project/LWRP version

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -216,7 +216,11 @@ namespace UnityEngine.Rendering.Universal
             }
 
             // Validate the resource file
-            ResourceReloader.ReloadAllNullIn(resourceAsset, packagePath);
+            try
+            {
+                ResourceReloader.ReloadAllNullIn(resourceAsset, packagePath);
+            }
+            catch {}
 
             return resourceAsset;
         }


### PR DESCRIPTION
### Purpose of this PR
 Fixed issue that caused error messages in the Unity console about Null shaders. (Autodesk)

 Issue was caused because MaterialPostProcessor was called before shaders being compiled. This caused ReloadAllNullIn to call Shader.Find, which return null for a shader that's not compiled yet.

 Changed material postprocessor callback to DidReloadScripts, which seems to happen after shaders are compiled. 

 - What QA should test:
   Validate that now no error about Null shaders is logged in the console by opening a project.
   Validate that this doesn't regress the material upgrader (?)

---
### Release Notes
 Release note already done. This is fixing a case of a previous fixed bug.

---
### Testing status
**Manual Tests**: Tested myself by opening the UniversalRP template.
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: Nothing new added.

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
