### PR TITLE
remove unneeded protected that trigger exception on rider

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDProbeUI.Drawers.cs
@@ -63,7 +63,7 @@ namespace UnityEditor.Rendering.HighDefinition
         static readonly GUIContent[] k_ModeContents = { new GUIContent("Baked"), new GUIContent("Custom"), new GUIContent("Realtime") };
         static readonly int[] k_ModeValues = { (int)ProbeSettings.Mode.Baked, (int)ProbeSettings.Mode.Custom, (int)ProbeSettings.Mode.Realtime };
 
-        protected internal struct Drawer<TProvider>
+        internal struct Drawer<TProvider>
             where TProvider : struct, IProbeUISettingsProvider, InfluenceVolumeUI.IInfluenceUISettingsProvider
         {
             // Toolbar content cache


### PR DESCRIPTION
### Purpose of this PR
Solve issue rised by Rider on wrong use of protected keyword

---
### Testing status

**Manual Tests**: 
**Automated Tests**: 

---
### Comments to reviewers
Linked to discution https://unity.slack.com/archives/C6Y79CZM0/p1573000718070400