### PR TITLE
[Shader Graph][Skip CI] Branch Node to Ternary Operator 

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The Create Node Menu now has a tree view and support for fuzzy field searching.
 
 ### Changed
-- The `Branch` node now uses a ternary operator (`Out = bool ? a : B`) instead of a linear interpolate function.
+- Changed the `Branch` node so that it uses a ternary operator (`Out = bool ? a : B`) instead of a linear interpolate function.
 
 ### Fixed
 - Edges no longer produce errors when you save a Shader Graph.

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - If Unity Editor Analytics are enabled, Shader Graph collects anonymous data about which nodes you use in your graphs. This helps the Shader Graph team focus our efforts on the most common graph scenarios, and better understand the needs of our customers. We don't track edge data and cannot recreate your graphs in any form.
 - The Create Node Menu now has a tree view and support for fuzzy field searching.
 
+### Changed
+- The `Branch` node now uses a ternary operator (`Out = bool ? a : B`) instead of a linear interpolate function.
+
 ### Fixed
 - Edges no longer produce errors when you save a Shader Graph.
 - Shader Graph no longer references the `NUnit` package.

--- a/com.unity.shadergraph/Documentation~/Branch-Node.md
+++ b/com.unity.shadergraph/Documentation~/Branch-Node.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Provides a dynamic branch to the shader. If input **Predicate** is true the return output will be equal to input **True**, otherwise it will be equal to input **False**. This is determined per vertex or per pixel depending on shader stage. Both sides of the branch will be calculated in the shader, even if one is never output.
+Provides a dynamic branch to the shader. If input **Predicate** is true the return output will be equal to input **True**, otherwise it will be equal to input **False**. This is determined per vertex or per pixel depending on shader stage. Both sides of the branch will be evaluated in the shader, and the branch not used will be discarded.
 
 ## Ports
 
@@ -20,6 +20,6 @@ The following example code represents one possible outcome of this node.
 ```
 void Unity_Branch_float4(float Predicate, float4 True, float4 False, out float4 Out)
 {
-    Out = lerp(False, True, Predicate);
+    Out = Predicate ? True : False;
 }
 ```

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/BranchNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/BranchNode.cs
@@ -26,7 +26,7 @@ namespace UnityEditor.ShaderGraph
             return
                 @"
 {
-    Out = lerp(False, True, Predicate);
+    Out = Predicate ? True : False;
 }
 ";
         }


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

The `Branch` node previously was performing a linear interpolate function and could lead to NaNs. It now performs a ternary operation `Out = bool ? a : b`.

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: No new tests, but confirmed with the existing `Logic` test scene that branch operations are behaving as expected. 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fternary-branch-node

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
