### PR TITLE
Fix lighting attenuation precision for Vulkan on Adreno GPUs

### DIFF
--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -41,7 +41,7 @@ struct Light
 {
     half3   direction;
     half3   color;
-    half    distanceAttenuation;
+    float   distanceAttenuation;
     half    shadowAttenuation;
 };
 
@@ -142,7 +142,7 @@ Light GetAdditionalPerObjectLight(int perObjectLightIndex, float3 positionWS)
     float distanceSqr = max(dot(lightVector, lightVector), HALF_MIN);
 
     half3 lightDirection = half3(lightVector * rsqrt(distanceSqr));
-    half attenuation = DistanceAttenuation(distanceSqr, distanceAndSpotAttenuation.xy) * AngleAttenuation(spotDirection.xyz, lightDirection, distanceAndSpotAttenuation.zw);
+    float attenuation = DistanceAttenuation(distanceSqr, distanceAndSpotAttenuation.xy) * AngleAttenuation(spotDirection.xyz, lightDirection, distanceAndSpotAttenuation.zw);
 
     Light light;
     light.direction = lightDirection;
@@ -516,9 +516,9 @@ void MixRealtimeAndBakedGI(inout Light light, half3 normalWS, inout half3 bakedG
 ///////////////////////////////////////////////////////////////////////////////
 //                      Lighting Functions                                   //
 ///////////////////////////////////////////////////////////////////////////////
-half3 LightingLambert(half3 lightColor, half3 lightDir, half3 normal)
+float3 LightingLambert(half3 lightColor, float3 lightDir, float3 normal)
 {
-    half NdotL = saturate(dot(normal, lightDir));
+    float NdotL = saturate(dot(normal, lightDir));
     return lightColor * NdotL;
 }
 
@@ -599,7 +599,7 @@ half4 UniversalFragmentBlinnPhong(InputData inputData, half3 diffuse, half4 spec
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, half4(0, 0, 0, 0));
 
     half3 attenuatedLightColor = mainLight.color * (mainLight.distanceAttenuation * mainLight.shadowAttenuation);
-    half3 diffuseColor = inputData.bakedGI + LightingLambert(attenuatedLightColor, mainLight.direction, inputData.normalWS);
+    float3 diffuseColor = inputData.bakedGI + LightingLambert(attenuatedLightColor, mainLight.direction, inputData.normalWS);
     half3 specularColor = LightingSpecular(attenuatedLightColor, mainLight.direction, inputData.normalWS, inputData.viewDirectionWS, specularGloss, smoothness);
 
 #ifdef _ADDITIONAL_LIGHTS


### PR DESCRIPTION
### Purpose of this PR
Fixes light attenuation precision for Vulkan running on Android Adreno GPUs
![AttenuationPrecision](https://user-images.githubusercontent.com/9800196/67685202-4f78a880-f99d-11e9-916f-c1cc9fcbe579.png)

Previous PR for GLES https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/3172

---
### Testing status
Manually tested on Galaxy Note9 (Adreno 630)
Project attached to fogbugz case: https://issuetracker.unity3d.com/product/unity/issues/guid/1131387/

---
### Comments to reviewers
