### PR TITLE
Remove 3 variants from the Lit shader

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl
@@ -8,7 +8,7 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Sampling/Sampling.hlsl"
 
 #ifndef UNITY_SPECCUBE_LOD_STEPS
-    #define UNITY_SPECCUBE_LOD_STEPS 6
+    #define UNITY_SPECCUBE_LOD_STEPS 6 // (MipCount - 1) : [0, 6]
 #endif
 
 //-----------------------------------------------------------------------------

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -411,6 +411,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Expose StartSinglePass() and StopSinglePass() as public interface for XRPass
 - Replaced the Texture array for 2D cookies (spot, area and directional lights) and for planar reflections by an atlas.
 - Moved the tier defining from the asset to the concerned volume components.
+- For Lit/LitTessellation/LayeredLit/LayeredLitTessellation shaders, replaced _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE, _DISPLACEMENT_LOCK_TILING_SCALE, and _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE with _MaterialInstanceFlags.
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.high-definition/Editor/AssetProcessors/MaterialPostProcessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/AssetProcessors/MaterialPostProcessor.cs
@@ -185,6 +185,7 @@ namespace UnityEditor.Rendering.HighDefinition
         {
              StencilRefactor,
              ZWriteForTransparent,
+             MaterialInstanceProperties
         };
 
         #region Migrations
@@ -265,6 +266,27 @@ namespace UnityEditor.Rendering.HighDefinition
                 material.SetFloat(kTransparentZWrite, material.GetZWrite() ? 1.0f : 0.0f);
 
             HDShaderUtils.ResetMaterialKeywords(material);
