### PR TITLE
added vulkan to shader multiview keyword check

### DIFF
--- a/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
@@ -7,7 +7,7 @@
 #define UNITY_STEREO_INSTANCING_ENABLED
 #endif
 
-#if defined(STEREO_MULTIVIEW_ON) && (defined(SHADER_API_GLES3) || defined(SHADER_API_GLCORE)) && !(defined(SHADER_API_SWITCH))
+#if defined(STEREO_MULTIVIEW_ON) && (defined(SHADER_API_GLES3) || defined(SHADER_API_GLCORE) || defined(SHADER_API_VULKAN)) && !(defined(SHADER_API_SWITCH))
     #define UNITY_STEREO_MULTIVIEW_ENABLED
 #endif
 


### PR DESCRIPTION
---
### Purpose of this PR
The shader keyword UNITY_STEREO_MULTIVIEW_ENABLED was not considering Vulkan.

---
### Testing status

**Manual Tests**: What did you do?
- [X] Opened test project + Run graphic tests locally
- [X] Built a player
- [X] Confirmed on Oculus Quest hardware.
