### PR TITLE
Bugfix: DoF kernel with one sample

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldKernel.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/DepthOfFieldKernel.compute
@@ -97,7 +97,9 @@ void MAIN(uint dispatchThreadId : SV_DispatchThreadID)
     );
 
     // Sample coordinates on a normalized square
-    float2 pos = kernelCoords / (SampleCount - 1.0).xx;
+    float2 pos = 0.0;
+    if(SampleCount > 1)
+        pos = kernelCoords / (SampleCount - 1.0).xx;
 
     // Grab the sample (range [-1,1])
     float2 smp = GetSample(pos);


### PR DESCRIPTION
This fixes a simple divide-by-zero bug in the DoF kernel generation code.

The bug can be reproduced by creating a default HDRP scene, enabling DoF in the post-process volume and then setting the quality to "low", which will run DoF with only one sample.