### PR TITLE
Decals layermask bug

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -136,6 +136,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed Light units not matching light type
 - Fixed QualitySettings panel not displaying HDRP Asset
 - Fixed y-flip in scene view with XR SDK
+- Fixed Decal projectors do not immediately respond when parent object layer mask is changed in editor.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjector.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjector.cs
@@ -30,8 +30,10 @@ namespace UnityEngine.Rendering.HighDefinition
                 OnValidate();
             }
         }
-       
+
+#if UNITY_EDITOR
         private int m_Layer;
+#endif
 
         [SerializeField]
         private float m_DrawDistance = 1000.0f;
@@ -226,8 +228,10 @@ namespace UnityEngine.Rendering.HighDefinition
             }
 
             Matrix4x4 sizeOffset = Matrix4x4.Translate(decalOffset) * Matrix4x4.Scale(decalSize);
+#if UNITY_EDITOR
             m_Layer = gameObject.layer;
-            m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, m_Layer, m_FadeFactor);
+#endif
+            m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, gameObject.layer, m_FadeFactor);
         }
 
         void OnDisable()
@@ -259,7 +263,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
                     if (m_Material != null)
                     {
-                        m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, m_Layer, m_FadeFactor);
+                        m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, gameObject.layer, m_FadeFactor);
 
                         if (!DecalSystem.IsHDRenderPipelineDecal(m_Material.shader)) // non HDRP/decal shaders such as shader graph decal do not affect transparency
                         {
@@ -277,7 +281,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 }
                 else // no material change, just update whatever else changed
                 {
-                    DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, m_Layer, m_FadeFactor);
+                    DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, gameObject.layer, m_FadeFactor);
                 }
             }
         }
@@ -289,7 +293,7 @@ namespace UnityEngine.Rendering.HighDefinition
             {
                 Matrix4x4 sizeOffset = Matrix4x4.Translate(decalOffset) * Matrix4x4.Scale(decalSize);
                 m_Layer = gameObject.layer;
-                DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, m_Layer, m_FadeFactor);
+                DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, gameObject.layer, m_FadeFactor);
             }
         }
 #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjector.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjector.cs
@@ -30,6 +30,8 @@ namespace UnityEngine.Rendering.HighDefinition
                 OnValidate();
             }
         }
+        [SerializeField]
+        private int m_Layer = -1;
 
         [SerializeField]
         private float m_DrawDistance = 1000.0f;
@@ -279,7 +281,19 @@ namespace UnityEngine.Rendering.HighDefinition
             }
         }
 
-        void LateUpdate()
+#if UNITY_EDITOR
+        void Update() // only run in editor
+        {
+            if(m_Layer != gameObject.layer)
+            {
+                Matrix4x4 sizeOffset = Matrix4x4.Translate(decalOffset) * Matrix4x4.Scale(decalSize);
+                DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, gameObject.layer, m_FadeFactor);
+                m_Layer = gameObject.layer;
+            }
+        }
+#endif
+
+            void LateUpdate()
         {
             if (m_Handle != null)
             {

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjector.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalProjector.cs
@@ -30,8 +30,8 @@ namespace UnityEngine.Rendering.HighDefinition
                 OnValidate();
             }
         }
-        [SerializeField]
-        private int m_Layer = -1;
+       
+        private int m_Layer;
 
         [SerializeField]
         private float m_DrawDistance = 1000.0f;
@@ -226,7 +226,8 @@ namespace UnityEngine.Rendering.HighDefinition
             }
 
             Matrix4x4 sizeOffset = Matrix4x4.Translate(decalOffset) * Matrix4x4.Scale(decalSize);
-            m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, gameObject.layer, m_FadeFactor);
+            m_Layer = gameObject.layer;
+            m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, m_Layer, m_FadeFactor);
         }
 
         void OnDisable()
@@ -258,7 +259,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
                     if (m_Material != null)
                     {
-                        m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, gameObject.layer, m_FadeFactor);
+                        m_Handle = DecalSystem.instance.AddDecal(position, rotation, Vector3.one, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Material, m_Layer, m_FadeFactor);
 
                         if (!DecalSystem.IsHDRenderPipelineDecal(m_Material.shader)) // non HDRP/decal shaders such as shader graph decal do not affect transparency
                         {
@@ -276,7 +277,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 }
                 else // no material change, just update whatever else changed
                 {
-                    DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, gameObject.layer, m_FadeFactor);
+                    DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, m_Layer, m_FadeFactor);
                 }
             }
         }
@@ -287,13 +288,13 @@ namespace UnityEngine.Rendering.HighDefinition
             if(m_Layer != gameObject.layer)
             {
                 Matrix4x4 sizeOffset = Matrix4x4.Translate(decalOffset) * Matrix4x4.Scale(decalSize);
-                DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, gameObject.layer, m_FadeFactor);
                 m_Layer = gameObject.layer;
+                DecalSystem.instance.UpdateCachedData(position, rotation, sizeOffset, m_DrawDistance, m_FadeScale, uvScaleBias, m_AffectsTransparency, m_Handle, m_Layer, m_FadeFactor);
             }
         }
 #endif
 
-            void LateUpdate()
+        void LateUpdate()
         {
             if (m_Handle != null)
             {


### PR DESCRIPTION
### Checklist for PR maker
- Have you added a Label? : HDRP, Universal, ShaderGraph etc...
- Have you added a label for backport (if needed)? : need-backport-2019.3  .  When the PR is backported the label will be change ton backported-2019.3
- Have you added a changelog? Each package have a changelog.
- Have you updated or added the documentation for you PR? When property name is changed, when a feature behavior is change, when adding a new features, think to update the documentation in the same PR.
- Have you added a graphic test for your PR (if needed)? When adding new feature or discovering a bug that isn't cover by a test, please add a graphic test

---
### Purpose of this PR
Fix https://fogbugz.unity3d.com/f/cases/1196646
---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides
- [x] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/decals-layermask-bug/.yamato%252Fupm-ci-hdrp.yml%2523All_HDRP_trunk/729875/job


Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
