### PR TITLE
Fix issue 1189196

### DIFF
--- a/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/Unity.Testing.SRP.Universal.Editor.asmdef
+++ b/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/Unity.Testing.SRP.Universal.Editor.asmdef
@@ -4,7 +4,9 @@
         "GUID:e18141520846dcc44b725b2f74e91229",
         "GUID:ed05cc0a83a5a40c0a6e72098212c312",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:0acc523941302664db1f4e527237feb3"
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:c579267770062bf448e75eb160330b7f",
+        "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
     "includePlatforms": [
         "Editor"
@@ -19,5 +21,6 @@
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs
+++ b/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+public class UniversalProjectEditorTests
+{
+    private static UniversalRenderPipelineAsset currentAsset;
+
+    [Test]
+    public void GetCurrentAsset()
+    {
+        GetUniversalAsset();
+    }
+
+    [Test]
+    public void GetCurrentRenderer()
+    {
+        GetUniversalAsset();
+
+        Assert.IsNotNull(currentAsset.scriptableRenderer, "Current ScriptableRenderer is null.");
+    }
+
+    //Utilities
+    void GetUniversalAsset()
+    {
+        var renderpipelineAsset = GraphicsSettings.currentRenderPipeline;
+
+        if(renderpipelineAsset == null)
+            Assert.Fail("No Render Pipeline Asset assigned.");
+
+        if (renderpipelineAsset.GetType() == typeof(UniversalRenderPipelineAsset))
+        {
+            currentAsset = renderpipelineAsset as UniversalRenderPipelineAsset;
+        }
+        else
+        {
+            Assert.Inconclusive("Project not setup for Universal RP.");
+        }
+    }
+}

--- a/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs.meta
+++ b/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ddf535d28d764921a6709da5d30ba07f
+timeCreated: 1572431758

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for additional Directional Lights. The amount of additional Directional Lights is limited by the maximum Per-object Lights in the Render Pipeline Asset.
 - Added default implementations of OnPreprocessMaterialDescription for FBX, Obj, Sketchup and 3DS file formats.
 
+### Changed
+- Moved the icon that indicates the type of a Light 2D from the Inspector header to the Light Type field.
+- Eliminated some GC allocations from the 2D Renderer.
+- Added SceneSelection pass for TerrainLit shader.
+
 ### Fixed
 - Fixed an issue where there were 2 widgets showing the outer angle of a spot light.
 - Fixed an issue where Unity rendered fullscreen quads with the pink error shader when you enabled the Stop NaN post-processing pass.
@@ -22,10 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Freeform 2D Lights were not culled correctly when there was a Falloff Offset.
 - Fixed an issue where Tilemap palettes were invisible in the Tile Palette window when the 2D Renderer was in use. [case 1162550](https://issuetracker.unity3d.com/issues/adding-tiles-in-the-tile-palette-makes-the-tiles-invisible)
 - Fixed issue where black emission would cause unneccesary inspector UI repaints [case 1105661](https://issuetracker.unity3d.com/issues/lwrp-inspector-window-is-being-repainted-when-using-the-material-with-emission-enabled-and-set-to-black-00-0)
-### Changed
-- Moved the icon that indicates the type of a Light 2D from the Inspector header to the Light Type field.
-- Eliminated some GC allocations from the 2D Renderer.
-- Added SceneSelection pass for TerrainLit shader.
+- Fixed an issue when trying to get the Renderer via API on the first frame [case 1189196](https://issuetracker.unity3d.com/product/unity/issues/guid/1189196/)
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -112,7 +112,7 @@ namespace UnityEngine.Rendering.Universal
 
         // Renderer settings
         [SerializeField] internal ScriptableRendererData[] m_RendererDataList = new ScriptableRendererData[1];
-        internal ScriptableRenderer[] m_Renderers;
+        internal ScriptableRenderer[] m_Renderers = new ScriptableRenderer[1];
         [SerializeField] int m_DefaultRendererIndex = 0;
 
         // General settings


### PR DESCRIPTION
### Purpose of this PR
Fix issue where getting the renderer on first frame resulted in a null, the list is now initialised as one meaning if you request the renderer it will be created rather than erring out with a null.

https://issuetracker.unity3d.com/product/unity/issues/guid/1189196/

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: Added two new editor tests in the Universal Project, `GetCurrentAsset` and `GetCurrentRenderer` 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/universal%252Fbugfix%252Fcase-1189196/.yamato%252Fupm-ci-universal.yml%2523All_Universal_fast-trunk/655665/job

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
