### PR TITLE
[2019.3 Backport] [7.3] group node fixes Shader Graph

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -32,8 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the redo functionality in Shader Graph often didn't work.
 - Fixed a bug where the input fields sometimes didn't render properly. [1176268](https://issuetracker.unity3d.com/issues/shadergraph-input-fields-get-cut-off-after-minimizing-and-maximizing-become-unusable)
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
-- Sticky Notes can now be grouped properly.
-- Fixed an issue where nodes couldn't be copied from a group.
+- Fixed Sticky Notes so that you can group them properly.
+- Fixed an issue where you couldn't copy nodes from a group.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the redo functionality in Shader Graph often didn't work.
 - Fixed a bug where the input fields sometimes didn't render properly. [1176268](https://issuetracker.unity3d.com/issues/shadergraph-input-fields-get-cut-off-after-minimizing-and-maximizing-become-unusable)
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
+- Sticky Notes can now be grouped properly.
+- Fixed an issue where nodes couldn't be copied from a group.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GraphData.cs
@@ -360,7 +360,7 @@ namespace UnityEditor.ShaderGraph
                 // If adding a Sub Graph node whose asset contains Keywords
                 // Need to restest Keywords against the variant limit
                 if(node is SubGraphNode subGraphNode &&
-                    subGraphNode.asset != null && 
+                    subGraphNode.asset != null &&
                     subGraphNode.asset.keywords.Count > 0)
                 {
                     OnKeywordChangedNoValidate();
@@ -1201,12 +1201,21 @@ namespace UnityEditor.ShaderGraph
                 }
 
                 AbstractMaterialNode abstractMaterialNode = (AbstractMaterialNode)node;
+
+                // If the node has a group guid and no group has been copied, reset the group guid.
                 // Check if the node is inside a group
-                if (groupGuidMap.ContainsKey(abstractMaterialNode.groupGuid))
+                if (abstractMaterialNode.groupGuid != Guid.Empty)
                 {
-                    var absNode = pastedNode as AbstractMaterialNode;
-                    absNode.groupGuid = groupGuidMap[abstractMaterialNode.groupGuid];
-                    pastedNode = absNode;
+                    if (groupGuidMap.ContainsKey(abstractMaterialNode.groupGuid))
+                    {
+                        var absNode = pastedNode as AbstractMaterialNode;
+                        absNode.groupGuid = groupGuidMap[abstractMaterialNode.groupGuid];
+                        pastedNode = absNode;
+                    }
+                    else
+                    {
+                        pastedNode.groupGuid = Guid.Empty;
+                    }
                 }
 
                 var drawState = node.drawState;

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -319,11 +319,19 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
             }
 
-            if (evt.ctrlKey && evt.keyCode == KeyCode.G)
+            if (evt.actionKey && evt.keyCode == KeyCode.G)
             {
-                if (m_GraphView.selection.OfType<MaterialNodeView>().Any())
+                if (m_GraphView.selection.OfType<GraphElement>().Any())
                 {
                     m_GraphView.GroupSelection();
+                }
+            }
+
+            if (evt.actionKey && evt.keyCode == KeyCode.U)
+            {
+                if (m_GraphView.selection.OfType<GraphElement>().Any())
+                {
+                    m_GraphView.RemoveFromGroupNode();
                 }
             }
         }
@@ -780,7 +788,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void AddGroup(GroupData groupData)
         {
-            ShaderGroup graphGroup = new ShaderGroup(m_Graph);
+            ShaderGroup graphGroup = new ShaderGroup();
 
             graphGroup.userData = groupData;
             graphGroup.title = groupData.title;

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -214,30 +214,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             graph.RemoveElements(groupItems.OfType<AbstractMaterialNode>().ToArray(), new IEdge[] {}, new [] {data}, groupItems.OfType<StickyNoteData>().ToArray());
         }
 
