### PR TITLE
Fix for decal mask map not considered for spec occlusion

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed emissive area light mesh non-uniform scale issues (1171739)
 - Fixed Hair and PBR shader graphs double sided modes
 - Fixed an issue where updating an HDRP asset in the Quality setting panel would not recreate the pipeline.
+- Fixed issue that prevented decals from modifying specular occlusion (case 1178272).
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed Hair and PBR shader graphs double sided modes
 - Fixed an issue where updating an HDRP asset in the Quality setting panel would not recreate the pipeline.
 - Fixed issue that prevented decals from modifying specular occlusion (case 1178272).
+- Fixed issue with decal mask map not considered in contributing to specular occlusion when receiver doesn't have a mask map (case 1178380)
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
@@ -234,6 +234,14 @@ $include("SharedCode.template.hlsl")
         // If user provide bent normal then we process a better term
         surfaceData.specularOcclusion = 1.0;
 
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
+#endif
+
 #if defined(_SPECULAR_OCCLUSION_CUSTOM)
         // Just use the value passed through via the slot (not active otherwise)
 #elif defined(_SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL)
@@ -243,14 +251,6 @@ $include("SharedCode.template.hlsl")
         surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 #else
         surfaceData.specularOcclusion = 1.0;
-#endif
-
-#if HAVE_DECALS
-        if (_EnableDecals)
-        {
-            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-        }
 #endif
 
 #ifdef DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
@@ -245,6 +245,14 @@ $include("SharedCode.template.hlsl")
         // If user provide bent normal then we process a better term
         surfaceData.specularOcclusion = 1.0;
 
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
+#endif
+
 #if defined(_SPECULAR_OCCLUSION_CUSTOM)
         // Just use the value passed through via the slot (not active otherwise)
 #elif defined(_SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL)
@@ -254,14 +262,6 @@ $include("SharedCode.template.hlsl")
         surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 #else
         surfaceData.specularOcclusion = 1.0;
-#endif
-
-#if HAVE_DECALS
-        if (_EnableDecals)
-        {
-            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-        }
 #endif
 
 #ifdef DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricRaytracingPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricRaytracingPass.template
@@ -207,6 +207,14 @@ Pass
         // If user provide bent normal then we process a better term
         surfaceData.specularOcclusion = 1.0;
 
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
+#endif
+
 #if defined(_SPECULAR_OCCLUSION_CUSTOM)
         // Just use the value passed through via the slot (not active otherwise)
 #elif defined(_SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL)
@@ -216,14 +224,6 @@ Pass
         surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 #else
         surfaceData.specularOcclusion = 1.0;
-#endif
-
-#if HAVE_DECALS
-        if (_EnableDecals)
-        {
-            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-        }
 #endif
 
 #ifdef DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -265,6 +265,14 @@ $include("SharedCode.template.hlsl")
         // If user provide bent normal then we process a better term
         surfaceData.specularOcclusion = 1.0;
 
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
+#endif
+
 #if defined(_SPECULAR_OCCLUSION_CUSTOM)
         // Just use the value passed through via the slot (not active otherwise)
 #elif defined(_SPECULAR_OCCLUSION_FROM_AO_BENT_NORMAL)
@@ -274,14 +282,6 @@ $include("SharedCode.template.hlsl")
         surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(N, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 #else
         surfaceData.specularOcclusion = 1.0;
-#endif
-
-#if HAVE_DECALS
-        if (_EnableDecals)
-        {
-            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-        }
 #endif
 
 #ifdef _ENABLE_GEOMETRIC_SPECULAR_AA

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
@@ -254,6 +254,14 @@ $include("SharedCode.template.hlsl")
         $Tangent: surfaceData.tangentWS = TransformTangentToWorld(surfaceDescription.Tangent, fragInputs.tangentToWorld);
         surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
 
+#if HAVE_DECALS
+        if (_EnableDecals)
+        {
+            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
+            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+        }
+#endif
+
         // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
         // If user provide bent normal then we process a better term
 #if defined(_SPECULAR_OCCLUSION_CUSTOM)
@@ -265,14 +273,6 @@ $include("SharedCode.template.hlsl")
         surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 #else
         surfaceData.specularOcclusion = 1.0;
-#endif
-
-#if HAVE_DECALS
-        if (_EnableDecals)
-        {
-            DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, surfaceDescription.Alpha);
-            ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-        }
 #endif
 
 #ifdef _ENABLE_GEOMETRIC_SPECULAR_AA

--- a/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/HDPBRPass.template
@@ -167,11 +167,7 @@ $include("SharedCode.template.hlsl")
 
         surfaceData.tangentWS = normalize(fragInputs.tangentToWorld[0].xyz);    // The tangent is not normalize in tangentToWorld for mikkt. TODO: Check if it expected that we normalize with Morten. Tag: SURFACE_GRADIENT
         surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
-
-        // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
-        // If user provide bent normal then we process a better term
-        surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
-
+        
 #if HAVE_DECALS
         if (_EnableDecals)
         {
@@ -179,6 +175,10 @@ $include("SharedCode.template.hlsl")
             ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
         }
 #endif
+
+        // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
+        // If user provide bent normal then we process a better term
+        surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 
 #ifdef DEBUG_DISPLAY
         if (_DebugMipMapMode != DEBUGMIPMAPMODE_NONE)

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
@@ -784,9 +784,10 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #else
     // If we have decals, we might still have a mask map to consider as it migth be coming from the decal.
 #if HAVE_DECALS
