### PR TITLE
backport for #5444 duplicate property name issue

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Shader Graph shaders using the `CameraNode` failed to build on PS4 with "incompatible argument list for call to 'mul'".
 - Fixed a bug where the redo functionality in Shader Graph often didn't work.
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
-- Fixed a bug where properties in the blackboard could have duplicate names.
+- Fixed a bug where Properties in the Blackboard could have duplicate names.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Shader Graph shaders using the `CameraNode` failed to build on PS4 with "incompatible argument list for call to 'mul'".
 - Fixed a bug where the redo functionality in Shader Graph often didn't work.
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
+- Fixed a bug where properties in the blackboard could have duplicate names.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -249,8 +249,8 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (!string.IsNullOrEmpty(newText) && newText != input.displayName)
             {
                 m_Graph.owner.RegisterCompleteObjectUndo("Edit Graph Input Name");
-                m_Graph.SanitizeGraphInputName(input);
                 input.displayName = newText;
+                m_Graph.SanitizeGraphInputName(input);
                 field.text = input.displayName;
                 DirtyNodes();
             }


### PR DESCRIPTION
Backport of #5444 
Fix for a regression in where property names could have the exact same name.
Switch 2 lines since name need to be sanitized after being set.
https://fogbugz.unity3d.com/f/cases/1173806/

YAMATO:
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fbackport-duplicate-property-name-issue/.yamato%252Fupm-ci-shadergraph.yml%2523All_ShaderGraph_fast-2019.3/1004486/job