### PR TITLE
Shader Graph: Color Properties to have IsGammaSpace() check

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where the redo functionality in Shader Graph often didn't work.
 - Fixed a bug where you could drag the Blackboard into a graph even when you disabled the Blackboard.
 - Documentation links on nodes now point to the correct URLs and package versions.
+- Fixed an issue where Color Properties did not convert to Linear Space, unlike Inline Color Nodes which did.
 
 ### Fixed
 - You can now smoothly edit controls on the `Dielectric Specular` node.

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/PropertyNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/PropertyNode.cs
@@ -139,7 +139,7 @@ namespace UnityEditor.ShaderGraph
                     sb.AppendLine($"$precision4 {GetVariableNameForSlot(OutputSlotId)} = {property.referenceName};");
                     break;
                 case PropertyType.Color:
-                    sb.AppendLine($"$precision4 {GetVariableNameForSlot(OutputSlotId)} = {property.referenceName};");
+                    sb.AppendLine($"$precision4 {GetVariableNameForSlot(OutputSlotId)} = IsGammaSpace() ? {property.referenceName} : float4(SRGBToLinear({property.referenceName}));");
                     break;
                 case PropertyType.Matrix2:
                     sb.AppendLine($"$precision2x2 {GetVariableNameForSlot(OutputSlotId)} = {property.referenceName};");
@@ -154,9 +154,9 @@ namespace UnityEditor.ShaderGraph
                     sb.AppendLine($"SamplerState {GetVariableNameForSlot(OutputSlotId)} = {property.referenceName};");
                     break;
                 case PropertyType.Gradient:
-                if(generationMode == GenerationMode.Preview)
+                    if(generationMode == GenerationMode.Preview)
                         sb.AppendLine($"Gradient {GetVariableNameForSlot(OutputSlotId)} = {GradientUtil.GetGradientForPreview(property.referenceName)};");
-                else
+                    else
                         sb.AppendLine($"Gradient {GetVariableNameForSlot(OutputSlotId)} = {property.referenceName};");
                     break;
             }


### PR DESCRIPTION
**Summary:**

Fix for https://fogbugz.unity3d.com/f/cases/1184248/
Presumably Zack's last fix for the January Quality Drive

* Was caused by the fact that ColorNodes had a 'IsGammaSpace() ?' check and the Color Properties did not.
* The bug thinks that the Inline node was incorrect. That is incorrect; Inline had it right: they were using a very intense color node (may want to explain that to them when we close the bug).

---
**To Optimize, or To Not Optimize..?:**

Feels like we should change both this and the Color node to use https://docs.unity3d.com/ScriptReference/QualitySettings-activeColorSpace.html
If we find a way to cause the Shaders to rebuild if the setting is changed.
_Discussion:_ https://unity.slack.com/archives/G7HQCPV71/p1579226248050000

My current thought is that we should perhaps do that for 2020, but backport this change to 19.3

---
**Manually Tested:**

* That the bug no longer reproduces
* My other SGs still seem to work fine
* Checked this in sub graphs real quick

---
**Halo Effect:** 2/4: This does affect color properties everywhere...
**Technical Risk:** 0/4: Simple single line change that other nodes are already using

---
**Notes to QA:**

* I was going to make a build of this, I didn't get around to it tonight (whether or not that's important, I have no reason to think so... but who knows)

---
**Yamato:**
...
