### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,10 @@
 /com.unity.render-pipelines.universal/Shaders/2D @Unity-Technologies/2d-graphics
 /com.unity.render-pipelines.universal/Editor/ShaderGraph/MasterNodes @Unity-Technologies/2d-graphics
 
-# Shadergraph
+# Shader Graph
+/com.unity.shadergraph/ @Unity-Technologies/shader-graph
 /com.unity.shadergraph/CHANGELOG.md @Unity-Technologies/gfx-docs
+/com.unity.shadergraph/Documentation~/ @Unity-Technologies/gfx-docs
 
 # Test systems
 /.yamato/ @Unity-Technologies/gfx-sdets


### PR DESCRIPTION
### Purpose of this PR

Updates Shader Graph code owners to @Unity-Technologies/shader-graph for anything non-docs in the `/com.unity.shadergraph/`, and @Unity-Technologies/gfx-docs for anything in `/com.unity.shadergraph/Documentation~/` in addition to the change log.