### PR TITLE
Surface Shader Graph

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Surface2DPass.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Surface2DPass.hlsl
@@ -1,0 +1,28 @@
+PackedVaryings vert(Attributes input)
+{
+    Varyings output = (Varyings)0;
+    output = BuildVaryings(input);
+    PackedVaryings packedOutput = (PackedVaryings)0;
+    packedOutput = PackVaryings(output);
+    return packedOutput;
+}
+
+half4 frag(PackedVaryings packedInput) : SV_TARGET
+{
+    Varyings unpacked = UnpackVaryings(packedInput);
+    UNITY_SETUP_INSTANCE_ID(unpacked);
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(unpacked);
+
+    SurfaceDescriptionInputs surfaceDescriptionInputs = BuildSurfaceDescriptionInputs(unpacked);
+    SurfaceDescription surfaceDescription = SurfaceDescriptionFunction(surfaceDescriptionInputs);
+
+    Light mainLight = GetMainLight(inputData.shadowCoord);
+    MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, half4(0, 0, 0, 0));
+
+    #if _AlphaClip
+        clip(surfaceDescription.Alpha - surfaceDescription.AlphaClipThreshold);
+    #endif
+
+    half4 color = half4(surfaceDescription.Diffuse + surfaceDescription.Emission, surfaceDescription.Alpha);
+    return color;
+}

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Surface2DPass.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Surface2DPass.hlsl
@@ -16,9 +16,6 @@ half4 frag(PackedVaryings packedInput) : SV_TARGET
     SurfaceDescriptionInputs surfaceDescriptionInputs = BuildSurfaceDescriptionInputs(unpacked);
     SurfaceDescription surfaceDescription = SurfaceDescriptionFunction(surfaceDescriptionInputs);
 
-    Light mainLight = GetMainLight(inputData.shadowCoord);
-    MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, half4(0, 0, 0, 0));
-
     #if _AlphaClip
         clip(surfaceDescription.Alpha - surfaceDescription.AlphaClipThreshold);
     #endif

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/SurfaceForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/SurfaceForwardPass.hlsl
@@ -1,0 +1,40 @@
+void BuildInputData(Varyings input, out InputData inputData)
+{
+    inputData.positionWS = input.positionWS;
+    inputData.normalWS = NormalizeNormalPerPixel(input.normalWS);
+    inputData.viewDirectionWS = SafeNormalize(input.viewDirectionWS);
+    inputData.shadowCoord = input.shadowCoord;
+    inputData.fogCoord = input.fogFactorAndVertexLight.x;
+    inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
+    inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.sh, inputData.normalWS);
+}
+
+PackedVaryings vert(Attributes input)
+{
+    Varyings output = (Varyings)0;
+    output = BuildVaryings(input);
+    PackedVaryings packedOutput = (PackedVaryings)0;
+    packedOutput = PackVaryings(output);
+    return packedOutput;
+}
+
+half4 frag(PackedVaryings packedInput) : SV_TARGET
+{
+    Varyings unpacked = UnpackVaryings(packedInput);
+    UNITY_SETUP_INSTANCE_ID(unpacked);
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(unpacked);
+
+    SurfaceDescriptionInputs surfaceDescriptionInputs = BuildSurfaceDescriptionInputs(unpacked);
+    SurfaceDescription surfaceDescription = SurfaceDescriptionFunction(surfaceDescriptionInputs);
+
+    #if _AlphaClip
+        clip(surfaceDescription.Alpha - surfaceDescription.AlphaClipThreshold);
+    #endif
+
+    InputData inputData;
+    BuildInputData(unpacked, inputData);
+
+    float3 color = float3(MixFog(surfaceDescription.Diffuse + surfaceDescription.Emission, inputData.fogCoord));
+
+    return half4(color.rgb, surfaceDescription.Alpha);
+}

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalSurfaceSubShader.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalSurfaceSubShader.cs
@@ -392,6 +392,9 @@ namespace UnityEditor.Rendering.Universal
         };
         #endregion
 
+        public UniversalSurfaceSubShader()
+        { }
+
         public int GetPreviewPassIndex() { return 0; }
 
         ActiveFields GetActiveFieldsFromMasterNode(StylizedMasterNode masterNode, ShaderPass pass)
