### PR TITLE
Fix how HDRP assets as dependencies are found.

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPPreprocessShaders.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/BuildProcessors/HDRPPreprocessShaders.cs
@@ -351,21 +351,31 @@ namespace UnityEditor.Rendering.HighDefinition
                 .Select(s => s.path);
 
             // Find all HDRP assets that are dependencies of the scenes.
-            _hdrpAssets = scenesPaths.Aggregate( new List<HDRenderPipelineAsset>(),
-                (list, scene) =>
+            var depsArray = AssetDatabase.GetDependencies(scenesPaths.ToArray());
+            HashSet<string> depsHash = new HashSet<string>(depsArray);
+
+            var guidRenderPipelineAssets = AssetDatabase.FindAssets("t:HDRenderPipelineAsset");
+
+            for (int i = 0; i < guidRenderPipelineAssets.Length; ++i)
+            {
+                var curGUID = guidRenderPipelineAssets[i];
+                var curPath = AssetDatabase.GUIDToAssetPath(curGUID);
+                if(depsHash.Contains(curPath))
                 {
-                    list.AddRange(
-                        AssetDatabase.GetDependencies(scene)
-                            .Select(AssetDatabase.LoadAssetAtPath<HDRenderPipelineAsset>)
-                            .Where( a => a != null && !list.Contains(a) )
-                        );
-                    return list;
-                });
+                    _hdrpAssets.Add(AssetDatabase.LoadAssetAtPath<HDRenderPipelineAsset>(curPath));
+                }
+            }
 
             // Add the HDRP assets that are in the Resources folders.
             _hdrpAssets.AddRange(
                 Resources.FindObjectsOfTypeAll<HDRenderPipelineAsset>()
                 .Where( a => !_hdrpAssets.Contains(a) )
+                );
+
+            // Add the HDRP assets that are labeled to be included
+            _hdrpAssets.AddRange(
+                AssetDatabase.FindAssets("t:HDRenderPipelineAsset l:" + HDEditorUtils.HDRPAssetBuildLabel)
+                    .Select(s => AssetDatabase.LoadAssetAtPath<HDRenderPipelineAsset>(AssetDatabase.GUIDToAssetPath(s)))
                 );
 
             // Discard duplicate entries

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDEditorUtils.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDEditorUtils.cs
@@ -19,7 +19,8 @@ namespace UnityEditor.Rendering.HighDefinition
             @"Packages/com.unity.render-pipelines.high-definition/Editor/USS/QualitySettings";
         internal const string WizardSheetPath =
             @"Packages/com.unity.render-pipelines.high-definition/Editor/USS/Wizard";
-        
+        internal const string HDRPAssetBuildLabel = "HDRP:IncludeInBuild";
+
         private static (StyleSheet baseSkin, StyleSheet professionalSkin, StyleSheet personalSkin) LoadStyleSheets(string basePath)
             => (
                 AssetDatabase.LoadAssetAtPath<StyleSheet>($"{basePath}.uss"),
@@ -63,7 +64,7 @@ namespace UnityEditor.Rendering.HighDefinition
         [Obsolete("Use HDShaderUtils.ResetMaterialKeywords instead")]
         public static bool ResetMaterialKeywords(Material material)
             => HDShaderUtils.ResetMaterialKeywords(material);
-        
+
         static readonly GUIContent s_OverrideTooltip = EditorGUIUtility.TrTextContent("", "Override this setting in component.");
         internal static bool FlagToggle<TEnum>(TEnum v, SerializedProperty property)
             where TEnum : struct, IConvertible // restrict to ~enum


### PR DESCRIPTION
### Purpose of this PR
Should reduce the evaluation of HDRP assets to include in the build (and used for shader variants stripping), and avoid issues on big projects.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player

**Automated Tests**: No change

---
### Overall Product Risks
**Technical Risk**: Low?

**Halo Effect**: None?
