### PR TITLE
Fix a migration issue with project that still had Very High as shadow filtering quality [Skip CI]

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -257,6 +257,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where PBR sky precomputation was reset incorrectly in some cases causing bad performance.
 - Fixed a bug due to depth history begin overriden too soon
 - Fixed CustomPassSampleCameraColor scale issue when called from Before Transparent injection point.
+- Fixed issue with upgrade of projects that still had Very High as shadow filtering quality.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.Migration.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.Migration.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.Rendering.HighDefinition
             AddFrameSettingDirectSpecularLighting,
             AddCustomPostprocessAndCustomPass,
             ScalableSettingsRefactor,
+            ShadowFilteringVeryHighQualityRemoval,
         }
 
         static readonly MigrationDescription<Version, HDRenderPipelineAsset> k_Migration = MigrationDescription.New(
@@ -67,6 +68,11 @@ namespace UnityEngine.Rendering.HighDefinition
                 shadowInit.shadowResolutionArea.schemaId = ScalableSettingSchemaId.With4Levels;
                 shadowInit.shadowResolutionDirectional.schemaId = ScalableSettingSchemaId.With4Levels;
                 shadowInit.shadowResolutionPunctual.schemaId = ScalableSettingSchemaId.With4Levels;
+            }),
+            MigrationStep.New(Version.ShadowFilteringVeryHighQualityRemoval, (HDRenderPipelineAsset data) =>
+            {
+                ref var shadowInit = ref data.m_RenderPipelineSettings.hdShadowInitParams;
+                shadowInit.shadowFilteringQuality = shadowInit.shadowFilteringQuality > HDShadowFilteringQuality.High ? HDShadowFilteringQuality.High : shadowInit.shadowFilteringQuality;
             })
         );
 


### PR DESCRIPTION
Adding a migration step for projects that still had Very High quality set for shadow filtering (we removed it a while back). 


Skipping CI since it is a migration step and we don't have Very High any more in our tests. 