-        // private void InitializePrecisionSubMenu(ContextualMenuPopulateEvent evt)
-        // {
-        //     // Default the menu buttons to disabled
-        //     DropdownMenuAction.Status inheritPrecisionAction = DropdownMenuAction.Status.Disabled;
-        //     DropdownMenuAction.Status floatPrecisionAction = DropdownMenuAction.Status.Disabled;
-        //     DropdownMenuAction.Status halfPrecisionAction = DropdownMenuAction.Status.Disabled;
-        //
-        //     // Check which precisions are available to switch to
-        //     foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
-        //     {
-        //         if (selectedNode.node.precision != Precision.Inherit)
-        //             inheritPrecisionAction = DropdownMenuAction.Status.Normal;
-        //         if (selectedNode.node.precision != Precision.Float)
-        //             floatPrecisionAction = DropdownMenuAction.Status.Normal;
-        //         if (selectedNode.node.precision != Precision.Half)
-        //             halfPrecisionAction = DropdownMenuAction.Status.Normal;
-        //     }
-        //
-        //     // Create the menu options
-        //     //evt.menu.AppendAction("Precision/Inherit", _ => SetNodePrecisionOnSelection(Precision.Inherit), (a) => inheritPrecisionAction);
-        //     //evt.menu.AppendAction("Precision/Float", _ => SetNodePrecisionOnSelection(Precision.Float), (a) => floatPrecisionAction);
-        //     //evt.menu.AppendAction("Precision/Half", _ => SetNodePrecisionOnSelection(Precision.Half), (a) => halfPrecisionAction);
-        // }
-
         private void InitializeViewSubMenu(ContextualMenuPopulateEvent evt)
         {
             // Default the menu buttons to disabled

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -81,65 +81,33 @@ namespace UnityEditor.ShaderGraph.Drawing
             if(evt.target is GraphView)
             {
                 evt.menu.InsertAction(1, "Create Sticky Note", (e) => { AddStickyNote(mousePosition); });
+
+                foreach (AbstractMaterialNode node in graph.GetNodes<AbstractMaterialNode>())
+                {
+                    if (node.hasPreview && node.previewExpanded == true)
+                        evt.menu.InsertAction(2, "Collapse All Previews", CollapsePreviews, (a) => DropdownMenuAction.Status.Normal);
+                    if (node.hasPreview && node.previewExpanded == false)
+                        evt.menu.InsertAction(2, "Expand All Previews", ExpandPreviews, (a) => DropdownMenuAction.Status.Normal);
+                }
+                evt.menu.AppendSeparator();
             }
 
             if (evt.target is GraphView || evt.target is Node)
             {
+                if (evt.target is Node node)
+                {
+                    if (!selection.Contains(node))
+                    {
+                        selection.Clear();
+                        selection.Add(node);
+                    }
+                }
+
                 InitializeViewSubMenu(evt);
 
                 evt.menu.AppendAction("Convert To Sub-graph", ConvertToSubgraph, ConvertToSubgraphStatus);
                 evt.menu.AppendAction("Convert To Inline Node", ConvertToInlineNode, ConvertToInlineNodeStatus);
                 evt.menu.AppendAction("Convert To Property", ConvertToProperty, ConvertToPropertyStatus);
-
-                evt.menu.AppendAction("Group Selection", _ => GroupSelection(), (a) =>
-                {
-                    List<ISelectable> filteredSelection = new List<ISelectable>();
-
-                    foreach (ISelectable selectedObject in selection)
-                    {
-                        if (selectedObject is Group)
-                            return DropdownMenuAction.Status.Disabled;
-                        VisualElement ve = selectedObject as VisualElement;
-                        if (ve.userData is AbstractMaterialNode)
-                        {
-                            var selectedNode = selectedObject as Node;
-                            if (selectedNode.GetContainingScope() is Group)
-                                return DropdownMenuAction.Status.Disabled;
-
-                            filteredSelection.Add(selectedObject);
-                        }
-                    }
-
-                    if (filteredSelection.Count > 0)
-                        return DropdownMenuAction.Status.Normal;
-                    else
-                        return DropdownMenuAction.Status.Disabled;
-                });
-
-                evt.menu.AppendAction("Ungroup Selection", RemoveFromGroupNode, (a) =>
-                {
-                    List<ISelectable> filteredSelection = new List<ISelectable>();
-
-                    foreach (ISelectable selectedObject in selection)
-                    {
-                        if (selectedObject is Group)
-                            return DropdownMenuAction.Status.Disabled;
-                        VisualElement ve = selectedObject as VisualElement;
-                        if (ve.userData is AbstractMaterialNode)
-                        {
-                            var selectedNode = selectedObject as Node;
-                            if (selectedNode.GetContainingScope() is Group)
-                                filteredSelection.Add(selectedObject);
-                        }
-                    }
-
-                    if (filteredSelection.Count > 0)
-                        return DropdownMenuAction.Status.Normal;
-                    else
-                        return DropdownMenuAction.Status.Disabled;
-                });
-
-                
 
                 var editorView = GetFirstAncestorOfType<GraphEditorView>();
                 if (editorView.colorManager.activeSupportsCustom && selection.OfType<MaterialNodeView>().Any())
@@ -165,32 +133,110 @@ namespace UnityEditor.ShaderGraph.Drawing
                 if (selection.OfType<IShaderNodeView>().Count() == 1)
                 {
                     evt.menu.AppendSeparator();
-                    evt.menu.AppendAction("Open Documentation", SeeDocumentation, SeeDocumentationStatus);
+                    evt.menu.AppendAction("Open Documentation _F1", SeeDocumentation, SeeDocumentationStatus);
                 }
                 if (selection.OfType<IShaderNodeView>().Count() == 1 && selection.OfType<IShaderNodeView>().First().node is SubGraphNode)
                 {
                     evt.menu.AppendSeparator();
-
                     evt.menu.AppendAction("Open Sub Graph", OpenSubGraph, (a) => DropdownMenuAction.Status.Normal);
                 }
+            }
+            evt.menu.AppendSeparator();
+            // This needs to work on nodes, groups and properties
+            if ((evt.target is Node) || (evt.target is StickyNote))
+            {
+                evt.menu.AppendAction("Group Selection %g", _ => GroupSelection(), (a) =>
+                {
+                    List<ISelectable> filteredSelection = new List<ISelectable>();
+
+                    foreach (ISelectable selectedObject in selection)
+                    {
+                        if (selectedObject is Group)
+                            return DropdownMenuAction.Status.Disabled;
+                        GraphElement ge = selectedObject as GraphElement;
+                        if (ge.userData is IGroupItem)
+                        {
+                            filteredSelection.Add(ge);
+                        }
+                    }
+
+                    if (filteredSelection.Count > 0)
+                        return DropdownMenuAction.Status.Normal;
+
+                    return DropdownMenuAction.Status.Disabled;
+                });
+
+                evt.menu.AppendAction("Ungroup Selection %u", _ => RemoveFromGroupNode(), (a) =>
+                {
+                    List<ISelectable> filteredSelection = new List<ISelectable>();
+
+                    foreach (ISelectable selectedObject in selection)
+                    {
+                        if (selectedObject is Group)
+                            return DropdownMenuAction.Status.Disabled;
+                        GraphElement ge = selectedObject as GraphElement;
+                        if (ge.userData is IGroupItem)
+                        {
+                            if (ge.GetContainingScope() is Group)
+                                filteredSelection.Add(ge);
+                        }
+                    }
+
+                    if (filteredSelection.Count > 0)
+                        return DropdownMenuAction.Status.Normal;
+
+                    return DropdownMenuAction.Status.Disabled;
+                });
+            }
+
+            if (evt.target is ShaderGroup shaderGroup)
+            {
+                if (!selection.Contains(shaderGroup))
+                {
+                    selection.Add(shaderGroup);
+                }
+
+                var data = shaderGroup.userData;
+                int count = evt.menu.MenuItems().Count;
+                evt.menu.InsertAction(count, "Delete Group and Contents", (e) => RemoveNodesInsideGroup(e, data), DropdownMenuAction.AlwaysEnabled);
             }
 
             if (evt.target is BlackboardField)
             {
                 evt.menu.AppendAction("Delete", (e) => DeleteSelectionImplementation("Delete", AskUser.DontAskUser), (e) => canDeleteSelection ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
             }
-            if (evt.target is MaterialGraphView)
-            {
-                foreach (AbstractMaterialNode node in graph.GetNodes<AbstractMaterialNode>())
-                {
-                    if (node.hasPreview && node.previewExpanded == true)
-                        evt.menu.AppendAction("Collapse All Previews", CollapsePreviews, (a) => DropdownMenuAction.Status.Normal);
-                    if (node.hasPreview && node.previewExpanded == false)
-                        evt.menu.AppendAction("Expand All Previews", ExpandPreviews, (a) => DropdownMenuAction.Status.Normal);
-                }
-                evt.menu.AppendSeparator();
-            }
         }
+
+        void RemoveNodesInsideGroup(DropdownMenuAction action, GroupData data)
+        {
+            graph.owner.RegisterCompleteObjectUndo("Delete Group and Contents");
+            var groupItems = graph.GetItemsInGroup(data);
+            graph.RemoveElements(groupItems.OfType<AbstractMaterialNode>().ToArray(), new IEdge[] {}, new [] {data}, groupItems.OfType<StickyNoteData>().ToArray());
+        }
+
+        // private void InitializePrecisionSubMenu(ContextualMenuPopulateEvent evt)
+        // {
+        //     // Default the menu buttons to disabled
+        //     DropdownMenuAction.Status inheritPrecisionAction = DropdownMenuAction.Status.Disabled;
+        //     DropdownMenuAction.Status floatPrecisionAction = DropdownMenuAction.Status.Disabled;
+        //     DropdownMenuAction.Status halfPrecisionAction = DropdownMenuAction.Status.Disabled;
+        //
+        //     // Check which precisions are available to switch to
+        //     foreach (MaterialNodeView selectedNode in selection.Where(x => x is MaterialNodeView).Select(x => x as MaterialNodeView))
+        //     {
+        //         if (selectedNode.node.precision != Precision.Inherit)
+        //             inheritPrecisionAction = DropdownMenuAction.Status.Normal;
+        //         if (selectedNode.node.precision != Precision.Float)
+        //             floatPrecisionAction = DropdownMenuAction.Status.Normal;
+        //         if (selectedNode.node.precision != Precision.Half)
+        //             halfPrecisionAction = DropdownMenuAction.Status.Normal;
+        //     }
+        //
+        //     // Create the menu options
+        //     //evt.menu.AppendAction("Precision/Inherit", _ => SetNodePrecisionOnSelection(Precision.Inherit), (a) => inheritPrecisionAction);
+        //     //evt.menu.AppendAction("Precision/Float", _ => SetNodePrecisionOnSelection(Precision.Float), (a) => floatPrecisionAction);
+        //     //evt.menu.AppendAction("Precision/Half", _ => SetNodePrecisionOnSelection(Precision.Half), (a) => halfPrecisionAction);
+        // }
 
         private void InitializeViewSubMenu(ContextualMenuPopulateEvent evt)
         {
@@ -293,9 +339,12 @@ namespace UnityEditor.ShaderGraph.Drawing
             graph.owner.RegisterCompleteObjectUndo("Create Group Node");
             graph.CreateGroup(groupData);
 
-            foreach (var shaderNodeView in selection.OfType<IShaderNodeView>())
+            foreach (var element in selection.OfType<GraphElement>())
             {
-                graph.SetGroup(shaderNodeView.node, groupData);
+                if (element.userData is IGroupItem groupItem)
+                {
+                    graph.SetGroup(groupItem, groupData);
+                }
             }
         }
 
@@ -309,20 +358,18 @@ namespace UnityEditor.ShaderGraph.Drawing
             graph.AddStickyNote(stickyNoteData);
         }
 
