### PR TITLE
Expose alpha cutoff material for ShaderGraphs

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added option to exclude camera motion from motion blur.
 - Added semi-transparent shadows for point and spot lights.
 - Added support for semi-transparent shadow for unlit shader and unlit shader graph.
+- Added the alpha clip enabled toggle to the material UI for all HDRP shader graphs.
 
 ### Fixed
 - Sorting, undo, labels, layout in the Lighting Explorer.

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeGUI.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         // For surface option shader graph we only want all unlit features but alpha clip, back then front rendering and SSR
         const SurfaceOptionUIBlock.Features   surfaceOptionFeatures = SurfaceOptionUIBlock.Features.Unlit
-            ^ SurfaceOptionUIBlock.Features.AlphaCutoff
+            ^ SurfaceOptionUIBlock.Features.AlphaCutoffThreshold
             ^ SurfaceOptionUIBlock.Features.ShowAfterPostProcessPass;
 
         MaterialUIBlockList uiBlocks = new MaterialUIBlockList

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
@@ -33,6 +33,7 @@ Pass
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature_local _ENABLE_FOG_ON_TRANSPARENT
+    #pragma shader_feature_local _ALPHATEST_ON
 
     //-------------------------------------------------------------------------------------
     // Graph Defines
@@ -290,7 +291,9 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
+#if _ALPHATEST_ON
         $AlphaTest:         DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
+#endif
 
         $DepthOffset: ApplyDepthOffsetPositionInput(V, surfaceDescription.DepthOffset, GetViewForwardDir(), GetWorldToHClipMatrix(), posInput);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
@@ -291,7 +291,7 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
-#if _ALPHATEST_ON
+#ifdef _ALPHATEST_ON
         $AlphaTest:         DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
 #endif
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricGUI.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         // For surface option shader graph we only want all unlit features but alpha clip, back then front rendering and SSR
         const SurfaceOptionUIBlock.Features   surfaceOptionFeatures = SurfaceOptionUIBlock.Features.Unlit
-            ^ SurfaceOptionUIBlock.Features.AlphaCutoff
+            ^ SurfaceOptionUIBlock.Features.AlphaCutoffThreshold
             ^ SurfaceOptionUIBlock.Features.BackThenFrontRendering
             ^ SurfaceOptionUIBlock.Features.ShowAfterPostProcessPass;
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
@@ -33,6 +33,7 @@ Pass
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature_local _ENABLE_FOG_ON_TRANSPARENT
+    #pragma shader_feature_local _ALPHATEST_ON
 
     //-------------------------------------------------------------------------------------
     // Graph Defines
@@ -347,7 +348,9 @@ Pass
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
+#if _ALPHATEST_ON
         $AlphaTest:         GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
+#endif
 
         $DepthOffset: ApplyDepthOffsetPositionInput(V, surfaceDescription.DepthOffset, GetViewForwardDir(), GetWorldToHClipMatrix(), posInput);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
@@ -348,7 +348,7 @@ Pass
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
-#if _ALPHATEST_ON
+#ifdef _ALPHATEST_ON
         $AlphaTest:         GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
 #endif
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairGUI.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         // For surface option shader graph we only want all unlit features but alpha clip and back then front rendering
         const SurfaceOptionUIBlock.Features   surfaceOptionFeatures = SurfaceOptionUIBlock.Features.Unlit
-            ^ SurfaceOptionUIBlock.Features.AlphaCutoff
+            ^ SurfaceOptionUIBlock.Features.AlphaCutoffThreshold
             ^ SurfaceOptionUIBlock.Features.BackThenFrontRendering
             ^ SurfaceOptionUIBlock.Features.ShowAfterPostProcessPass;
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -327,7 +327,7 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
-#if _ALPHATEST_ON
+#ifdef _ALPHATEST_ON
         $AlphaTest:         DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
         $AlphaTestPrepass:  DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPrepass);
         $AlphaTestPostpass: DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPostpass);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -33,6 +33,7 @@ Pass
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
     #pragma shader_feature_local _ENABLE_FOG_ON_TRANSPARENT
+    #pragma shader_feature_local _ALPHATEST_ON
 
     //-------------------------------------------------------------------------------------
     // Graph Defines
