### PR TITLE
Automate resources checking button with reflection

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineEditorResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineEditorResources.cs
@@ -92,15 +92,9 @@ namespace UnityEngine.Rendering.HighDefinition
             if (UnityEditor.EditorPrefs.GetBool("DeveloperMode")
                 && GUILayout.Button("Reload All"))
             {
-                var resources = target as HDRenderPipelineEditorResources;
-                resources.defaultScene = null;
-                resources.defaultSkyAndFogProfile = null;
-                resources.defaultPostProcessingProfile = null;
-                resources.defaultDiffusionProfileSettingsList = null;
-                resources.materials = null;
-                resources.textures = null;
-                resources.shaders = null;
-                resources.shaderGraphs = null;
+                foreach(var field in typeof(HDRenderPipelineEditorResources).GetFields())
+                    field.SetValue(target, null);
+
                 ResourceReloader.ReloadAllNullIn(target, HDUtils.GetHDRenderPipelinePath());
             }
         }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineRayTracingResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineRayTracingResources.cs
@@ -89,8 +89,9 @@ namespace UnityEngine.Rendering.HighDefinition
                 if (UnityEditor.EditorPrefs.GetBool("DeveloperMode")
                     && GUILayout.Button("Reload All"))
                 {
-                    var resources = target as HDRenderPipelineRayTracingResources;
-                    resources = null;
+                    foreach (var field in typeof(HDRenderPipelineRayTracingResources).GetFields())
+                        field.SetValue(target, null);
+
                     ResourceReloader.ReloadAllNullIn(target, HDUtils.GetHDRenderPipelinePath());
                 }
             }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPipelineResources.cs
@@ -348,11 +348,9 @@ namespace UnityEngine.Rendering.HighDefinition
             if (UnityEditor.EditorPrefs.GetBool("DeveloperMode")
                 && GUILayout.Button("Reload All"))
             {
-                var resources = target as RenderPipelineResources;
-                resources.materials = null;
-                resources.textures = null;
-                resources.shaders = null;
-                resources.shaderGraphs = null;
+                foreach (var field in typeof(RenderPipelineResources).GetFields())
+                    field.SetValue(target, null);
+
                 ResourceReloader.ReloadAllNullIn(target, HDUtils.GetHDRenderPipelinePath());
             }
         }


### PR DESCRIPTION
### Purpose of this PR
The resources reloading internal button on Resources assets was not checking everything.
This PR automate the nullify to all field of the files to ensure the reloading paths are correct when checking them.

---
### Testing status

**Manual Tests**: 
Tested locally. No usual test relevant for this.

---
### Comments to reviewers
@anisunity for info, the version in raytracing resources was not nullifying anything so it was basically not testing paths before.