### PR TITLE
Fix a typo in VFX Shader Graph output code

### DIFF
--- a/com.unity.visualeffectgraph/CHANGELOG.md
+++ b/com.unity.visualeffectgraph/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Subgraph operators appear on drag edge on graph.
 - Sample Scene Color & Scene Depth from Shader Graph Integration using High Definition and Universal Render Pipeline
 - Removed Unnecessary reference to HDRP Runtime Assembly in VFX Runtime Assembly
+- Fix typo in view direction computation with Shader Graph integration
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.visualeffectgraph/Editor/ShaderGraph/VFXShaderGraphParticleOutput.cs
+++ b/com.unity.visualeffectgraph/Editor/ShaderGraph/VFXShaderGraphParticleOutput.cs
@@ -474,7 +474,7 @@ namespace UnityEditor.VFX
 
                             if (graphCode.requirements.requiresViewDir != NeededCoordinateSpace.None)
                             {
-                                callSG.builder.AppendLine("float3 V = GetWorldSpaceNormalizeViewDir(VFXGetPositionRWS(i.VFX_VARYING_POSWS);");
+                                callSG.builder.AppendLine("float3 V = GetWorldSpaceNormalizeViewDir(VFXGetPositionRWS(i.VFX_VARYING_POSWS));");
                                 if ((graphCode.requirements.requiresViewDir & NeededCoordinateSpace.World) != 0)
                                     callSG.builder.AppendLine("INSG.WorldSpaceViewDirection = V;");
                                 if ((graphCode.requirements.requiresViewDir & NeededCoordinateSpace.Object) != 0)


### PR DESCRIPTION
Fixed a typo (missing closing brace) that causes a shader compilation error when using a View Direction node in a shader graph and assigning it to a particle output context of a visual effect graph.

Fogbugz case: https://fogbugz.unity3d.com/f/cases/1204027

Here is a test project that simply applies view direction as per-pixel particle color in a VFX graph. It causes a shader compilation error before applying this fix: https://github.com/keijiro/SrpTest

