### PR TITLE
Binding correctly the sky texture for both forward and deferred ray tracing modes

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingDeferredLightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingDeferredLightLoop.cs
@@ -45,6 +45,7 @@ namespace UnityEngine.Rendering.HighDefinition
             public RTHandle directionBuffer;
             public RTHandle depthStencilBuffer;
             public RTHandle normalBuffer;
+            public Texture skyTexture;
 
             // Temporary buffers
             public RTHandle gbuffer0;
@@ -111,6 +112,7 @@ namespace UnityEngine.Rendering.HighDefinition
             deferredResources.directionBuffer = directionBuffer;
             deferredResources.depthStencilBuffer = m_SharedRTManager.GetDepthStencilBuffer();
             deferredResources.normalBuffer = m_SharedRTManager.GetNormalBuffer();
+            deferredResources.skyTexture = m_SkyManager.skyReflection;
 
             // Temporary buffers
             deferredResources.gbuffer0 = m_RaytracingGBufferManager.GetBuffer(0);
@@ -233,7 +235,8 @@ namespace UnityEngine.Rendering.HighDefinition
             uint heightResolution = (uint)parameters.height;
 
             // Include the sky if required
-            cmd.SetGlobalInt(HDShaderIDs._RaytracingIncludeSky, parameters.includeSky ? 1 : 0);
+            cmd.SetRayTracingIntParam(parameters.gBufferRaytracingRT, HDShaderIDs._RaytracingIncludeSky, parameters.includeSky ? 1 : 0);
+            cmd.SetRayTracingTextureParam(parameters.gBufferRaytracingRT, HDShaderIDs._SkyTexture, buffers.skyTexture);
 
             // Only compute diffuse lighting if required
             CoreUtils.SetKeyword(cmd, "DIFFUSE_LIGHTING_ONLY", parameters.diffuseLightingOnly);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingIndirectDiffuse.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingIndirectDiffuse.cs
@@ -205,9 +205,6 @@ namespace UnityEngine.Rendering.HighDefinition
 
                 BindRayTracedIndirectDiffuseData(cmd, hdCamera, rtEnvironment, indirectDiffuseRT, settings, lightClusterSettings);
 
-                // Set the data for the ray miss
-                cmd.SetRayTracingTextureParam(indirectDiffuseRT, HDShaderIDs._SkyTexture, m_SkyManager.skyReflection);
-
                 // Run the computation
                 CoreUtils.SetKeyword(cmd, "DIFFUSE_LIGHTING_ONLY", true);
                 CoreUtils.SetKeyword(cmd, "MULTI_BOUNCE_INDIRECT", false);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
@@ -106,6 +106,9 @@ namespace UnityEngine.Rendering.HighDefinition
 
             // Set the number of bounces for reflections
             cmd.SetGlobalInt(HDShaderIDs._RaytracingMaxRecursion, settings.bounceCount.value);
+
+            // Set the data for the ray miss
+            cmd.SetRayTracingTextureParam(reflectionShader, HDShaderIDs._SkyTexture, m_SkyManager.skyReflection);
         }
 
         DeferredLightingRTParameters PrepareReflectionDeferredLightingRTParameters(HDCamera hdCamera, HDRaytracingEnvironment rtEnv)
@@ -223,9 +226,6 @@ namespace UnityEngine.Rendering.HighDefinition
             {
                 // Bind all the required data for ray tracing
                 BindRayTracedReflectionData(cmd, hdCamera, rtEnvironment, reflectionShaderRT, settings, lightClusterSettings);
-
-                // Set the data for the ray miss
-                cmd.SetRayTracingTextureParam(reflectionShaderRT, HDShaderIDs._SkyTexture, m_SkyManager.skyReflection);
 
                 // Run the computation
                 if (settings.fullResolution.value)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/Deferred/RaytracingGBuffer.raytrace
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/Deferred/RaytracingGBuffer.raytrace
@@ -59,7 +59,7 @@ int _RaytracingHalfResolution;
 [shader("miss")]
 void MissShaderGBuffer(inout RayIntersectionGBuffer rayIntersection : SV_RayPayload)
 {
-    if(_RaytracingIncludeSky != 0)
+    if (_RaytracingIncludeSky != 0)
     {
         rayIntersection.gBufferData.gbuffer3 = SAMPLE_TEXTURECUBE_ARRAY_LOD(_SkyTexture, s_trilinear_clamp_sampler, rayIntersection.incidentDirection, 0.0f, 0);
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl
@@ -13,7 +13,7 @@ int                                     _RaytracingMaxRecursion;
 float                                   _RaytracingIntensityClamp;
 float                                   _RaytracingReflectionMaxDistance;
 float                                   _RaytracingReflectionMinSmoothness;
-uint                                    _RaytracingIncludeSky;
+int                                     _RaytracingIncludeSky;
 int                                     _RaytracingFrameIndex;
 float                                   _RaytracingPixelSpreadAngle;
 int                                     _RayCountEnabled;


### PR DESCRIPTION
All in the title. 
Bug reported by @Alex-Hughes 