+        }
+
+        static void MaterialInstanceProperties(Material material, HDShaderUtils.ShaderID id)
+        {
+            // For Lit/LitTessellation/LayeredLit/LayeredLitTessellation shaders, we replaced
+            //     #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
+            //     #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
+            //     #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
+            // with
+            //     [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
+            // Try not to touch irrelevant materials.
+            if (material.shader.name.Contains("HDRP") && material.shader.name.Contains("Lit"))
+            {
+                if (material.HasProperty(BaseLitGUI.kDisplacementMode))
+                {
+                    BaseLitGUI.SetDisplacementScaleLocks(material);
+                }
+
+                HDShaderUtils.ResetMaterialKeywords(material);
+            }
         }
 
         #endregion

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/BaseLitGUI.cs
@@ -36,6 +36,8 @@ namespace UnityEditor.Rendering.HighDefinition
         {
             material.SetupBaseUnlitKeywords();
 
+            int materialInstanceFlags = 0;
+
             bool doubleSidedEnable = material.HasProperty(kDoubleSidedEnable) ? material.GetFloat(kDoubleSidedEnable) > 0.0f : false;
             if (doubleSidedEnable)
             {
@@ -70,10 +72,14 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 bool displacementLockObjectScale = material.GetFloat(kDisplacementLockObjectScale) > 0.0;
                 bool displacementLockTilingScale = material.GetFloat(kDisplacementLockTilingScale) > 0.0;
+
                 // Tessellation reuse vertex flag.
-                CoreUtils.SetKeyword(material, "_VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE", displacementLockObjectScale && (enableVertexDisplacement || enableTessellationDisplacement));
-                CoreUtils.SetKeyword(material, "_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE", displacementLockObjectScale && enablePixelDisplacement);
-                CoreUtils.SetKeyword(material, "_DISPLACEMENT_LOCK_TILING_SCALE", displacementLockTilingScale && enableDisplacement);
+                //CoreUtils.SetKeyword(material, "_VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE", displacementLockObjectScale && (enableVertexDisplacement || enableTessellationDisplacement));
+                //CoreUtils.SetKeyword(material, "_PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE", displacementLockObjectScale && enablePixelDisplacement);
+                //CoreUtils.SetKeyword(material, "_DISPLACEMENT_LOCK_TILING_SCALE", displacementLockTilingScale && enableDisplacement);
+
+                materialInstanceFlags |= displacementLockObjectScale ? (int)MaterialInstanceFlags.DisplacementLockObjectScale : 0;
+                materialInstanceFlags |= displacementLockTilingScale ? (int)MaterialInstanceFlags.DisplacementLockTilingScale : 0;
 
                 // Depth offset is only enabled if per pixel displacement is
                 bool depthOffsetEnable = (material.GetFloat(kDepthOffsetEnable) > 0.0f) && enablePixelDisplacement;
@@ -94,6 +100,8 @@ namespace UnityEditor.Rendering.HighDefinition
             CoreUtils.SetKeyword(material, "_DISABLE_DECALS", material.HasProperty(kSupportDecals) && material.GetFloat(kSupportDecals) == 0.0);
             CoreUtils.SetKeyword(material, "_DISABLE_SSR", material.HasProperty(kReceivesSSR) && material.GetFloat(kReceivesSSR) == 0.0);
             CoreUtils.SetKeyword(material, "_ENABLE_GEOMETRIC_SPECULAR_AA", material.HasProperty(kEnableGeometricSpecularAA) && material.GetFloat(kEnableGeometricSpecularAA) == 1.0);
+
+            material.SetInt(kMaterialInstanceFlags, materialInstanceFlags);
         }
 
         static public void SetupStencil(Material material, bool receivesSSR, bool useSplitLighting)

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/ComputeGgxIblSampleData.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/GGXConvolution/ComputeGgxIblSampleData.compute
@@ -17,6 +17,7 @@ RWTexture2D<float4> output; // [MAX_SAMPLE_CNT x UNITY_SPECCUBE_LOD_STEPS]
 
 // Cannot use (MAX_SAMPLE_CNT x UNITY_SPECCUBE_LOD_STEPS) since
 // the thread group becomes too large for some platforms.
+// We do not need to filter the MIP 0, so we start sampling at the MIP level 1.
 [numthreads(8, UNITY_SPECCUBE_LOD_STEPS, 1)]
 void ComputeGgxIblSampleData(uint3 groupThreadId : SV_GroupThreadID)
 {
@@ -25,7 +26,7 @@ void ComputeGgxIblSampleData(uint3 groupThreadId : SV_GroupThreadID)
     for (uint s = 0; s < numSamplesPerThread; s++)
     {
         uint  sampleIndex = groupThreadId.x * numSamplesPerThread + s;
-        uint  mipLevel    = groupThreadId.y + 1;
+        uint  mipLevel    = groupThreadId.y + 1; // We do not filter the MIP 0
         float roughness   = PerceptualRoughnessToRoughness(MipmapLevelToPerceptualRoughness(mipLevel));
         uint  sampleCount = GetIBLRuntimeFilterSampleCount(mipLevel);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -384,9 +384,6 @@ Shader "HDRP/LayeredLit"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
-    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
 
     #pragma shader_feature_local _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR
     #pragma shader_feature_local _LAYER_TILING_COUPLED_WITH_UNIFORM_OBJECT_SCALE
@@ -419,7 +416,7 @@ Shader "HDRP/LayeredLit"
     // _ENABLESPECULAROCCLUSION keyword is obsolete but keep here for compatibility. Do not used
     // _ENABLESPECULAROCCLUSION and _SPECULAR_OCCLUSION_X can't exist at the same time (the new _SPECULAR_OCCLUSION replace it)
     // When _ENABLESPECULAROCCLUSION is found we define _SPECULAR_OCCLUSION_X so new code to work
-    #pragma shader_feature _ENABLESPECULAROCCLUSION                     // Non-local 
+    #pragma shader_feature _ENABLESPECULAROCCLUSION                     // Non-local
     #pragma shader_feature _ _SPECULAR_OCCLUSION_NONE _SPECULAR_OCCLUSION_FROM_BENT_NORMAL_MAP // Non-local
     #ifdef _ENABLESPECULAROCCLUSION
     #define _SPECULAR_OCCLUSION_FROM_BENT_NORMAL_MAP

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -5,6 +5,12 @@ Shader "HDRP/LayeredLit"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bit field containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        // Used to enable a material feature at runtime rather than compile time
+        // (to reduce the number of variants that must be compiled in advance).
+        // Do not use this in performance-critical parts of code.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -378,9 +384,9 @@ Shader "HDRP/LayeredLit"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
-    #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
+    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
 
     #pragma shader_feature_local _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR
     #pragma shader_feature_local _LAYER_TILING_COUPLED_WITH_UNIFORM_OBJECT_SCALE

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitData.hlsl
@@ -403,24 +403,26 @@ void GetLayerTexCoord(FragInputs input, inout LayerTexCoord layerTexCoord)
 void ApplyDisplacementTileScale(inout float height0, inout float height1, inout float height2, inout float height3)
 {
     // When we change the tiling, we have want to conserve the ratio with the displacement (and this is consistent with per pixel displacement)
-#ifdef _DISPLACEMENT_LOCK_TILING_SCALE
-    float tileObjectScale = 1.0;
-    #ifdef _LAYER_TILING_COUPLED_WITH_UNIFORM_OBJECT_SCALE
-    // Extract scaling from world transform
-    float4x4 worldTransform = GetObjectToWorldMatrix();
-    // assuming uniform scaling, take only the first column
-    tileObjectScale = length(float3(worldTransform._m00, worldTransform._m01, worldTransform._m02));
-    #endif
+    if ((_MaterialInstanceFlags & MATERIALINSTANCEFLAGS_DISPLACEMENT_LOCK_TILING_SCALE) != 0)
+    {
 
-    // TODO: precompute all these scaling factors!
-    height0 *= _InvTilingScale0;
-    #if !defined(_MAIN_LAYER_INFLUENCE_MODE)
-    height0 /= tileObjectScale;  // We only affect layer0 in case we are not in influence mode (i.e we should not change the base object)
-    #endif
-    height1 = (height1 / tileObjectScale) * _InvTilingScale1;
-    height2 = (height2 / tileObjectScale) * _InvTilingScale2;
-    height3 = (height3 / tileObjectScale) * _InvTilingScale3;
-#endif
+        float tileObjectScale = 1.0;
+        #ifdef _LAYER_TILING_COUPLED_WITH_UNIFORM_OBJECT_SCALE
+        // Extract scaling from world transform
+        float4x4 worldTransform = GetObjectToWorldMatrix();
+        // assuming uniform scaling, take only the first column
+        tileObjectScale = length(float3(worldTransform._m00, worldTransform._m01, worldTransform._m02));
+        #endif
+
+        // TODO: precompute all these scaling factors!
+        height0 *= _InvTilingScale0;
+        #if !defined(_MAIN_LAYER_INFLUENCE_MODE)
+        height0 /= tileObjectScale;  // We only affect layer0 in case we are not in influence mode (i.e we should not change the base object)
+        #endif
+        height1 = (height1 / tileObjectScale) * _InvTilingScale1;
+        height2 = (height2 / tileObjectScale) * _InvTilingScale2;
+        height3 = (height3 / tileObjectScale) * _InvTilingScale3;
+    }
 }
 
 // This function is just syntaxic sugar to nullify height not used based on heightmap avaibility and layer

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -394,9 +394,6 @@ Shader "HDRP/LayeredLitTessellation"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _TESSELLATION_DISPLACEMENT _PIXEL_DISPLACEMENT
-    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature_local _TESSELLATION_PHONG
 
     #pragma shader_feature_local _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR
@@ -430,7 +427,7 @@ Shader "HDRP/LayeredLitTessellation"
     // _ENABLESPECULAROCCLUSION keyword is obsolete but keep here for compatibility. Do not used
     // _ENABLESPECULAROCCLUSION and _SPECULAR_OCCLUSION_X can't exist at the same time (the new _SPECULAR_OCCLUSION replace it)
     // When _ENABLESPECULAROCCLUSION is found we define _SPECULAR_OCCLUSION_X so new code to work
-    #pragma shader_feature _ENABLESPECULAROCCLUSION                     // Non-local 
+    #pragma shader_feature _ENABLESPECULAROCCLUSION                     // Non-local
     #pragma shader_feature _ _SPECULAR_OCCLUSION_NONE _SPECULAR_OCCLUSION_FROM_BENT_NORMAL_MAP // Non-local
     #ifdef _ENABLESPECULAROCCLUSION
     #define _SPECULAR_OCCLUSION_FROM_BENT_NORMAL_MAP

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLitTessellation.shader
@@ -5,6 +5,12 @@ Shader "HDRP/LayeredLitTessellation"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bit field containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        // Used to enable a material feature at runtime rather than compile time
+        // (to reduce the number of variants that must be compiled in advance).
+        // Do not use this in performance-critical parts of code.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -388,9 +394,9 @@ Shader "HDRP/LayeredLitTessellation"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _TESSELLATION_DISPLACEMENT _PIXEL_DISPLACEMENT
-    #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
+    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature_local _TESSELLATION_PHONG
 
     #pragma shader_feature_local _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -5,6 +5,12 @@ Shader "HDRP/Lit"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bit field containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        // Used to enable a material feature at runtime rather than compile time
+        // (to reduce the number of variants that must be compiled in advance).
+        // Do not use this in performance-critical parts of code.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -240,9 +246,9 @@ Shader "HDRP/Lit"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
-    #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
+    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature_local _ _REFRACTION_PLANE _REFRACTION_SPHERE _REFRACTION_THIN
 
     #pragma shader_feature_local _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -246,9 +246,6 @@ Shader "HDRP/Lit"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
-    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature_local _ _REFRACTION_PLANE _REFRACTION_SPHERE _REFRACTION_THIN
 
     #pragma shader_feature_local _ _EMISSIVE_MAPPING_PLANAR _EMISSIVE_MAPPING_TRIPLANAR

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitData.hlsl
@@ -10,6 +10,7 @@
 //-------------------------------------------------------------------------------------
 // Fill SurfaceData/Builtin data function
 //-------------------------------------------------------------------------------------
+#include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Sampling/SampleUVMapping.hlsl"
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl"
 #ifndef SHADER_STAGE_RAY_TRACING
@@ -214,7 +215,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
     alphaCutoff = _AlphaCutoffPostpass;
     #endif
 
-    #if SHADERPASS == SHADERPASS_SHADOWS 
+    #if SHADERPASS == SHADERPASS_SHADOWS
         GENERIC_ALPHA_TEST(alphaValue, _UseShadowThreshold ? _AlphaCutoffShadow : alphaCutoff);
     #else
         GENERIC_ALPHA_TEST(alphaValue, alphaCutoff);

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDataDisplacement.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitDataDisplacement.hlsl
@@ -18,7 +18,7 @@ float3 GetDisplacementObjectScale(bool vertexDisplacement)
     }
 
 #if defined(_PIXEL_DISPLACEMENT)
-    bool applyObjectScale = (_MaterialInstanceFlags & MATERIALINSTANCEFLAGS_DISPLACEMENT_LOCK_OBJECT_SCALE) != 0);
+    bool applyObjectScale = (_MaterialInstanceFlags & MATERIALINSTANCEFLAGS_DISPLACEMENT_LOCK_OBJECT_SCALE) != 0;
 #else
     bool applyObjectScale = true;
 #endif

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitProperties.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitProperties.hlsl
@@ -100,6 +100,7 @@ SAMPLER(sampler_LayerInfluenceMaskMap);
 CBUFFER_START(UnityPerMaterial)
 
 // shared constant between lit and layered lit
+int   _MaterialInstanceFlags;
 float _AlphaCutoff;
 float _UseShadowThreshold;
 float _AlphaCutoffShadow;

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -5,6 +5,12 @@ Shader "HDRP/LitTessellation"
         // Versioning of material to help for upgrading
         [HideInInspector] _HdrpVersion("_HdrpVersion", Float) = 2
 
+        // A bit field containing up to 24 bits. See the "MaterialInstanceFlags" enum.
+        // Used to enable a material feature at runtime rather than compile time
+        // (to reduce the number of variants that must be compiled in advance).
+        // Do not use this in performance-critical parts of code.
+        [HideInInspector] _MaterialInstanceFlags("_MaterialInstanceFlags", Int) = 0
+
         // Following set of parameters represent the parameters node inside the MaterialGraph.
         // They are use to fill a SurfaceData. With a MaterialGraph this should not exist.
 
@@ -249,9 +255,9 @@ Shader "HDRP/LitTessellation"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _TESSELLATION_DISPLACEMENT _PIXEL_DISPLACEMENT
-    #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
+    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
+    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature_local _TESSELLATION_PHONG
     #pragma shader_feature_local _ _REFRACTION_PLANE _REFRACTION_SPHERE _REFRACTION_THIN
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/LitTessellation.shader
@@ -255,9 +255,6 @@ Shader "HDRP/LitTessellation"
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _TESSELLATION_DISPLACEMENT _PIXEL_DISPLACEMENT
-    // #pragma shader_feature_local _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE
-    // #pragma shader_feature_local _DISPLACEMENT_LOCK_TILING_SCALE
-    // #pragma shader_feature_local _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
     #pragma shader_feature_local _TESSELLATION_PHONG
     #pragma shader_feature_local _ _REFRACTION_PLANE _REFRACTION_SPHERE _REFRACTION_THIN
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs
@@ -1,0 +1,9 @@
+namespace UnityEngine.Rendering.HighDefinition
+{
+    [GenerateHLSL]
+    public enum MaterialInstanceFlags
+    {
+        DisplacementLockObjectScale = 1,
+        DisplacementLockTilingScale = 2
+    }
+}

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl
@@ -1,0 +1,14 @@
+//
+// This file was automatically generated. Please don't edit by hand.
+//
+
+#ifndef MATERIALINSTANCEFLAGS_CS_HLSL
+#define MATERIALINSTANCEFLAGS_CS_HLSL
+//
+// UnityEditor.Experimental.Rendering.HDPipeline.MaterialInstanceFlags:  static fields
+//
+#define MATERIALINSTANCEFLAGS_DISPLACEMENT_LOCK_OBJECT_SCALE (1)
+#define MATERIALINSTANCEFLAGS_DISPLACEMENT_LOCK_TILING_SCALE (2)
+
+
+#endif

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 74cb3ead77df80845abe43071da85879
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.meta
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialInstanceFlags.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c098e41ae4775c459c2728104ed1d89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -897,6 +897,8 @@ namespace UnityEngine.Rendering.HighDefinition
     // Shared material property names
     static class HDMaterialProperties
     {
+        public const string kMaterialInstanceFlags = "_MaterialInstanceFlags";
+
         // Stencil properties
         public const string kStencilRef = "_StencilRef";
         public const string kStencilWriteMask = "_StencilWriteMask";


### PR DESCRIPTION
### Purpose of this PR
I need to remove several variants to solve the SpeedTree case.
So, for Lit/LitTessellation/LayeredLit/LayeredLitTessellation shaders, I replaced _VERTEX_DISPLACEMENT_LOCK_OBJECT_SCALE, _DISPLACEMENT_LOCK_TILING_SCALE, and _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE with _MaterialInstanceFlags. I will reclaim two variants in the next PR (for a bug fix and a perf uplift).

---
### Testing status

**Manual Tests**: Tested on SRP Data repository.
**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

---
### Comments to reviewers
I have NOT upgraded the materials. I HAVE written the upgrader. It appears to work. We can upgrade materials after we are done reviewing the code.

### Comments to QA
Must test all combinations of "Lock Object Scale" and "Lock Tiling Scale" for Vertex Displacement, Tessellation Displacement, and Pixel Displacement before and after this change. You can start with some assets in the SRP Data repository (there is a setup with tessellation and pixel displacement side by side in which they look nearly identical).