### PR TITLE
HDRP shader stripping optimization/refactor

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/BaseShaderPreprocessor.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using UnityEditor.Rendering;
-using UnityEditor.Rendering.Utilities;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.HighDefinition;
@@ -63,26 +61,13 @@ namespace UnityEditor.Rendering.HighDefinition
             };
         }
 
-        public bool ShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet,
-            ShaderCompilerData inputData)
-        {
-            return IsMaterialQualityVariantStripped(hdrpAsset, inputData) || DoShadersStripper(hdrpAsset, shader, snippet, inputData);
-        }
+		// Prepare any per-shader data needed for variant stripping. For example pass name checks etc.
+        public abstract void PrepareShaderStripping(Shader shader, ShaderSnippetData snippet);
 
-        protected abstract bool DoShadersStripper(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet, ShaderCompilerData inputData);
+        // Check if this shader snippet (specific pass/program type/shader) should be stripped as a whole.
+        public abstract bool ShouldStripShader(HDRenderPipelineAsset hdrpAsset, Shader shader, ShaderSnippetData snippet);
 
-        protected static bool IsMaterialQualityVariantStripped(HDRenderPipelineAsset hdrpAsset, ShaderCompilerData inputData)
-        {
-            var shaderMaterialLevel = inputData.shaderKeywordSet.GetMaterialQuality();
-            // if there are material quality defines in this shader
-            // and they don't match the material quality accepted by the hdrp asset
-            if (shaderMaterialLevel != 0 && (hdrpAsset.materialQualityLevels & shaderMaterialLevel) == 0)
-            {
-                // then strip this variant
-                return true;
-            }
-
-            return false;
-        }
+        // Check if this specific variant should be stripped.
+        public abstract bool ShouldStripVariant(HDRenderPipelineAsset hdrpAsset, ShaderCompilerData inputData);
     }
 }


### PR DESCRIPTION
### Purpose of this PR
HDRP shader stripping scripts were structured in a way that made it easy to make the mistake of doing per-shader work in the innermost variant stripping loop. When the shader variant amounts approach gazillions it can make a big difference.
 
I restructured the BaseShaderPreprocessor interface into three stages:
1) PrepareShaderStripping: Do all the global preparation here, pass name checks etc.
2) ShouldStripShader: Check if this whole shader pass could be stripped (e.g. SceneSelectionPass).
3) ShouldStripVariant: Check if a specific variant should be stripped (keyword based checks)

Torbjörn's recent optimization pass already removed the biggest slowness in the stripping. However, this PR shaves some ~10% further off a warm project build time. A synthetic stripping test was sped up by ~50%

---
### Release Notes
Refactored/optimized HDRP stripping scripts

---
### Testing status
Yamato tests look ok. HDRP_Standalone has the same failure as the master has atm (some lighting difference)

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: None

---
### Comments to reviewers

