### PR TITLE
Release/2019.3 fix warning script for old baked probes

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -213,6 +213,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix light limit counts specified on the HDRP asset
 - Fixed Quality Settings for SSR, Contact Shadows and Ambient Occlusion volume components
 - Fixed decalui deriving from hdshaderui instead of just shaderui
+- Added a fix script to handle the warning 'referenced script in (GameObject 'SceneIDMap') is missing'
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Documentation~/Upgrading-from-2019.2-to-2019.3.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Upgrading-from-2019.2-to-2019.3.md
@@ -83,3 +83,8 @@ When you upgrade your **High Definition RP** package, Unity now upgrades each of
 
 To do this, Unity opens a prompt when you begin the upgrade, asking if you want to save your Project. It keeps attempting to upgrade old files until you agree to save your Project.
 
+## Missing Script for GameObject SceneIDMap
+
+For scene with baked probes authored prior to 2019.3, you may ran into a warning concerning a missing script for a GameObject named SceneIDMap when entering play mode.
+To fix it, you can load the scene in the editor and click on "Edit/Render Pipeline/Fix Warning 'referenced script in (Game Object 'SceneIDMap') is missing' in loaded scenes".
+

--- a/com.unity.render-pipelines.high-definition/Editor/Upgraders/UpgradeMenuItem.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Upgraders/UpgradeMenuItem.cs
@@ -8,6 +8,8 @@ using UnityEditor.ShaderGraph;
 
 // Include material common properties names
 using static UnityEngine.Rendering.HighDefinition.HDMaterialProperties;
+using UnityEngine.SceneManagement;
+using UnityEngine.Assertions;
 
 namespace UnityEditor.Rendering.HighDefinition
 {
@@ -186,7 +188,7 @@ namespace UnityEditor.Rendering.HighDefinition
         [MenuItem("Edit/Render Pipeline/Reset All ShaderGraph Materials BlendStates (Scene)")]
         static public void UpgradeAllShaderGraphMaterialBlendStatesScene()
         {
-            var materials = Resources.FindObjectsOfTypeAll< Material >();
+            var materials = Resources.FindObjectsOfTypeAll<Material>();
 
             foreach (var mat in materials)
             {
@@ -194,6 +196,42 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 if (!string.IsNullOrEmpty(path))
                     UpdateMaterial_ShaderGraphRenderStates(path, mat);
+            }
+        }
+
+        [MenuItem("Edit/Render Pipeline/Fix Warning 'referenced script in (Game Object 'SceneIDMap') is missing' in loaded scenes")]
+        static public void FixWarningGameObjectSceneIDMapIsMissingInLoadedScenes()
+        {
+            var rootCache = new List<GameObject>();
+            for (var i = 0; i < SceneManager.sceneCount; ++i)
+                FixWarningGameObjectSceneIDMapIsMissingFor(SceneManager.GetSceneAt(i), rootCache);
+        }
+
+        static void FixWarningGameObjectSceneIDMapIsMissingFor(Scene scene, List<GameObject> rootCache)
+        {
+            Assert.IsTrue(scene.isLoaded);
+
+            var roots = rootCache ?? new List<GameObject>();
+            roots.Clear();
+            scene.GetRootGameObjects(roots);
+            for (var i = roots.Count - 1; i >= 0; --i)
+            {
+                if (roots[i].name == "SceneIDMap")
+                {
+                    if (roots[i].GetComponent<SceneObjectIDMapSceneAsset>() == null)
+                    {
+                        // This gameObject must have SceneObjectIDMapSceneAsset
+                        // If not, then Unity can't find the component.
+                        // We can remove it, it will be regenerated properly by rebaking
+                        // the probes.
+                        //
+                        // This happens for scene with baked probes authored before renaming
+                        // the HDRP's namespaces without the 'Experiemental' prefix.
+                        // The serialization used this path explicitly, thus the Unity serialization
+                        // system lost the reference to the MonoBehaviour
+                        Object.DestroyImmediate(roots[i]);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### Purpose of this PR
Backport of https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/5152/files

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally

**Automated Tests**: -

**Yamato**: (Select your branch):-
---
### Comments to reviewers

