### PR TITLE
Added Package Validation Config File

### DIFF
--- a/com.unity.render-pipelines.core/ValidationConfig.json
+++ b/com.unity.render-pipelines.core/ValidationConfig.json
@@ -1,0 +1,12 @@
+{
+    "FilenameValidation":
+    {
+        "Filenames":
+        [
+            {
+                "Filename": "ShaderLibrary/API/Switch.hlsl*",
+                "Targets": "+Switch"
+            }
+        ]
+    }
+}

--- a/com.unity.render-pipelines.core/ValidationConfig.json.meta
+++ b/com.unity.render-pipelines.core/ValidationConfig.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 75497c58fb28415a98098a98e7133272
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added ValidationConfig.json file to eliminate false-positive internal package validation suite warnings

---
### Purpose of this PR
The internal package validation system flags the `ShaderLibrary/API/Switch.hlsl` file as being Switch specific and reports a warning stating that it should not be published.  This file is known to be safe for publication however so this PR adds a config file that gives the package validation system this information and eliminates the warning.

---
### Testing status

**Manual Tests**: 
- [ ] Ran the internal package validation suite on the existing package locally, verified the warning was emitted
- [ ] Added the config file in this PR
- [ ] Rebuilt the package and re-ran the internal package validation suite locally, verified that the warning was no longer present

**Automated Tests**: The internal validation suite is not yet enabled in upm-ci@stable so this cannot easily be tested on Yamato, no difference from local behaviour is expected though.
