### PR TITLE
Workaround for Single-Pass and Single-Pass Instanced testing issues in #4802

### DIFF
--- a/TestProjects/ShaderGraphUniversalStereo/ProjectSettings/ProjectSettings.asset
+++ b/TestProjects/ShaderGraphUniversalStereo/ProjectSettings/ProjectSettings.asset
@@ -42,8 +42,8 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1024
-  defaultScreenHeight: 768
+  defaultScreenWidth: 640
+  defaultScreenHeight: 360
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 1
@@ -80,7 +80,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 0
@@ -91,7 +91,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0


### PR DESCRIPTION
### Purpose of this PR
#4802 is currently blocked because the Graphics Test Framework is not able to actually test Single Pass and Single Pass Instanced due to the method used for capturing actual frame images.

This PR fixes that by using ScreenCapture.CaptureScreenshot, which should actually be the thing used for all graphics tests as it captures the final result and does not do some hard-to-fix reconstruction based on a list of active cameras.

Once this PR is approved (or before if you think that makes sense) I'd like to move the functionality that I added and which is currently only available in the ShaderGraphUniversalStereo project into the Graphics Testing Framework and make it available for all tests.

Also, hopefully there is a broader discussion around what exactly the Test Framework is supposed to test (e.g. how are reference images for Quest captured - this should be exactly the images from Quest, not images captured in Editor, to enable accurate tests on output and not on arbitrary RenderTextures). I think testing the output of ScreenCapture.CaptureScreenshot makes sense, as this is what should actually be tested, even if it makes setup (making sure window sizes match etc.) a bit more complicated.

---
### Testing status

**Manual Tests**: What did you do?
- [X] Opened test project + Run graphic tests locally
- [X] Built a player
- Other: this enables more tests to run correctly but requires some additional changes. Notably, built players currently would need to produce exactly the image size as the reference image. The current code takes care of resizing the player to match the reference image, but ideally this means ref images should be captured from target platforms (e.g. for Quest, where player is not resizable).

I tested this by merging it into #4802 where tests currently (incorrectly) fail, with this PR they succeed.

Any test projects to go with this to help reviewers?
#4802 is a good testcase of the workarounds / improvements here.

---
### Comments to reviewers
Notes for the reviewers you have assigned.
