### PR TITLE
Lighting explorer fixes

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -192,6 +192,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                     HDLightType lightType = lightData.type;
 
+                    EditorGUI.BeginProperty(r, GUIContent.none, prop);
                     EditorGUI.BeginChangeCheck();
                     lightType = (HDLightType)EditorGUI.IntPopup(r, (int)lightType, HDStyles.LightTypeTitles, HDStyles.LightTypeValues);
 
@@ -200,6 +201,7 @@ namespace UnityEditor.Rendering.HighDefinition
                         Undo.RecordObjects(new Object[] { prop.serializedObject.targetObject, lightData }, "Changed light type");
                         lightData.type = lightType;
                     }
+                    EditorGUI.EndProperty();
                 }, (lprop, rprop) =>
                 {
                     TryGetAdditionalLightData(lprop, out var lLightData);

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -211,10 +211,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return ((int)lLightData.type).CompareTo((int)rLightData.type);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObjects(new Object[] { target.serializedObject.targetObject, tLightData }, "Changed light type");
@@ -265,10 +262,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return ((float)lLightData.intensity).CompareTo((float)rLightData.intensity);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed light intensity");
@@ -302,10 +296,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return ((int)lLightData.lightUnit).CompareTo((int)rLightData.lightUnit);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed light unit");
@@ -349,10 +340,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return (lLightData.useContactShadow.useOverride ? -1 : (int)lLightData.useContactShadow.level).CompareTo(rLightData.useContactShadow.useOverride ? -1 : (int)rLightData.useContactShadow.level);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed contact shadows");
@@ -409,10 +397,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return lEnabled.CompareTo(rEnabled);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     var hdrp = GraphicsSettings.currentRenderPipeline as HDRenderPipelineAsset;
@@ -454,10 +439,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return ((int)lLightData.shadowResolution.level).CompareTo((int)rLightData.shadowResolution.level);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed contact shadow resolution");
@@ -517,10 +499,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return lResolution.CompareTo(rResolution);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     var hdrp = GraphicsSettings.currentRenderPipeline as HDRenderPipelineAsset;
@@ -561,10 +540,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return lLightData.affectDiffuse.CompareTo(rLightData.affectDiffuse);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed affects diffuse");
@@ -598,10 +574,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return lLightData.affectSpecular.CompareTo(rLightData.affectSpecular);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed affects specular");
@@ -635,10 +608,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return lLightData.fadeDistance.CompareTo(rLightData.fadeDistance);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed light fade distance");
@@ -672,10 +642,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return lLightData.shadowFadeDistance.CompareTo(rLightData.shadowFadeDistance);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed light shadow fade distance");
@@ -712,10 +679,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     return ((int)lLightData.lightlayersMask).CompareTo((int)rLightData.lightlayersMask);
                 }, (target, source) => 
                 {
-                    TryGetAdditionalLightData(target, out var tLightData);
-                    TryGetAdditionalLightData(source, out var sLightData);
-
-                    if (!tLightData || !sLightData)
+                    if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
                     Undo.RecordObject(tLightData, "Changed light layer");

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -877,7 +877,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     }
 
                     reflectionData.Update();
-                    EditorGUI.PropertyField(r, reflectionData.FindProperty("m_ProbeSettings.camera.frustum.nearClipPlane"), GUIContent.none);
+                    EditorGUI.PropertyField(r, reflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane"), GUIContent.none);
                     reflectionData.ApplyModifiedProperties();
                 }, (lprop, rprop) =>
                 {
@@ -887,7 +887,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (IsNullComparison(lReflectionData, rReflectionData, out var order))
                         return order; 
 
-                    return lReflectionData.FindProperty("m_ProbeSettings.camera.frustum.nearClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.nearClipPlane").floatValue);
+                    return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.nearClipPlane").floatValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FarClip, "m_FarClip", 60, (r, prop, dep) =>                        // 5: Far clip
                 {
@@ -898,7 +898,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     }
 
                     reflectionData.Update();
