### PR TITLE
Clear shader error cache every time we save the graph

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -341,6 +341,10 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                 ShaderGraphAnalytics.SendShaderGraphEvent(selectedGuid, graphObject.graph);
 
+                var oldShader = AssetDatabase.LoadAssetAtPath<Shader>(path);
+                if (oldShader != null)
+                    ShaderUtil.ClearShaderMessages(oldShader);
+
                 UpdateShaderGraphOnDisk(path);
 
                 if (GraphData.onSaveGraph != null)
@@ -349,7 +353,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     if (shader != null)
                     {
                         GraphData.onSaveGraph(shader, (graphObject.graph.outputNode as MasterNode).saveContext);
-                    }                    
+                    }
                 }
             }
 


### PR DESCRIPTION
This is a partial workaround for an AssetDb behavior change. It keeps old error messages from re-appearing on the material inspector after you fix an issue with a Custom Function Node. See https://fogbugz.unity3d.com/f/cases/1196304/.

There are still instances where this issue will reproduce, specifically with CFNs in subgraphs or when importing a graph from the cache server. Fixing those will require a more significant change but this is low-risk and eliminates the most common cause of this issue.

*NO CHANGELOG* - since this doesn't fully fix the bug, I don't want to highlight it.

### Checklist for PR maker
- [X] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.

---
### Purpose of this PR
Partial fix for https://fogbugz.unity3d.com/f/cases/1196304

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 
Created and cleared errors on custom nodes in several scenarios.

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fclear-errors-on-save

---
### Comments to reviewers
As discussed above, this does not solve the specific repro steps in the bug (with subgraphs) but it does fix the following repro:
1. Create Shader Graph
2. Add Custom Function Node, add an output port named "Out", and wire it to the master node
3. In "String" mode, add a non-compiling piece of code (I like to use `Out = 0.6; a` so I can easily clear the error)
4. Save the graph, then select the graph asset in the Project Browser
5. Observe the error appears in the inspector
6. Back in the graph, fix the error in the CFN so the error badge in the graph goes away
7. Save the graph, then select the graph in the Project Browser
8. Observe the error is gone
9. Select another asset, then re-select the graph
10. Observe the error is back. 
