### PR TITLE
Inner cone angle is now working.

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Lighting/CoreLightEditorUtilities.cs
+++ b/com.unity.render-pipelines.core/Editor/Lighting/CoreLightEditorUtilities.cs
@@ -352,7 +352,7 @@ namespace UnityEditor.Rendering
             return s_PointLightHandle.radius;
         }
 
-        static bool drawInnerConeAngle = false;
+        static bool drawInnerConeAngle = true;
 
         /// <summary>
         /// Draw a gizmo for a spot light.
@@ -431,7 +431,6 @@ namespace UnityEditor.Rendering
             }
 
             // Draw inner handles
-            // Commented until inner angle will bake
             float innerAngle = 0;
             const string innerLabel = "Inner Angle: ";
             if (light.innerSpotAngle > 0f && drawInnerConeAngle)
@@ -462,8 +461,7 @@ namespace UnityEditor.Rendering
             if (GUI.changed)
             {
                 light.spotAngle = outerAngle;
-                // Commented until inner cone angle bakes
-                //spotlight.innerSpotAngle = innerAngle;
+                light.innerSpotAngle = innerAngle;
                 light.range = Math.Max(range, 0.01f);
                 light.shadowNearPlane = Mathf.Clamp(nearPlaneRange, 0.1f, light.range);
             }

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added shader function `GetMainLightShadowParams`. This returns a half4 for the main light that packs shadow strength in x component and shadow soft property in y component.
 - Added shader function `GetAdditionalLightShadowParams`. This returns a half4 for an additional light that packs shadow strength in x component and shadow soft property in y component.
 - Added new Gizmos for Lights.
+- Added manipulation handles for the inner cone angle for spot lights.
 
 ### Changed
 - Increased visible lights limit for the forward renderer. It now supports 256 visible lights except in mobile platforms. Mobile platforms support 32 visible lights.

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineLightEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineLightEditor.cs
@@ -132,6 +132,7 @@ namespace UnityEditor.Rendering.Universal
 
             EditorGUILayout.Space();
 
+            CheckLightmappingConsistency();
             using (var group = new EditorGUILayout.FadeGroupScope(1.0f - m_AnimAreaOptions.faded))
                 if (group.visible)
                 {
@@ -165,6 +166,16 @@ namespace UnityEditor.Rendering.Universal
                 EditorGUILayout.HelpBox(s_Styles.DisabledLightWarning.text, MessageType.Warning);
 
             serializedObject.ApplyModifiedProperties();
+        }
+
+        void CheckLightmappingConsistency()
+        {
+            //Universal render-pipeline only supports baked area light, enforce it as this inspector is the universal one.
+            if (settings.isAreaLightType && settings.lightmapping.intValue != (int)LightmapBakeType.Baked)
+            {
+                settings.lightmapping.intValue = (int)LightmapBakeType.Baked;
+                serializedObject.ApplyModifiedProperties();
+            }
         }
 
         void SetOptions(AnimBool animBool, bool initialize, bool targetValue)

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineLightEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineLightEditor.cs
@@ -196,8 +196,7 @@ namespace UnityEditor.Rendering.Universal
         void DrawSpotAngle()
         {
             EditorGUILayout.Slider(settings.spotAngle, 1f, 179f, s_Styles.SpotAngle);
-            // Disable until baking of inner angle works
-            //settings.DrawInnerAndOuterSpotAngle();
+            settings.DrawInnerAndOuterSpotAngle();
         }
 
         void DrawAdditionalShadowData()

--- a/com.unity.render-pipelines.universal/Runtime/ForwardLights.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardLights.cs
@@ -161,7 +161,7 @@ namespace UnityEngine.Rendering.Universal
                 // Particle lights will use an inline function
                 float cosInnerAngle;
                 if (lightData.light != null)
-                    cosInnerAngle = Mathf.Cos(LightmapperUtils.ExtractInnerCone(lightData.light) * 0.5f);
+                    cosInnerAngle = Mathf.Cos(lightData.light.innerSpotAngle * Mathf.Deg2Rad * 0.5f);
                 else
                     cosInnerAngle = Mathf.Cos((2.0f * Mathf.Atan(Mathf.Tan(lightData.spotAngle * 0.5f * Mathf.Deg2Rad) * (64.0f - 18.0f) / 64.0f)) * 0.5f);
                 float smoothAngleRange = Mathf.Max(0.001f, cosInnerAngle - cosOuterAngle);

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -145,8 +145,8 @@ namespace UnityEngine.Rendering.Universal
 
 #if UNITY_EDITOR
             SceneViewDrawMode.ResetDrawMode();