-                    EditorGUI.PropertyField(r, reflectionData.FindProperty("m_ProbeSettings.camera.frustum.farClipPlane"), GUIContent.none);
+                    EditorGUI.PropertyField(r, reflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane"), GUIContent.none);
                     reflectionData.ApplyModifiedProperties();
                 }, (lprop, rprop) =>
                 {
@@ -908,7 +908,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (IsNullComparison(lReflectionData, rReflectionData, out var order))
                         return order; 
 
-                    return lReflectionData.FindProperty("m_ProbeSettings.camera.frustum.farClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.farClipPlane").floatValue);
+                    return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.farClipPlane").floatValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.ParallaxCorrection, "m_BoxProjection", 215, (r, prop, dep) =>   // 6. Use Influence volume as proxy
                 {

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -688,13 +688,14 @@ namespace UnityEditor.Rendering.HighDefinition
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.IsPrefab, "m_Intensity", 120, (r, prop, dep) =>               // 21: Prefab
                 {
                     if (!TryGetLightPrefabData(prop, out var isPrefab, out var prefabRoot))
-                    {
                         return;
-                    }
 
                     if (isPrefab)
                     {
-                        EditorGUI.ObjectField(r, prefabRoot, typeof(GameObject), false);
+                        using (new EditorGUI.DisabledScope(true))
+                        {
+                            EditorGUI.ObjectField(r, prefabRoot, typeof(GameObject), false);
+                        }
                     }
                 }, (lprop, rprop) =>
                 {

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -846,6 +846,14 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lReflectionData.FindProperty("m_ProbeSettings.mode").intValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.mode").intValue);
+                }, (target, source) => 
+                {
+                    if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))
+                        return;
+
+                    tReflectionData.Update();
+                    tReflectionData.FindProperty("m_ProbeSettings.mode").intValue = sReflectionData.FindProperty("m_ProbeSettings.mode").intValue;
+                    tReflectionData.ApplyModifiedProperties();
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.Shape, "m_Mode", 70, (r, prop, dep) =>                              // 3: Shape
                 {
@@ -867,6 +875,14 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lReflectionData.FindProperty("m_ProbeSettings.influence.m_Shape").intValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.influence.m_Shape").intValue);
+                }, (target, source) => 
+                {
+                    if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))
+                        return;
+
+                    tReflectionData.Update();
+                    tReflectionData.FindProperty("m_ProbeSettings.influence.m_Shape").intValue = sReflectionData.FindProperty("m_ProbeSettings.influence.m_Shape").intValue;
+                    tReflectionData.ApplyModifiedProperties();
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.NearClip, "m_NearClip", 65, (r, prop, dep) =>                      // 4: Near clip
                 {
@@ -888,6 +904,14 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.nearClipPlane").floatValue);
+                }, (target, source) => 
+                {
+                    if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))
+                        return;
+
+                    tReflectionData.Update();
+                    tReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane").floatValue = sReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane").floatValue;
+                    tReflectionData.ApplyModifiedProperties();
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FarClip, "m_FarClip", 60, (r, prop, dep) =>                        // 5: Far clip
                 {
@@ -909,6 +933,14 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.farClipPlane").floatValue);
+                }, (target, source) => 
+                {
+                    if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))
+                        return;
+
+                    tReflectionData.Update();
+                    tReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane").floatValue = sReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane").floatValue;
+                    tReflectionData.ApplyModifiedProperties();
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.ParallaxCorrection, "m_BoxProjection", 215, (r, prop, dep) =>   // 6. Use Influence volume as proxy
                 {
@@ -930,6 +962,14 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lReflectionData.FindProperty("m_ProbeSettings.proxySettings.useInfluenceVolumeAsProxyVolume").boolValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.proxySettings.useInfluenceVolumeAsProxyVolume").boolValue);
+                }, (target, source) => 
+                {
+                    if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))
+                        return;
+
+                    tReflectionData.Update();
+                    tReflectionData.FindProperty("m_ProbeSettings.proxySettings.useInfluenceVolumeAsProxyVolume").boolValue = sReflectionData.FindProperty("m_ProbeSettings.proxySettings.useInfluenceVolumeAsProxyVolume").boolValue;
+                    tReflectionData.ApplyModifiedProperties();
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.Weight, "m_Mode", 60, (r, prop, dep) =>                            // 7: Weight
                 {
@@ -951,6 +991,14 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lReflectionData.FindProperty("m_ProbeSettings.lighting.weight").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.lighting.weight").floatValue);
+                }, (target, source) => 
+                {
+                    if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))
+                        return;
+
+                    tReflectionData.Update();
+                    tReflectionData.FindProperty("m_ProbeSettings.lighting.weight").floatValue = sReflectionData.FindProperty("m_ProbeSettings.lighting.weight").floatValue;
+                    tReflectionData.ApplyModifiedProperties();
                 }),
             };
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -250,7 +250,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     intensity = EditorGUI.FloatField(r, intensity);
                     if (EditorGUI.EndChangeCheck())
                     {
-                        Undo.RecordObject(lightData, "Changed light intensity");
+                        Undo.RecordObjects(new Object[] { prop.serializedObject.targetObject, lightData }, "Changed light intensity");
                         lightData.intensity = intensity;
                     }
                 }, (lprop, rprop) =>
