### PR TITLE
Fixed issues with the debug menu caused by a previous PR.

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerBitField.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerBitField.cs
@@ -8,10 +8,13 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerBitField : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        UIFoldout valueToggle;
+        /// <summary>Name of the widget.</summary>
+        public Text nameLabel;
+        /// <summary>Value toggle.</summary>
+        public UIFoldout valueToggle;
 
-        List<DebugUIHandlerIndirectToggle> toggles;
+        /// <summary>Toggles for the bitfield.</summary>
+        public List<DebugUIHandlerIndirectToggle> toggles;
 
         DebugUI.BitField m_Field;
         DebugUIHandlerContainer m_Container;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerButton.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerButton.cs
@@ -7,7 +7,8 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerButton : DebugUIHandlerWidget
     {
-        Text nameLabel;
+        /// <summary>Name of the widget.</summary>
+        public Text nameLabel;
         DebugUI.Button m_Field;
 
         internal override void SetWidget(DebugUI.Widget widget)

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerCanvas.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerCanvas.cs
@@ -5,10 +5,15 @@ using UnityEngine.Rendering;
 
 namespace UnityEngine.Rendering.UI
 {
+    /// <summary>
+    /// Debug UI Prefab bundle.
+    /// </summary>
     [Serializable]
-    class DebugUIPrefabBundle
+    public class DebugUIPrefabBundle
     {
+        /// <summary>type of the widget.</summary>
         public string type;
+        /// <summary>Prefab for the widget.</summary>
         public RectTransform prefab;
     }
 
@@ -20,8 +25,10 @@ namespace UnityEngine.Rendering.UI
         int m_DebugTreeState;
         Dictionary<Type, Transform> m_PrefabsMap;
 
-        internal Transform panelPrefab;
-        internal List<DebugUIPrefabBundle> prefabs;
+        /// <summary>Panel prefab.</summary>
+        public Transform panelPrefab;
+        /// <summary>List of prefabs.</summary>
+        public List<DebugUIPrefabBundle> prefabs;
 
         List<DebugUIHandlerPanel> m_UIPanels;
         int m_SelectedPanel;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerColor.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerColor.cs
@@ -7,14 +7,21 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerColor : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        UIFoldout valueToggle;
-        Image colorImage;
+        /// <summary>Name of the widget.</summary>
+        public Text nameLabel;
+        /// <summary>/// <summary>Name of the widget.</summary>alue toggle.</summary>
+        public UIFoldout valueToggle;
+        /// <summary>Color image.</summary>
+        public Image colorImage;
 
-        DebugUIHandlerIndirectFloatField fieldR;
-        DebugUIHandlerIndirectFloatField fieldG;
-        DebugUIHandlerIndirectFloatField fieldB;
-        DebugUIHandlerIndirectFloatField fieldA;
+        /// <summary>Red float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldR;
+        /// <summary>Green float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldG;
+        /// <summary>Blue float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldB;
+        /// <summary>Alpha float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldA;
 
         DebugUI.ColorField m_Field;
         DebugUIHandlerContainer m_Container;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerContainer.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerContainer.cs
@@ -8,8 +8,9 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerContainer : MonoBehaviour
     {
+        /// <summary>Content holder.</summary>
         [SerializeField]
-        internal RectTransform contentHolder;
+        public RectTransform contentHolder;
 
         internal DebugUIHandlerWidget GetFirstItem()
         {

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerEnumField.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerEnumField.cs
@@ -8,8 +8,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerEnumField : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        internal protected Text valueLabel;
+        /// <summary>Name of the enum field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the enum field.</summary>
+        public Text valueLabel;
         internal protected DebugUI.EnumField m_Field;
 
         internal override void SetWidget(DebugUI.Widget widget)

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerFloatField.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerFloatField.cs
@@ -7,8 +7,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerFloatField : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        Text valueLabel;
+        /// <summary>Name of the enum field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the enum field.</summary>
+        public Text valueLabel;
         DebugUI.FloatField m_Field;
 
         internal override void SetWidget(DebugUI.Widget widget)

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerFoldout.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerFoldout.cs
@@ -7,8 +7,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerFoldout : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        UIFoldout valueToggle;
+        /// <summary>Name of the Foldout.</summary>
+        public Text nameLabel;
+        /// <summary>Toggle value of the Foldout.</summary>
+        public UIFoldout valueToggle;
 
         DebugUI.Foldout m_Field;
         DebugUIHandlerContainer m_Container;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerGroup.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerGroup.cs
@@ -7,8 +7,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerGroup : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        Transform header;
+        /// <summary>Name of the group.</summary>
+        public Text nameLabel;
+        /// <summary>Header of the group.</summary>
+        public Transform header;
         DebugUI.Container m_Field;
         DebugUIHandlerContainer m_Container;
 

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerIndirectFloatField.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerIndirectFloatField.cs
@@ -8,8 +8,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerIndirectFloatField : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        Text valueLabel;
+        /// <summary>Name of the indirect float field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the indirect float field.</summary>
+        public Text valueLabel;
 
         /// <summary>
         /// Getter function for this indirect widget.

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerIndirectToggle.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerIndirectToggle.cs
@@ -12,8 +12,10 @@ namespace UnityEngine.Rendering.UI
         /// Label of the widget.
         /// </summary>
         public Text nameLabel;
-        Toggle valueToggle;
-        Image checkmarkImage;
+        /// <summary>Toggle of the toggle field.</summary>
+        public Toggle valueToggle;
+        /// <summary>Checkmark image.</summary>
+        public Image checkmarkImage;
 
         /// <summary>
         /// Getter function for this indirect widget.

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerIntField.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerIntField.cs
@@ -7,8 +7,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerIntField : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        Text valueLabel;
+        /// <summary>Name of the int field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the int field.</summary>
+        public Text valueLabel;
         DebugUI.IntField m_Field;
 
         internal override void SetWidget(DebugUI.Widget widget)

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerPanel.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerPanel.cs
@@ -7,9 +7,12 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerPanel : MonoBehaviour
     {
-        Text nameLabel;
-        ScrollRect scrollRect;
-        RectTransform viewport;
+        /// <summary>Name of the panel.</summary>
+        public Text nameLabel;
+        /// <summary>Scroll rect of the panel.</summary>
+        public ScrollRect scrollRect;
+        /// <summary>Viewport of the panel.</summary>
+        public RectTransform viewport;
 
         RectTransform m_ScrollTransform;
         RectTransform m_ContentTransform;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerToggle.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerToggle.cs
@@ -7,9 +7,12 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerToggle : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        internal protected Toggle valueToggle;
-        Image checkmarkImage;
+        /// <summary>Name of the toggle.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the toggle.</summary>
+        public Toggle valueToggle;
+        /// <summary>Checkermark image.</summary>
+        public Image checkmarkImage;
 
         internal protected DebugUI.BoolField m_Field;
 

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerUIntField.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerUIntField.cs
@@ -8,8 +8,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerUIntField : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        Text valueLabel;
+        /// <summary>Name of the indirect uint field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the indirect uint field.</summary>
+        public Text valueLabel;
         DebugUI.UIntField m_Field;
 
         internal override void SetWidget(DebugUI.Widget widget)

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerValue.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerValue.cs
@@ -7,8 +7,10 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerValue : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        Text valueLabel;
+        /// <summary>Name of the value field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the value field.</summary>
+        public Text valueLabel;
         DebugUI.Value m_Field;
 
         float m_Timer;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerVector2.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerVector2.cs
@@ -7,11 +7,15 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerVector2 : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        UIFoldout valueToggle;
+        /// <summary>Name of the Vector2 field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the Vector2 toggle.</summary>
+        public UIFoldout valueToggle;
 
-        DebugUIHandlerIndirectFloatField fieldX;
-        DebugUIHandlerIndirectFloatField fieldY;
+        /// <summary>X float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldX;
+        /// <summary>Y float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldY;
 
         DebugUI.Vector2Field m_Field;
         DebugUIHandlerContainer m_Container;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerVector3.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerVector3.cs
@@ -7,12 +7,17 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerVector3 : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        UIFoldout valueToggle;
+        /// <summary>Name of the Vector3 field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the Vector3 toggle.</summary>
+        public UIFoldout valueToggle;
 
-        DebugUIHandlerIndirectFloatField fieldX;
-        DebugUIHandlerIndirectFloatField fieldY;
-        DebugUIHandlerIndirectFloatField fieldZ;
+        /// <summary>X float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldX;
+        /// <summary>Y float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldY;
+        /// <summary>Z float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldZ;
 
         DebugUI.Vector3Field m_Field;
         DebugUIHandlerContainer m_Container;

--- a/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerVector4.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/Prefabs/Scripts/DebugUIHandlerVector4.cs
@@ -7,13 +7,19 @@ namespace UnityEngine.Rendering.UI
     /// </summary>
     public class DebugUIHandlerVector4 : DebugUIHandlerWidget
     {
-        Text nameLabel;
-        UIFoldout valueToggle;
+        /// <summary>Name of the Vector4 field.</summary>
+        public Text nameLabel;
+        /// <summary>Value of the Vector4 toggle.</summary>
+        public UIFoldout valueToggle;
 
-        DebugUIHandlerIndirectFloatField fieldX;
-        DebugUIHandlerIndirectFloatField fieldY;
-        DebugUIHandlerIndirectFloatField fieldZ;
-        DebugUIHandlerIndirectFloatField fieldW;
+        /// <summary>X float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldX;
+        /// <summary>Y float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldY;
+        /// <summary>Z float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldZ;
+        /// <summary>W float field.</summary>
+        public DebugUIHandlerIndirectFloatField fieldW;
 
         DebugUI.Vector4Field m_Field;
         DebugUIHandlerContainer m_Container;


### PR DESCRIPTION
### Purpose of this PR
Fixed issues with the debug menu caused by a previous PR.
DebugUIHandler classes had broken serialized properties after accessibility change, breaking the runtime debug window.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
