### PR TITLE
Backport: fixed GLES2 compilation error #5341

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [7.1.7] - 2019-12-11
 
 ### Fixed
+- Fixed shader compile errors about LODDitheringTransition not being supported in GLES2.
+
+### Changed
 - Enable RWTexture2D, RWTexture2DArray, RWTexture3D in gles 3.1
 
 ## [7.1.6] - 2019-11-22

--- a/com.unity.render-pipelines.core/ShaderLibrary/CommonDeprecated.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/CommonDeprecated.hlsl
@@ -3,7 +3,7 @@
 
 // Function that are in this file shouldn't be use. they are obsolete and could be removed in the future
 // they are here to keep compatibility with previous version
-
+#if !defined(SHADER_API_GLES)
 // Please use void LODDitheringTransition(uint2 fadeMaskSeed, float ditherFactor)
 void LODDitheringTransition(uint3 fadeMaskSeed, float ditherFactor)
 {
@@ -13,5 +13,6 @@ void LODDitheringTransition(uint3 fadeMaskSeed, float ditherFactor)
     p = (ditherFactor >= 0.5) ? p : 1 - p;
     clip(ditherFactor - p);
 }
+#endif
 
 #endif


### PR DESCRIPTION
Fixed error about LODDitheringTransition not being supported in GLES2.