### PR TITLE
Fixing spot light cookies not working in ray traced reflections and GI

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -232,6 +232,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix recursive ray tracing not working anymore after intermediate buffer refactor.
 - Fix ray traced shadow denoising not working (history rejected all the time).
 - Fixed shader warning on xbox one
+- Fixed cookies not working for spot lights in ray traced reflections, ray traced GI and recursive rendering
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightCluster.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightCluster.cs
@@ -499,6 +499,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 lightData.up = light.transform.up;
                 lightData.right = light.transform.right;
 
+                lightData.boxLightSafeExtent = 1.0f;
                 if (lightData.lightType == GPULightType.ProjectorBox)
                 {
                     // Rescale for cookies and windowing.
@@ -574,22 +575,20 @@ namespace UnityEngine.Rendering.HighDefinition
                 lightData.shadowIndex = -1;
                 lightData.screenSpaceShadowIndex = -1;
 
-                if (light.cookie != null)
+
+                if (light != null && light.cookie != null)
                 {
                     // TODO: add texture atlas support for cookie textures.
-                    // TODO: why not using GPULightData here too?
                     switch (lightType)
                     {
                         case HDLightType.Spot:
                             lightData.cookieIndex = m_RenderPipeline.m_TextureCaches.cookieTexArray.FetchSlice(cmd, light.cookie);
                             break;
                         case HDLightType.Point:
-                        case HDLightType.Area:
                             lightData.cookieIndex = m_RenderPipeline.m_TextureCaches.cubeCookieTexArray.FetchSlice(cmd, light.cookie);
                             break;
                     }
                 }
-                // TODO: why not using GPULightData here too?
                 else if (lightType == HDLightType.Spot && additionalLightData.spotLightShape != SpotLightShape.Cone)
                 {
                     // Projectors lights must always have a cookie texture.


### PR DESCRIPTION
Spot lights used to be black in RT Reflections, GI and recursive rendering if a cookie texture was assigned to them.