### PR TITLE
Added Save As functionality

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added samples for Procedural Patterns to the package.
 - You can now use the right-click context menu to delete Sticky Notes.
+- You can now Save your Graph as something else.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added samples for Procedural Patterns to the package.
 - You can now use the right-click context menu to delete Sticky Notes.
-- You can now Save your Graph as something else.
+- You can now save your graph as a new Asset.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -1264,9 +1264,14 @@ namespace UnityEditor.ShaderGraph
 
         public void OnBeforeSerialize()
         {
-            m_SerializableNodes = SerializationHelper.Serialize(GetNodes<AbstractMaterialNode>());
+            var nodes = GetNodes<AbstractMaterialNode>().ToList();
+            nodes.Sort((x1, x2) => x1.guid.CompareTo(x2.guid));
+            m_SerializableNodes = SerializationHelper.Serialize(nodes.AsEnumerable());
+            m_Edges.Sort();
             m_SerializableEdges = SerializationHelper.Serialize<IEdge>(m_Edges);
+            m_Properties.Sort((x1, x2) => x1.guid.CompareTo(x2.guid));
             m_SerializedProperties = SerializationHelper.Serialize<AbstractShaderProperty>(m_Properties);
+            m_Keywords.Sort((x1, x2) => x1.guid.CompareTo(x2.guid));
             m_SerializedKeywords = SerializationHelper.Serialize<ShaderKeyword>(m_Keywords);
             m_ActiveOutputNodeGuidSerialized = m_ActiveOutputNodeGuid == Guid.Empty ? null : m_ActiveOutputNodeGuid.ToString();
         }

--- a/com.unity.shadergraph/Editor/Data/Implementation/Edge.cs
+++ b/com.unity.shadergraph/Editor/Data/Implementation/Edge.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.Graphing
 {
     [Serializable]
-    class Edge : IEdge
+    class Edge : IEdge, IComparable<Edge>
     {
         [SerializeField]
         private SlotReference m_OutputSlot;
@@ -55,6 +55,15 @@ namespace UnityEditor.Graphing
                 // Can't make fields readonly due to Unity serialization
                 return (m_OutputSlot.GetHashCode() * 397) ^ m_InputSlot.GetHashCode();
             }
+        }
+
+        public int CompareTo(Edge other)
+        {
+            if (ReferenceEquals(this, other)) return 0;
+            if (ReferenceEquals(null, other)) return 1;
+            var outputSlotComparison = m_OutputSlot.CompareTo(other.m_OutputSlot);
+            if (outputSlotComparison != 0) return outputSlotComparison;
+            return m_InputSlot.CompareTo(other.m_InputSlot);
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Interfaces/Graph/SlotReference.cs
+++ b/com.unity.shadergraph/Editor/Data/Interfaces/Graph/SlotReference.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace UnityEditor.Graphing
 {
     [Serializable]
-    struct SlotReference : ISerializationCallbackReceiver, IEquatable<SlotReference>
+    struct SlotReference : ISerializationCallbackReceiver, IEquatable<SlotReference>, IComparable<SlotReference>
     {
         [SerializeField]
         private int m_SlotId;
@@ -63,6 +63,13 @@ namespace UnityEditor.Graphing
             {
                 return (m_SlotId * 397) ^ m_NodeGUID.GetHashCode();
             }
+        }
+
+        public int CompareTo(SlotReference other)
+        {
+            var nodeGUIDComparison = m_NodeGUID.CompareTo(other.m_NodeGUID);
+            if (nodeGUIDComparison != 0) return nodeGUIDComparison;
+            return m_SlotId.CompareTo(other.m_SlotId);
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -87,7 +87,10 @@ namespace UnityEditor.ShaderGraph.Drawing
         public string selectedGuid
         {
             get { return m_Selected; }
-            private set { m_Selected = value; }
+            private set
+            {
+                m_Selected = value;
+            }
         }
 
         public string assetName
@@ -363,17 +366,21 @@ namespace UnityEditor.ShaderGraph.Drawing
                     if (!string.IsNullOrEmpty(newPath))
                     {
                         var success = FileUtilities.WriteShaderGraphToDisk(newPath, graphObject.graph);
-                        AssetDatabase.Refresh();
+                        AssetDatabase.ImportAsset(newPath);
                         if (success)
                         {
                             ShaderGraphImporterEditor.ShowGraphEditWindow(newPath);
-                            var shader = AssetDatabase.LoadAssetAtPath<Shader>(path);
                             if (GraphData.onSaveGraph != null)
                             {
+                                var shader = AssetDatabase.LoadAssetAtPath<Shader>(newPath);
                                 GraphData.onSaveGraph(shader);
                             }
                         }
                     }
+                }
+                else
+                {
+                    UpdateAsset();
                 }
 
                 graphObject.isDirty = false;
@@ -761,7 +768,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 Texture2D icon = GetThemeIcon(graphObject.graph);
 
                 // This is adding the icon at the front of the tab
-                titleContent = EditorGUIUtility.TrTextContentWithIcon("", icon);
+                titleContent = EditorGUIUtility.TrTextContentWithIcon(selectedGuid, icon);
                 UpdateTitle();
 
                 Repaint();

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -58,6 +58,8 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         public Action saveRequested { get; set; }
 
+        public Action saveAsRequested { get; set; }
+
         public Func<bool> isCheckedOut { get; set; }
 
         public Action checkOut { get; set; }
@@ -145,6 +147,11 @@ namespace UnityEditor.ShaderGraph.Drawing
                     {
                         if (saveRequested != null)
                             saveRequested();
+                    }
+                    GUILayout.Space(6);
+                    if (GUILayout.Button("Save As...", EditorStyles.toolbarButton))
+                    {
+                        saveAsRequested();
                     }
                     GUILayout.Space(6);
                     if (GUILayout.Button("Show In Project", EditorStyles.toolbarButton))
@@ -1009,6 +1016,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (m_GraphView != null)
             {
                 saveRequested = null;
+                saveAsRequested = null;
                 convertToSubgraphRequested = null;
                 showInProjectRequested = null;
                 foreach (var node in m_GraphView.Children().OfType<IShaderNodeView>())

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
@@ -51,7 +51,22 @@ namespace UnityEditor.ShaderGraph
             anyShaders |= movedAssets.Any(val => val.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
             if (anyShaders)
                 UpdateAfterAssetChange(movedAssets);
-            
+
+            var windows = Resources.FindObjectsOfTypeAll<MaterialGraphEditWindow>();
+
+            var changedGraphGuids = importedAssets
+                .Where(x => x.EndsWith(ShaderGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase)
+                    || x.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase))
+                .Select(AssetDatabase.AssetPathToGUID)
+                .ToList();
+            foreach (var window in windows)
+            {
+                if (changedGraphGuids.Contains(window.selectedGuid))
+                {
+                    window.CheckForChanges();
+                }
+            }
+
             var changedFiles = movedAssets.Union(importedAssets)
                 .Where(x => x.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase)
                 || CustomFunctionNode.s_ValidExtensions.Contains(Path.GetExtension(x)))
@@ -61,7 +76,6 @@ namespace UnityEditor.ShaderGraph
 
             if (changedFiles.Count > 0)
             {
-                var windows = Resources.FindObjectsOfTypeAll<MaterialGraphEditWindow>();
                 foreach (var window in windows)
                 {
                     window.ReloadSubGraphsOnNextUpdate(changedFiles);

--- a/com.unity.shadergraph/Editor/Util/FileUtilities.cs
+++ b/com.unity.shadergraph/Editor/Util/FileUtilities.cs
@@ -14,11 +14,16 @@ namespace UnityEditor.ShaderGraph
                 throw new ArgumentNullException(nameof(data));
             }
 
+            return WriteToDisk(path, EditorJsonUtility.ToJson(data, true));
+        }
+
+        public static bool WriteToDisk(string path, string text)
+        {
             CheckoutIfValid(path);
 
             try
             {
-                File.WriteAllText(path, EditorJsonUtility.ToJson(data, true));
+                File.WriteAllText(path, text);
             }
             catch (Exception e)
             {
@@ -27,7 +32,7 @@ namespace UnityEditor.ShaderGraph
                 {
                         FileInfo fileInfo = new FileInfo(path);
                         fileInfo.IsReadOnly = false;
-                        File.WriteAllText(path, EditorJsonUtility.ToJson(data, true));
+                        File.WriteAllText(path, text);
                         return true;
                 }
                 Debug.LogException(e);


### PR DESCRIPTION
### Purpose of this PR
We need save as functionality and this PR solves that.

![save_as](https://user-images.githubusercontent.com/35328557/64705973-1cdc2480-d4b1-11e9-9200-dd4f969d83ed.gif)

Also the tab now gets a * if it is different from the file on Disk. 

---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fsave-as/.yamato%252Fupm-ci-shadergraph.yml%2523All_ShaderGraph/444859/job

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: None, Low, Medium, High?
Low-ish

**Halo Effect**: None, Low, Medium, High?
Low-ish

---
### Comments to reviewers
Notes for the reviewers you have assigned.
