### PR TITLE
Fix colum headers

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -320,6 +320,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue on metal with edge of decal having artifact by delaying discard of fragments during decal projection
 - Fixed various shader warning
 - Fixing unnecessary memory allocations in the ray tracing cluster build
+- Fixed duplicate column labels in LightEditor's light tab
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -71,8 +71,10 @@ namespace UnityEditor.Rendering.HighDefinition
             public static readonly GUIContent Unit = EditorGUIUtility.TrTextContent("Unit");
             public static readonly GUIContent ColorTemperature = EditorGUIUtility.TrTextContent("Color Temperature");
             public static readonly GUIContent Shadows = EditorGUIUtility.TrTextContent("Shadows");
-            public static readonly GUIContent ContactShadows = EditorGUIUtility.TrTextContent("Contact Shadows");
-            public static readonly GUIContent ShadowResolution = EditorGUIUtility.TrTextContent("Shadows Resolution");
+            public static readonly GUIContent ContactShadowsLevel = EditorGUIUtility.TrTextContent("Contact Shadows Level");
+            public static readonly GUIContent ContactShadowsValue = EditorGUIUtility.TrTextContent("Contact Shadows Value");
+            public static readonly GUIContent ShadowResolutionLevel = EditorGUIUtility.TrTextContent("Shadows Resolution Level");
+            public static readonly GUIContent ShadowResolutionValue = EditorGUIUtility.TrTextContent("Shadows Resolution Value");
             public static readonly GUIContent ShapeWidth = EditorGUIUtility.TrTextContent("Shape Width");
             public static readonly GUIContent VolumeProfile = EditorGUIUtility.TrTextContent("Volume Profile");
             public static readonly GUIContent ColorTemperatureMode = EditorGUIUtility.TrTextContent("Use Color Temperature");
@@ -225,7 +227,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.ColorTemperatureMode, "m_UseColorTemperature", 150),        // 6: Color Temperature Mode
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.ColorTemperature, "m_ColorTemperature", 120, (r, prop, dep) => // 7: Color Temperature
                 {
-                    if (prop.serializedObject.FindProperty("m_UseColorTemperature").boolValue)
+                    using(new EditorGUI.DisabledScope(!prop.serializedObject.FindProperty("m_UseColorTemperature").boolValue))
                     {
                         EditorGUI.PropertyField(r, prop, GUIContent.none);
                     }
@@ -316,7 +318,7 @@ namespace UnityEditor.Rendering.HighDefinition
                         prop.intValue = shadows ? (int)LightShadows.Soft : (int)LightShadows.None;
                     }
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.ContactShadows, "m_Shadows.m_Type", 115, (r, prop, dep) =>      // 12: Contact Shadows level
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.ContactShadowsLevel, "m_Shadows.m_Type", 115, (r, prop, dep) =>      // 12: Contact Shadows level
                 {
                     if(!TryGetAdditionalLightData(prop, out var lightData))
                     {
@@ -351,7 +353,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     tLightData.useContactShadow.level = sLightData.useContactShadow.level;
                     tLightData.useContactShadow.useOverride = sLightData.useContactShadow.useOverride;
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.ContactShadows, "m_Shadows.m_Type", 115, (r, prop, dep) =>  // 13: Contact Shadows override
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.ContactShadowsValue, "m_Shadows.m_Type", 115, (r, prop, dep) =>  // 13: Contact Shadows override
                 {
                     if(!TryGetAdditionalLightData(prop, out var lightData))
                     {
@@ -414,7 +416,7 @@ namespace UnityEditor.Rendering.HighDefinition
                         tUseContactShadow.@override = sUseContactShadow.@override;
                     }
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.ShadowResolution, "m_Intensity", 130, (r, prop, dep) =>         // 14: Shadow Resolution level
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Enum, HDStyles.ShadowResolutionLevel, "m_Intensity", 130, (r, prop, dep) =>         // 14: Shadow Resolution level
                 {
                     if(!TryGetAdditionalLightData(prop, out var lightData))
                     {
@@ -450,7 +452,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     tLightData.shadowResolution.level = sLightData.shadowResolution.level;
                     tLightData.shadowResolution.useOverride = sLightData.shadowResolution.useOverride;
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Int, HDStyles.ShadowResolution, "m_Intensity", 130, (r, prop, dep) =>          // 15: Shadow resolution override
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Int, HDStyles.ShadowResolutionValue, "m_Intensity", 130, (r, prop, dep) =>          // 15: Shadow resolution override
                 {
                     var hdrp = HDRenderPipeline.currentAsset;
 


### PR DESCRIPTION
### Purpose of this PR
Rename the column of the Light Explorer for HDRP lights and make color temperature use same concept (show but disabled) than the actual value of scalable settings.

---
### Testing status

**Manual Tests**: 
- [x] Checked new UI names with UX convention

---
### Comments to reviewers
It is not possible to hide the value column in case of scalable settings as it display what correspond to the selected level when not editable. So here I prefer to display the color temperature but in a disabled state for coherency>