### PR TITLE
Toggled off two stereo Post FX tests per case 1180414.

### DIFF
--- a/TestProjects/UniversalGfxTestStereo/ProjectSettings/EditorBuildSettings.asset
+++ b/TestProjects/UniversalGfxTestStereo/ProjectSettings/EditorBuildSettings.asset
@@ -41,10 +41,10 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/013_xr_PostFX_Simple.unity
     guid: 553df5bb3e439234fb07fc04c0a61198
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/014_xr_PostFX_Complex_NoAA.unity
     guid: 976626cc568ea4e40b8255c49e3d51c3
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/015_xr_PostFX_FXAA.unity
     guid: 87d52919694318342adeb912caaf63a1
   - enabled: 1


### PR DESCRIPTION
### Checklist for PR maker
- Have you added a Label? : No.
- Have you added a label for backport (if needed)? : N/A; no backport needed.
- Have you added a changelog? No.
- Have you updated or added the documentation for you PR? N/A; no docs needed.
- Have you added a graphic test for your PR (if needed)? N/A. 

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Two of the new tests created by the following PR fail due to known case 1180414, so this PR merely toggles off those two tests until the bug is fixed.  
https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/4679

---
### Testing status

**Manual Tests**: What did you do?
- [ Yes] Opened test project + Run graphic tests locally
- [ No] Built a player
- [N/A ] Checked new UI names with UX convention
- [ N/A] Tested UI multi-edition + Undo/Redo
- [ No] C# and shader warnings (supress shader cache to see them)
- [No ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
Tests are running now. 
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/urp_stereo_instancing_dennisd/.yamato%252Fupm-ci-abv.yml%2523all_project_ci/581069/job

Any test projects to go with this to help reviewers?
No.
---
### Comments to reviewers
@sophiaaar By the time the aforementioned tests finish I'll be asleep but you will be at your office.  If the results and my one-file code change look okay, could you go ahead and mere this?  Otherwise, let me know how I can help. 
