### PR TITLE
Discard invalid pixels when doing deferred lighting in compute (for camera stacking)

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -552,6 +552,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Spot light shapes are now correctly taken into account when baking
 - Now the static lighting sky will correctly take the default values for non-overridden properties
 - Fixed material albedo affecting the lux meter
+- Extra test in deferred compute shading to avoid shading pixels that were not rendered by the current camera (for camera stacking)
 
 ### Changed
 - Optimization: Reduce the group size of the deferred lighting pass from 16x16 to 8x8

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
@@ -112,6 +112,7 @@ CBUFFER_END
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl"
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl"
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.hlsl"
+#include "Packages/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStencilUsage.cs.hlsl"
 
 #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
 
@@ -119,6 +120,7 @@ CBUFFER_END
 // variable declaration
 //-------------------------------------------------------------------------------------
 
+TEXTURE2D_X_UINT2(_StencilTexture);
 RW_TEXTURE2D_X(float3, diffuseLightingUAV);
 RW_TEXTURE2D_X(float4, specularLightingUAV);
 
@@ -175,10 +177,10 @@ void SHADE_OPAQUE_ENTRY(uint3 dispatchThreadId : SV_DispatchThreadID, uint2 grou
     {
         return;
     }
-
-    // This is required for camera stacking: Since the depth is preserved between layers, we might have a valid depth but invalid normal
-    // Note: Renderdoc does not show any extra fetch for thic check, since the same value is also used/fetched later
-    if (all(FetchRawNormalBuffer(posInput.positionSS) == UNITY_INVALID_NORMALBUFFER_VALUE))
+    
+    // This is required for camera stacking and other cases where we might have a valid depth value in the depth buffer, but the pixel was not covered by this camera
+    uint stencilVal = GetStencilValue(LOAD_TEXTURE2D_X(_StencilTexture, pixelCoord.xy));
+    if ((stencilVal & STENCILUSAGE_REQUIRES_DEFERRED_LIGHTING) == 0)
     {
         return;
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/Deferred.compute
@@ -176,6 +176,13 @@ void SHADE_OPAQUE_ENTRY(uint3 dispatchThreadId : SV_DispatchThreadID, uint2 grou
         return;
     }
 
+    // This is required for camera stacking: Since the depth is preserved between layers, we might have a valid depth but invalid normal
+    // Note: Renderdoc does not show any extra fetch for thic check, since the same value is also used/fetched later
+    if (all(FetchRawNormalBuffer(posInput.positionSS) == UNITY_INVALID_NORMALBUFFER_VALUE))
+    {
+        return;
+    }
+
     float3 V = GetWorldSpaceNormalizeViewDir(posInput.positionWS);
 
     BSDFData bsdfData;

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -3564,14 +3564,7 @@ namespace UnityEngine.Rendering.HighDefinition
                     cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs.specularLightingUAV, resources.colorBuffers[0]);
                     cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs.diffuseLightingUAV, resources.colorBuffers[1]);
 
-                    if (resources.depthStencilBuffer.rt.stencilFormat == GraphicsFormat.None) // We are accessing MSAA resolved version and not the depth stencil buffer directly.
-                    {
-                        cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs._StencilTexture, resources.depthStencilBuffer);
-                    }
-                    else
-                    {
-                        cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs._StencilTexture, resources.depthStencilBuffer, 0, RenderTextureSubElement.Stencil);
-                    }
+                    cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs._StencilTexture, resources.depthStencilBuffer, 0, RenderTextureSubElement.Stencil);
 
                     // always do deferred lighting in blocks of 16x16 (not same as tiled light size)
                     if (parameters.enableFeatureVariants)

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoop.cs
@@ -3564,6 +3564,15 @@ namespace UnityEngine.Rendering.HighDefinition
                     cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs.specularLightingUAV, resources.colorBuffers[0]);
                     cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs.diffuseLightingUAV, resources.colorBuffers[1]);
 
