### PR TITLE
[2019.3 Backport][ShaderGraph][Skip CI] Fix Properties from the Blackboard can be dragged into the Graph when Blackboard is disabled

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the input fields sometimes didn't render properly. [1176268](https://issuetracker.unity3d.com/issues/shadergraph-input-fields-get-cut-off-after-minimizing-and-maximizing-become-unusable)
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
 - Fixed a bug where Properties in the Blackboard could have duplicate names.
-- Fixed a bug where Blackboard can be dragged into the Graph when Blackboard is disabled
 - Fixed a bug where you could drag the Blackboard properties into a graph even when you disabled the Blackboard.
 
 ## [7.1.1] - 2019-09-05

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -35,8 +35,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where Properties in the Blackboard could have duplicate names.
 - Fixed a bug where Blackboard can be dragged into the Graph when Blackboard is disabled
 - Fixed a bug where you could drag the Blackboard properties into a graph even when you disabled the Blackboard.
-- Sticky Notes can now be grouped properly.
-- Fixed an issue where nodes couldn't be copied from a group.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the input fields sometimes didn't render properly. [1176268](https://issuetracker.unity3d.com/issues/shadergraph-input-fields-get-cut-off-after-minimizing-and-maximizing-become-unusable)
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
 - Fixed a bug where Properties in the Blackboard could have duplicate names.
+- Fixed a bug where Blackboard can be dragged into the Graph when Blackboard is disabled
+- Sticky Notes can now be grouped properly.
+- Fixed an issue where nodes couldn't be copied from a group.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
 - Fixed a bug where Properties in the Blackboard could have duplicate names.
 - Fixed a bug where Blackboard can be dragged into the Graph when Blackboard is disabled
+- Fixed a bug where you could drag the Blackboard properties into a graph even when you disabled the Blackboard.
 - Sticky Notes can now be grouped properly.
 - Fixed an issue where nodes couldn't be copied from a group.
 

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -207,7 +207,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                             m_UserViewSettings.colorProvider = m_ColorManager.activeProviderName;
                         }
 
-                        ToggleSubWindows();
+                        UpdateSubWindowsVisibility();
 
                         var serializedViewSettings = JsonUtility.ToJson(m_UserViewSettings);
                         EditorUserSettings.SetConfigValue(k_UserViewSettings, serializedViewSettings);
@@ -233,7 +233,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                 CreateMasterPreview();
 
-                ToggleSubWindows();
+                UpdateSubWindowsVisibility();
 
                 m_GraphView.graphViewChanged = GraphViewChanged;
 
@@ -273,7 +273,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             Add(content);
         }
 
-        void ToggleSubWindows()
+        void UpdateSubWindowsVisibility()
         {
             if (m_UserViewSettings.isBlackboardVisible)
                 m_GraphView.Insert(m_GraphView.childCount, m_BlackboardProvider.blackboard);

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -207,8 +207,8 @@ namespace UnityEditor.ShaderGraph.Drawing
                             m_UserViewSettings.colorProvider = m_ColorManager.activeProviderName;
                         }
 
-                        m_MasterPreviewView.visible = m_UserViewSettings.isPreviewVisible;
-                        m_BlackboardProvider.blackboard.visible = m_UserViewSettings.isBlackboardVisible;
+                        ToggleSubWindows();
+
                         var serializedViewSettings = JsonUtility.ToJson(m_UserViewSettings);
                         EditorUserSettings.SetConfigValue(k_UserViewSettings, serializedViewSettings);
                     }
@@ -231,9 +231,9 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_BlackboardProvider = new BlackboardProvider(graph);
                 m_GraphView.Add(m_BlackboardProvider.blackboard);
 
-                m_BlackboardProvider.blackboard.visible = m_UserViewSettings.isBlackboardVisible;
-
                 CreateMasterPreview();
+
+                ToggleSubWindows();
 
                 m_GraphView.graphViewChanged = GraphViewChanged;
 
@@ -273,6 +273,19 @@ namespace UnityEditor.ShaderGraph.Drawing
             Add(content);
         }
 
+        void ToggleSubWindows()
+        {
+            if (m_UserViewSettings.isBlackboardVisible)
+                m_GraphView.Insert(m_GraphView.childCount, m_BlackboardProvider.blackboard);
+            else
+                m_BlackboardProvider.blackboard.RemoveFromHierarchy();
+
+            if (m_UserViewSettings.isPreviewVisible)
+                m_GraphView.Insert(m_GraphView.childCount, m_MasterPreviewView);
+            else
+                m_MasterPreviewView.RemoveFromHierarchy();
+        }
+
         Action<Group, string> m_GraphViewGroupTitleChanged;
         Action<Group, IEnumerable<GraphElement>> m_GraphViewElementsAddedToGroup;
         Action<Group, IEnumerable<GraphElement>> m_GraphViewElementsRemovedFromGroup;
@@ -301,7 +314,6 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             masterPreviewViewDraggable.OnDragFinished += UpdateSerializedWindowLayout;
             m_MasterPreviewView.previewResizeBorderFrame.OnResizeFinished += UpdateSerializedWindowLayout;
-            m_MasterPreviewView.visible = m_UserViewSettings.isPreviewVisible;
         }
 
         void OnKeyDown(KeyDownEvent evt)


### PR DESCRIPTION
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Backport #5062 

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
