### PR TITLE
Remove docs team from changelog reviews [Skip CI]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,6 @@
 
 # Universal RP General
 /com.unity.render-pipelines.universal/ @Unity-Technologies/universal-rp-team
-/com.unity.render-pipelines.universal/CHANGELOG.md @Unity-Technologies/gfx-docs
 
 # Universal RP 2D Renderer
 /com.unity.render-pipelines.universal/Editor/2D @Unity-Technologies/2d-graphics
@@ -12,7 +11,6 @@
 
 # Shader Graph
 /com.unity.shadergraph/ @Unity-Technologies/shader-graph @Unity-Technologies/gfx-qa-bellevue
-/com.unity.shadergraph/CHANGELOG.md @Unity-Technologies/gfx-docs
 
 # Test systems
 /.yamato/ @Unity-Technologies/gfx-sdets
@@ -21,4 +19,3 @@
 
 # LWRP (Legacy)
 /com.unity.render-pipelines.lightweight/ @Unity-Technologies/universal-rp-team
-/com.unity.render-pipelines.lightweight/CHANGELOG.md @Unity-Technologies/gfx-docs


### PR DESCRIPTION
### Purpose of this PR
Docs team does not want to be code owners of changelogs any more. We will discuss adding them as codeowners on the ~Documentation directories in the future.

---
### Testing status
No testing possible for github features.