@@ -326,10 +327,12 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
+#if _ALPHATEST_ON
         $AlphaTest:         DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
         $AlphaTestPrepass:  DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPrepass);
         $AlphaTestPostpass: DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPostpass);
         $AlphaTestShadow:   DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdShadow);
+#endif
 
         $DepthOffset: ApplyDepthOffsetPositionInput(V, surfaceDescription.DepthOffset, GetViewForwardDir(), GetWorldToHClipMatrix(), posInput);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitGUI.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         // For surface option shader graph we only want all unlit features but alpha clip and back then front rendering
         const SurfaceOptionUIBlock.Features   surfaceOptionFeatures = SurfaceOptionUIBlock.Features.Unlit
-            ^ SurfaceOptionUIBlock.Features.AlphaCutoff
+            ^ SurfaceOptionUIBlock.Features.AlphaCutoffThreshold
             ^ SurfaceOptionUIBlock.Features.BackThenFrontRendering
             ^ SurfaceOptionUIBlock.Features.ShowAfterPostProcessPass;
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
@@ -32,6 +32,7 @@ Pass
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature_local _ENABLE_FOG_ON_TRANSPARENT
+    #pragma shader_feature_local _ALPHATEST_ON
 
     //-------------------------------------------------------------------------------------
     // Graph Defines
@@ -378,10 +379,12 @@ Pass
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
+#if _ALPHATEST_ON
         $AlphaTest:         GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
         $AlphaTestPrepass:  GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPrepass);
         $AlphaTestPostpass: GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPostpass);
         $AlphaTestShadow:   GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdShadow);
+#endif
 
         $DepthOffset: ApplyDepthOffsetPositionInput(V, surfaceDescription.DepthOffset, GetViewForwardDir(), GetWorldToHClipMatrix(), posInput);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitPass.template
@@ -379,7 +379,7 @@ Pass
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
-#if _ALPHATEST_ON
+#ifdef _ALPHATEST_ON
         $AlphaTest:         GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
         $AlphaTestPrepass:  GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPrepass);
         $AlphaTestPostpass: GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThresholdDepthPostpass);

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitGUI.cs
@@ -13,7 +13,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         // For surface option shader graph we only want all unlit features but alpha clip and back then front rendering
         const SurfaceOptionUIBlock.Features   surfaceOptionFeatures = SurfaceOptionUIBlock.Features.Unlit
-            ^ SurfaceOptionUIBlock.Features.AlphaCutoff
+            ^ SurfaceOptionUIBlock.Features.AlphaCutoffThreshold
             ^ SurfaceOptionUIBlock.Features.BackThenFrontRendering
             ^ SurfaceOptionUIBlock.Features.ShowAfterPostProcessPass;
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
@@ -551,7 +551,7 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
-#if _ALPHATEST_ON
+#ifdef _ALPHATEST_ON
         $AlphaTest:         DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
 #endif
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
@@ -33,6 +33,7 @@ Pass
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
     #pragma shader_feature_local _ENABLE_FOG_ON_TRANSPARENT
+    #pragma shader_feature_local _ALPHATEST_ON
 
     //-------------------------------------------------------------------------------------
     // Variant Definitions
