### PR TITLE
Fix test scenes broken by renderer refactor PR #4325

### DIFF
--- a/TestProjects/UniversalGraphicsTest/Assets/CommonAssets/UniversalRPAsset.asset
+++ b/TestProjects/UniversalGraphicsTest/Assets/CommonAssets/UniversalRPAsset.asset
@@ -18,6 +18,10 @@ MonoBehaviour:
   m_RendererData: {fileID: 0}
   m_RendererDataList:
   - {fileID: 11400000, guid: f59607d3476b54858a594ea904187fb5, type: 2}
+  - {fileID: 11400000, guid: 676c15eaf197b43079a39998e6c23816, type: 2}
+  - {fileID: 11400000, guid: d64ea0335006ff349b4370486ce0a18f, type: 2}
+  - {fileID: 11400000, guid: d5955759d603da64a9b41edf667c7011, type: 2}
+  - {fileID: 11400000, guid: e46834cadfc4eb241bd46a362765a390, type: 2}
   m_DefaultRendererIndex: 0
   m_RequireDepthTexture: 0
   m_RequireOpaqueTexture: 1

--- a/TestProjects/UniversalGraphicsTest/Assets/Scenes/045_CustomLWPipe.unity
+++ b/TestProjects/UniversalGraphicsTest/Assets/Scenes/045_CustomLWPipe.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.1802837, g: 0.22571404, b: 0.30692273, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -96,7 +96,8 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
-  m_LightingDataAsset: {fileID: 112000002, guid: 27168aa7a3b58824d82d4f8e64521b74,
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 112000002, guid: 0d54ea8b8bb6b46af9f185f49efa3381,
     type: 2}
   m_UseShadowmask: 0
 --- !u!196 &4
@@ -268,6 +269,7 @@ MonoBehaviour:
     TargetHeight: 512
     PerPixelCorrectnessThreshold: 0.005
     AverageCorrectnessThreshold: 0.001
+    UseHDR: 0
   WaitFrames: 0
 --- !u!20 &380492253
 Camera:
@@ -341,8 +343,16 @@ MonoBehaviour:
   m_RenderShadows: 1
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
-  m_RendererOverrideOption: 0
-  m_RendererData: {fileID: 11400000, guid: e46834cadfc4eb241bd46a362765a390, type: 2}
+  m_RendererIndex: 4
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
@@ -371,8 +381,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 707831285}
   m_Enabled: 1
-  serializedVersion: 9
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10

--- a/TestProjects/UniversalGraphicsTest/Assets/Scenes/052_LWCallbacks.unity
+++ b/TestProjects/UniversalGraphicsTest/Assets/Scenes/052_LWCallbacks.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028364, g: 0.22571398, b: 0.30692267, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -472,8 +472,7 @@ MonoBehaviour:
   m_RenderShadows: 1
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
-  m_RendererOverrideOption: 0
-  m_RendererData: {fileID: 11400000, guid: 676c15eaf197b43079a39998e6c23816, type: 2}
+  m_RendererIndex: 1
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1
@@ -503,6 +502,7 @@ MonoBehaviour:
     TargetHeight: 720
     PerPixelCorrectnessThreshold: 0.005
     AverageCorrectnessThreshold: 0.001
+    UseHDR: 0
   WaitFrames: 2
 --- !u!1 &1018272651
 GameObject:

--- a/TestProjects/UniversalGraphicsTest/Assets/Scenes/056_2D_Lights-Shadows.unity
+++ b/TestProjects/UniversalGraphicsTest/Assets/Scenes/056_2D_Lights-Shadows.unity
@@ -157,6 +157,7 @@ MonoBehaviour:
     TargetHeight: 360
     PerPixelCorrectnessThreshold: 0.005
     AverageCorrectnessThreshold: 0.0005
+    UseHDR: 0
   WaitFrames: 0
 --- !u!20 &380492253
 Camera:
@@ -230,8 +231,7 @@ MonoBehaviour:
   m_RenderShadows: 0
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
-  m_RendererOverrideOption: 0
-  m_RendererData: {fileID: 11400000, guid: d5955759d603da64a9b41edf667c7011, type: 2}
+  m_RendererIndex: 3
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1

