### PR TITLE
Fix Redo for Shader Graph

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where adding the first output to a Sub Graph without any outputs prior caused Shader Graphs containing the Sub Graph to break.
 - Fixed an issue where Shader Graph shaders using the `CameraNode` failed to build on PS4 with "incompatible argument list for call to 'mul'".
 - Fixed a bug that caused problems with Blackboard property ordering.
-- Fixed a bug where, a majority of the time, redo inside Shader Graph didn't work.
+- Fixed a bug where the redo functionality in Shader Graph often didn't work.
 
 ### Fixed
 - You can now smoothly edit controls on the `Dielectric Specular` node.

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where adding the first output to a Sub Graph without any outputs prior caused Shader Graphs containing the Sub Graph to break.
 - Fixed an issue where Shader Graph shaders using the `CameraNode` failed to build on PS4 with "incompatible argument list for call to 'mul'".
 - Fixed a bug that caused problems with Blackboard property ordering.
+- Fixed a bug where, a majority of the time, redo inside Shader Graph didn't work.
 
 ### Fixed
 - You can now smoothly edit controls on the `Dielectric Specular` node.

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -130,7 +130,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
                 contents.Add(m_PreviewFiller);
 
-                SetPreviewExpandedStateOnSelection(node.previewExpanded);
+                UpdatePreviewExpandedState(node.previewExpanded);
             }
 
             // Add port input container, which acts as a pixel cache for all port inputs


### PR DESCRIPTION
Fixes high user-pain bug "[ShaderGraph] Cannot redo undone actions when certain nodes are added to a graph"
https://fogbugz.unity3d.com/f/cases/1186225/

Actually fixes a whole lot more than that, from my testing Redo wasn't working >95% of the time.

Was caused by each node clearing graph view selection and then setting itself as selected each undo, unnecessarily, which Graph View would record the selection clearing & adding for each one. This would cause Graph View to lose recorded undos if the graph was even remotely medium sized.

---
**Notice:** 

Bigger & better branch (which fixes a few more fixes) can be found here: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/5353

Please at least have a review for that PR before merging this one.

---
**Notes for QA:** 

- _Test all the things to Undo -> Redo!_
- See Extended Version PR for list of known bugs that you might run into (both ones that that one fixes and  doesn't).
- Please test combinations of expanding and collapsing nodes, including single node, multiple nodes that are selected, and popup menus. See Zack if confused on all the options.
- I'm not sure which PR you want to test (yet), or if you are okay with testing both. Unless if instructed otherwise, you may want to wait a little before testing this.

---

Yamato: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline