### PR TITLE
Fix linear depth computation in the orthographic mode

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDecal.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDecal.hlsl
@@ -53,8 +53,10 @@ void Frag(  PackedVaryingsToPS packedInput,
         clip(-1);
 #else // Decal mesh
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS.xyz, uint2(0, 0));
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS.xyz, uint2(0, 0));
 
 #ifdef VARYINGS_NEED_POSITION_WS
         float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl
@@ -45,8 +45,10 @@ void Frag(  PackedVaryingsToPS packedInput
     UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(packedInput);
     FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDistortion.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDistortion.hlsl
@@ -29,8 +29,10 @@ float4 Frag(PackedVaryingsToPS packedInput) : SV_Target
     UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(packedInput);
     FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForward.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForward.hlsl
@@ -84,8 +84,10 @@ void Frag(PackedVaryingsToPS packedInput,
 
     uint2 tileIndex = uint2(input.positionSS.xy) / GetTileSize();
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS.xyz, tileIndex);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS.xyz, tileIndex);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForwardUnlit.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassForwardUnlit.hlsl
@@ -29,8 +29,10 @@ float4 Frag(PackedVaryingsToPS packedInput) : SV_Target
     UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(packedInput);
     FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassGBuffer.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassGBuffer.hlsl
@@ -34,8 +34,10 @@ void Frag(  PackedVaryingsToPS packedInput,
     UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(packedInput);
     FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassLightTransport.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassLightTransport.hlsl
@@ -76,8 +76,10 @@ float4 Frag(PackedVaryingsToPS packedInput) : SV_Target
 {
     FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassMotionVectors.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassMotionVectors.hlsl
@@ -56,8 +56,10 @@ void Frag(  PackedVaryingsToPS packedInput
 {
     FragInputs input = UnpackVaryingsMeshToFragInputs(packedInput.vmesh);
 
+    float linDepth = IsPerspectiveProjection() ? input.positionSS.w : dot(input.positionRWS.xyz, GetViewForwardDir());
+
     // input.positionSS is SV_Position
-    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, input.positionSS.w, input.positionRWS);
+    PositionInputs posInput = GetPositionInput(input.positionSS.xy, _ScreenSize.zw, input.positionSS.z, linDepth, input.positionRWS);
 
 #ifdef VARYINGS_NEED_POSITION_WS
     float3 V = GetWorldSpaceNormalizeViewDir(input.positionRWS);


### PR DESCRIPTION
### Purpose of this PR
Fix linear depth computation in the orthographic mode
Fix https://fogbugz.unity3d.com/f/cases/edit/1167427/

---
### Release Notes
Fix linear depth computation in the orthographic mode

---
### Testing status
**Katana Tests**: No

**Manual Tests**: Yes
