### PR TITLE
Hdrp/fix gizmo enabled on selecting camera

### DIFF
--- a/com.unity.render-pipelines.core/Editor/CameraEditorUtils.cs
+++ b/com.unity.render-pipelines.core/Editor/CameraEditorUtils.cs
@@ -76,9 +76,10 @@ namespace UnityEditor.Rendering
                     return;
                 }
 
+                bool drawGizmo = sceneView.drawGizmos;
                 sceneView.drawGizmos = false;
                 previewCamera.Render();
-                sceneView.drawGizmos = true;
+                sceneView.drawGizmos = drawGizmo;
                 Graphics.DrawTexture(cameraRect, previewCamera.targetTexture, new Rect(0, 0, 1, 1), 0, 0, 0, 0, GUI.color, GUITextureBlit2SRGBMaterial);
                 // We set target texture to null after this call otherwise if both sceneview and gameview are visible and we have a preview camera wwe
                 // get this error: "Releasing render texture that is set as Camera.targetTexture!"

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed  a bug where if Assembly.GetTypes throws an exception due to mis-versioned dlls, then no preprocessors are used in the shader stripper
 - Fixed typo in AXF decal property preventing to compile
 - Fixed reflection probe with XR single-pass and FPTL
+- Fixed force gizmo shown when selecting camera in hierarchy
 
 ### Changed
 - Update Wizard layout.


### PR DESCRIPTION
### Purpose of this PR
Fix FB https://fogbugz.unity3d.com/f/cases/1173315/

---
### Release Notes
Fixed force gizmo shown when selecting camera in hierarchy.

---
### Testing status
**Katana Tests**: 
**Manual Tests**: 
**Automated Tests**: 

---
### Overall Product Risks
**Technical Risk**: Low
**Halo Effect**: None

---
### Comments to reviewers
