### PR TITLE
Exposed Serialized

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Graphs/BooleanShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/BooleanShaderProperty.cs
@@ -46,6 +46,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/ColorShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ColorShaderProperty.cs
@@ -13,14 +13,14 @@ namespace UnityEditor.ShaderGraph.Internal
         {
             displayName = "Color";
         }
-        
+
         public override PropertyType propertyType => PropertyType.Color;
-        
+
         internal override bool isBatchable => true;
         internal override bool isExposable => true;
         internal override bool isRenamable => true;
         internal override bool isGpuInstanceable => true;
-        
+
         internal string hdrTagString => colorMode == ColorMode.HDR ? "[HDR]" : "";
 
         internal override string GetPropertyBlockString()
@@ -32,7 +32,7 @@ namespace UnityEditor.ShaderGraph.Internal
         {
             return $"Color_{GuidEncoder.Encode(guid)}";
         }
-        
+
         [SerializeField]
         ColorMode m_ColorMode;
 
@@ -41,7 +41,7 @@ namespace UnityEditor.ShaderGraph.Internal
             get => m_ColorMode;
             set => m_ColorMode = value;
         }
-        
+
         internal override AbstractMaterialNode ToConcreteNode()
         {
             return new ColorNode { color = new ColorNode.Color(value, colorMode) };
@@ -54,7 +54,7 @@ namespace UnityEditor.ShaderGraph.Internal
                 name = referenceName,
                 colorValue = value
             };
-        }        
+        }
 
         internal override ShaderInput Copy()
         {
@@ -62,6 +62,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value,
                 colorMode = colorMode
             };

--- a/com.unity.shadergraph/Editor/Data/Graphs/CubemapShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/CubemapShaderProperty.cs
@@ -67,6 +67,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/GradientShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GradientShaderProperty.cs
@@ -97,6 +97,7 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Matrix2ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Matrix2ShaderProperty.cs
@@ -45,6 +45,7 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Matrix3ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Matrix3ShaderProperty.cs
@@ -46,6 +46,7 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Matrix4ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Matrix4ShaderProperty.cs
@@ -14,9 +14,9 @@ namespace UnityEditor.ShaderGraph
             value = Matrix4x4.identity;
         }
         internal override bool isGpuInstanceable => true;
-        
+
         public override PropertyType propertyType => PropertyType.Matrix4;
-        
+
         internal override AbstractMaterialNode ToConcreteNode()
         {
             return new Matrix4Node
@@ -43,6 +43,7 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/SamplerStateShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SamplerStateShaderProperty.cs
@@ -59,6 +59,7 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 overrideReferenceName = overrideReferenceName,
                 value = value
             };

--- a/com.unity.shadergraph/Editor/Data/Graphs/ShaderInput.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ShaderInput.cs
@@ -59,6 +59,14 @@ namespace UnityEditor.ShaderGraph.Internal
         }
 
         [SerializeField]
+        bool m_Expanded = false;
+
+        public bool expanded
+        {
+            get => m_Expanded;
+            set => m_Expanded = value;
+        }
+
         bool m_GeneratePropertyBlock = true;
 
         internal bool generatePropertyBlock

--- a/com.unity.shadergraph/Editor/Data/Graphs/ShaderKeyword.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ShaderKeyword.cs
@@ -19,7 +19,7 @@ namespace UnityEditor.ShaderGraph
         {
             this.displayName = keywordType.ToString();
             this.keywordType = keywordType;
-            
+
             // Add sensible default entries for Enum type
             if(keywordType == KeywordType.Enum)
             {
@@ -112,7 +112,7 @@ namespace UnityEditor.ShaderGraph
         [SerializeField]
         private bool m_IsExposable = true;
 
-        internal override bool isExposable => m_IsExposable 
+        internal override bool isExposable => m_IsExposable
             && (keywordType == KeywordType.Enum || referenceName.EndsWith("_ON"));
 
         internal override bool isRenamable => isEditable;
@@ -142,7 +142,7 @@ namespace UnityEditor.ShaderGraph
                     // Reference name must be appended with _ON but must be removed when generating block
                     if(referenceName.EndsWith("_ON"))
                         return $"[Toggle]{referenceName.Remove(referenceName.Length - 3, 3)}(\"{displayName}\", Float) = {value}";
-                    else 
+                    else
                         return string.Empty;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -196,6 +196,7 @@ namespace UnityEditor.ShaderGraph
                 overrideReferenceName = overrideReferenceName,
                 generatePropertyBlock = generatePropertyBlock,
                 m_IsExposable = isExposable,
+                expanded = expanded,
                 isEditable = isEditable,
                 keywordType = keywordType,
                 keywordDefinition = keywordDefinition,

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
@@ -65,6 +65,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
@@ -78,6 +78,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture3DShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture3DShaderProperty.cs
@@ -65,6 +65,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
@@ -16,14 +16,14 @@ namespace UnityEditor.ShaderGraph.Internal
         {
             displayName = "Vector1";
         }
-        
+
         public override PropertyType propertyType => PropertyType.Vector1;
-        
+
         internal override bool isBatchable => true;
         internal override bool isExposable => true;
         internal override bool isRenamable => true;
         internal override bool isGpuInstanceable => true;
-        
+
         string enumTagString
         {
             get
@@ -60,7 +60,7 @@ namespace UnityEditor.ShaderGraph.Internal
                     return $"{hideTagString}{referenceName}(\"{displayName}\", Float) = {NodeUtils.FloatToShaderValue(value)}";
             }
         }
-        
+
         [SerializeField]
         FloatType m_FloatType = FloatType.Default;
 
@@ -86,7 +86,7 @@ namespace UnityEditor.ShaderGraph.Internal
             get => m_EnumType;
             set => m_EnumType = value;
         }