-            Lightmapping.ResetDelegate();
 #endif
+            Lightmapping.ResetDelegate();
             CameraCaptureBridge.enabled = false;
         }
 

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -4,7 +4,6 @@ using Unity.Collections;
 using UnityEditor;
 using UnityEditor.Rendering.Universal;
 #endif
-using UnityEngine.Experimental.GlobalIllumination;
 using UnityEngine.Scripting.APIUpdating;
 using Lightmapping = UnityEngine.Experimental.GlobalIllumination.Lightmapping;
 
@@ -130,10 +129,8 @@ namespace UnityEngine.Rendering.Universal
             // For compatibility reasons we also match old LightweightPipeline tag.
             Shader.globalRenderPipeline = "UniversalPipeline,LightweightPipeline";
 
-            // Editor only.
-#if UNITY_EDITOR
             Lightmapping.SetDelegate(lightsDelegate);
-#endif
+
             CameraCaptureBridge.enabled = true;
 
             RenderingUtils.ClearSystemInfoCache();
@@ -148,9 +145,8 @@ namespace UnityEngine.Rendering.Universal
 
 #if UNITY_EDITOR
             SceneViewDrawMode.ResetDrawMode();
-#endif
-
             Lightmapping.ResetDelegate();
+#endif
             CameraCaptureBridge.enabled = false;
         }
 
@@ -247,7 +243,7 @@ namespace UnityEngine.Rendering.Universal
             SceneViewDrawMode.SetupDrawMode();
 #endif
         }
-		
+
 		static bool PlatformNeedsToKillAlpha()
 		{
 			return Application.platform == RuntimePlatform.IPhonePlayer ||
@@ -581,48 +577,8 @@ namespace UnityEngine.Rendering.Universal
             Shader.SetGlobalMatrix(PerCameraBuffer._InvCameraViewProj, invViewProjMatrix);
         }
 
-        // Editor only.
-#if UNITY_EDITOR
-        static Lightmapping.RequestLightsDelegate lightsDelegate = (Light[] requests, NativeArray<LightDataGI> lightsOutput) =>
-        {
-            LightDataGI lightData = new LightDataGI();
 
-            for (int i = 0; i < requests.Length; i++)
-            {
-                Light light = requests[i];
-                switch (light.type)
-                {
-                    case LightType.Directional:
-                        DirectionalLight directionalLight = new DirectionalLight();
-                        LightmapperUtils.Extract(light, ref directionalLight); lightData.Init(ref directionalLight);
-                        break;
-                    case LightType.Point:
-                        PointLight pointLight = new PointLight();
-                        LightmapperUtils.Extract(light, ref pointLight); lightData.Init(ref pointLight);
-                        break;
-                    case LightType.Spot:
-                        SpotLight spotLight = new SpotLight();
-                        LightmapperUtils.Extract(light, ref spotLight); lightData.Init(ref spotLight);
-                        break;
-                    case LightType.Area:
-                        RectangleLight rectangleLight = new RectangleLight();
-                        LightmapperUtils.Extract(light, ref rectangleLight); lightData.Init(ref rectangleLight);
-                        light.lightmapBakeType = LightmapBakeType.Baked;
-                        break;
-                    case LightType.Disc:
-                        DiscLight discLight = new DiscLight();
-                        LightmapperUtils.Extract(light, ref discLight); lightData.Init(ref discLight);
-                        light.lightmapBakeType = LightmapBakeType.Baked;
-                        break;
-                    default:
-                        lightData.InitNoBake(light.GetInstanceID());
-                        break;
-                }
 
-                lightData.falloff = FalloffType.InverseSquared;
-                lightsOutput[i] = lightData;
-            }
-        };
-#endif
+
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using Unity.Collections;
 using UnityEngine.Scripting.APIUpdating;
 
+using UnityEngine.Experimental.GlobalIllumination;
+using Lightmapping = UnityEngine.Experimental.GlobalIllumination.Lightmapping;
+
 namespace UnityEngine.Rendering.Universal
 {
     [MovedFrom("UnityEngine.Rendering.LWRP")] public enum MixedLightingSetup
@@ -181,11 +184,71 @@ namespace UnityEngine.Rendering.Universal
                 desc.msaaSamples = msaaSamples;
                 desc.sRGB = (QualitySettings.activeColorSpace == ColorSpace.Linear);
             }
