### PR TITLE
[Shader Graph] Fix Bug output value vert is not initialized in Universal

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Documentation links on nodes now point to the correct URLs and package versions.
 - You can now smoothly edit controls on the `Dielectric Specular` node.
 - Fixed Blackboard Properties to support scientific notation.
+- Fixed a bug where the error `Output value 'vert' is not initialized` displayed on all PBR graphs in Universal. [1210710](https://issuetracker.unity3d.com/issues/output-value-vert-is-not-completely-initialized-error-is-thrown-when-pbr-graph-is-created-using-urp)
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/CodeGen/ShaderSpliceUtil.cs
+++ b/com.unity.shadergraph/Editor/CodeGen/ShaderSpliceUtil.cs
@@ -321,7 +321,7 @@ namespace UnityEditor.ShaderGraph
             packer.AddShaderChunk(packedStruct + " " + packerFunction + "(" + unpackedStruct + " input)");
             packer.AddShaderChunk("{");
             packer.Indent();
-            packer.AddShaderChunk(packedStruct + " output;");
+            packer.AddShaderChunk(packedStruct + " output = (" + packedStruct + ")0;");
 
             //   unpackedStruct unpackerFunction(packedStruct input)
             //   {
@@ -330,7 +330,7 @@ namespace UnityEditor.ShaderGraph
             unpacker.AddShaderChunk(unpackedStruct + " " + unpackerFunction + "(" + packedStruct + " input)");
             unpacker.AddShaderChunk("{");
             unpacker.Indent();
-            unpacker.AddShaderChunk(unpackedStruct + " output;");
+            unpacker.AddShaderChunk(unpackedStruct + " output = (" + unpackedStruct + ")0;");
 
             // TODO: this could do a better job packing
             // especially if we allowed breaking up fields across multiple interpolators (to pack them into remaining space...)


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Fixes case [1210710](https://issuetracker.unity3d.com/issues/output-value-vert-is-not-completely-initialized-error-is-thrown-when-pbr-graph-is-created-using-urp) [internal link](https://fogbugz.unity3d.com/f/cases/1210710/) where the warning message "Output value 'vert' is not completely initialize would display on all PBR graphs in Universal. 

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] C# and shader warnings (supress shader cache to see them)

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
**Note to QA:** Because of bug [1196304 - internal link](https://fogbugz.unity3d.com/f/cases/1196304/) graphs with the warning already present may not be cleared even after the fix. Please confirm with the following repro steps: 
Previous behavior:
1. Create new PBR graph. 
2. Highlight asset and observe warning. 

Fixed behavior: 
1. Create new PBR graph.  
2. Highlight asset and observe no warning. 