### PR TITLE
[Shader Graph] Fix 1184621

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - You can now save your graph as a new Asset.
 
 ### Fixed
-- When saving a Shader Graph, edges no longer produce errors.
+- Edges no longer produce errors when you save a Shader Graph.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - You can now use the right-click context menu to delete Sticky Notes.
 - You can now save your graph as a new Asset.
 
+### Fixed
+- When saving a Shader Graph, edges no longer produce errors.
+
 ## [7.1.1] - 2019-09-05
 ### Added
 - You can now define shader keywords on the Blackboard. Use these keywords on the graph to create static branches in the generated shader.

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -202,9 +202,9 @@ namespace UnityEditor.ShaderGraph
         #region Edge data
 
         [NonSerialized]
-        List<IEdge> m_Edges = new List<IEdge>();
+        List<Edge> m_Edges = new List<Edge>();
 
-        public IEnumerable<IEdge> edges
+        public IEnumerable<Edge> edges
         {
             get { return m_Edges; }
         }
@@ -641,7 +641,7 @@ namespace UnityEditor.ShaderGraph
             e = m_Edges.FirstOrDefault(x => x.Equals(e));
             if (e == null)
                 throw new ArgumentException("Trying to remove an edge that does not exist.", "e");
-            m_Edges.Remove(e);
+            m_Edges.Remove(e as Edge);
 
             List<IEdge> inputNodeEdges;
             if (m_NodeEdges.TryGetValue(e.inputSlot.nodeGuid, out inputNodeEdges))
@@ -1269,7 +1269,7 @@ namespace UnityEditor.ShaderGraph
             nodes.Sort((x1, x2) => x1.guid.CompareTo(x2.guid));
             m_SerializableNodes = SerializationHelper.Serialize(nodes.AsEnumerable());
             m_Edges.Sort();
-            m_SerializableEdges = SerializationHelper.Serialize<IEdge>(m_Edges);
+            m_SerializableEdges = SerializationHelper.Serialize<Edge>(m_Edges);
             m_Properties.Sort((x1, x2) => x1.guid.CompareTo(x2.guid));
             m_SerializedProperties = SerializationHelper.Serialize<AbstractShaderProperty>(m_Properties);
             m_Keywords.Sort((x1, x2) => x1.guid.CompareTo(x2.guid));
@@ -1310,7 +1310,7 @@ namespace UnityEditor.ShaderGraph
 
             m_SerializableNodes = null;
 
-            m_Edges = SerializationHelper.Deserialize<IEdge>(m_SerializableEdges, GraphUtil.GetLegacyTypeRemapping());
+            m_Edges = SerializationHelper.Deserialize<Edge>(m_SerializableEdges, GraphUtil.GetLegacyTypeRemapping());
             m_SerializableEdges = null;
             foreach (var edge in m_Edges)
                 AddEdgeToNodeEdges(edge);


### PR DESCRIPTION
### Purpose of this PR
Fixes Fogbugz case 1184621.

#4583 intoduced an `IComparible` error as it was attempting to sort `GraphData.m_Edges` which was of type `IEdge`. This PR changes this variable to be of type `Edge` which implements `IComparible`.

Note that all serialized edges were of type `Edge` (which implements `IEdge`) anyway, so this does not affect serialized graph datas.

Ideally we would remove the interface `IEdge` entirely, but it is plumbed in deep and too big of a change to be considered a simple bug fix. This is our best choice right now imo.

---
### Release Notes
Changelog

---
### Testing status
**Katana Tests**: Running...

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: N/A

Any test projects to go with this to help reviewers? N/A

---
### Overall Product Risks
**Technical Risk**: Low - Shouldnt affect anything

**Halo Effect**: Low - Shouldnt affect anything

---
### Comments to reviewers
N/A