@@ -415,8 +418,6 @@ namespace UnityEditor.Rendering.Universal
             {
                 baseActiveFields.Add("AlphaClip");
             }
-
-            // baseActiveFields.Add("Normal");
 
             baseActiveFields.Add("SpecularSetup");
 
@@ -502,8 +503,5 @@ namespace UnityEditor.Rendering.Universal
         {
             return renderPipelineAsset is UniversalRenderPipelineAsset;
         }
-
-        public UniversalLitSubShader()
-        { }
     }
 }

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalSurfaceSubShader.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalSurfaceSubShader.cs
@@ -1,0 +1,509 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph;
+using UnityEditor.ShaderGraph.Internal;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+using Data.Util;
+
+namespace UnityEditor.Rendering.Universal
+{
+    [Serializable]
+    class UniversalSurfaceSubShader : ISurfaceSubShader
+    {
+        #region Passes
+        ShaderPass m_ForwardPass = new ShaderPass
+        {
+            // Definition
+            displayName = "Universal Forward",
+            referenceName = "SHADERPASS_FORWARD",
+            lightMode = "UniversalForward",
+            passInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/SurfaceForwardPass.hlsl",
+            varyingsInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl",
+            useInPreview = true,
+
+            // Port mask
+            vertexPorts = new List<int>()
+            {
+                StylizedMasterNode.VertexNormalSlotId,
+                StylizedMasterNode.VertexPositionSlotId,
+                StylizedMasterNode.VertexTangentSlotId,
+            },
+            pixelPorts = new List<int>
+            {
+                StylizedMasterNode.AlphaSlotId,
+                StylizedMasterNode.AlphaThresholdSlotId,
+                StylizedMasterNode.DiffuseSlotId,
+                StylizedMasterNode.EmissionSlotId,
+            },
+
+            // Required fields
+            requiredAttributes = new List<string>()
+            {
+                "Attributes.uv1", //needed for meta vertex position
+            },
+
+            // Required fields
+            requiredVaryings = new List<string>()
+            {
+                "Varyings.positionWS",
+                "Varyings.normalWS",
+                "Varyings.tangentWS",               // needed for vertex lighting
+                "Varyings.bitangentWS",
+                "Varyings.viewDirectionWS",
+                "Varyings.lightmapUV",
+                "Varyings.sh",
+                "Varyings.fogFactorAndVertexLight", // fog and vertex lighting, vert input is dependency
+                "Varyings.shadowCoord",             // shadow coord, vert input is dependency
+            },
+
+            // Pass setup
+            includes = new List<string>()
+            {
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl",
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl",
+            },
+            pragmas = new List<string>()
+            {
+                "prefer_hlslcc gles",
+                "exclude_renderers d3d11_9x",
+                "target 2.0",
+                "multi_compile_fog",
+                "multi_compile_instancing",
+            },
+            keywords = new KeywordDescriptor[]
+            {
+                s_LightmapKeyword,
+                s_DirectionalLightmapCombinedKeyword,
+                s_MainLightShadowsKeyword,
+                s_MainLightShadowsCascadeKeyword,
+                s_AdditionalLightsKeyword,
+                s_AdditionalLightShadowsKeyword,
+                s_ShadowsSoftKeyword,
+                s_MixedLightingSubtractiveKeyword,
+            },
+        };
+
+        ShaderPass m_DepthOnlyPass = new ShaderPass()
+        {
+            // Definition
+            displayName = "DepthOnly",
+            referenceName = "SHADERPASS_DEPTHONLY",
+            lightMode = "DepthOnly",
+            passInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/DepthOnlyPass.hlsl",
+            varyingsInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl",
+            useInPreview = true,
+
+            // Port mask
+            vertexPorts = new List<int>()
+            {
+                StylizedMasterNode.VertexNormalSlotId,
+                StylizedMasterNode.VertexPositionSlotId,
+                StylizedMasterNode.VertexTangentSlotId,
+            },
+            pixelPorts = new List<int>()
+            {
+                StylizedMasterNode.AlphaSlotId,
+                StylizedMasterNode.AlphaThresholdSlotId
+            },
+
+            // Render State Overrides
+            ZWriteOverride = "ZWrite On",
+            ColorMaskOverride = "ColorMask 0",
+
+            // Pass setup
+            includes = new List<string>()
+            {
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl",
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl",
+            },
+            pragmas = new List<string>()
+            {
+                "prefer_hlslcc gles",
+                "exclude_renderers d3d11_9x",
+                "target 2.0",
+                "multi_compile_instancing",
+            },
+        };
+
+        ShaderPass m_ShadowCasterPass = new ShaderPass()
+        {
+            // Definition
+            displayName = "ShadowCaster",
+            referenceName = "SHADERPASS_SHADOWCASTER",
+            lightMode = "ShadowCaster",
+            passInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShadowCasterPass.hlsl",
+            varyingsInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl",
+
+            // Port mask
+            vertexPorts = new List<int>()
+            {
+                StylizedMasterNode.VertexNormalSlotId,
+                StylizedMasterNode.VertexPositionSlotId,
+                StylizedMasterNode.VertexTangentSlotId
+            },
+            pixelPorts = new List<int>()
+            {
+                StylizedMasterNode.AlphaSlotId,
+                StylizedMasterNode.AlphaThresholdSlotId
+            },
+
+            // Required fields
+            requiredAttributes = new List<string>()
+            {
+                "Attributes.normalOS",
+            },
+
+            // Render State Overrides
+            ZWriteOverride = "ZWrite On",
+            ZTestOverride = "ZTest LEqual",
+
+            // Pass setup
+            includes = new List<string>()
+            {
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl",
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl",
+            },
+            pragmas = new List<string>()
+            {
+                "prefer_hlslcc gles",
+                "exclude_renderers d3d11_9x",
+                "target 2.0",
+                "multi_compile_instancing",
+            },
+        };
+
+        ShaderPass m_LitMetaPass = new ShaderPass()
+        {
+            // Definition
+            displayName = "Meta",
+            referenceName = "SHADERPASS_META",
+            lightMode = "Meta",
+            passInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/LightingMetaPass.hlsl",
+            varyingsInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl",
+
+            // Port mask
+            vertexPorts = new List<int>()
+            {
+                StylizedMasterNode.VertexNormalSlotId,
+                StylizedMasterNode.VertexPositionSlotId,
+                StylizedMasterNode.VertexTangentSlotId
+            },
+            pixelPorts = new List<int>()
+            {
+                StylizedMasterNode.AlphaSlotId,
+                StylizedMasterNode.AlphaThresholdSlotId,
+                StylizedMasterNode.DiffuseSlotId,
+                StylizedMasterNode.EmissionSlotId,
+            },
+
+            // Required fields
+            requiredAttributes = new List<string>()
+            {
+                "Attributes.uv1", //needed for meta vertex position
+                "Attributes.uv2", //needed for meta vertex position
+            },
+
+            // Render State Overrides
+            ZWriteOverride = "ZWrite On",
+            ZTestOverride = "ZTest LEqual",
+
+            // Pass setup
+            includes = new List<string>()
+            {
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/MetaInput.hlsl",
+            },
+            pragmas = new List<string>()
+            {
+                "prefer_hlslcc gles",
+                "exclude_renderers d3d11_9x",
+                "target 2.0",
+            },
+            keywords = new KeywordDescriptor[]
+            {
+                s_SmoothnessChannelKeyword,
+            },
+        };
+
+        ShaderPass m_2DPass = new ShaderPass()
+        {
+            // Definition
+            referenceName = "SHADERPASS_2D",
+            lightMode = "Universal2D",
+            passInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Surface2DPass.hlsl",
+            varyingsInclude = "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl",
+
+            // Port mask
+            vertexPorts = new List<int>()
+            {
+                StylizedMasterNode.VertexNormalSlotId,
+                StylizedMasterNode.VertexPositionSlotId,
+                StylizedMasterNode.VertexTangentSlotId
+            },
+            pixelPorts = new List<int>()
+            {
+                StylizedMasterNode.AlphaSlotId,
+                StylizedMasterNode.AlphaThresholdSlotId,
+                StylizedMasterNode.DiffuseSlotId,
+                StylizedMasterNode.EmissionSlotId,
+            },
+
+            // Pass setup
+            includes = new List<string>()
+            {
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl",
+                "Packages/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl",
+                "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl",
+            },
+            pragmas = new List<string>()
+            {
+                "prefer_hlslcc gles",
+                "exclude_renderers d3d11_9x",
+                "target 2.0",
+                "multi_compile_instancing",
+            },
+        };
+        #endregion
+
+        #region Keywords
+        static KeywordDescriptor s_AdditionalLightsKeyword = new KeywordDescriptor()
+        {
+            displayName = "Additional Lights",
+            referenceName = "_ADDITIONAL_LIGHTS",
+            type = KeywordType.Enum,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+            entries = new KeywordEntry[]
+            {
+                new KeywordEntry() { displayName = "Vertex", referenceName = "LIGHTS_VERTEX" },
+                new KeywordEntry() { displayName = "Fragment", referenceName = "LIGHTS" },
+                new KeywordEntry() { displayName = "Off", referenceName = "OFF" },
+            }
+        };
+
+        static KeywordDescriptor s_AdditionalLightShadowsKeyword = new KeywordDescriptor()
+        {
+            displayName = "Additional Light Shadows",
+            referenceName = "_ADDITIONAL_LIGHT_SHADOWS",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_DirectionalLightmapCombinedKeyword = new KeywordDescriptor()
+        {
+            displayName = "Directional Lightmap Combined",
+            referenceName = "DIRLIGHTMAP_COMBINED",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_LightmapKeyword = new KeywordDescriptor()
+        {
+            displayName = "Lightmap",
+            referenceName = "LIGHTMAP_ON",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_MainLightShadowsCascadeKeyword = new KeywordDescriptor()
+        {
+            displayName = "Main Light Shadows Cascade",
+            referenceName = "_MAIN_LIGHT_SHADOWS_CASCADE",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_MainLightShadowsKeyword = new KeywordDescriptor()
+        {
+            displayName = "Main Light Shadows",
+            referenceName = "_MAIN_LIGHT_SHADOWS",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_MixedLightingSubtractiveKeyword = new KeywordDescriptor()
+        {
+            displayName = "Mixed Lighting Subtractive",
+            referenceName = "_MIXED_LIGHTING_SUBTRACTIVE",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_SampleGIKeyword = new KeywordDescriptor()
+        {
+            displayName = "Sample GI",
+            referenceName = "_SAMPLE_GI",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.ShaderFeature,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_ShadowScreen = new KeywordDescriptor()
+        {
+            displayName = "Screen Space Shadows",
+            referenceName = "SHADOWS_SCREEN",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_ShadowsSoftKeyword = new KeywordDescriptor()
+        {
+            displayName = "Shadows Soft",
+            referenceName = "_SHADOWS_SOFT",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
+        static KeywordDescriptor s_SmoothnessChannelKeyword = new KeywordDescriptor()
+        {
+            displayName = "Smoothness Channel",
+            referenceName = "_SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.ShaderFeature,
+            scope = KeywordScope.Global,
+        };
+        #endregion
+
+        public int GetPreviewPassIndex() { return 0; }
+
+        ActiveFields GetActiveFieldsFromMasterNode(StylizedMasterNode masterNode, ShaderPass pass)
+        {
+            var activeFields = new ActiveFields();
+            var baseActiveFields = activeFields.baseInstance;
+
+            // Graph Vertex
+            if (masterNode.IsSlotConnected(StylizedMasterNode.VertexPositionSlotId)
+                || masterNode.IsSlotConnected(StylizedMasterNode.VertexNormalSlotId)
+                || masterNode.IsSlotConnected(StylizedMasterNode.VertexTangentSlotId))
+            {
+                baseActiveFields.Add("features.graphVertex");
+            }
+
+            // Graph Pixel (always enabled)
+            baseActiveFields.Add("features.graphPixel");
+
+            if (masterNode.IsSlotConnected(StylizedMasterNode.AlphaThresholdSlotId)
+                || masterNode.GetInputSlots<Vector1MaterialSlot>().First(x => x.id == StylizedMasterNode.AlphaThresholdSlotId).value > 0.0f)
+            {
+                baseActiveFields.Add("AlphaClip");
+            }
+
+            // baseActiveFields.Add("Normal");
+
+            baseActiveFields.Add("SpecularSetup");
+
+            // Keywords for transparent
+            // #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
+            if (masterNode.surfaceType != ShaderGraph.SurfaceType.Opaque)
+            {
+                // transparent-only defines
+                baseActiveFields.Add("SurfaceType.Transparent");
+
+                // #pragma shader_feature _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
+                if (masterNode.alphaMode == AlphaMode.Alpha)
+                {
+                    baseActiveFields.Add("BlendMode.Alpha");
+                }
+                else
+                if (masterNode.alphaMode == AlphaMode.Additive)
+                {
+                    baseActiveFields.Add("BlendMode.Add");
+                }
+                else
+                if (masterNode.alphaMode == AlphaMode.Premultiply)
+                {
+                    baseActiveFields.Add("BlendMode.Premultiply");
+                }
+            }
+
+            return activeFields;
+        }
+
+        bool GenerateShaderPass(StylizedMasterNode masterNode, ShaderPass pass, GenerationMode mode, ShaderGenerator result, List<string> sourceAssetDependencyPaths)
+        {
+            UniversalShaderGraphUtilities.SetRenderState(masterNode.surfaceType, masterNode.alphaMode, masterNode.twoSided.isOn, ref pass);
+
+            // apply master node options to active fields
+            var activeFields = GetActiveFieldsFromMasterNode(masterNode, pass);
+
+            return ShaderGraph.GenerationUtils.GenerateShaderPass(masterNode,
+                                                                  pass,
+                                                                  mode,
+                                                                  activeFields,
+                                                                  result,
+                                                                  sourceAssetDependencyPaths,
+                                                                  UniversalShaderGraphResources.s_Dependencies,
+                                                                  UniversalShaderGraphResources.s_ResourceClassName,
+                                                                  UniversalShaderGraphResources.s_AssemblyName);
+        }
+
+        public string GetSubshader(IMasterNode masterNode, GenerationMode mode, List<string> sourceAssetDependencyPaths = null)
+        {
+            if (sourceAssetDependencyPaths is object)
+            {
+                // UniversalLitSubShader.cs
+                sourceAssetDependencyPaths.Add(AssetDatabase.GUIDToAssetPath("6a3b5a2c061d41747a1db8342a00e1dc"));
+            }
+
+            // Master Node data
+            var litMasterNode = masterNode as StylizedMasterNode;
+            var subShader = new ShaderGenerator();
+
+            subShader.AddShaderChunk("SubShader", true);
+            subShader.AddShaderChunk("{", true);
+            subShader.Indent();
+            {
+                var surfaceTags = ShaderGenerator.BuildMaterialTags(litMasterNode.surfaceType);
+                var tagsBuilder = new ShaderStringBuilder(0);
+                surfaceTags.GetTags(tagsBuilder, "UniversalPipeline");
+                subShader.AddShaderChunk(tagsBuilder.ToString());
+
+                GenerateShaderPass(litMasterNode, m_ForwardPass, mode, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPass(litMasterNode, m_ShadowCasterPass, mode, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPass(litMasterNode, m_DepthOnlyPass, mode, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPass(litMasterNode, m_LitMetaPass, mode, subShader, sourceAssetDependencyPaths);
+                GenerateShaderPass(litMasterNode, m_2DPass, mode, subShader, sourceAssetDependencyPaths);
+            }
+            subShader.Deindent();
+            subShader.AddShaderChunk("}", true);
+
+            return subShader.GetShaderString(0);
+        }
+
+        public bool IsPipelineCompatible(RenderPipelineAsset renderPipelineAsset)
+        {
+            return renderPipelineAsset is UniversalRenderPipelineAsset;
+        }
+
+        public UniversalLitSubShader()
+        { }
+    }
+}

--- a/com.unity.shadergraph/Editor/AssetCallbacks/CreateShaderGraph.cs
+++ b/com.unity.shadergraph/Editor/AssetCallbacks/CreateShaderGraph.cs
@@ -21,5 +21,11 @@ namespace UnityEditor.ShaderGraph
         {
             GraphUtil.CreateNewGraph(new VfxMasterNode());
         }
+
+        [MenuItem("Assets/Create/Shader/Surface Shader Graph", false, 208)]
+        public static void CreateStylizedMasterMaterialGraph()
+        {
+            GraphUtil.CreateNewGraph(new SurfaceMasterNode());
+        }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/ISurfaceSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/ISurfaceSubShader.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace UnityEditor.ShaderGraph
+{
+    interface ISurfaceSubShader : ISubShader
+    { }
+}

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/SurfaceMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/SurfaceMasterNode.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph.Drawing;
+using UnityEditor.ShaderGraph.Drawing.Controls;
+using UnityEditor.ShaderGraph.Internal;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace UnityEditor.ShaderGraph
+{
+    [Serializable]
+    [Title("Master", "Stylized")]
+    class StylizedMasterNode : MasterNode<ISurfaceSubShader>, IMayRequirePosition, IMayRequireNormal, IMayRequireTangent
+    {
+        public const string AlphaSlotName = "Alpha";
+        public const string AlphaClipThresholdSlotName = "AlphaClipThreshold";
+        public const string DiffuseSlotName = "Diffuse";
+        public const string EmissionSlotName = "Emission";
+        public const string VertexNormalSlotName = "Vertex Normal";
+        public const string VertexPositionSlotName = "Vertex Position";
+        public const string VertexTangentSlotName = "Vertex Tangent";
+
+        public const int AlphaSlotId = 5;
+        public const int AlphaThresholdSlotId = 6;
+        public const int DiffuseSlotId = 3;
+        public const int EmissionSlotId = 4;
+        public const int VertexNormalSlotId = 1;
+        public const int VertexPositionSlotId = 0;
+        public const int VertexTangentSlotId = 2;
+
+        [SerializeField]
+        AlphaMode m_AlphaMode;
+
+        [SerializeField]
+        SurfaceType m_SurfaceType;
+
+        [SerializeField]
+        bool m_TwoSided;
+
+        public StylizedMasterNode()
+        {
+            UpdateNodeAfterDeserialization();
+        }
+
+        public AlphaMode alphaMode
+        {
+            get { return m_AlphaMode; }
+            set
+            {
+                if (m_AlphaMode == value)
+                    return;
+
+                m_AlphaMode = value;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        public SurfaceType surfaceType
+        {
+            get { return m_SurfaceType; }
+            set
+            {
+                if (m_SurfaceType == value)
+                    return;
+
+                m_SurfaceType = value;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        public ToggleData twoSided
+        {
+            get { return new ToggleData(m_TwoSided); }
+            set
+            {
+                if (m_TwoSided == value.isOn)
+                    return;
+                m_TwoSided = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        public sealed override void UpdateNodeAfterDeserialization()
+        {
+            base.UpdateNodeAfterDeserialization();
+            name = "Surface Shader Master";
+            AddSlot(new PositionMaterialSlot(VertexPositionSlotId, VertexPositionSlotName, VertexPositionSlotName, CoordinateSpace.Object, ShaderStageCapability.Vertex));
+            AddSlot(new NormalMaterialSlot(VertexNormalSlotId, VertexNormalSlotName, VertexNormalSlotName, CoordinateSpace.Object, ShaderStageCapability.Vertex));
+            AddSlot(new TangentMaterialSlot(VertexTangentSlotId, VertexTangentSlotName, VertexTangentSlotName, CoordinateSpace.Object, ShaderStageCapability.Vertex));
+            AddSlot(new ColorRGBMaterialSlot(DiffuseSlotId, DiffuseSlotName, DiffuseSlotName, SlotType.Input, Color.grey, ColorMode.Default, ShaderStageCapability.Fragment));
+            AddSlot(new ColorRGBMaterialSlot(EmissionSlotId, EmissionSlotName, EmissionSlotName, SlotType.Input, Color.black, ColorMode.HDR, ShaderStageCapability.Fragment));
+            AddSlot(new Vector1MaterialSlot(AlphaSlotId, AlphaSlotName, AlphaSlotName, SlotType.Input, 1f, ShaderStageCapability.Fragment));
+            AddSlot(new Vector1MaterialSlot(AlphaThresholdSlotId, AlphaClipThresholdSlotName, AlphaClipThresholdSlotName, SlotType.Input, 0.5f, ShaderStageCapability.Fragment));
+
+            // Clear out slot names that do not match the slots we support.
+            RemoveSlotsNameNotMatching(new[] {
+                                        VertexPositionSlotId,
+                                        VertexNormalSlotId,
+                                        VertexTangentSlotId,
+                                        DiffuseSlotId,
+                                        EmissionSlotId,
+                                        AlphaSlotId,
+                                        AlphaThresholdSlotId,
+                                    }, true);
+        }
+
+        protected override VisualElement CreateCommonSettingsElement()
+        {
+            return new StylizedSettingsView(this);
+        }
+
+        public NeededCoordinateSpace RequiresNormal(ShaderStageCapability stageCapability)
+        {
+            List<MaterialSlot> slots = new List<MaterialSlot>();
+            GetSlots(slots);
+
+            List<MaterialSlot> validSlots = new List<MaterialSlot>();
+            for (int i = 0; i < slots.Count; i++)
+            {
+                if (slots[i].stageCapability != ShaderStageCapability.All && slots[i].stageCapability != stageCapability)
+                    continue;
+
+                validSlots.Add(slots[i]);
+            }
+            return validSlots.OfType<IMayRequireNormal>().Aggregate(NeededCoordinateSpace.None, (mask, node) => mask | node.RequiresNormal(stageCapability));
+        }
+
+        public NeededCoordinateSpace RequiresPosition(ShaderStageCapability stageCapability)
+        {
+            List<MaterialSlot> slots = new List<MaterialSlot>();
+            GetSlots(slots);
+
+            List<MaterialSlot> validSlots = new List<MaterialSlot>();
+            for (int i = 0; i < slots.Count; i++)
+            {
+                if (slots[i].stageCapability != ShaderStageCapability.All && slots[i].stageCapability != stageCapability)
+                    continue;
+
+                validSlots.Add(slots[i]);
+            }
+            return validSlots.OfType<IMayRequirePosition>().Aggregate(NeededCoordinateSpace.None, (mask, node) => mask | node.RequiresPosition(stageCapability));
+        }
+
+        public NeededCoordinateSpace RequiresTangent(ShaderStageCapability stageCapability)
+        {
+            List<MaterialSlot> slots = new List<MaterialSlot>();
+            GetSlots(slots);
+
+            List<MaterialSlot> validSlots = new List<MaterialSlot>();
+            for (int i = 0; i < slots.Count; i++)
+            {
+                if (slots[i].stageCapability != ShaderStageCapability.All && slots[i].stageCapability != stageCapability)
+                    continue;
+
+                validSlots.Add(slots[i]);
+            }
+            return validSlots.OfType<IMayRequireTangent>().Aggregate(NeededCoordinateSpace.None, (mask, node) => mask | node.RequiresTangent(stageCapability));
+        }
+    }
+}

--- a/com.unity.shadergraph/Editor/Drawing/Views/SurfaceSettingsView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/SurfaceSettingsView.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor.ShaderGraph;
+using UnityEditor.Graphing.Util;
+using UnityEditor.ShaderGraph.Drawing.Controls;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace UnityEditor.ShaderGraph.Drawing
+{
+    class SurfaceSettingsView : VisualElement
+    {
+        StylizedMasterNode m_Node;
+
+        public StylizedSettingsView(StylizedMasterNode node)
+        {
+            m_Node = node;
+
+            PropertySheet ps = new PropertySheet();
+
+            ps.Add(new PropertyRow(new Label("Surface")), (row) =>
+            {
+                row.Add(new EnumField(SurfaceType.Opaque), (field) =>
+                {
+                    field.value = m_Node.surfaceType;
+                    field.RegisterValueChangedCallback(ChangeSurface);
+                });
+            });
+
+            ps.Add(new PropertyRow(new Label("Blend")), (row) =>
+            {
+                row.Add(new EnumField(AlphaMode.Additive), (field) =>
+                {
+                    field.value = m_Node.alphaMode;
+                    field.RegisterValueChangedCallback(ChangeAlphaMode);
+                });
+            });
+
+            ps.Add(new PropertyRow(new Label("Two Sided")), (row) =>
+            {
+                row.Add(new Toggle(), (toggle) =>
+                {
+                    toggle.value = m_Node.twoSided.isOn;
+                    toggle.OnToggleChanged(ChangeTwoSided);
+                });
+            });
+
+            Add(ps);
+        }
+
+        void ChangeSurface(ChangeEvent<Enum> evt)
+        {
+            if (Equals(m_Node.surfaceType, evt.newValue))
+                return;
+
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Surface Change");
+            m_Node.surfaceType = (SurfaceType)evt.newValue;
+        }
+
+        void ChangeAlphaMode(ChangeEvent<Enum> evt)
+        {
+            if (Equals(m_Node.alphaMode, evt.newValue))
+                return;
+
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Alpha Mode Change");
+            m_Node.alphaMode = (AlphaMode)evt.newValue;
+        }
+
+        void ChangeTwoSided(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Two Sided Change");
+            ToggleData td = m_Node.twoSided;
+            td.isOn = evt.newValue;
+            m_Node.twoSided = td;
+        }
+    }
+}


### PR DESCRIPTION
This change adds a Surface Shader master node to Shader Graph for Universal Render Pipeline.

The Surface Shader Master is intended to be a master node which supports stylized shader graphs like a Unlit Master, will all of the functionality and power of a PBR Master. Surface Shader Master does not provide any intrinsic lighting or shadowing (ala Unlit Master), but does provide access to the Unity libraries which do provide lighting and shading (ala PBR Master), without any keywords that disable functionality.

The goal is to provide a master node from which creators are free to create the effects and appearances they want, without limitation imposed by intrinsic behaviors.

I was inspired to submit this after read/watching the following content (provided by Unity) because in all cases the author/speaker lamented the lack of functionality provided by Shader Graph. The same lack of functionality I was being personally annoyed by as well.

* https://www.youtube.com/watch?v=DOLE4nrK97g
* https://blogs.unity3d.com/2019/07/31/custom-lighting-in-shader-graph-expanding-your-graphs-in-2019/
* https://connect.unity.com/p/zelda-inspired-toon-shading-in-shadergraph

Below are a couple of screen captures I've taken of the new graph in action. The first image is a capture of a graph using the new node (I've chose to implement something akin to the links above). The second image is a capture of the Game View using a material created by the graph in the previous image.

**Graph View**
![image](https://user-images.githubusercontent.com/11578325/67690922-2132a300-f974-11e9-80dd-9e4d12d6df67.png)

**Game View** (2 capsules + 1 cube)
![image](https://user-images.githubusercontent.com/11578325/67690839-fea08a00-f973-11e9-821a-08bb54847d3e.png)

I have been wrestling with the name because naming things is difficult. Originally, I named it "stylized master" because my goal was to support a mode stylized look. However, it was pointed out to me that it could support more than just "stylized" shaders -- and it was more like a surface shader for Shader Graph. Hence the current name of "Surface Shader Master". I am 100% open to better names.

Other names I've though of (and discarded):
 - **Basic Graph**: because while it is basic, newer users might assume it is the easiest one to start with (and it is quite the opposite).
 - **Simple Graph**: see _Basic Graph_.
 - **Customizable Graph**: because aren't _all_ grpahs customizable? I mean, that is the point.

---
Caveats:
- My first PR for anything Unity related, so I am sure I've done something wrong code wise. I'll be happy to conform the changes as needed, just let me know in the PR comments / review.
- I have been unsuccessful in getting any kind of testing, or even local builds (outside of Unity itself) working. I have been able to build and use the new master node using Unity 2019.3b8
---
Leaving the lengthy checklist of what to do when submitting a PR below, to be completed after I know if there is any desire for this kind of change.

### Checklist for PR maker
- Have you added a Label? : HDRP, Universal, ShaderGraph etc...
- Have you added a label for backport (if needed)? : need-backport-2019.3  .  When the PR is backported the label will be change ton backported-2019.3
- Have you added a changelog? Each package have a changelog.
- Have you updated or added the documentation for you PR? When property name is changed, when a feature behavior is change, when adding a new features, think to update the documentation in the same PR.
- Have you added a graphic test for your PR (if needed)? When adding new feature or discovering a bug that isn't cover by a test, please add a graphic test
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (suppress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: manually compiled and executed the code inside Unity, including created an example graph and used it to create a material and applied that material in a scene.

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
