### PR TITLE
Fp16 fix error calculation

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Restored usage of ENABLE_VR to fix compilation errors on some platforms.
 - Only call SetDirty on an object when actually modifying it in SRP updater utility 
+- Added a saturate to avoid fp16 calculation go above 1
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/BSDF.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/BSDF.hlsl
@@ -231,7 +231,7 @@ real V_SmithJointGGX(real NdotL, real NdotV, real roughness)
 // Inline D_GGX() * V_SmithJointGGX() together for better code generation.
 real DV_SmithJointGGX(real NdotH, real NdotL, real NdotV, real roughness, real partLambdaV)
 {
-    real a2 = Sq(roughness);
+    real a2 = saturate(Sq(roughness));
     real s = (NdotH * a2 - NdotH) * NdotH + 1.0;
 
     real lambdaV = NdotL * partLambdaV;


### PR DESCRIPTION
### Purpose of this PR
On iOS and MacOs, when using fp16, the specular lighting values can go wrong because of precision issue. Added a saturate to a value that should be between 0 and 1 anyway, but if it goes beyond one, then some results can be wrong in the rest of the calculation.
---
---
### Testing status
**Katana Tests**: First off we need to make sure the Katana SRP tests are green?

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

Launch Katana (Link on master here - update for your branch):
https://katana.bf.unity3d.com/projects/com.unity.render-pipelines/builders?ScriptableRenderLoop_branch=master&automation-tools_branch=master&unity_branch=trunk&sort=1-asc

Alternative, launch Yamato (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Overall Product Risks
**Technical Risk**: Low

**Halo Effect**: Low

---
### Comments to reviewers
Notes for the reviewers you have assigned.
