### PR TITLE
Fix disk change check

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Documentation links on nodes now point to the correct URLs and package versions.
 - You can now smoothly edit controls on the `Dielectric Specular` node.
 - Fixed Blackboard Properties to support scientific notation.
+- Fixed an issue where modifying a Sub Graph would cause open Shader Graphs using the Sub Graph to mistake the change for on disk changes.
 
 ## [7.1.1] - 2019-09-05
 ### Added


### PR DESCRIPTION
### Purpose of this PR
Fixes FB-1198885. The issue is that when the user has an open Shader Graph that is modified, external changes to Sub Graphs in use involving input/output will cause the main Shader Graph to think that the asset changed on disk, and thus ask if the user wants to reload the graph. 

I have fixed this by keeping around the original JSON string from last disk access -- i.e. opening the window, or saving the asset -- and then using that to check for disk changes.

---
### Testing status

**Manual Tests**: What did you do?
- Repro the issue without the fix
- Verify that the issue does not repro with the fix
- Actual file changes still yields the dialog

**Automated Tests**: UI only changes, no tests