### PR TITLE
[2019.3 Backport] [7.3] Shader Graph Blackboard: Scientific Notation Fix (+Infinity support)

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the input fields sometimes didn't render properly. [1176268](https://issuetracker.unity3d.com/issues/shadergraph-input-fields-get-cut-off-after-minimizing-and-maximizing-become-unusable)
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
 - Fixed a bug where Properties in the Blackboard could have duplicate names.
-- Blackboard Properties can now properly support scientific notation.
+- Fixed Blackboard Properties to support scientific notation
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the input fields sometimes didn't render properly. [1176268](https://issuetracker.unity3d.com/issues/shadergraph-input-fields-get-cut-off-after-minimizing-and-maximizing-become-unusable)
 - Fixed a bug where the Gradient property didn't work with all system locales. [1140924](https://issuetracker.unity3d.com/issues/shader-graph-shader-doesnt-compile-when-using-a-gradient-property-and-a-regional-format-with-comma-decimal-separator-is-used)
 - Fixed a bug where Properties in the Blackboard could have duplicate names.
+- Blackboard Properties can now properly support scientific notation.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
@@ -48,19 +48,21 @@ namespace UnityEditor.ShaderGraph.Internal
 
         internal override string GetPropertyBlockString()
         {
+            string valueString = NodeUtils.FloatToShaderValueShaderLabSafe(value);
+
             switch(floatType)
             {
                 case FloatType.Slider:
-                    return $"{hideTagString}{referenceName}(\"{displayName}\", Range({NodeUtils.FloatToShaderValue(m_RangeValues.x)}, {NodeUtils.FloatToShaderValue(m_RangeValues.y)})) = {NodeUtils.FloatToShaderValue(value)}";
+                    return $"{hideTagString}{referenceName}(\"{displayName}\", Range({NodeUtils.FloatToShaderValue(m_RangeValues.x)}, {NodeUtils.FloatToShaderValue(m_RangeValues.y)})) = {valueString}";
                 case FloatType.Integer:
-                    return $"{hideTagString}{referenceName}(\"{displayName}\", Int) = {NodeUtils.FloatToShaderValue(value)}";
+                    return $"{hideTagString}{referenceName}(\"{displayName}\", Int) = {valueString}";
                 case FloatType.Enum:
-                    return $"{hideTagString}{enumTagString}{referenceName}(\"{displayName}\", Float) = {NodeUtils.FloatToShaderValue(value)}";
+                    return $"{hideTagString}{enumTagString}{referenceName}(\"{displayName}\", Float) = {valueString}";
                 default:
-                    return $"{hideTagString}{referenceName}(\"{displayName}\", Float) = {NodeUtils.FloatToShaderValue(value)}";
+                    return $"{hideTagString}{referenceName}(\"{displayName}\", Float) = {valueString}";
             }
         }
-        
+
         [SerializeField]
         FloatType m_FloatType = FloatType.Default;
 

--- a/com.unity.shadergraph/Editor/Data/Graphs/VectorShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/VectorShaderProperty.cs
@@ -14,7 +14,7 @@ namespace UnityEditor.ShaderGraph.Internal
 
         internal override string GetPropertyBlockString()
         {
-            return $"{hideTagString}{referenceName}(\"{displayName}\", Vector) = ({NodeUtils.FloatToShaderValue(value.x)}, {NodeUtils.FloatToShaderValue(value.y)}, {NodeUtils.FloatToShaderValue(value.z)}, {NodeUtils.FloatToShaderValue(value.w)})";
+            return $"{hideTagString}{referenceName}(\"{displayName}\", Vector) = ({NodeUtils.FloatToShaderValueShaderLabSafe(value.x)}, {NodeUtils.FloatToShaderValueShaderLabSafe(value.y)}, {NodeUtils.FloatToShaderValueShaderLabSafe(value.z)}, {NodeUtils.FloatToShaderValueShaderLabSafe(value.w)})";
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
+++ b/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
@@ -335,15 +335,42 @@ namespace UnityEditor.Graphing
         public static string FloatToShaderValue(float value)
         {
             if (Single.IsPositiveInfinity(value))
-                return "1.#INF";
-            else if (Single.IsNegativeInfinity(value))
-                return "-1.#INF";
-            else if (Single.IsNaN(value))
-                return "NAN";
-            else
             {
-                return value.ToString(CultureInfo.InvariantCulture);
+                return "1.#INF";
             }
+            if (Single.IsNegativeInfinity(value))
+            {
+                return "-1.#INF";
+            }
+            if (Single.IsNaN(value))
+            {
+                return "NAN";
+            }
+
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        // A number large enough to become Infinity (~FLOAT_MAX_VALUE * 10) + explanatory comment
+        private const string k_ShaderLabInfinityAlternatrive = "3402823500000000000000000000000000000000 /* Infinity */";
+
+        // ShaderLab doesn't support Scientific Notion nor Infinity. To stop from generating a broken shader we do this.
+        public static string FloatToShaderValueShaderLabSafe(float value)
+        {
+            if (Single.IsPositiveInfinity(value))
+            {
+                return k_ShaderLabInfinityAlternatrive;
+            }
+            if (Single.IsNegativeInfinity(value))
+            {
+                return "-" + k_ShaderLabInfinityAlternatrive;
+            }
+            if (Single.IsNaN(value))
+            {
+                return "NAN"; // A real error has occured, in this case we should break the shader.
+            }
+
+            // For single point precision, reserve 54 spaces (e-45 min + ~9 digit precision). See floating-point-numeric-types (Microsoft docs).
+            return value.ToString("0.######################################################", CultureInfo.InvariantCulture);
         }
     }
 }


### PR DESCRIPTION
Backport of #5481 

---
**Manual Tested:**
* Quickly just opened 19.3 with the branch, created a SG using scientific notation & infinity and plopped it on a sphere in the scene

---
**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252F19.3%252Fblackboard-scientific-notation-fix
