### PR TITLE
Fix nullrefs in the material editor when entering play mode

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Decal/DecalUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Decal/DecalUI.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new DecalSortingInputsUIBlock((MaterialUIBlock.Expandable)Expandable.Sorting),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             LoadMaterialProperties(props);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Decal/ShaderGraph/DecalGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Decal/ShaderGraph/DecalGUI.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new DecalSortingInputsUIBlock((MaterialUIBlock.Expandable)Expandable.Sorting),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             // always instanced
             SerializedProperty instancing = materialEditor.serializedObject.FindProperty("m_EnableInstancingVariants");

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeGUI.cs
@@ -22,7 +22,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new ShaderGraphUIBlock(MaterialUIBlock.Expandable.ShaderGraph),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new ShaderGraphUIBlock(MaterialUIBlock.Expandable.ShaderGraph),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new ShaderGraphUIBlock(MaterialUIBlock.Expandable.ShaderGraph),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/LayeredLit/LayeredLitGUI.cs
@@ -35,7 +35,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/LitGUI.cs
@@ -26,7 +26,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new ShaderGraphUIBlock(MaterialUIBlock.Expandable.ShaderGraph),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new ShaderGraphUIBlock(MaterialUIBlock.Expandable.ShaderGraph),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/TerrainLit/TerrainLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/TerrainLit/TerrainLitGUI.cs
@@ -28,7 +28,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             FindMaterialProperties(props);
             using (var changed = new EditorGUI.ChangeCheckScope())

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/HDShaderGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/HDShaderGUI.cs
@@ -32,6 +32,20 @@ namespace UnityEditor.Rendering.HighDefinition
             SetupMaterialKeywordsAndPassInternal(material);
         }
 
+        public sealed override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        {
+            if (!(RenderPipelineManager.currentPipeline is HDRenderPipeline))
+            {
+                EditorGUILayout.HelpBox("Editing HDRP materials is only supported when an HDRP asset assigned in the graphic settings", MessageType.Warning);
+            }
+            else
+            {
+                OnMaterialGUI(materialEditor, props);
+            }
+        }
+
+        protected abstract void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props);
+
         protected static void ResetMaterialCustomRenderQueue(Material material)
         {
             HDRenderQueue.RenderQueueType targetQueueType;

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitGUI.cs
@@ -24,7 +24,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new ShaderGraphUIBlock(MaterialUIBlock.Expandable.ShaderGraph, ShaderGraphUIBlock.Features.Unlit),
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/UnlitGUI.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.Rendering.HighDefinition
             new AdvancedOptionsUIBlock(MaterialUIBlock.Expandable.Advance, AdvancedOptionsUIBlock.Features.Instancing | AdvancedOptionsUIBlock.Features.AddPrecomputedVelocity)
         };
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        protected override void OnMaterialGUI(MaterialEditor materialEditor, MaterialProperty[] props)
         {
             using (var changed = new EditorGUI.ChangeCheckScope())
             {


### PR DESCRIPTION
### Purpose of this PR
Fix a nullref that happens when a material UI is visible in the inspector when passing play mode.