-
-        void RemoveFromGroupNode(DropdownMenuAction action)
+        public void RemoveFromGroupNode()
         {
             graph.owner.RegisterCompleteObjectUndo("Ungroup Node(s)");
-            foreach (ISelectable selectable in selection)
+            foreach (var element in selection.OfType<GraphElement>())
             {
-                var node = selectable as Node;
-                if(node == null)
-                    continue;
-
-                Group group = node.GetContainingScope() as Group;
-                if (group != null)
+                if (element.userData is IGroupItem)
                 {
-                    group.RemoveElement(node);
+                    Group group = element.GetContainingScope() as Group;
+                    if (group != null)
+                    {
+                        group.RemoveElement(element);
+                    }
                 }
             }
         }
@@ -535,7 +582,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             // Filter nodes that cannot be deleted
             var nodesToDelete = selection.OfType<IShaderNodeView>().Where(v => !(v.node is SubGraphOutputNode) && v.node.canDeleteNode).Select(x => x.node);
-            
+
             // Add keyword nodes dependent on deleted keywords
             nodesToDelete = nodesToDelete.Union(keywordNodes);
 
@@ -551,13 +598,13 @@ namespace UnityEditor.ShaderGraph.Drawing
                     keywordsDirty = true;
                 }
             }
-            
+
             graph.owner.RegisterCompleteObjectUndo(operationName);
             graph.RemoveElements(nodesToDelete.ToArray(),
                 selection.OfType<Edge>().Select(x => x.userData).OfType<IEdge>().ToArray(),
                 selection.OfType<ShaderGroup>().Select(x => x.userData).ToArray(),
                 selection.OfType<StickyNote>().Select(x => x.userData).ToArray());