-            
+
             desc.enableRandomWrite = false;
             desc.bindMS = false;
             desc.useDynamicScale = camera.allowDynamicResolution;
             return desc;
         }
+
+        static Lightmapping.RequestLightsDelegate lightsDelegate = (Light[] requests, NativeArray<LightDataGI> lightsOutput) =>
+        {
+            // Editor only.
+#if UNITY_EDITOR
+            LightDataGI lightData = new LightDataGI();
+
+            for (int i = 0; i < requests.Length; i++)
+            {
+                Light light = requests[i];
+                switch (light.type)
+                {
+                    case LightType.Directional:
+                        DirectionalLight directionalLight = new DirectionalLight();
+                        LightmapperUtils.Extract(light, ref directionalLight);
+                        lightData.Init(ref directionalLight);
+                        break;
+                    case LightType.Point:
+                        PointLight pointLight = new PointLight();
+                        LightmapperUtils.Extract(light, ref pointLight);
+                        lightData.Init(ref pointLight);
+                        break;
+                    case LightType.Spot:
+                        SpotLight spotLight = new SpotLight();
+                        LightmapperUtils.Extract(light, ref spotLight);
+                        spotLight.innerConeAngle = light.innerSpotAngle * Mathf.Deg2Rad;
+                        lightData.Init(ref spotLight);
+                        break;
+                    case LightType.Area:
+                        RectangleLight rectangleLight = new RectangleLight();
+                        LightmapperUtils.Extract(light, ref rectangleLight);
+                        lightData.Init(ref rectangleLight);
+                        light.lightmapBakeType = LightmapBakeType.Baked;
+                        break;
+                    case LightType.Disc:
+                        DiscLight discLight = new DiscLight();
+                        LightmapperUtils.Extract(light, ref discLight);
+                        lightData.Init(ref discLight);
+                        light.lightmapBakeType = LightmapBakeType.Baked;
+                        break;
+                    default:
+                        lightData.InitNoBake(light.GetInstanceID());
+                        break;
+                }
+
+                lightData.falloff = FalloffType.InverseSquared;
+                lightsOutput[i] = lightData;
+            }
+#else
+            LightDataGI lightData = new LightDataGI();
+
+            for (int i = 0; i < requests.Length; i++)
+            {
+                Light light = requests[i];
+                lightData.InitNoBake(light.GetInstanceID());
+                lightsOutput[i] = lightData;
+            }
+            Debug.LogWarning("Realtime GI is not supported in Universal Pipeline.");
+#endif
+        };
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -221,14 +221,14 @@ namespace UnityEngine.Rendering.Universal
                     case LightType.Area:
                         RectangleLight rectangleLight = new RectangleLight();
                         LightmapperUtils.Extract(light, ref rectangleLight);
+                        rectangleLight.mode = LightMode.Baked;
                         lightData.Init(ref rectangleLight);
-                        light.lightmapBakeType = LightmapBakeType.Baked;
                         break;
                     case LightType.Disc:
                         DiscLight discLight = new DiscLight();
                         LightmapperUtils.Extract(light, ref discLight);
+                        discLight.mode = LightMode.Baked;
                         lightData.Init(ref discLight);
-                        light.lightmapBakeType = LightmapBakeType.Baked;
                         break;
                     default:
                         lightData.InitNoBake(light.GetInstanceID());

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -216,6 +216,7 @@ namespace UnityEngine.Rendering.Universal
                         SpotLight spotLight = new SpotLight();
                         LightmapperUtils.Extract(light, ref spotLight);
                         spotLight.innerConeAngle = light.innerSpotAngle * Mathf.Deg2Rad;
+                        spotLight.angularFalloff = AngularFalloffType.AnalyticAndInnerAngle;
                         lightData.Init(ref spotLight);
                         break;
                     case LightType.Area:


### PR DESCRIPTION
### Purpose of this PR
This PR is exposing the inner cone angle handles and the User can now use those to drive the inner angle of the light.

![inner_cone_angle](https://user-images.githubusercontent.com/35328557/63759169-5875cc80-c8bd-11e9-81f4-dc5b7cac9fcb.gif)

---

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [X] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/urp%252Flight-inner-cone-angle/.yamato%252Fupm-ci-universal.yml%2523All_Universal/400465/job

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Medium

**Halo Effect**: None, Low, Medium, High?
Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
