### PR TITLE
Added Renderer2D custom features/passes support

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [8.0.0] - 2019-11-18
 ### Added
+- Added custom render feature support for 2D Renderer.
 - Added the option to strip Terrain hole Shader variants.
 - Added support for additional Directional Lights. The amount of additional Directional Lights is limited by the maximum Per-object Lights in the Render Pipeline Asset.
 - Added default implementations of OnPreprocessMaterialDescription for FBX, Obj, Sketchup and 3DS file formats.

--- a/com.unity.render-pipelines.universal/Editor/2D/Renderer2DDataEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/2D/Renderer2DDataEditor.cs
@@ -1,10 +1,11 @@
 using UnityEngine;
+using UnityEditor.Rendering.Universal;
 using UnityEngine.Experimental.Rendering.Universal;
 
 namespace UnityEditor.Experimental.Rendering.Universal
 {
     [CustomEditor(typeof(Renderer2DData), true)]
-    internal class Renderer2DDataEditor : Editor
+    internal class Renderer2DDataEditor : ScriptableRendererDataEditor
     {
         class Styles
         {
@@ -188,6 +189,8 @@ namespace UnityEditor.Experimental.Rendering.Universal
 
             m_WasModified |= serializedObject.hasModifiedProperties;
             serializedObject.ApplyModifiedProperties();
+
+            base.OnInspectorGUI(); // Draw the base UI, contains ScriptableRenderFeatures list
         }
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/2D/Renderer2D.cs
+++ b/com.unity.render-pipelines.universal/Runtime/2D/Renderer2D.cs
@@ -144,6 +144,11 @@ namespace UnityEngine.Experimental.Rendering.Universal
                 }
             }
 
+            for (int i = 0; i < rendererFeatures.Count; ++i)
+            {
+                rendererFeatures[i].AddRenderPasses(this, ref renderingData);
+            }
+
             if (requireFinalBlitPass)
             {
                 m_FinalBlitPass.Setup(cameraTargetDescriptor, finalBlitSourceHandle);


### PR DESCRIPTION
### Purpose of this PR
This PR adds missing custom render features to the 2D renderer, which are pretty usefull in URP/LWRP.
Also, this PR follows my forum [post](https://forum.unity.com/threads/urp-2d-renderer-custom-feature.778946/).

---
### Testing status
- [X] Built a player
- [X] C# warnings
- [X] Basic command buffer manipulation (clearing a render target, drawing simple geometry)

---
### Comments to reviewers
I've tested it locally, with basic command buffer things, like clearing RenderTarget etc.
Probably needs a lot more testing and while I'm already using it, I'll add fixes - if there will be any needed.