### PR TITLE
[Backport] Fix node doc links

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
@@ -624,10 +624,7 @@ namespace UnityEditor.Rendering.HighDefinition
             UpdateNodeAfterDeserialization();
         }
 
-        public override string documentationURL
-        {
-            get { return null; }
-        }
+        public override string documentationURL => Documentation.GetPageLink("Master-Node-Hair");
 
         public sealed override void UpdateNodeAfterDeserialization()
         {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -788,7 +788,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
         public override string documentationURL
         {
-            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/HD-Lit-Master-Node"; }
+            get { return null; }
         }
 
         public bool HasRefraction()

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
@@ -317,10 +317,7 @@ namespace UnityEditor.Rendering.HighDefinition
             UpdateNodeAfterDeserialization();
         }
 
-        public override string documentationURL
-        {
-            get { return null; }
-        }
+        public override string documentationURL => Documentation.GetPageLink("Master-Node-Unlit");
 
         public bool HasDistortion()
         {

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/DiffusionProfileNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/DiffusionProfileNode.cs
@@ -21,10 +21,7 @@ namespace UnityEditor.Rendering.HighDefinition
             UpdateNodeAfterDeserialization();
         }
 
-        public override string documentationURL
-        {
-            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/Diffusion-Profile-Node"; }
-        }
+        public override string documentationURL => Documentation.GetPageLink("SGNode-Diffusion-Profile");
 
         [SerializeField, Obsolete("Use m_DiffusionProfileAsset instead.")]
         UnityEditor.ShaderGraph.Drawing.Controls.PopupList m_DiffusionProfile = new UnityEditor.ShaderGraph.Drawing.Controls.PopupList();

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/EmissionNode.cs
@@ -25,11 +25,7 @@ namespace UnityEditor.Rendering.HighDefinition
             UpdateNodeAfterDeserialization();
         }
 
-        public override string documentationURL
-        {
-            // TODO: write the doc
-            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/Emission-Node"; }
-        }
+        public override string documentationURL => Documentation.GetPageLink("SGNode-Emission");
 
         [SerializeField]
         EmissiveIntensityUnit _intensityUnit;

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ExposureNode.cs
@@ -35,11 +35,7 @@ namespace UnityEditor.Rendering.HighDefinition
             UpdateNodeAfterDeserialization();
         }
 
-        public override string documentationURL
-        {
-            // TODO: write the doc
-            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/Exposure-Node"; }
-        }
+        public override string documentationURL => Documentation.GetPageLink("SGNode-Exposure");
 
         [SerializeField]
         ExposureType        m_ExposureType;

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/HDSceneColorNode.cs
@@ -19,11 +19,7 @@ namespace UnityEditor.Rendering.HighDefinition
             UpdateNodeAfterDeserialization();
         }
 
-        public override string documentationURL
-        {
-            // TODO: write the doc
-            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/HD-Scene-Color-Node"; }
-        }
+        public override string documentationURL => Documentation.GetPageLink("SGNode-HD-Scene-Color");
 
         [SerializeField]
         bool                m_Exposure;

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ParallaxOcclusionMappingNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/Nodes/ParallaxOcclusionMappingNode.cs
@@ -21,11 +21,7 @@ namespace UnityEditor.Rendering.HighDefinition
             UpdateNodeAfterDeserialization();
         }
 
