### PR TITLE
hdrp and vfx tests target 2080ti platforms

### DIFF
--- a/.yamato/upm-ci-hdrp.yml
+++ b/.yamato/upm-ci-hdrp.yml
@@ -12,6 +12,10 @@ platforms:
     type: Unity::metal::macmini
     image: slough-ops/macos-10.14-xcode
     flavor: m1.mac
+  - name: Linux
+    type: Unity::VM::GPU
+    image: cds-ops/ubuntu-18.04-base:latest
+    flavor: b1.large
 testplatforms:
   - name: playmode
     args: --suite=playmode
@@ -25,11 +29,18 @@ projects:
 win_apis:
   - name: DX11
     cmd: -force-d3d11
+  - name: DX12
+    cmd: -force-d3d12
   - name: Vulkan
     cmd: -force-vulkan
 mac_apis:
   - name: metal
   - name: openglcore
+linux_apis:
+  - name: OpenGLCore
+    cmd: -force-glcore
+  - name: Vulkan
+    cmd: -force-vulkan
 ---
 {% for project in projects %}
 {% for editor in editors %}
@@ -46,9 +57,10 @@ mac_apis:
     type: Unity::VM
     {% else %}
     type: {{ platform.type }}
-    {% endif %} 
-    image: {{ platform.image }}      
-    flavor: {{ platform.flavor }}
+    model: rtx2080
+    {% endif %}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
   commands:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git TestProjects/{{ project.folder }}/utr
     - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
@@ -103,6 +115,39 @@ mac_apis:
       paths:
         - "**/test-results/**"
 {% endif %}
+{% endfor %}
+
+{% elsif platform.name == "Linux" %}
+
+{% for testplatform in testplatforms %}
+{% for linux_api in linux_apis %}
+# Separate block for linux, because the linux agents currently need extra configuration
+{{ project.name }}_Linux_{{ linux_api.name }}_{{ testplatform.name }}_{{ editor.version }}:
+  name : {{ project.name }} on Linux_{{ linux_api.name }}_{{ testplatform.name }} on version {{ editor.version }}
+  agent:
+    {% if testplatform.name == "editmode" %}
+    type: Unity::VM
+    {% else %}
+    type: {{ platform.type }}
+    {% endif %} 
+    image: {{ platform.image }}      
+    flavor: {{ platform.flavor }}
+  commands:
+    - sudo -H pip install --upgrade pip
+    - sudo -H pip install unity-downloader-cli --extra-index-url https://artifactory.eu-cph-1.unityops.net/api/pypi/common-python/simple
+    - sudo npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - git clone git@github.cds.internal.unity3d.com:unity/utr.git TestProjects/{{ project.folder }}/utr
+    - cd TestProjects/{{ project.folder }} && sudo unity-downloader-cli {{ editor.cmd }} -c editor --wait --published
+    {% if testplatform.name == "Standalone" %}
+    - cd TestProjects/{{ project.folder }} && DISPLAY=:0.0 utr/utr {{ testplatform.args }}Linux64 --extra-editor-arg="-executemethod" --extra-editor-arg="CustomBuild.BuildLinux{{ linux_api.name }}Linear" --testproject=. --editor-location=.Editor --artifacts_path=upm-ci~/test-results
+    {% else %}
+    - cd TestProjects/{{ project.folder }} && DISPLAY=:0.0 utr/utr --extra-editor-arg="{{ linux_api.cmd }}"  {{ testplatform.args }} --testproject=. --editor-location=.Editor --artifacts_path=upm-ci~/test-results
+    {% endif %}
+  artifacts:
+    logs:
+      paths:
+        - "**/upm-ci~/test-results/**/*"  
+{% endfor %}   
 {% endfor %}
 
 

--- a/.yamato/upm-ci-vfxmain.yml
+++ b/.yamato/upm-ci-vfxmain.yml
@@ -50,9 +50,10 @@ linux_apis:
     type: Unity::VM
     {% else %}
     type: {{ platform.type }}
-    {% endif %} 
-    image: {{ platform.image }}      
-    flavor: {{ platform.flavor }}
+    model: rtx2080
+    {% endif %}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
   commands:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git TestProjects/{{ project.folder }}/utr
     - npm install upm-ci-utils -g --registry https://api.bintray.com/npm/unity/unity-npm


### PR DESCRIPTION
Also enable dx12 tests for HDRP.

---
### Purpose of this PR
HDRP and VFX tests will now run on 2080ti machines for faster iterations.
Also add dx12 as target api for HDRP playmode tests. Updated reference images will come later on.

This PR basically moves the two .yml files that were originally modified here : https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/4908

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/yamato%252Fhdrp-vfx-2080ti
