### PR TITLE
Rename some code to XR single-pass instead of stereo

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Textures/TextureXR.cs
+++ b/com.unity.render-pipelines.core/Runtime/Textures/TextureXR.cs
@@ -10,10 +10,7 @@ namespace UnityEngine.Rendering
         {
             set
             {
-                //if (value > HighDefinition.ShaderConfig.s_XrMaxViews)
-                //    throw new System.NotImplementedException("Invalid XR setup for single-pass instancing: you must increase ShaderConfig.XrMaxViews");
-                //else
-                    m_MaxViews = value;
+                m_MaxViews = value;
             }
         }
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/Filtering.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Filtering.hlsl
@@ -125,7 +125,7 @@ float4 SampleTexture2DBicubic(TEXTURE2D_PARAM(tex, smp), float2 coord, float4 te
 
 #if !defined(SHADER_API_GLES)
 // texSize = (width, height, 1/width, 1/height)
-// texture array version for stereo instancing
+// texture array version for XR single-pass
 float4 SampleTexture2DBicubic(TEXTURE2D_ARRAY_PARAM(tex, smp), float2 coord, float4 texSize, float2 maxCoord, uint slice)
 {
     float2 xy = coord * texSize.xy + 0.5;

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugViewTiles.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugViewTiles.shader
@@ -94,7 +94,7 @@ Shader "Hidden/HDRP/DebugViewTiles"
                 uint2 pixelCoord = (tileCoord + uint2((quadVertex+1) & 1, (quadVertex >> 1) & 1)) * tileSize;
 
 #if defined(UNITY_STEREO_INSTANCING_ENABLED)
-                // With instancing, all tiles from the indirect buffer are processed so we need to discard them if they don't match the current eye index
+                // With XR single-pass, all tiles from the indirect buffer are processed so we need to discard them if they don't match the current eye index
                 uint tile_StereoEyeIndex = tileIndex >> TILE_INDEX_SHIFT_EYE;
                 if (unity_StereoEyeIndex != tile_StereoEyeIndex)
                     variant = -1;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl
@@ -110,7 +110,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData preLightData, BS
     context.shadowValue      = 1;
     context.sampleReflection = 0;
 
-    // With XR single-pass instancing and camera-relative: offset position to do lighting computations from the combined center view (original camera matrix).
+    // With XR single-pass and camera-relative: offset position to do lighting computations from the combined center view (original camera matrix).
     // This is required because there is only one list of lights generated on the CPU. Shadows are also generated once and shared between the instanced views.
     ApplyCameraRelativeXR(posInput.positionWS);
     

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VBuffer.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VBuffer.hlsl
@@ -40,7 +40,7 @@ float4 SampleVBuffer(TEXTURE3D_PARAM(VBuffer, clampSampler),
     float4 result = 0;
 
     #if defined(UNITY_STEREO_INSTANCING_ENABLED)
-        // With XR single-pass instancing, one 3D buffer is used to store all views (split along w)
+        // With XR single-pass, one 3D buffer is used to store all views (split along w)
         w = (w + unity_StereoEyeIndex) * _VBufferRcpInstancedViewCount;
 
         // Manually clamp w with a safe limit to avoid linear interpolation from the others views

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/VolumetricLighting/VolumetricLighting.compute
@@ -572,7 +572,7 @@ void FillVolumetricLightingBuffer(LightLoopContext context, uint featureFlags,
         float4 normalizedBlendValue = normalizedVoxelValue;
 
     #if (SHADEROPTIONS_CAMERA_RELATIVE_RENDERING != 0) && defined(USING_STEREO_MATRICES)
-        // With XR single-pass instancing, remove the camera-relative offset for the reprojected sample
+        // With XR single-pass, remove the camera-relative offset for the reprojected sample
         centerWS -= _WorldSpaceCameraPosViewOffset;
     #endif
 

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/PostProcessSystem.cs
@@ -827,7 +827,7 @@ namespace UnityEngine.Rendering.HighDefinition
             Assert.IsTrue(nearLayerActive || farLayerActive);
 
             bool bothLayersActive = nearLayerActive && farLayerActive;
-            bool useTiles = !camera.xr.instancingEnabled;
+            bool useTiles = !camera.xr.singlePassEnabled;
             bool hqFiltering = m_DepthOfField.highQualityFiltering.value;
 
             const uint kIndirectNearOffset = 0u * sizeof(uint);

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/Exposure.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/Exposure.compute
@@ -121,7 +121,7 @@ void KManualCameraExposure(uint2 dispatchThreadId : SV_DispatchThreadID)
 [numthreads(8,8,1)]
 void KPrePass(uint2 dispatchThreadId : SV_DispatchThreadID)
 {
-    // For XR, interleave single-pass instancing views in a checkerboard pattern
+    // For XR, interleave single-pass views in a checkerboard pattern
     UNITY_STEREO_ASSIGN_COMPUTE_EYE_INDEX((dispatchThreadId.x + dispatchThreadId.y) % _XRViewCount)
 
     PositionInputs posInputs = GetPositionInput(float2(dispatchThreadId), 1.0 / 1024.0, uint2(8u, 8u));

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -418,8 +418,8 @@ namespace UnityEngine.Rendering.HighDefinition
 
             UpdateViewConstants(ref mainViewConstants, proj, view, cameraPosition, jitterProjectionMatrix, updatePreviousFrameConstants);
 
-            // XR instancing support
-            if (xr.instancingEnabled)
+            // XR single-pass support
+            if (xr.singlePassEnabled)
             {
                 for (int viewIndex = 0; viewIndex < viewCount; ++viewIndex)
                 {
@@ -432,7 +432,7 @@ namespace UnityEngine.Rendering.HighDefinition
             }
             else
             {
-                // Compute shaders always use the XR instancing path due to the lack of multi-compile
+                // Compute shaders always use the XR single-pass path due to the lack of multi-compile
                 xrViewConstants[0] = mainViewConstants;
             }
 
@@ -620,7 +620,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
         public void GetPixelCoordToViewDirWS(Vector4 resolution, ref Matrix4x4[] transforms)
         {
-            if (xr.instancingEnabled)
+            if (xr.singlePassEnabled)
             {
                 for (int viewIndex = 0; viewIndex < viewCount; ++viewIndex)
                 {
@@ -847,7 +847,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
             cmd.SetGlobalInt(HDShaderIDs._FrameCount,        frameCount);
 
-            // TODO: qualify this code with xrInstancingEnabled when compute shaders can use keywords
+            // TODO: qualify this code with xr.singlePassEnabled when compute shaders can use keywords
             cmd.SetGlobalInt(HDShaderIDs._XRViewCount, viewCount);
             cmd.SetGlobalBuffer(HDShaderIDs._XRViewConstants, xrViewConstantsGpu);
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/XR/XRSystem.cs
@@ -13,7 +13,7 @@ namespace UnityEngine.Rendering.HighDefinition
     {
         None,                       // default layout
         TestComposite,              // split the  into tiles to simulate multi-pass
-        TestSinglePassOneEye,       // render only eye with single-pass instancing path
+        TestSinglePassOneEye,       // render only eye with single-pass path
     }
 
     internal class XRSystem
@@ -216,7 +216,7 @@ namespace UnityEngine.Rendering.HighDefinition
 #if ENABLE_XR_MODULE
         void CreateLayoutFromXrSdk(Camera camera)
         {
-            bool CanUseInstancing(XRDisplaySubsystem.XRRenderPass renderPass)
+            bool CanUseSinglePass(XRDisplaySubsystem.XRRenderPass renderPass)
             {
                 if (renderPass.renderTargetDesc.dimension != TextureDimension.Tex2DArray)
                     return false;
@@ -241,7 +241,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 display.GetRenderPass(renderPassIndex, out var renderPass);
                 display.GetCullingParameters(camera, renderPass.cullingPassIndex, out var cullingParams);
 
-                if (CanUseInstancing(renderPass))
+                if (CanUseSinglePass(renderPass))
                 {
                     var xrPass = XRPass.Create(renderPass, multipassId: framePasses.Count, cullingParams, occlusionMeshMaterial);
 
@@ -345,7 +345,7 @@ namespace UnityEngine.Rendering.HighDefinition
             {
                 var xrPass = XRPass.Create(framePasses.Count, cullingParams, camera.targetTexture);
 
-                // 2x single-pass instancing
+                // 2x single-pass
                 for (int i = 0; i < 2; ++i)
                     xrPass.AddView(camera.projectionMatrix, camera.worldToCameraMatrix, camera.pixelRect);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/TextureXR.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/TextureXR.hlsl
@@ -3,7 +3,7 @@
 
 // single-pass instancing is the default VR method for HDRP
 // multi-pass is working but not recommended due to lower performance
-// multi-view is not yet supported
+// single-pass multi-view is not yet supported
 // single-pass doule-wide is deprecated
 
 // Must be in sync with C# with property useTexArray in TextureXR.cs
@@ -13,7 +13,7 @@
 
 // Validate supported platforms
 #if defined(STEREO_INSTANCING_ON) && !defined(UNITY_TEXTURE2D_X_ARRAY_SUPPORTED)
-    #error Single-pass stereo instancing is not supported on this platform (see UNITY_TEXTURE2D_X_ARRAY_SUPPORTED).
+    #error Single-pass instancing is not supported on this platform (see UNITY_TEXTURE2D_X_ARRAY_SUPPORTED).
 #endif
 
 #if defined(UNITY_SINGLE_PASS_STEREO)
@@ -25,7 +25,7 @@
     #define USE_TEXTURE2D_X_AS_ARRAY
 #endif
 
-// Early defines for single-pass stereo instancing
+// Early defines for single-pass instancing
 #if defined(STEREO_INSTANCING_ON) && defined(UNITY_TEXTURE2D_X_ARRAY_SUPPORTED)
     #define UNITY_STEREO_INSTANCING_ENABLED
 #endif
@@ -40,8 +40,8 @@
     #define USING_STEREO_MATRICES
 #endif
 
-// Helper macros to handle XR instancing with Texture2DArray
-// With single-pass stereo instancing, unity_StereoEyeIndex is used to select the eye in the current context.
+// Helper macros to handle XR single-pass with Texture2DArray
+// With single-pass instancing, unity_StereoEyeIndex is used to select the eye in the current context.
 // Otherwise, the index is statically set to 0
 #if defined(USE_TEXTURE2D_X_AS_ARRAY)
 


### PR DESCRIPTION
### Purpose of this PR
Rename **stereo** to a more generic **XR single-pass**

---
### Testing status
**Katana Tests**: [running](https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?automation-tools_branch=master&ScriptableRenderLoop_branch=hdrp-xr-rename-single-pass&unity_branch=trunk&sort=1-asc)

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally

---
### Overall Product Risks
**Technical Risk**: None

**Halo Effect**: None

---
### Comments to reviewers
No code change, just renaming.