-    
+
         Type m_CSharpEnumType;
 
         public Type cSharpEnumType
@@ -96,7 +96,7 @@ namespace UnityEditor.ShaderGraph.Internal
         }
 
         List<string> m_EnumNames = new List<string>();
-        
+
         public List<string> enumNames
         {
             get => m_EnumNames;
@@ -110,7 +110,7 @@ namespace UnityEditor.ShaderGraph.Internal
             get => m_EnumValues;
             set => m_EnumValues = value;
         }
-        
+
         internal override AbstractMaterialNode ToConcreteNode()
         {
             switch (m_FloatType)
@@ -141,6 +141,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value,
                 floatType = floatType,
                 rangeValues = rangeValues,

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector2ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector2ShaderProperty.cs
@@ -38,6 +38,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector3ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector3ShaderProperty.cs
@@ -39,6 +39,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector4ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector4ShaderProperty.cs
@@ -13,9 +13,9 @@ namespace UnityEditor.ShaderGraph.Internal
             displayName = "Vector4";
         }
         internal override bool isGpuInstanceable => true;
-        
+
         public override PropertyType propertyType => PropertyType.Vector4;
-        
+
         internal override AbstractMaterialNode ToConcreteNode()
         {
             var node = new Vector4Node();
@@ -41,6 +41,7 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
+                expanded = expanded,
                 value = value
             };
         }

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -22,13 +22,6 @@ namespace UnityEditor.ShaderGraph.Drawing
         bool m_EditPathCancelled = false;
         List<Node> m_SelectedNodes = new List<Node>();
 
-        Dictionary<ShaderInput, bool> m_ExpandedInputs = new Dictionary<ShaderInput, bool>();
-
-        public Dictionary<ShaderInput, bool> expandedInputs
-        {
-            get { return m_ExpandedInputs; }
-        }
-
         public string assetName
         {
             get { return blackboard.title; }
@@ -273,11 +266,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                 AddInputRow(input, index: m_Graph.GetGraphInputIndex(input));
             }
 
-            foreach (var expandedInput in expandedInputs)
-            {
-                SessionState.SetBool(expandedInput.Key.guid.ToString(), expandedInput.Value);
-            }
-
             if (m_Graph.movedInputs.Any())
             {
                 foreach (var row in m_InputRows.Values)
@@ -289,7 +277,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                 foreach (var keyword in m_Graph.keywords)
                     m_KeywordSection.Add(m_InputRows[keyword.guid]);
             }
-            m_ExpandedInputs.Clear();
         }
 
         void AddInputRow(ShaderInput input, bool create = false, int index = -1)
@@ -322,6 +309,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                         m_PropertySection.Add(row);
                     else
                         m_PropertySection.Insert(index, row);
+
                     break;
                 }
                 case ShaderKeyword keyword:
@@ -339,6 +327,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                         m_KeywordSection.Add(row);
                     else
                         m_KeywordSection.Insert(index, row);
+
                     break;
                 }
                 default:
@@ -357,7 +346,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             expandButton.RegisterCallback<MouseDownEvent>(evt => OnExpanded(evt, input), TrickleDown.TrickleDown);
 
             m_InputRows[input.guid] = row;
-            m_InputRows[input.guid].expanded = SessionState.GetBool(input.guid.ToString(), true);
+            m_InputRows[input.guid].expanded = input.expanded;
 
             if (create)
             {
@@ -375,7 +364,8 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void OnExpanded(MouseDownEvent evt, ShaderInput input)
         {
-            m_ExpandedInputs[input] = !m_InputRows[input.guid].expanded;
+            input.expanded = !input.expanded;
+            m_Graph.owner.isDirty = true;
         }
 
         void DirtyNodes()


### PR DESCRIPTION
Main PR: #5045

A removed part of 20% branch because I'd figured it was like a no go due to Martin's work on the topic 😅, but perhaps worth discussing.

Makes Exposed Serialized.
Pros:
* Exposed status is now duplicated, something I often find I want.
* Remembered always; between closing & open files, opening & closing, unity sessions, moving between graphs, ect.
* Kept when copying and pasting between graphs too.
Cons:
* Changing the exposed status of a property will now renders the graph dirty (trigging needs-save), although this field could be ignored in the function that handles that.
* More data == bad ?

Misc thoughts:
* If we don't roll with an ability to duplicate a Shader Input's exposed status, I think it may be best to set exposed to false by default. Of course this may also be resolved by the internal inspector.
* Otherwise, could be worth looking into Duplication remembering Exposed status after your changes land Martin.