@@ -550,7 +551,9 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky..
+#if _ALPHATEST_ON
         $AlphaTest:         DoAlphaTest(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
+#endif
 
         $DepthOffset: ApplyDepthOffsetPositionInput(V, surfaceDescription.DepthOffset, GetViewForwardDir(), GetWorldToHClipMatrix(), posInput);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
@@ -378,17 +378,21 @@ namespace UnityEditor.Rendering.HighDefinition
             if (alphaCutoffEnable != null && alphaCutoffEnable.floatValue == 1.0f)
             {
                 EditorGUI.indentLevel++;
-                if ((m_Features & Features.AlphaCutoffThreshold) != 0)
+
+                if (alphaCutoff != null)
                     materialEditor.ShaderProperty(alphaCutoff, Styles.alphaCutoffText);
 
-                if (useShadowThreshold != null)
-                    materialEditor.ShaderProperty(useShadowThreshold, Styles.useShadowThresholdText);
-
-                if (alphaCutoffShadow != null && useShadowThreshold != null && useShadowThreshold.floatValue == 1.0f && (m_Features & Features.AlphaCutoffShadowThreshold) != 0)
+                if ((m_Features & Features.AlphaCutoffThreshold) != 0)
                 {
-                    EditorGUI.indentLevel++;
-                    materialEditor.ShaderProperty(alphaCutoffShadow, Styles.alphaCutoffShadowText);
-                    EditorGUI.indentLevel--;
+                    if (useShadowThreshold != null)
+                        materialEditor.ShaderProperty(useShadowThreshold, Styles.useShadowThresholdText);
+
+                    if (alphaCutoffShadow != null && useShadowThreshold != null && useShadowThreshold.floatValue == 1.0f && (m_Features & Features.AlphaCutoffShadowThreshold) != 0)
+                    {
+                        EditorGUI.indentLevel++;
+                        materialEditor.ShaderProperty(alphaCutoffShadow, Styles.alphaCutoffShadowText);
+                        EditorGUI.indentLevel--;
+                    }
                 }
 
                 // With transparent object and few specific materials like Hair, we need more control on the cutoff to apply

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/HDShaderGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/HDShaderGUI.cs
@@ -86,7 +86,7 @@ namespace UnityEditor.Rendering.HighDefinition
         }
 
         readonly static string[] floatPropertiesToSynchronize = {
-            kAlphaCutoffEnabled, "_UseShadowThreshold", kReceivesSSR, kUseSplitLighting
+            "_UseShadowThreshold", kReceivesSSR, kUseSplitLighting
         };
 
         protected static void SynchronizeShaderGraphProperties(Material material)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitGUI.cs
@@ -14,7 +14,7 @@ namespace UnityEditor.Rendering.HighDefinition
     {
         // For surface option shader graph we only want all unlit features but alpha clip, double sided mode and back then front rendering
         const SurfaceOptionUIBlock.Features   surfaceOptionFeatures = SurfaceOptionUIBlock.Features.Unlit
-            ^ SurfaceOptionUIBlock.Features.AlphaCutoff
+            ^ SurfaceOptionUIBlock.Features.AlphaCutoffThreshold
             ^ SurfaceOptionUIBlock.Features.DoubleSidedNormalMode
             ^ SurfaceOptionUIBlock.Features.BackThenFrontRendering;
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
@@ -41,6 +41,7 @@ Pass
     // Keyword for transparent
     #pragma shader_feature _SURFACE_TYPE_TRANSPARENT
     #pragma shader_feature_local _ _BLENDMODE_ALPHA _BLENDMODE_ADD _BLENDMODE_PRE_MULTIPLY
+    #pragma shader_feature_local _ALPHATEST_ON
 
     #pragma shader_feature_local        _ENABLE_FOG_ON_TRANSPARENT
     $AddPrecomputedVelocity:            #define _ADD_PRECOMPUTED_VELOCITY
@@ -187,7 +188,9 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky.
+#if _ALPHATEST_ON
         $AlphaTest: GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
+#endif
 
         BuildSurfaceData(fragInputs, surfaceDescription, V, posInput, surfaceData);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitPass.template
@@ -188,7 +188,7 @@ $include("SharedCode.template.hlsl")
 
         // Perform alpha test very early to save performance (a killed pixel will not sample textures)
         // TODO: split graph evaluation to grab just alpha dependencies first? tricky.
-#if _ALPHATEST_ON
+#ifdef _ALPHATEST_ON
         $AlphaTest: GENERIC_ALPHA_TEST(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);
 #endif
 


### PR DESCRIPTION
### Purpose of this PR
Added the alpha clip enabled toggle to the material UI for all HDRP shader graphs.
Note: ketwords and properties were already exposed so i just enabled the UI and the shader feature in the templates.

![image](https://user-images.githubusercontent.com/6877923/73283089-ddf60380-41f2-11ea-90d2-c59770984f39.png)

Alpha cliping can now be disabled in the material UI of ShaderGraphs. Use Shadow Threshold is not exposed and disabled with the alaph clipping toggle.

https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/HDRP%252Ffeature%252Fexpose-alpha-cutoff-material/.yamato%252Fupm-ci-hdrp.yml%2523All_HDRP_fast-trunk/1159283/job