### PR TITLE
Disable "Copy Shader" for VFX master node

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -37,9 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Shader Graph shaders using the `CameraNode` failed to build on PS4 with "incompatible argument list for call to 'mul'".
 - Fixed a bug that caused problems with Blackboard property ordering.
 - Fixed a bug where the redo functionality in Shader Graph often didn't work.
-
-### Fixed
 - You can now smoothly edit controls on the `Dielectric Specular` node.
+- "Copy Shader" has been removed from the VFX Master Node, as it cannot work with the current implementation. 
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -311,7 +311,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                         _ => isActive ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
                 }
 
-                var canViewShader = node.hasPreview || node is IMasterNode || node is SubGraphOutputNode;
+                var canViewShader = !(node is VfxMasterNode) && (node.hasPreview || node is IMasterNode || node is SubGraphOutputNode);
                 evt.menu.AppendAction("Copy Shader", CopyToClipboard,
                     _ => canViewShader ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Hidden,
                     GenerationMode.ForReals);


### PR DESCRIPTION
### Purpose of this PR
Fixes UNITY-1206090 by removing the "Copy Shader" option for the VFX master node.

---
### Testing status

**Manual Tests**: Verified locally

**Automated Tests**: Shader Graph UI changes only, which doesn't have automated tests.