### PR TITLE
Add dirty for asset modified by wizard

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Configuration.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Configuration.cs
@@ -263,7 +263,9 @@ namespace UnityEditor.Rendering.HighDefinition
             if (!IsHdrpAssetUsedCorrect())
                 FixHdrpAssetUsed(fromAsync: false);
 
-            HDRenderPipeline.currentAsset.enableSRPBatcher = true;
+            var hdAsset = HDRenderPipeline.currentAsset;
+            hdAsset.enableSRPBatcher = true;
+            EditorUtility.SetDirty(hdAsset);
         }
 
         bool IsHdrpAssetDiffusionProfileCorrect()
@@ -271,7 +273,6 @@ namespace UnityEditor.Rendering.HighDefinition
             var profileList = HDRenderPipeline.defaultAsset?.diffusionProfileSettingsList;
             return IsHdrpAssetUsedCorrect() && profileList.Length != 0 && profileList.Any(p => p != null);
         }
-
         void FixHdrpAssetDiffusionProfile()
         {
             if (!IsHdrpAssetUsedCorrect())
@@ -279,6 +280,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
             var hdAsset = HDRenderPipeline.currentAsset;
             hdAsset.diffusionProfileSettingsList = hdAsset.renderPipelineEditorResources.defaultDiffusionProfileSettingsList;
+            EditorUtility.SetDirty(hdAsset);
         }
 
         bool IsDefaultSceneCorrect()
@@ -306,6 +308,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
             var hdAsset = HDRenderPipeline.currentAsset;
             EditorDefaultSettings.GetOrAssignDefaultVolumeProfile(hdAsset);
+            EditorUtility.SetDirty(hdAsset);
         }
 
         #endregion


### PR DESCRIPTION
### Purpose of this PR
When you do a fix all in the Wizard for HDRP+DXR and you have existing asset that have modification done by the wizard and that then you need to restart due to graphic API changed, all modification in the assets are losts. (This not concerne creation)

This PR fix the missing dirty on edited assets

---
### Testing status

**Manual Tests**: 

**Automated Tests**: 

---
### Comments to reviewers
