### PR TITLE
[2019.3 Backport][7.3] Shader Graph to allow Dragging of Blackboard Properties accross different SGs windows

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added support for users to drag and drop Blackboard Properties from one graph to another.
+
 ## [7.2.0] - 2019-11-20
 ### Added
 - Added samples for Procedural Patterns to the package.

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -755,6 +755,16 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     case AbstractShaderProperty property:
                     {
+                        var matchingProperty = graph.properties.FirstOrDefault(p => p.guid == property.guid);
+                        // This could be from another graph, in which case we add a copy to this graph.
+                        if (matchingProperty == null)
+                        {
+                            property = (AbstractShaderProperty)property.Copy();
+                            // In this case, we do want to copy the overrideReferenceName
+                            property.overrideReferenceName = property.overrideReferenceName;
+                            graph.AddGraphInput(property);
+                        }
+
                         var node = new PropertyNode();
                         var drawState = node.drawState;
                         drawState.position =  new Rect(nodePosition, drawState.position.size);
@@ -767,6 +777,16 @@ namespace UnityEditor.ShaderGraph.Drawing
                     }
                     case ShaderKeyword keyword:
                     {
+                        var matchingKeyword = graph.properties.FirstOrDefault(p => p.guid == keyword.guid);
+                        // This could be from another graph, in which case we add a copy to this graph.
+                        if (matchingKeyword == null)
+                        {
+                            keyword = (ShaderKeyword)keyword.Copy();
+                            // In this case, we do want to copy the overrideReferenceName
+                            keyword.overrideReferenceName = keyword.overrideReferenceName;
+                            graph.AddGraphInput(keyword);
+                        }
+
                         var node = new KeywordNode();
                         var drawState = node.drawState;
                         drawState.position =  new Rect(nodePosition, drawState.position.size);

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -779,12 +779,11 @@ namespace UnityEditor.ShaderGraph.Drawing
                     case ShaderKeyword keyword:
                     {
                         // This could be from another graph, in which case we add a copy of the ShaderInput to this graph.
-                        if (graph.properties.FirstOrDefault(p => p.guid == keyword.guid) == null)
+                        if (graph.properties.FirstOrDefault(k => k.guid == keyword.guid) == null)
                         {
                             var copy = (ShaderKeyword)keyword.Copy();
                             graph.SanitizeGraphInputName(copy);
-                            copy.overrideReferenceName = keyword.overrideReferenceName; // In this case, we do want to copy the overrideReferenceName
-                            graph.SanitizeGraphInputReferenceName(copy, keyword.overrideReferenceName);
+                            graph.SanitizeGraphInputReferenceName(copy, keyword.overrideReferenceName); // We do want to copy the overrideReferenceName
 
                             keyword = copy;
                             graph.AddGraphInput(keyword);

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -755,13 +755,14 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     case AbstractShaderProperty property:
                     {
-                        var matchingProperty = graph.properties.FirstOrDefault(p => p.guid == property.guid);
-                        // This could be from another graph, in which case we add a copy to this graph.
-                        if (matchingProperty == null)
+                        // This could be from another graph, in which case we add a copy of the ShaderInput to this graph.
+                        if (graph.properties.FirstOrDefault(p => p.guid == property.guid) == null)
                         {
-                            property = (AbstractShaderProperty)property.Copy();
-                            // In this case, we do want to copy the overrideReferenceName
-                            property.overrideReferenceName = property.overrideReferenceName;
+                            var copy = (AbstractShaderProperty)property.Copy();
+                            graph.SanitizeGraphInputName(copy);
+                            graph.SanitizeGraphInputReferenceName(copy, property.overrideReferenceName); // We do want to copy the overrideReferenceName
+
+                            property = copy;
                             graph.AddGraphInput(property);
                         }
 
@@ -777,13 +778,15 @@ namespace UnityEditor.ShaderGraph.Drawing
                     }
                     case ShaderKeyword keyword:
                     {
-                        var matchingKeyword = graph.properties.FirstOrDefault(p => p.guid == keyword.guid);
-                        // This could be from another graph, in which case we add a copy to this graph.
-                        if (matchingKeyword == null)
+                        // This could be from another graph, in which case we add a copy of the ShaderInput to this graph.
+                        if (graph.properties.FirstOrDefault(p => p.guid == keyword.guid) == null)
                         {
-                            keyword = (ShaderKeyword)keyword.Copy();
-                            // In this case, we do want to copy the overrideReferenceName
-                            keyword.overrideReferenceName = keyword.overrideReferenceName;
+                            var copy = (ShaderKeyword)keyword.Copy();
+                            graph.SanitizeGraphInputName(copy);
+                            copy.overrideReferenceName = keyword.overrideReferenceName; // In this case, we do want to copy the overrideReferenceName
+                            graph.SanitizeGraphInputReferenceName(copy, keyword.overrideReferenceName);
+
+                            keyword = copy;
                             graph.AddGraphInput(keyword);
                         }
 


### PR DESCRIPTION
**Do not merge before 7.2 / January 21st, this is a backport for 7.3**

---
**Summary:**
Backport of #5516 

---

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252F19.3%252Fcopy-shader-input-across-graphs