--- a/TestProjects/UniversalGraphicsTest/Assets/Scenes/056_2D_Lights.unity
+++ b/TestProjects/UniversalGraphicsTest/Assets/Scenes/056_2D_Lights.unity
@@ -229,6 +229,7 @@ MonoBehaviour:
     TargetHeight: 360
     PerPixelCorrectnessThreshold: 0.005
     AverageCorrectnessThreshold: 0.0005
+    UseHDR: 0
   WaitFrames: 0
 --- !u!20 &380492253
 Camera:
@@ -302,8 +303,7 @@ MonoBehaviour:
   m_RenderShadows: 0
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
-  m_RendererOverrideOption: 0
-  m_RendererData: {fileID: 11400000, guid: d5955759d603da64a9b41edf667c7011, type: 2}
+  m_RendererIndex: 3
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1

--- a/TestProjects/UniversalGraphicsTest/Assets/Scenes/056_2D_Lights_Shader_Graph.unity
+++ b/TestProjects/UniversalGraphicsTest/Assets/Scenes/056_2D_Lights_Shader_Graph.unity
@@ -229,6 +229,7 @@ MonoBehaviour:
     TargetHeight: 360
     PerPixelCorrectnessThreshold: 0.005
     AverageCorrectnessThreshold: 0.0005
+    UseHDR: 0
   WaitFrames: 0
 --- !u!20 &380492253
 Camera:
@@ -302,8 +303,7 @@ MonoBehaviour:
   m_RenderShadows: 0
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
-  m_RendererOverrideOption: 0
-  m_RendererData: {fileID: 11400000, guid: d5955759d603da64a9b41edf667c7011, type: 2}
+  m_RendererIndex: 3
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1

--- a/TestProjects/UniversalGraphicsTest/Assets/Scenes/059_2D_PixelPerfect_PostProcessing.unity
+++ b/TestProjects/UniversalGraphicsTest/Assets/Scenes/059_2D_PixelPerfect_PostProcessing.unity
@@ -98,7 +98,7 @@ LightmapSettings:
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_UseShadowmask: 0
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -612,8 +612,7 @@ MonoBehaviour:
   m_RenderShadows: 0
   m_RequiresDepthTextureOption: 0
   m_RequiresOpaqueTextureOption: 0
-  m_RendererOverrideOption: 0
-  m_RendererData: {fileID: 11400000, guid: d5955759d603da64a9b41edf667c7011, type: 2}
+  m_RendererIndex: 3
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1

--- a/TestProjects/UniversalGraphicsTest/Assets/Scenes/070_2D_Forward_Shader_Compatibility_2D.unity
+++ b/TestProjects/UniversalGraphicsTest/Assets/Scenes/070_2D_Forward_Shader_Compatibility_2D.unity
@@ -96,6 +96,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 0
 --- !u!196 &4
@@ -156,6 +157,7 @@ MonoBehaviour:
     TargetHeight: 360
     PerPixelCorrectnessThreshold: 0.005
     AverageCorrectnessThreshold: 0.0005
+    UseHDR: 0
   WaitFrames: 0
 --- !u!20 &380492253
 Camera:
@@ -229,8 +231,16 @@ MonoBehaviour:
   m_RenderShadows: 0
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
-  m_RendererOverrideOption: 0
-  m_RendererData: {fileID: 11400000, guid: d64ea0335006ff349b4370486ce0a18f, type: 2}
+  m_RendererIndex: 2
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
   m_Version: 2
@@ -274,6 +284,8 @@ MonoBehaviour:
   m_UseNormalMap: 0
   m_LightOrder: 0
   m_AlphaBlendOnOverlap: 0
+  m_ShadowIntensity: 0
+  m_ShadowVolumeIntensity: 0
   m_PointLightInnerAngle: 360
   m_PointLightOuterAngle: 360
   m_PointLightInnerRadius: 0


### PR DESCRIPTION
### Purpose of this PR
The PR #4325 broke a few test with the workflow change and these were not updated with the PR.
Added all custom renderers to the Pipeline asset and set the respective ones in each test scene.

---
### Testing status
Launch Katana:
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=universal%2Ffix-custom-renderer-test-scenes&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Yamato:
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/universal%252Ffix-custom-renderer-test-scenes/.yamato%252Fupm-ci-universal.yml%2523All_Universal/390745/job

---
### Overall Product Risks
**Technical Risk**: None - test scene fixes only

**Halo Effect**: None

---
### Comments to reviewers
Notes for the reviewers you have assigned.