-        public override string documentationURL
-        {
-            // This still needs to be added.
-            get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/Parallax-Occlusion-Mapping-Node"; }
-        }
+        public override string documentationURL => Documentation.GetPageLink("SGNode-Parallax-Occlusion-Mapping");
 
         // Input slots
         private const int kHeightmapSlotId = 2;

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where `GetWorldSpaceNormalizeViewDir()` could cause undeclared indentifier errors. [1190606](https://issuetracker.unity3d.com/issues/view-dir-node-plugged-into-vertex-position-creates-error-undeclared-identifier-getworldspacenormalizeviewdir)
 - Fixed a bug where Emission on PBR Shader Graphs in the Universal RP would not bake to lightmaps. [1190225](https://issuetracker.unity3d.com/issues/emissive-custom-pbr-shadergraph-material-only-works-for-primitive-unity-objects)
 - Fixed a bug where Shader Graph shaders were writing to `POSITION` instead of `SV_POSITION`, which caused PS4 builds to fail.
+- Documentation links on nodes now point to the correct URLs and package versions.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
+++ b/com.unity.shadergraph/Editor/Data/Implementation/NodeUtils.cs
@@ -6,6 +6,7 @@ using System.Text;
 using UnityEditor.ShaderGraph;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine;
+using UnityEngine.Rendering.ShaderGraph;
 
 namespace UnityEditor.Graphing
 {
@@ -18,7 +19,7 @@ namespace UnityEditor.Graphing
 
     static class NodeUtils
     {
-        public static string docURL = "https://github.com/Unity-Technologies/ScriptableRenderPipeline/tree/master/com.unity.shadergraph/Documentation%7E/";
+        static string NodeDocSuffix = "-Node";
 
         public static void SlotConfigurationExceptionIfBadConfiguration(AbstractMaterialNode node, IEnumerable<int> expectedInputSlots, IEnumerable<int> expectedOutputSlots)
         {
@@ -81,7 +82,7 @@ namespace UnityEditor.Graphing
             Exclude
         }
 
-        public static void DepthFirstCollectNodesFromNode(List<AbstractMaterialNode> nodeList, AbstractMaterialNode node, 
+        public static void DepthFirstCollectNodesFromNode(List<AbstractMaterialNode> nodeList, AbstractMaterialNode node,
             IncludeSelf includeSelf = IncludeSelf.Include, IEnumerable<int> slotIds = null, List<KeyValuePair<ShaderKeyword, int>> keywordPermutation = null)
         {
             // no where to start
@@ -176,9 +177,9 @@ namespace UnityEditor.Graphing
                 nodeList.Add(node);
         }
 
-        public static string GetDocumentationString(AbstractMaterialNode node)
+        public static string GetDocumentationString(string pageName)
         {
-            return $"{docURL}{node.name.Replace(" ", "-")}"+"-Node.md";
+            return Documentation.GetPageLink(pageName.Replace(" ", "-") + NodeDocSuffix);
         }
 
         static Stack<MaterialSlot> s_SlotStack = new Stack<MaterialSlot>();

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -84,7 +84,8 @@ namespace UnityEditor.ShaderGraph
             set { m_Name = value; }
         }
 
-        public virtual string documentationURL => NodeUtils.GetDocumentationString(this);
+        protected virtual string documentationPage => name;
+        public virtual string documentationURL => NodeUtils.GetDocumentationString(documentationPage);
 
         public virtual bool canDeleteNode
         {

--- a/com.unity.shadergraph/Editor/Data/Nodes/MasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/MasterNode.cs
@@ -49,7 +49,7 @@ namespace UnityEditor.ShaderGraph
 
         public virtual void ProcessPreviewMaterial(Material Material) {}
     }
-    
+
     [Serializable]
     abstract class MasterNode<T> : MasterNode
         where T : class, ISubShader
@@ -89,7 +89,7 @@ namespace UnityEditor.ShaderGraph
 
         public sealed override string GetShader(GenerationMode mode, string outputName, out List<PropertyCollector.TextureInfo> configuredTextures, List<string> sourceAssetDependencyPaths = null)
         {
-            var activeNodeList = ListPool<AbstractMaterialNode>.Get();
+            var activeNodeList = Graphing.ListPool<AbstractMaterialNode>.Get();
             NodeUtils.DepthFirstCollectNodesFromNode(activeNodeList, this);
 
             var shaderProperties = new PropertyCollector();
@@ -103,7 +103,7 @@ namespace UnityEditor.ShaderGraph
             if(owner.GetKeywordPermutationCount() > ShaderGraphPreferences.variantLimit)
             {
                 owner.AddValidationError(tempId, ShaderKeyword.kVariantLimitWarning, Rendering.ShaderCompilerMessageSeverity.Error);
-                
+
                 configuredTextures = shaderProperties.GetConfiguredTexutres();
                 return ShaderGraphImporter.k_ErrorShader;
             }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/IsFrontFaceNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Utility/Logic/IsFrontFaceNode.cs
@@ -12,11 +12,6 @@ namespace UnityEditor.ShaderGraph
 			UpdateNodeAfterDeserialization();
 		}
 
-		public override string documentationURL
-		{
-			get { return "https://github.com/Unity-Technologies/ShaderGraph/wiki/Is-Front-Face-Node"; }
-		}
-
 		public override bool hasPreview { get { return false; } }
 
 		public const int OutputSlotId = 0;

--- a/com.unity.shadergraph/Editor/Data/SubGraph/SubGraphOutputNode.cs
+++ b/com.unity.shadergraph/Editor/Data/SubGraph/SubGraphOutputNode.cs
@@ -6,6 +6,7 @@ using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine;
 using UnityEditor.Graphing;
 using UnityEditor.Rendering;
+using UnityEngine.Rendering.ShaderGraph;
 using UnityEngine.UIElements;
 
 namespace UnityEditor.ShaderGraph
@@ -19,7 +20,8 @@ namespace UnityEditor.ShaderGraph
             name = "Output";
         }
 
-        public override string documentationURL => $"{NodeUtils.docURL}Sub-graph.md";
+        // Link to the Sub Graph overview page instead of the specific Node page, seems more useful
+        public override string documentationURL => Documentation.GetPageLink("Sub-graph");
 
         void ValidateShaderStage()
             {

--- a/com.unity.shadergraph/Editor/Unity.ShaderGraph.Editor.asmdef
+++ b/com.unity.shadergraph/Editor/Unity.ShaderGraph.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "Unity.ShaderGraph.Editor",
     "references": [
         "GUID:a2b0e253c44e0427f9c718f9e5c1c7e3",
-        "GUID:ade7125e800904674ba0c115208f7ed5"
+        "GUID:ade7125e800904674ba0c115208f7ed5",
+        "GUID:df380645f10b7bc4b97d4f5eb6303d95"
     ],
     "includePlatforms": [
         "Editor"

--- a/com.unity.shadergraph/Editor/Util/Documentation.cs
+++ b/com.unity.shadergraph/Editor/Util/Documentation.cs
@@ -1,8 +1,8 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Unity.RenderPipelines.HighDefinition.Editor.Tests")]
+[assembly: InternalsVisibleTo("Unity.ShaderGraph.Editor.Tests")]
 
-namespace UnityEngine.Rendering.HighDefinition
+namespace UnityEngine.Rendering.ShaderGraph
 {
     //Need to live in Runtime as Attribute of documentation is on Runtime classes \o/
     class Documentation : DocumentationInfo
@@ -10,7 +10,7 @@ namespace UnityEngine.Rendering.HighDefinition
         //This must be used like
         //[HelpURL(Documentation.baseURL + Documentation.version + Documentation.subURL + "some-page" + Documentation.endURL)]
         //It cannot support String.Format nor string interpolation
-        internal const string baseURL = "https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@";
+        internal const string baseURL = "https://docs.unity3d.com/Packages/com.unity.shadergraph@";
         internal const string subURL = "/manual/";
         internal const string endURL = ".html";
 

--- a/com.unity.shadergraph/Editor/Util/Documentation.cs.meta
+++ b/com.unity.shadergraph/Editor/Util/Documentation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a567520c18010479aaafcdc0b5a358b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Backport of https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/5395/commits/f8afe8413a59eb7d744b59bad7f137309c0e58ed

### Purpose of this PR
Fixes node doc links to point to correctly versioned package docs.

---
### Testing status
Opened project, tested nodes.
