### PR TITLE
Fix recursive sub graph import

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Sticky Notes can now be grouped properly.
 - Fixed an issue where nodes couldn't be copied from a group.
 - Fixed an issue where adding the first output to a Sub Graph without any outputs prior caused Shader Graphs containing the Sub Graph to break.
+- Self-referencing Sub Graphs no longer causes importing to go into an infinite loop.
 
 ## [7.1.1] - 2019-09-05
 ### Added


### PR DESCRIPTION
### Purpose of this PR
Fixes FB-1198653. The are two issues at hand here.

When a sub graph references itself, it ends up trying to load the asset that is currently being imported. This doesn't happen if there is 1 sub graph in-between due to how the sub graph importer works. Anyway, this causes an assertion in ADB, because you obviously can't do that. But then we hit a bug in ADB, where it doesn't mark the asset as failed-to-import, so it tries again, and goes into an infinite loop. This has been fixed by moving the circular dependency check up earlier.

But, that caused us to hit the same bug in another way. Before the actual import, ADB gathers dependencies by calling `GatherDependenciesFromSourceFile` on importers that support it, like ours. It then orders things correctly, and does the actual import. This also has a circular dependency check, but like before it fails to mark the assets as failed-to-import, and so goes into an infinite loop. This should be fixed in ADB, but the bug is there now, and we need to handle it.

So the workaround I've made is to fully gather dependencies in that callback, and if we detect circular dependencies, return an empty list instead, and when that then goes to import we mark up the dependencies the old-fashioned way using `AssetImportContext.DependsOnSourceAsset`, so that we still get a re-import if any of those dependencies change. (The latter part is needed because we're returning an empty list, so we don't get that for free anymore.)

This is somewhat slower, as `GatherDependenciesFromSourceFile` now has to recursively gather dependencies, whereas before it only had to go 1 level deep. So when this eventually gets fixed in ADB, we should `#ifdef` the workaround based on the version that the fix lands in.

### Testing status

**Manual Tests**:
- Followed repro steps from bug, and verified the fix locally:
  1. Create 2 subgraphs, sub1 and sub2
  2. Drag and drop sub1 into sub2 and connect it to the output
  3. With sub2 open, click "Save As" and replace sub1.

**Automated Tests**: We don't want to add a test for this, since it would cause the agent to go into an infinite loop on failure.
