### PR TITLE
[Universal] Timeline dependency fix

### DIFF
--- a/TestProjects/UniversalGfxTestStereo/Packages/manifest.json
+++ b/TestProjects/UniversalGfxTestStereo/Packages/manifest.json
@@ -17,7 +17,7 @@
     "com.unity.test-framework": "1.1.1",
     "com.unity.testframework.graphics": "file:../../../com.unity.testframework.graphics",
     "com.unity.textmeshpro": "2.0.1",
-    "com.unity.timeline": "1.2.2",
+    "com.unity.timeline": "1.2.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.legacyinputhelpers": "2.0.4",
     "com.unity.modules.ai": "1.0.0",

--- a/TestProjects/UniversalGraphicsTest/Packages/manifest.json
+++ b/TestProjects/UniversalGraphicsTest/Packages/manifest.json
@@ -17,7 +17,7 @@
     "com.unity.test-framework": "1.1.1",
     "com.unity.testframework.graphics": "file:../../../com.unity.testframework.graphics",
     "com.unity.textmeshpro": "2.0.1",
-    "com.unity.timeline": "1.1.0",
+    "com.unity.timeline": "1.2.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.legacyinputhelpers": "2.0.4",
     "com.unity.modules.ai": "1.0.0",


### PR DESCRIPTION
### Purpose of this PR
Update timeline dependency version in the Universal projects (regular and stereo) manifest to stop the 
```
An error occurred while resolving packages:
 Project has invalid dependencies:
   com.unity.timeline: Package [com.unity.timeline@1.1.0] cannot be found
```
error from occurring.

---
### Testing status

**Yamato**:
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/universal%252Ftimeline-dependency-fix

Error no longer occurs, and the projects pass

Note that the Github API doesn't update the test status if a test is re-run at the same changeset - so the OSX Metal test shows as failing, but it actually passed (see the link above)