@@ -267,7 +267,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
-                    Undo.RecordObject(tLightData, "Changed light intensity");
+                    Undo.RecordObjects(new Object[] { prop.serializedObject.targetObject, tLightData }, "Changed light intensity");
                     tLightData.intensity = sLightData.intensity;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.Unit, "m_Intensity", 70, (r, prop, dep) =>                      // 9: Unit
@@ -870,7 +870,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (IsNullComparison(lReflectionData, rReflectionData, out var order))
                         return order; 
 
-                    return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.nearClipPlane").floatValue);
+                    return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.nearClipPlane").floatValue);
                 }, (target, source) => 
                 {
                     if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))
@@ -899,7 +899,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (IsNullComparison(lReflectionData, rReflectionData, out var order))
                         return order; 
 
-                    return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.camera.frustum.farClipPlane").floatValue);
+                    return lReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane").floatValue.CompareTo(rReflectionData.FindProperty("m_ProbeSettings.cameraSettings.frustum.farClipPlane").floatValue);
                 }, (target, source) => 
                 {
                     if (!TryGetAdditionalReflectionData(target, out var tReflectionData) || !TryGetAdditionalReflectionData(source, out var sReflectionData))

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -217,7 +217,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (!tLightData || !sLightData)
                         return; 
 
-                    Undo.RecordObject(tLightData, "Changed light type");
+                    Undo.RecordObjects(new Object[] { target.serializedObject.targetObject, tLightData }, "Changed light type");
                     tLightData.type = sLightData.type;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.Mode, "m_Lightmapping", 90),                                    // 3: Mixed mode

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -192,15 +192,14 @@ namespace UnityEditor.Rendering.HighDefinition
 
                     HDLightType lightType = lightData.type;
 
-                    EditorGUI.BeginProperty(r, GUIContent.none, prop);
                     EditorGUI.BeginChangeCheck();
                     lightType = (HDLightType)EditorGUI.IntPopup(r, (int)lightType, HDStyles.LightTypeTitles, HDStyles.LightTypeValues);
 
                     if (EditorGUI.EndChangeCheck())
                     {
+                        Undo.RecordObject(lightData, "Changed light type");
                         lightData.type = lightType;
                     }
-                    EditorGUI.EndProperty();
                 
                 }, (lprop, rprop) =>
                 {

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -197,7 +197,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                     if (EditorGUI.EndChangeCheck())
                     {
-                        Undo.RecordObject(lightData, "Changed light type");
+                        Undo.RecordObjects(new Object[] { prop.serializedObject.targetObject, lightData }, "Changed light type");
                         lightData.type = lightType;
                     }
                 }, (lprop, rprop) =>

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -200,7 +200,6 @@ namespace UnityEditor.Rendering.HighDefinition
                         Undo.RecordObject(lightData, "Changed light type");
                         lightData.type = lightType;
                     }
-                
                 }, (lprop, rprop) =>
                 {
                     TryGetAdditionalLightData(lprop, out var lLightData);
@@ -210,7 +209,6 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return ((int)lLightData.type).CompareTo((int)rLightData.type);
-
                 }, (target, source) => 
                 {
                     TryGetAdditionalLightData(target, out var tLightData);
@@ -219,6 +217,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (!tLightData || !sLightData)
                         return; 
 
+                    Undo.RecordObject(tLightData, "Changed light type");
                     tLightData.type = sLightData.type;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.Mode, "m_Lightmapping", 90),                                    // 3: Mixed mode
