### PR TITLE
 Added callback to SRP to hook up pipeline MSAA settings.

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -702,6 +702,8 @@ namespace UnityEngine.Rendering.Universal
         }
 #endif
 
+        public override int antiAliasingSampleCount => msaaSampleCount;
+
         public void OnBeforeSerialize()
         {
         }

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
@@ -163,12 +163,6 @@ namespace UnityEngine.Rendering.Universal
 
             ConfigureCameraTarget(m_ActiveCameraColorAttachment.Identifier(), m_ActiveCameraDepthAttachment.Identifier());
 
-            // if rendering to intermediate render texture we don't have to create msaa backbuffer
-            int backbufferMsaaSamples = (intermediateRenderTexture) ? 1 : cameraTargetDescriptor.msaaSamples;
-            
-            if (Camera.main == camera && camera.cameraType == CameraType.Game && camera.targetTexture == null)
-                SetupBackbufferFormat(backbufferMsaaSamples, renderingData.cameraData.isStereoEnabled);
-            
             for (int i = 0; i < rendererFeatures.Count; ++i)
             {
                 rendererFeatures[i].AddRenderPasses(this, ref renderingData);
@@ -363,30 +357,6 @@ namespace UnityEngine.Rendering.Universal
             CommandBufferPool.Release(cmd);
         }
 
-        void SetupBackbufferFormat(int msaaSamples, bool stereo)
-        {
-#if ENABLE_VR
-            bool msaaSampleCountHasChanged = false;
-            int currentQualitySettingsSampleCount = QualitySettings.antiAliasing;
-            if (currentQualitySettingsSampleCount != msaaSamples &&
-                !(currentQualitySettingsSampleCount == 0 && msaaSamples == 1))
-            {
-                msaaSampleCountHasChanged = true;
-            }
-
-            // There's no exposed API to control how a backbuffer is created with MSAA
-            // By settings antiAliasing we match what the amount of samples in camera data with backbuffer
-            // We only do this for the main camera and this only takes effect in the beginning of next frame.
-            // This settings should not be changed on a frame basis so that's fine.
-            QualitySettings.antiAliasing = msaaSamples;
-
-            if (stereo && msaaSampleCountHasChanged)
-                XR.XRDevice.UpdateEyeTextureMSAASetting();
-#else
-            QualitySettings.antiAliasing = msaaSamples;
-#endif
-        }
-        
         bool RequiresIntermediateColorTexture(ref RenderingData renderingData, RenderTextureDescriptor baseDescriptor)
         {
             ref CameraData cameraData = ref renderingData.cameraData;

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -192,6 +192,11 @@ namespace UnityEngine.Rendering.Universal
 
             SortStable(m_ActiveRenderPassQueue);
 
+#if ENABLE_VR
+            if (renderingData.cameraData.isStereoEnabled)
+                XR.XRDevice.UpdateEyeTextureMSAASetting();
+#endif
+
             // Cache the time for after the call to `SetupCameraProperties` and set the time variables in shader
             // For now we set the time variables per camera, as we plan to remove `SetupCamearProperties`.
             // Setting the time per frame would take API changes to pass the variable to each camera render.

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -132,10 +132,6 @@ namespace UnityEngine.Rendering.Universal
             PerCameraBuffer._ScaledScreenParams = Shader.PropertyToID("_ScaledScreenParams");
             PerCameraBuffer._WorldSpaceCameraPos = Shader.PropertyToID("_WorldSpaceCameraPos");
 
-            // Let engine know we have MSAA on for cases where we support MSAA backbuffer
-            if (QualitySettings.antiAliasing != asset.msaaSampleCount)
-                QualitySettings.antiAliasing = asset.msaaSampleCount;
-
             // For compatibility reasons we also match old LightweightPipeline tag.
             Shader.globalRenderPipeline = "UniversalPipeline,LightweightPipeline";
 


### PR DESCRIPTION
### Purpose of this PR
Removed dependency from QualitySettings.antiAliasing from URP by exposing a delegate to allow Unity to query antialiasing from SRP.

This fixes 1195272 (https://issuetracker.unity3d.com/issues/lwrp-the-anti-alias-quality-settings-value-is-changing-without-user-interaction)

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**:  Already covered by tests.

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

---
### Comments to reviewers
 This requires engine PR that exposes `antiAliasingSampleCount` in the RenderPipeline. All places that engine relies on QualitySettings.antiAliasing have been updated to call this new API in SRP to return pipeline msaa samples. Default values for any SRP is 1 (no msaa).