-            
+
             foreach (var selectable in selection)
             {
                 var field = selectable as BlackboardField;
@@ -689,7 +736,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (textureArray != null)
             {
                 graph.owner.RegisterCompleteObjectUndo("Drag Texture Array");
-                
+
                 var node = new SampleTexture2DArrayNode();
                 var drawState = node.drawState;
                 drawState.position = new Rect(nodePosition, drawState.position.size);
@@ -721,7 +768,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (cubemap != null)
             {
                 graph.owner.RegisterCompleteObjectUndo("Drag Cubemap");
-                
+
                 var node = new SampleCubemapNode();
                 var drawState = node.drawState;
                 drawState.position = new Rect(nodePosition, drawState.position.size);
@@ -748,7 +795,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             var blackboardField = obj as BlackboardField;
             if (blackboardField != null)
-            {   
+            {
                 graph.owner.RegisterCompleteObjectUndo("Drag Graph Input");
 
                 switch(blackboardField.userData)

--- a/com.unity.shadergraph/Editor/Drawing/Views/ShaderGroup.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/ShaderGroup.cs
@@ -19,25 +19,15 @@ namespace UnityEditor.ShaderGraph
             set => base.userData = value;
         }
 
-        public ShaderGroup(GraphData graph)
+        public ShaderGroup()
         {
-            m_Graph = graph;
             VisualElementExtensions.AddManipulator(this, new ContextualMenuManipulator(BuildContextualMenu));
+            style.backgroundColor = new StyleColor(new Color(25/255f, 25/255f, 25/255f, 25/255f));
+            capabilities |= Capabilities.Ascendable;
         }
 
         public void BuildContextualMenu(ContextualMenuPopulateEvent evt)
         {
-            if (evt.target is ShaderGroup)
-            {
-                evt.menu.AppendAction("Delete Group and Contents", RemoveNodesInsideGroup, DropdownMenuAction.AlwaysEnabled);
-            }
-        }
-
-        void RemoveNodesInsideGroup(DropdownMenuAction action)
-        {
-            m_Graph.owner.RegisterCompleteObjectUndo("Delete Group and Contents");
-            var groupItems = m_Graph.GetItemsInGroup(userData);
-            m_Graph.RemoveElements(groupItems.OfType<AbstractMaterialNode>().ToArray(), new IEdge[] {}, new [] {userData}, groupItems.OfType<StickyNoteData>().ToArray());
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/Views/StickyNote.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/StickyNote.cs
@@ -455,7 +455,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     evt.menu.AppendAction("Light Theme", OnChangeTheme, e => DropdownMenuAction.Status.Normal, Theme.Classic);
                 else
                     evt.menu.AppendAction("Dark Theme", OnChangeTheme, e => DropdownMenuAction.Status.Normal, Theme.Black);
-
+                evt.menu.AppendSeparator();
                 foreach (TextSize value in System.Enum.GetValues(typeof(TextSize)))
                 {
                     evt.menu.AppendAction(value.ToString() + " Text Size", OnChangeSize, e => DropdownMenuAction.Status.Normal, value);
@@ -464,7 +464,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                 evt.menu.AppendAction("Fit To Text", OnFitToText, e => DropdownMenuAction.Status.Normal);
                 evt.menu.AppendSeparator();
-                
+
                 evt.menu.AppendAction("Delete",  OnDelete, e => DropdownMenuAction.Status.Normal);
                 evt.menu.AppendSeparator();
             }
@@ -475,7 +475,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_Graph.owner.RegisterCompleteObjectUndo("Delete Sticky Note");
             m_Graph.RemoveStickyNote(userData);
         }
-        
+
         void OnTitleChange(EventBase e)
         {
             //m_Graph.owner.RegisterCompleteObjectUndo("Title Changed");


### PR DESCRIPTION
---
### Purpose of this PR
Fixing this issue https://fogbugz.unity3d.com/f/cases/1186834/
Where nodes couldn't be copied out from Groups into other graphs.

---
**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252F2019.3%252Fbackport-group-node-fixes/.yamato%252Fupm-ci-shadergraph.yml%2523All_ShaderGraph_fast-2019.3/1064884/job
