### PR TITLE
Disable deprecation warning

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
@@ -342,13 +342,14 @@ namespace UnityEditor.Rendering.HighDefinition
                         }
                     case ProbeSettings.Mode.Baked:
                         {
+#pragma warning disable 618
                             if (UnityEditor.Lightmapping.giWorkflowMode
                                 != UnityEditor.Lightmapping.GIWorkflowMode.OnDemand)
                             {
                                 EditorGUILayout.HelpBox("Baking of this probe is automatic because this probe's type is 'Baked' and the Lighting window is using 'Auto Baking'. The texture created is stored in the GI cache.", MessageType.Info);
                                 break;
                             }
-
+#pragma warning restore 618
                             GUI.enabled = serialized.target.enabled;
 
                             // Bake button in non-continous mode

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyManager.cs
@@ -386,7 +386,9 @@ namespace UnityEngine.Rendering.HighDefinition
 
             bool useRealtimeGI = true;
 #if UNITY_EDITOR
+#pragma warning disable 618
             useRealtimeGI = UnityEditor.Lightmapping.realtimeGI;
+#pragma warning restore 618
 #endif
             // Working around GI current system
             // When using baked lighting, setting up the ambient probe should be sufficient => We only need to update RenderSettings.ambientProbe with either the static or visual sky ambient probe (computed from GPU)

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineLightEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineLightEditor.cs
@@ -58,8 +58,9 @@ namespace UnityEditor.Rendering.Universal
         public bool bakedShadowRadius { get { return typeIsSame && (lightProperty.type == LightType.Point || lightProperty.type == LightType.Spot) && settings.isBakedOrMixed; } }
         public bool bakedShadowAngle { get { return typeIsSame && lightProperty.type == LightType.Directional && settings.isBakedOrMixed; } }
         public bool shadowOptionsValue { get { return shadowTypeIsSame && lightProperty.shadows != LightShadows.None; } }
-
+#pragma warning disable 618
         public bool bakingWarningValue { get { return !UnityEditor.Lightmapping.bakedGI && lightmappingTypeIsSame && settings.isBakedOrMixed; } }
+#pragma warning restore 618
         public bool showLightBounceIntensity { get { return true; } }
 
         public bool isShadowEnabled { get { return settings.shadowsType.intValue != 0; } }

--- a/com.unity.testframework.graphics/Editor/SetupGraphicsTestCases.cs
+++ b/com.unity.testframework.graphics/Editor/SetupGraphicsTestCases.cs
@@ -125,9 +125,9 @@ namespace UnityEditor.TestTools.Graphics
                     Scene currentScene = EditorSceneManagement.EditorSceneManager.GetSceneAt(1);
 
                     EditorSceneManagement.EditorSceneManager.SetActiveScene(currentScene);
-
+#pragma warning disable 618
                     Lightmapping.giWorkflowMode = Lightmapping.GIWorkflowMode.OnDemand;
-                    
+#pragma warning restore 618
                     EditorUtility.DisplayProgressBar($"Baking Test Scenes {(sceneIndex + 1).ToString()}/{totalScenes.ToString()}", $"Baking {sceneAsset.name}", ((float)sceneIndex / totalScenes));
 
                     Lightmapping.Bake();
@@ -218,7 +218,9 @@ ReflectionProbe-*";
 
                     EditorSceneManagement.EditorSceneManager.OpenScene(scenePath, EditorSceneManagement.OpenSceneMode.Single);
                     EditorSceneManagement.EditorSceneManager.SetActiveScene( EditorSceneManagement.EditorSceneManager.GetSceneAt(0) );
+#pragma warning disable 618
                     Lightmapping.giWorkflowMode = Lightmapping.GIWorkflowMode.OnDemand;
+#pragma warning restore 618
                     EditorSceneManagement.EditorSceneManager.SaveScene( EditorSceneManagement.EditorSceneManager.GetSceneAt(0) );
                 }
 


### PR DESCRIPTION
### Purpose of this PR
https://ono.unity3d.com/unity/unity/pull-request/95782/_/lighting/lighting-settings-asset-take2 will hopefully land in 20.1 and will make all old settings API points for Lightmapping obsolete. They are still usable but will fire a warning. These changes make sure that we can still use the old API but it won't cause compile or runtime issues. 
---
### Testing status

**Manual Tests**: What did you do?
Nothing. It all seems to work with just disabling this warning. Have had to do this on a lot of code before. 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)
I have tests in my trunk PR that makes sure the old API still works and returns the same as the new. 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/lighting%252Flighting-settings-asset-take2-2
Ran the tests against my branch to make sure it will work once it lands. 

---
### Comments to reviewers
There is an internal API called `Lightmapping.GetLightingSettingsOrDefaultsFallback()` but we can't allow this to be public since we can't allow users to possibly change the global default settings that is read-only. Not sure how to do this in a nicer way for HDRPs right now. 