### PR TITLE
Fix triplanar node using camera relative position in HDRP

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a shader compatibility issue in the SRP Batcher when you use a hybrid instancing custom variable.
 - Fixed an issue where Unity would crash when you imported a Shader Graph Asset with invalid formatting.
 - Fixed an issue with the animated preview when there is no Camera with animated Materials in the Editor.
+- Fixed the triplanar node using the camera relative position in HDRP.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a shader compatibility issue in the SRP Batcher when you use a hybrid instancing custom variable.
 - Fixed an issue where Unity would crash when you imported a Shader Graph Asset with invalid formatting.
 - Fixed an issue with the animated preview when there is no Camera with animated Materials in the Editor.
-- Fixed the triplanar node using the camera relative position in HDRP.
+- Triplanar nodes no longer use Camera-relative world space by default in HDRP.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
@@ -61,7 +61,7 @@ namespace UnityEditor.ShaderGraph
             AddSlot(new Vector4MaterialSlot(OutputSlotId, kOutputSlotName, kOutputSlotName, SlotType.Output, Vector4.zero, ShaderStageCapability.Fragment));
             AddSlot(new Texture2DInputMaterialSlot(TextureInputId, kTextureInputName, kTextureInputName));
             AddSlot(new SamplerStateMaterialSlot(SamplerInputId, kSamplerInputName, kSamplerInputName, SlotType.Input));
-            AddSlot(new PositionMaterialSlot(PositionInputId, kPositionInputName, kPositionInputName, CoordinateSpace.World));
+            AddSlot(new PositionMaterialSlot(PositionInputId, kPositionInputName, kPositionInputName, CoordinateSpace.AbsoluteWorld));
             AddSlot(new NormalMaterialSlot(NormalInputId, kNormalInputName, kNormalInputName, CoordinateSpace.World));
             AddSlot(new Vector1MaterialSlot(TileInputId, kTileInputName, kTileInputName, SlotType.Input, 1));
             AddSlot(new Vector1MaterialSlot(BlendInputId, kBlendInputName, kBlendInputName, SlotType.Input, 1));
@@ -163,7 +163,7 @@ namespace UnityEditor.ShaderGraph
 
         public NeededCoordinateSpace RequiresPosition(ShaderStageCapability stageCapability)
         {
-            return CoordinateSpace.World.ToNeededCoordinateSpace();
+            return CoordinateSpace.AbsoluteWorld.ToNeededCoordinateSpace();
         }
 
         public NeededCoordinateSpace RequiresNormal(ShaderStageCapability stageCapability)

--- a/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/UV/TriplanarNode.cs
@@ -163,7 +163,7 @@ namespace UnityEditor.ShaderGraph
 
         public NeededCoordinateSpace RequiresPosition(ShaderStageCapability stageCapability)
         {
-            return CoordinateSpace.AbsoluteWorld.ToNeededCoordinateSpace();
+            return CoordinateSpace.AbsoluteWorld.ToNeededCoordinateSpace() | CoordinateSpace.World.ToNeededCoordinateSpace();
         }
 
         public NeededCoordinateSpace RequiresNormal(ShaderStageCapability stageCapability)


### PR DESCRIPTION
### Purpose of this PR
Fix triplanar node using camera relative position in HDRP

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/shadergraph%252Ffix%252Ftriplanar_node_absolute_world/.yamato%252Fupm-ci-abv.yml%2523all_project_ci