@@ -255,6 +254,25 @@ namespace UnityEditor.Rendering.HighDefinition
                         Undo.RecordObject(lightData, "Changed light intensity");
                         lightData.intensity = intensity;
                     }
+                }, (lprop, rprop) =>
+                {
+                    TryGetAdditionalLightData(lprop, out var lLightData);
+                    TryGetAdditionalLightData(rprop, out var rLightData);
+
+                    if (IsNullComparison(lLightData, rLightData, out var order))
+                        return order; 
+
+                    return ((float)lLightData.intensity).CompareTo((float)rLightData.intensity);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed light intensity");
+                    tLightData.intensity = sLightData.intensity;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.Unit, "m_Intensity", 70, (r, prop, dep) =>                      // 9: Unit
                 {
@@ -282,6 +300,16 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return ((int)lLightData.lightUnit).CompareTo((int)rLightData.lightUnit);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed light unit");
+                    tLightData.lightUnit = sLightData.lightUnit;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.IndirectMultiplier, "m_BounceIntensity", 115),                 // 10: Indirect multiplier
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.Shadows, "m_Shadows.m_Type", 60, (r, prop, dep) =>          // 11: Shadows
@@ -319,6 +347,17 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return (lLightData.useContactShadow.useOverride ? -1 : (int)lLightData.useContactShadow.level).CompareTo(rLightData.useContactShadow.useOverride ? -1 : (int)rLightData.useContactShadow.level);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed contact shadows");
+                    tLightData.useContactShadow.level = sLightData.useContactShadow.level;
+                    tLightData.useContactShadow.useOverride = sLightData.useContactShadow.useOverride;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.ContactShadows, "m_Shadows.m_Type", 115, (r, prop, dep) =>  // 13: Contact Shadows override
                 {
@@ -368,6 +407,23 @@ namespace UnityEditor.Rendering.HighDefinition
                     bool rEnabled = rUseContactShadow.useOverride ? rUseContactShadow.@override : HDAdditionalLightData.ScalableSettings.UseContactShadow(hdrp)[rUseContactShadow.level]; 
 
                     return lEnabled.CompareTo(rEnabled);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    var hdrp = GraphicsSettings.currentRenderPipeline as HDRenderPipelineAsset;
+                    var tUseContactShadow = tLightData.useContactShadow;
+                    var sUseContactShadow = sLightData.useContactShadow;
+
+                    if (tUseContactShadow.useOverride)
+                    { 
+                        Undo.RecordObject(tLightData, "Changed contact shadow override");
+                        tUseContactShadow.@override = sUseContactShadow.@override;
+                    }
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.ShadowResolution, "m_Intensity", 130, (r, prop, dep) =>         // 14: Shadow Resolution level
                 {
@@ -396,6 +452,17 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return ((int)lLightData.shadowResolution.level).CompareTo((int)rLightData.shadowResolution.level);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed contact shadow resolution");
+                    tLightData.shadowResolution.level = sLightData.shadowResolution.level;
+                    tLightData.shadowResolution.useOverride = sLightData.shadowResolution.useOverride;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Int, HDStyles.ShadowResolution, "m_Intensity", 130, (r, prop, dep) =>          // 15: Shadow resolution override
                 {
@@ -448,6 +515,23 @@ namespace UnityEditor.Rendering.HighDefinition
                     int rResolution = rShadowResolution.useOverride ? rShadowResolution.@override : (hdrp == null ? -1 : HDLightUI.ScalableSettings.ShadowResolution(rLightShape, hdrp)[rShadowResolution.level]); 
 
                     return lResolution.CompareTo(rResolution);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    var hdrp = GraphicsSettings.currentRenderPipeline as HDRenderPipelineAsset;
+                    var tShadowResolution = tLightData.shadowResolution;
+                    var sShadowResolution = sLightData.shadowResolution;
+
+                    if (tShadowResolution.useOverride)
+                    { 
+                        Undo.RecordObject(tLightData, "Changed shadow resolution override");
+                        tShadowResolution.@override = sShadowResolution.@override;
+                    }
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.AffectDiffuse, "m_Intensity", 95, (r, prop, dep) =>         // 16: Affect Diffuse
                 {
@@ -475,6 +559,16 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lLightData.affectDiffuse.CompareTo(rLightData.affectDiffuse);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed affects diffuse");
+                    tLightData.affectDiffuse = sLightData.affectDiffuse;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.AffectSpecular, "m_Intensity", 100, (r, prop, dep) =>       // 17: Affect Specular
                 {
@@ -502,6 +596,16 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lLightData.affectSpecular.CompareTo(rLightData.affectSpecular);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed affects specular");
+                    tLightData.affectSpecular = sLightData.affectSpecular;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FadeDistance, "m_Intensity", 95, (r, prop, dep) =>             // 18: Fade Distance
                 {
@@ -529,6 +633,16 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lLightData.fadeDistance.CompareTo(rLightData.fadeDistance);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed light fade distance");
+                    tLightData.fadeDistance = sLightData.fadeDistance;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.ShadowFadeDistance, "m_Intensity", 145, (r, prop, dep) =>      // 19: Shadow Fade Distance
                 {
@@ -556,6 +670,16 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return lLightData.shadowFadeDistance.CompareTo(rLightData.shadowFadeDistance);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed light shadow fade distance");
+                    tLightData.shadowFadeDistance = sLightData.shadowFadeDistance;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.LightLayer, "m_RenderingLayerMask", 145, (r, prop, dep) =>    // 20: Light Layer
                 {
@@ -586,6 +710,16 @@ namespace UnityEditor.Rendering.HighDefinition
                         return order; 
 
                     return ((int)lLightData.lightlayersMask).CompareTo((int)rLightData.lightlayersMask);
+                }, (target, source) => 
+                {
+                    TryGetAdditionalLightData(target, out var tLightData);
+                    TryGetAdditionalLightData(source, out var sLightData);
+
+                    if (!tLightData || !sLightData)
+                        return; 
+
+                    Undo.RecordObject(tLightData, "Changed light layer");
+                    tLightData.lightlayersMask = sLightData.lightlayersMask;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.IsPrefab, "m_Intensity", 120, (r, prop, dep) =>               // 21: Prefab
                 {

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -246,6 +246,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                     float intensity = lightData.intensity;
 
+                    EditorGUI.BeginProperty(r, GUIContent.none, prop);
                     EditorGUI.BeginChangeCheck();
                     intensity = EditorGUI.FloatField(r, intensity);
                     if (EditorGUI.EndChangeCheck())
@@ -253,6 +254,7 @@ namespace UnityEditor.Rendering.HighDefinition
                         Undo.RecordObjects(new Object[] { prop.serializedObject.targetObject, lightData }, "Changed light intensity");
                         lightData.intensity = intensity;
                     }
+                    EditorGUI.EndProperty();
                 }, (lprop, rprop) =>
                 {
                     TryGetAdditionalLightData(lprop, out var lLightData);
@@ -267,7 +269,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     if (!TryGetAdditionalLightData(target, out var tLightData) || !TryGetAdditionalLightData(source, out var sLightData))
                         return; 
 
-                    Undo.RecordObjects(new Object[] { prop.serializedObject.targetObject, tLightData }, "Changed light intensity");
+                    Undo.RecordObjects(new Object[] { target.serializedObject.targetObject, tLightData }, "Changed light intensity");
                     tLightData.intensity = sLightData.intensity;
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.Unit, "m_Intensity", 70, (r, prop, dep) =>                      // 9: Unit


### PR DESCRIPTION
### Purpose of this PR
Fixing more issues with the Lighting Explorer:
* Fixed multi-edit and undo on Light and Reflection probes
* Disables the prefab field since it's not editable
* Fixed null-ref issue on Reflection probes
* Fixed HDLightType for Lights

### Testing status
I have extensively tested and made sure all fields work (sorting, multi-edit, undo etc) 
I would love to have someone else make sure all this works:
* Sorting of each column for Lights, Volumes and Reflection probes etc.
* Select a few row, change a value, and then hit undo (this should multi-edit, and then revert back properly) 

### When backporting
Please be aware that the name change "camera" -> "cameraSettings" might not work on older versions of Unity. This was a regression in newer versions, and might need to remain how it was. Not sure when this name change happened so this will need to be tested by whoever is doing the backport :) The rest of the changes should be simple to merge in. 