### PR TITLE
Added code to ensure we always create a buffer of at least one element

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/ShaderData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ShaderData.cs
@@ -57,6 +57,7 @@ namespace UnityEngine.Rendering.Universal
 
         ComputeBuffer GetOrUpdateBuffer<T>(ref ComputeBuffer buffer, int size) where T : struct
         {
+            size = Math.Max(1, size);
             if (buffer == null)
             {
                 buffer = new ComputeBuffer(size, Marshal.SizeOf<T>());


### PR DESCRIPTION
### Purpose of this PR
Fixes an issue where an exception about a zero sized compute buffer would be thrown when using Vulkan or Metal as the graphics API.

Light culling it seems can sometimes return zero lights during the first frame, which causes the ShaderData to request a zero sized compute buffer which isn't valid. This change ensures we always request a buffer of at least 1 element.

---
### Release Notes
N/A

---
### Testing status

**Manual Tests**: Local tested just to make sure things worked as intended.
**Automated Tests**:  Nothing new added.

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None
**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
