### PR TITLE
Allow connections to different shader stages

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - If Unity Editor Analytics are enabled, Shader Graph collects anonymous data about which nodes you use in your graphs. This helps the Shader Graph team focus our efforts on the most common graph scenarios, and better understand the needs of our customers. We don't track edge data and cannot recreate your graphs in any form.
 - The Create Node Menu now has a tree view and support for fuzzy field searching.
 
+### Changed
+- Nodes can now have output connections to different shader stages at the same time.
+
 ### Fixed
 - Edges no longer produce errors when you save a Shader Graph.
 - Shader Graph no longer references the `NUnit` package.

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -50,8 +50,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                 return compatibleAnchors;
 
             var startStage = startSlot.stageCapability;
-            if (startStage == ShaderStageCapability.All)
-                startStage = NodeUtils.GetEffectiveShaderStageCapability(startSlot, true) & NodeUtils.GetEffectiveShaderStageCapability(startSlot, false);
 
             foreach (var candidateAnchor in ports.ToList())
             {
@@ -62,9 +60,6 @@ namespace UnityEditor.ShaderGraph.Drawing
                 if (startStage != ShaderStageCapability.All)
                 {
                     var candidateStage = candidateSlot.stageCapability;
-                    if (candidateStage == ShaderStageCapability.All)
-                        candidateStage = NodeUtils.GetEffectiveShaderStageCapability(candidateSlot, true)
-                            & NodeUtils.GetEffectiveShaderStageCapability(candidateSlot, false);
                     if (candidateStage != ShaderStageCapability.All && candidateStage != startStage)
                         continue;
                 }


### PR DESCRIPTION
### Purpose of this PR
UNITY-1149465 highlights an issue with our decision to not allow a node to output to different shader stages at the same time. The reasoning behind that decision was that in some cases it would yield different results. If no issues with allowing this are found, I think we should make that change.

---
### Testing status

This PR only contains Shader Graph UI-changes, which is currently not testable. Will run Yamato regardless.

---
### Comments to reviewers
This should probably have a big round of manual testing, especially wrt. sub graphs.