### PR TITLE
Fixed an issue where passing a null ProfilingSampler would cause a null ref exception.

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Debugging/ProfilingScope.cs
+++ b/com.unity.render-pipelines.core/Runtime/Debugging/ProfilingScope.cs
@@ -200,11 +200,20 @@ namespace UnityEngine.Rendering
         /// <param name="sampler">Profiling Sampler to be used for this scope.</param>
         public ProfilingScope(CommandBuffer cmd, ProfilingSampler sampler)
         {
-            m_Name = sampler.name; // Don't use CustomSampler.name because it causes garbage
             m_Cmd = cmd;
             m_Disposed = false;
-            m_Sampler = sampler.sampler;
-            m_InlineSampler = sampler.inlineSampler;
+            if (sampler != null)
+            {
+                m_Name = sampler.name; // Don't use CustomSampler.name because it causes garbage
+                m_Sampler = sampler.sampler;
+                m_InlineSampler = sampler.inlineSampler;
+            }
+            else
+            {
+                m_Name = "NullProfilingSampler"; // Don't use CustomSampler.name because it causes garbage
+                m_Sampler = null;
+                m_InlineSampler = null;
+            }
 
             if (cmd != null)
 #if UNITY_USE_RECORDER

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -323,6 +323,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixing unnecessary memory allocations in the ray tracing cluster build
 - Fixed duplicate column labels in LightEditor's light tab
 - Fixed white and dark flashes on scenes with very high or very low exposure when Automatic Exposure is being used.
+- Fixed an issue where passing a null ProfilingSampler would cause a null ref exception.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled


### PR DESCRIPTION
### Purpose of this PR
Fixed an issue where passing a null ProfilingSampler would cause a null ref exception.
