### PR TITLE
[VFX] Fix editor test

### DIFF
--- a/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXComponentTest.cs
+++ b/TestProjects/VisualEffectGraph/Assets/AllTests/Editor/Tests/VFXComponentTest.cs
@@ -1045,7 +1045,8 @@ namespace UnityEditor.VFX.Test
 
             var types = Enum.GetValues(typeof(VFXValueType)).Cast<VFXValueType>()
                 .Where(e => e != VFXValueType.Spline
-                    &&  e != VFXValueType.None).ToArray();
+                        &&  e != VFXValueType.Buffer //TODO : Remove this when Buffer as exposed property is possible
+                        &&  e != VFXValueType.None).ToArray();
             foreach (var parameter in VFXLibrary.GetParameters())
             {
                 var newInstance = parameter.CreateInstance();


### PR DESCRIPTION
### Purpose of this PR
Fix issue with editor test due to recent pull request adding `Buffer` in VFXValueType : 
https://ono.unity3d.com/unity/unity/pull-request/97143/_/graphics/vfx/feature/buffer-support

This job is concerned : https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/vfx%252Ffix%252Feditor-test-buffer/.yamato%252Fupm-ci-vfxmain.yml%2523VFXMain_Win_DX11_editmode_trunk/877329/job
