### PR TITLE
fix for uss warning

### DIFF
--- a/com.unity.visualeffectgraph/Editor Default Resources/uss/VFXBlackboard.uss
+++ b/com.unity.visualeffectgraph/Editor Default Resources/uss/VFXBlackboard.uss
@@ -71,7 +71,7 @@ VFXBlackboardRow.hovered #pill #selection-border
 VFXBlackboardCategory #name-field
 {
     position:absolute;
-    left:16;
+    left:16px;
     right:0;
     top:0;
     bottom:0;


### PR DESCRIPTION
### Purpose of this PR
fix for uss warning
---
### Release Notes
Please add any useful notes about the feature/fix that might be helpful for others.

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?

**Halo Effect**: None, Low, Medium, High?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
