### PR TITLE
Make default URP terrain shader compile without errors or warnings

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue with the null check when `UniversalRenderPipelineLightEditor.cs` tries to access `SceneView.lastActiveSceneView`.
 - Fixed an issue where the 'Depth Texture' drop down was incorrectly disabled in the Camera Inspector. 
 - Fixed an issue that caused errors if you disabled the VR Module when building a project.
-- Fixed shader errors and warnings in the default Universal Terrain shader. [case 1185948](https://issuetracker.unity3d.com/issues/urp-terrain-slash-lit-base-pass-shader-does-not-compile)
+- Fixed shader errors and warnings in the default Universal RP Terrain Shader. [case 1185948](https://issuetracker.unity3d.com/issues/urp-terrain-slash-lit-base-pass-shader-does-not-compile)
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue with the null check when `UniversalRenderPipelineLightEditor.cs` tries to access `SceneView.lastActiveSceneView`.
 - Fixed an issue where the 'Depth Texture' drop down was incorrectly disabled in the Camera Inspector. 
 - Fixed an issue that caused errors if you disabled the VR Module when building a project.
+- Fixed shader errors and warnings in the default Universal Terrain shader. [case 1185948](https://issuetracker.unity3d.com/issues/urp-terrain-slash-lit-base-pass-shader-does-not-compile)
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitBasemapGen.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitBasemapGen.shader
@@ -65,7 +65,7 @@ Shader "Hidden/Universal Render Pipeline/Terrain/Lit (Basemap Gen)"
             
             Varyings Vert(Attributes IN)
             {
-                Varyings output;
+                Varyings output = (Varyings) 0;
                 
                 output.clipPos = TransformWorldToHClip(IN.positionOS.xyz);
                 
@@ -147,7 +147,7 @@ Shader "Hidden/Universal Render Pipeline/Terrain/Lit (Basemap Gen)"
             
             Varyings Vert(Attributes IN)
             {
-                Varyings output;
+                Varyings output = (Varyings)0;
                 
                 output.clipPos = TransformWorldToHClip(IN.positionOS.xyz);
                 

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitMetaPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitMetaPass.hlsl
@@ -3,6 +3,20 @@
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/MetaInput.hlsl"
 
+struct Attributes
+{
+    float4 positionOS   : POSITION;
+    float2 uv0          : TEXCOORD0;
+    float2 uv1          : TEXCOORD1;
+    float2 uv2          : TEXCOORD2;
+};
+
+struct Varyings
+{
+    float4 positionCS   : SV_POSITION;
+    float2 uv           : TEXCOORD0;
+};
+
 Varyings TerrainVertexMeta(Attributes input)
 {
     Varyings output;


### PR DESCRIPTION
### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Fixing warnings and errors in the default URP terrain shader.
https://fogbugz.unity3d.com/f/cases/1185948/

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [x] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