-    if (_EnableDecals && (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK))
+    if (_EnableDecals)
     {
-        surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(dot(surfaceData.normalWS, V), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
+        if(decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK)
+            surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(dot(surfaceData.normalWS, V), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
     }
 #else
     surfaceData.specularOcclusion = 1.0;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
@@ -761,6 +761,14 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 
     surfaceData.geomNormalWS = input.tangentToWorld[2];
 
+#if HAVE_DECALS
+    if (_EnableDecals)
+    {
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+    }
+#endif
+
     // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
     // If user provide bent normal then we process a better term
 #if (defined(_BENTNORMALMAP0) || defined(_BENTNORMALMAP1) || defined(_BENTNORMALMAP2) || defined(_BENTNORMALMAP3)) && defined(_ENABLESPECULAROCCLUSION)
@@ -774,14 +782,6 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(dot(surfaceData.normalWS, V), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
 #else
     surfaceData.specularOcclusion = 1.0;
-#endif
-
-#if HAVE_DECALS
-    if (_EnableDecals)
-    {
-        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-    }
 #endif
 
 #ifdef _ENABLE_GEOMETRIC_SPECULAR_AA

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
@@ -212,7 +212,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     surfaceData.geomNormalWS = input.tangentToWorld[2];
 
 #if HAVE_DECALS
-    DecalSurfaceData decalSurfaceData;
+    DecalSurfaceData decalSurfaceData = (DecalSurfaceData)0;
     if (_EnableDecals)
     {
         decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
@@ -235,9 +235,10 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 
 #if HAVE_DECALS
     // If we have decals, we might still have a mask map to consider as it migth be coming from the decal.
-    if (_EnableDecals && (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK))
+    if (_EnableDecals)
     {
-        surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
+        if (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK)
+            surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(dot(surfaceData.normalWS, V), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
     }
 #else
     surfaceData.specularOcclusion = 1.0;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
@@ -211,6 +211,14 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 
     surfaceData.geomNormalWS = input.tangentToWorld[2];
 
+#if HAVE_DECALS
+    if (_EnableDecals)
+    {
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+    }
+#endif
+
     // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
     // If user provide bent normal then we process a better term
 #if defined(_BENTNORMALMAP) && defined(_ENABLESPECULAROCCLUSION)
@@ -228,14 +236,6 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 
     // This is use with anisotropic material
     surfaceData.tangentWS = Orthonormalize(surfaceData.tangentWS, surfaceData.normalWS);
-
-#if HAVE_DECALS
-    if (_EnableDecals)
-    {
-        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
-        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
-    }
-#endif
 
 #ifdef _ENABLE_GEOMETRIC_SPECULAR_AA
     // Specular AA

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
@@ -212,7 +212,7 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
     float3 bentNormalWS = surfaceData.normalWS;
 
 #if HAVE_DECALS
-    DecalSurfaceData decalSurfaceData;
+    DecalSurfaceData decalSurfaceData = (DecalSurfaceData)0;
     if (_EnableDecals)
     {
         float alpha = 1.0; // unused
@@ -228,9 +228,10 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
 
 #if HAVE_DECALS
     // If we have decals, we might still have a mask map to consider as it migth be coming from the decal.
-    if (_EnableDecals && (decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK))
+    if (_EnableDecals)
     {
-        surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
+        if((decalSurfaceData.HTileMask & DBUFFERHTILEBIT_MASK))
+            surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
     }
 #else
     surfaceData.specularOcclusion = 1.0f;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/TerrainLit/TerrainLitData.hlsl
@@ -211,13 +211,6 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
 
     float3 bentNormalWS = surfaceData.normalWS;
 
-    // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
-#ifdef _MASKMAP
-    surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
-#else
-    surfaceData.specularOcclusion = 1.0;
-#endif
-
 #if HAVE_DECALS
     if (_EnableDecals)
     {
@@ -225,6 +218,13 @@ void GetSurfaceAndBuiltinData(inout FragInputs input, float3 V, inout PositionIn
         DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
         ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
     }
+#endif
+
+    // By default we use the ambient occlusion with Tri-ace trick (apply outside) for specular occlusion.
+#ifdef _MASKMAP
+    surfaceData.specularOcclusion = GetSpecularOcclusionFromAmbientOcclusion(ClampNdotV(dot(surfaceData.normalWS, V)), surfaceData.ambientOcclusion, PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness));
+#else
+    surfaceData.specularOcclusion = 1.0;
 #endif
 
 #ifdef DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/XR/XRSystem.cs
@@ -284,7 +284,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
         internal void RenderMirrorView(CommandBuffer cmd)
         {
-#if ENABLE_XR_MODULE
+#if false
             if (display == null || !display.running)
                 return;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/XR/XRSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/XR/XRSystem.cs
@@ -284,7 +284,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
         internal void RenderMirrorView(CommandBuffer cmd)
         {
-#if false
+#if ENABLE_XR_MODULE
             if (display == null || !display.running)
                 return;
 


### PR DESCRIPTION
IMPORTANT! Note this is dependent on this being merged first: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/4582  (this branched off that branch)

Fix for https://fogbugz.unity3d.com/f/cases/1178380/ 