### PR TITLE
Bugfix #1144710: UniversalRenderPipelineMaterialUpgrader trying to upgrade URP Shaders

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue that caused errors if you disabled the VR Module when building a project.
 - Fixed an issue where the default TerrainLit Material was outdated, which caused the default Terrain to use per-vertex normals instead of per-pixel normals.
 - Fixed shader errors and warnings in the default Universal RP Terrain Shader. [case 1185948](https://issuetracker.unity3d.com/issues/urp-terrain-slash-lit-base-pass-shader-does-not-compile)
+- Fixed an issue with UniversalRenderPipelineMaterialUpgrader trying to upgrade standard Universal shaders [case 1144710](https://issuetracker.unity3d.com/issues/upgrading-to-lwrp-materials-is-trying-to-upgrade-lwrp-materials)
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineMaterialUpgrader.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineMaterialUpgrader.cs
@@ -19,7 +19,10 @@ namespace UnityEditor.Rendering.Universal
             List<MaterialUpgrader> upgraders = new List<MaterialUpgrader>();
             GetUpgraders(ref upgraders);
 
-            MaterialUpgrader.UpgradeProjectFolder(upgraders, "Upgrade to UniversalRP Materials", MaterialUpgrader.UpgradeFlags.LogMessageWhenNoUpgraderFound);
+            HashSet<string> shaderNamesToIgnore = new HashSet<string>();
+            GetShaderNamesToIgnore(ref shaderNamesToIgnore);
+
+            MaterialUpgrader.UpgradeProjectFolder(upgraders, shaderNamesToIgnore, "Upgrade to UniversalRP Materials", MaterialUpgrader.UpgradeFlags.LogMessageWhenNoUpgraderFound);
         }
 
         [MenuItem("Edit/Render Pipeline/Universal Render Pipeline/Upgrade Selected Materials to UniversalRP Materials", priority = CoreUtils.editMenuPriority2)]
@@ -28,7 +31,27 @@ namespace UnityEditor.Rendering.Universal
             List<MaterialUpgrader> upgraders = new List<MaterialUpgrader>();
             GetUpgraders(ref upgraders);
 
-            MaterialUpgrader.UpgradeSelection(upgraders, "Upgrade to UniversalRP Materials", MaterialUpgrader.UpgradeFlags.LogMessageWhenNoUpgraderFound);
+            HashSet<string> shaderNamesToIgnore = new HashSet<string>();
+            GetShaderNamesToIgnore(ref shaderNamesToIgnore);
+
+            MaterialUpgrader.UpgradeSelection(upgraders, shaderNamesToIgnore, "Upgrade to UniversalRP Materials", MaterialUpgrader.UpgradeFlags.LogMessageWhenNoUpgraderFound);
+        }
+
+        private static void GetShaderNamesToIgnore(ref HashSet<string> shadersToIgnore)
+        {
+            shadersToIgnore.Add("Universal Render Pipeline/Baked Lit");
+            shadersToIgnore.Add("Universal Render Pipeline/Lit");
+            shadersToIgnore.Add("Universal Render Pipeline/Particles/Lit");
+            shadersToIgnore.Add("Universal Render Pipeline/Particles/Simple Lit");
+            shadersToIgnore.Add("Universal Render Pipeline/Particles/Unlit");
+            shadersToIgnore.Add("Universal Render Pipeline/Simple Lit");
+            shadersToIgnore.Add("Universal Render Pipeline/Nature/SpeedTree7");
+            shadersToIgnore.Add("Universal Render Pipeline/Nature/SpeedTree7 Billboard");
+            shadersToIgnore.Add("Universal Render Pipeline/Nature/SpeedTree8");
+            shadersToIgnore.Add("Universal Render Pipeline/2D/Sprite-Lit-Default");
+            shadersToIgnore.Add("Universal Render Pipeline/Terrain/Lit");
+            shadersToIgnore.Add("Universal Render Pipeline/Unlit");
+            shadersToIgnore.Add("Sprites/Default");
         }
 
         private static void GetUpgraders(ref List<MaterialUpgrader> upgraders)


### PR DESCRIPTION
### Purpose of this PR
Fixing an issue where the UniversalRenderPipelineMaterialUpgrader tries to upgrade URP Shaders
https://issuetracker.unity3d.com/issues/upgrading-to-lwrp-materials-is-trying-to-upgrade-lwrp-materials

---
### Testing status

**Manual Tests**: What did you do?
- [X ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?
The test project given in the issue.