### PR TITLE
Fix GetOutputNodeType returning null

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -1004,16 +1004,27 @@ namespace UnityEditor.ShaderGraph
 
         public static Type GetOutputNodeType(string path)
         {
-            var metadata = AssetDatabase.LoadAssetAtPath<ShaderGraphMetadata>(path);
-            if (metadata != null)
+            ShaderGraphMetadata metadata = null;
+            foreach (var asset in AssetDatabase.LoadAllAssetsAtPath(path))
             {
-                var outputNodeTypeName = metadata.outputNodeTypeName;
-                foreach (var type in TypeCache.GetTypesDerivedFrom<IMasterNode>())
+                if (asset is ShaderGraphMetadata metadataAsset)
                 {
-                    if (type.FullName == outputNodeTypeName)
-                    {
-                        return type;
-                    }
+                    metadata = metadataAsset;
+                    break;
+                }
+            }
+
+            if (metadata == null)
+            {
+                return null;
+            }
+
+            var outputNodeTypeName = metadata.outputNodeTypeName;
+            foreach (var type in TypeCache.GetTypesDerivedFrom<IMasterNode>())
+            {
+                if (type.FullName == outputNodeTypeName)
+                {
+                    return type;
                 }
             }
 


### PR DESCRIPTION
### Purpose of this PR
The improvements to GetOutputNodeType introduced by #4414 were causing it to always return `null` due to the combination of [`LoadAssetAtPath`](https://docs.unity3d.com/ScriptReference/AssetDatabase.LoadAssetAtPath.html) and the metadata sub-asset being hidden in the hierarchy. Using [`LoadAllAssetsAtPath`](https://docs.unity3d.com/ScriptReference/AssetDatabase.LoadAllAssetsAtPath.html) and then manually filtering for `ShaderGraphMetadata` fixes this issue.

---
### Release Notes
No release notes because the bug hasn't gone out in a release.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: Locally verified issue and fix.

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low