+                    if (resources.depthStencilBuffer.rt.stencilFormat == GraphicsFormat.None) // We are accessing MSAA resolved version and not the depth stencil buffer directly.
+                    {
+                        cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs._StencilTexture, resources.depthStencilBuffer);
+                    }
+                    else
+                    {
+                        cmd.SetComputeTextureParam(parameters.deferredComputeShader, kernel, HDShaderIDs._StencilTexture, resources.depthStencilBuffer, 0, RenderTextureSubElement.Stencil);
+                    }
+
                     // always do deferred lighting in blocks of 16x16 (not same as tiled light size)
                     if (parameters.enableFeatureVariants)
                     {

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
@@ -39,7 +39,6 @@
 
 // GBuffer texture declaration
 TEXTURE2D_X(_GBufferTexture0);
-TEXTURE2D_X(_GBufferTexture1);
 TEXTURE2D_X(_GBufferTexture2);
 TEXTURE2D_X(_GBufferTexture3); // Bake lighting and/or emissive
 TEXTURE2D_X(_GBufferTexture4); // Light layer or shadow mask
@@ -649,13 +648,14 @@ uint DecodeFromGBuffer(uint2 positionSS, uint tileFeatureFlags, out BSDFData bsd
     ZERO_INITIALIZE(BSDFData, bsdfData);
     // Note: Some properties of builtinData are not used, just init all at 0 to silent the compiler
     ZERO_INITIALIZE(BuiltinData, builtinData);
+    NormalData normalData;
 
     // Isolate material features.
     tileFeatureFlags &= MATERIAL_FEATURE_MASK_FLAGS;
 
     GBufferType0 inGBuffer0 = LOAD_TEXTURE2D_X(_GBufferTexture0, positionSS);
-    GBufferType1 inGBuffer1 = LOAD_TEXTURE2D_X(_GBufferTexture1, positionSS);
     GBufferType2 inGBuffer2 = LOAD_TEXTURE2D_X(_GBufferTexture2, positionSS);
+    DecodeFromNormalBuffer(positionSS, normalData);
 
     // BuiltinData
     builtinData.bakeDiffuseLighting = LOAD_TEXTURE2D_X(_GBufferTexture3, positionSS).rgb;  // This also contain emissive (and * AO if no lightlayers)
@@ -742,8 +742,6 @@ uint DecodeFromGBuffer(uint2 positionSS, uint tileFeatureFlags, out BSDFData bsd
     // Decompress feature-agnostic data from the G-Buffer.
     float3 baseColor = inGBuffer0.rgb;
 
-    NormalData normalData;
-    DecodeFromNormalBuffer(inGBuffer1, positionSS, normalData);
     bsdfData.normalWS = normalData.normalWS;
     bsdfData.geomNormalWS = bsdfData.normalWS; // No geometric normal in deferred, use normal map
     bsdfData.perceptualRoughness = normalData.perceptualRoughness;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/NormalBuffer.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/NormalBuffer.hlsl
@@ -5,6 +5,8 @@
 // Encoding/decoding normal buffer functions
 // ----------------------------------------------------------------------------
 
+#define UNITY_INVALID_NORMALBUFFER_VALUE float4(0.0, 0.0, 0.0, 0.0)
+
 struct NormalData
 {
     float3 normalWS;
@@ -44,6 +46,11 @@ void DecodeFromNormalBuffer(uint2 positionSS, out NormalData normalData)
 {
     float4 normalBuffer = LOAD_TEXTURE2D_X(_NormalBufferTexture, positionSS);
     DecodeFromNormalBuffer(normalBuffer, positionSS, normalData);
+}
+
+float4 FetchRawNormalBuffer(uint2 positionSS)
+{
+    return LOAD_TEXTURE2D_X(_NormalBufferTexture, positionSS);
 }
 
 // OUTPUT_NORMAL_NORMALBUFFER start from SV_Target0 as it is used during depth prepass where there is no color buffer

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/NormalBuffer.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/NormalBuffer.hlsl
@@ -5,8 +5,6 @@
 // Encoding/decoding normal buffer functions
 // ----------------------------------------------------------------------------
 
-#define UNITY_INVALID_NORMALBUFFER_VALUE float4(0.0, 0.0, 0.0, 0.0)
-
 struct NormalData
 {
     float3 normalWS;
@@ -46,11 +44,6 @@ void DecodeFromNormalBuffer(uint2 positionSS, out NormalData normalData)
 {
     float4 normalBuffer = LOAD_TEXTURE2D_X(_NormalBufferTexture, positionSS);
     DecodeFromNormalBuffer(normalBuffer, positionSS, normalData);
-}
-
-float4 FetchRawNormalBuffer(uint2 positionSS)
-{
-    return LOAD_TEXTURE2D_X(_NormalBufferTexture, positionSS);
 }
 
 // OUTPUT_NORMAL_NORMALBUFFER start from SV_Target0 as it is used during depth prepass where there is no color buffer


### PR DESCRIPTION
When configuring HDRP to do camera stacking (by not clearing color/depth and clearing the stencil), an extra check is required in deferred compute lighting to ensure we don't write on pixels that have a valid depth from a previous camera in the stack, but were not covered by the current camera.

---

### Testing status

**Manual Tests**: What did you do?
I have tested this on a compositor that is setting up camera stacking on-top of HDRP. Poke me if you want a copy of the project (it is a few GBs).

---
### Comments to reviewers
Notes for the reviewers you have assigned.
