### PR TITLE
Bugfix 1162556: Soft particles not rendering when depth texture was not enabled

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue that caused errors if you disabled the VR Module when building a project.
 - Fixed an issue where the default TerrainLit Material was outdated, which caused the default Terrain to use per-vertex normals instead of per-pixel normals.
 - Fixed shader errors and warnings in the default Universal RP Terrain Shader. [case 1185948](https://issuetracker.unity3d.com/issues/urp-terrain-slash-lit-base-pass-shader-does-not-compile)
+- Fixed an issue with soft particles not rendering when depth texture was disabled [case 1162556](https://issuetracker.unity3d.com/issues/lwrp-unlit-particles-shader-is-not-rendered-when-soft-particles-are-enabled-on-built-application)
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Editor/ShaderGUI/ParticleGUI.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGUI/ParticleGUI.cs
@@ -3,6 +3,7 @@ using UnityEditorInternal;
 using System.Linq;
 using System.Collections.Generic;
 using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
 using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEditor.Rendering.Universal.ShaderGUI
@@ -176,6 +177,18 @@ namespace UnityEditor.Rendering.Universal.ShaderGUI
 
                     if (enabled >= 0.5f)
                     {
+                        UniversalRenderPipelineAsset urpAsset = GraphicsSettings.renderPipelineAsset as UniversalRenderPipelineAsset;
+                        if (urpAsset != null)
+                        {
+                            if (!urpAsset.supportsCameraDepthTexture)
+                            {
+                                GUIStyle warnStyle = new GUIStyle(GUI.skin.label);
+                                warnStyle.fontStyle = FontStyle.BoldAndItalic;
+                                warnStyle.wordWrap = true;
+                                GUILayout.Label("WARNING: Soft Particles require depth texture. Please enable \"Depth Texture\" in the Universal Render Pipeline settings.", warnStyle);
+                            }
+                        }
+
                         EditorGUI.indentLevel++;
                         BaseShaderGUI.TwoFloatSingleLine(new GUIContent("Surface Fade"),
                             properties.softParticlesNearFadeDistance,

--- a/com.unity.render-pipelines.universal/Runtime/Passes/DepthOnlyPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/DepthOnlyPass.cs
@@ -58,6 +58,7 @@ namespace UnityEngine.Rendering.Universal.Internal
             CommandBuffer cmd = CommandBufferPool.Get(m_ProfilerTag);
             using (new ProfilingScope(cmd, m_ProfilingSampler))
             {
+                CoreUtils.SetKeyword(cmd, ShaderKeywordStrings.DepthTextureAvailable, true);
                 context.ExecuteCommandBuffer(cmd);
                 cmd.Clear();
 

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -415,6 +415,7 @@ namespace UnityEngine.Rendering.Universal
             cmd.DisableShaderKeyword(ShaderKeywordStrings.AdditionalLightShadows);
             cmd.DisableShaderKeyword(ShaderKeywordStrings.SoftShadows);
             cmd.DisableShaderKeyword(ShaderKeywordStrings.MixedLightingSubtractive);
+            cmd.DisableShaderKeyword(ShaderKeywordStrings.DepthTextureAvailable);
 
             // Required by VolumeSystem / PostProcessing.
             VolumeManager.instance.Update(cameraData.volumeTrigger, cameraData.volumeLayerMask);

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -127,6 +127,8 @@ namespace UnityEngine.Rendering.Universal
         public static readonly string SoftShadows = "_SHADOWS_SOFT";
         public static readonly string MixedLightingSubtractive = "_MIXED_LIGHTING_SUBTRACTIVE";
 
+        public static readonly string DepthTextureAvailable = "_DEPTH_TEXTURE_AVAILABLE";
+
         public static readonly string DepthNoMsaa = "_DEPTH_NO_MSAA";
         public static readonly string DepthMsaa2 = "_DEPTH_MSAA_2";
         public static readonly string DepthMsaa4 = "_DEPTH_MSAA_4";

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLit.shader
@@ -113,6 +113,7 @@ Shader "Universal Render Pipeline/Particles/Lit"
             // -------------------------------------
             // Unity defined keywords
             #pragma multi_compile_fog
+            #pragma multi_compile _ _DEPTH_TEXTURE_AVAILABLE
 
             #pragma vertex ParticlesLitVertex
             #pragma fragment ParticlesLitFragment

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
@@ -37,7 +37,7 @@ struct VaryingsParticle
 #if defined(_FLIPBOOKBLENDING_ON)
     float3 texcoord2AndBlend        : TEXCOORD5;
 #endif
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     float4 projectedPosition        : TEXCOORD6;
 #endif
 
@@ -132,7 +132,7 @@ VaryingsParticle ParticlesLitVertex(AttributesParticle input)
     output.texcoord2AndBlend.z = input.texcoordBlend;
 #endif
 
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     output.projectedPosition = vertexInput.positionNDC;
 #endif
 
@@ -154,7 +154,7 @@ half4 ParticlesLitFragment(VaryingsParticle input) : SV_Target
 #endif
 
     float4 projectedPosition = float4(0,0,0,0);
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     projectedPosition = input.projectedPosition;
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitInput.hlsl
@@ -48,7 +48,7 @@ half4 SampleAlbedo(float2 uv, float3 blendUv, half4 color, float4 particleColor,
 
     AlphaDiscard(albedo.a, _Cutoff);
 
-#if defined(_SOFTPARTICLES_ON)
+#if defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)
         ALBEDO_MUL *= SoftParticles(SOFT_PARTICLE_NEAR_FADE, SOFT_PARTICLE_INV_FADE_DISTANCE, projectedPosition);
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLit.shader
@@ -120,6 +120,7 @@ Shader "Universal Render Pipeline/Particles/Simple Lit"
             // -------------------------------------
             // Unity defined keywords
             #pragma multi_compile_fog
+            #pragma multi_compile _ _DEPTH_TEXTURE_AVAILABLE
 
             #pragma vertex ParticlesLitVertex
             #pragma fragment ParticlesLitFragment

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitForwardPass.hlsl
@@ -38,7 +38,7 @@ struct VaryingsParticle
 #if defined(_FLIPBOOKBLENDING_ON)
     float3 texcoord2AndBlend        : TEXCOORD5;
 #endif
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     float4 projectedPosition        : TEXCOORD6;
 #endif
 
@@ -129,7 +129,7 @@ VaryingsParticle ParticlesLitVertex(AttributesParticle input)
     output.texcoord2AndBlend.z = input.texcoordBlend;
 #endif
 
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     output.projectedPosition = ComputeScreenPos(vertexInput.positionCS);
 #endif
 
@@ -152,7 +152,7 @@ half4 ParticlesLitFragment(VaryingsParticle input) : SV_Target
 #endif
 
     float4 projectedPosition = float4(0,0,0,0);
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     projectedPosition = input.projectedPosition;
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitInput.hlsl
@@ -41,7 +41,7 @@ half4 SampleAlbedo(float2 uv, float3 blendUv, half4 color, float4 particleColor,
 
     AlphaDiscard(albedo.a, _Cutoff);
 
- #if defined(_SOFTPARTICLES_ON)
+ #if defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)
      ALBEDO_MUL *= SoftParticles(SOFT_PARTICLE_NEAR_FADE, SOFT_PARTICLE_INV_FADE_DISTANCE, projectedPosition);
  #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlit.shader
@@ -94,6 +94,7 @@ Shader "Universal Render Pipeline/Particles/Unlit"
             // -------------------------------------
             // Unity defined keywords
             #pragma multi_compile_fog
+            #pragma multi_compile _ _DEPTH_TEXTURE_AVAILABLE
 
             #pragma vertex vertParticleUnlit
             #pragma fragment fragParticleUnlit

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
@@ -37,7 +37,7 @@ struct VaryingsParticle
 #if defined(_FLIPBOOKBLENDING_ON)
     float3 texcoord2AndBlend        : TEXCOORD5;
 #endif
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     float4 projectedPosition        : TEXCOORD6;
 #endif
 
@@ -116,7 +116,7 @@ VaryingsParticle vertParticleUnlit(AttributesParticle input)
     output.texcoord2AndBlend.z = input.texcoordBlend;
 #endif
 
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     output.projectedPosition = ComputeScreenPos(vertexInput.positionCS);
 #endif
 
@@ -135,7 +135,7 @@ half4 fragParticleUnlit(VaryingsParticle input) : SV_Target
 #endif
 
     float4 projectedPosition = float4(0,0,0,0);
-#if defined(_SOFTPARTICLES_ON) || defined(_FADING_ON) || defined(_DISTORTION_ON)
+#if (defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)) || defined(_FADING_ON) || defined(_DISTORTION_ON)
     projectedPosition = input.projectedPosition;
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitInput.hlsl
@@ -34,7 +34,7 @@ half4 SampleAlbedo(float2 uv, float3 blendUv, half4 color, float4 particleColor,
 
     AlphaDiscard(albedo.a, _Cutoff);
 
- #if defined(_SOFTPARTICLES_ON)
+ #if defined(_SOFTPARTICLES_ON) && defined(_DEPTH_TEXTURE_AVAILABLE)
      ALBEDO_MUL *= SoftParticles(SOFT_PARTICLE_NEAR_FADE, SOFT_PARTICLE_INV_FADE_DISTANCE, projectedPosition);
  #endif
 


### PR DESCRIPTION
**DONT FORGET TO ADD A CHANGELOG**

### Checklist for PR maker
- [X] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Fixing an issue with Particles not rendering when Soft Particles were enabled but Depth texture has not been enabled. Added a warning label in the shader gui that gets displayed when this happens.

---
### Testing status

**Manual Tests**: What did you do?
- [X] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
I've reluctantly added a new keyword **"DEPTH_TEXTURE_AVAILABLE"** that get enabled if DepthOnlyPass is executed. That keyword is now used in combination with **"_SOFTPARTICLES_ON"**.
