### PR TITLE
Made URP MaterialDescriptionPreprocessors private. [2020.1]

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Particle shaders now receive shadows
 - The Scene view now mirrors the Volume Layer Mask set on the Main Camera.
 - Drawing order of SRPDefaultUnlit is now the same as the Built-in Render Pipline.
+- Made MaterialDescriptionPreprocessors private.
 
 ### Fixed
 - Fixed an issue where linear to sRGB conversion occurred twice on certain Android devices.

--- a/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/AutodeskInteractiveMaterialImport.cs
+++ b/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/AutodeskInteractiveMaterialImport.cs
@@ -4,7 +4,7 @@ using UnityEngine.Rendering;
 
 namespace UnityEditor.Rendering.Universal
 {
-    public class AutodeskInteractiveMaterialImport : AssetPostprocessor
+    class AutodeskInteractiveMaterialImport : AssetPostprocessor
     {
         static readonly uint k_Version = 1;
         static readonly int k_Order = 3;

--- a/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/FBXMaterialDescriptionPreprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/FBXMaterialDescriptionPreprocessor.cs
@@ -1,12 +1,10 @@
-using System;
 using System.IO;
 using UnityEditor.AssetImporters;
 using UnityEngine;
 
 namespace UnityEditor.Rendering.Universal
 {
-    [Obsolete("FBXMaterialDescriptionPreprocessor is deprecated, consider creating a new AsserPostProcessor rather than overriding it.")]
-    public class FBXMaterialDescriptionPreprocessor : AssetPostprocessor
+    class FBXMaterialDescriptionPreprocessor : AssetPostprocessor
     {
         static readonly uint k_Version = 1;
         static readonly int k_Order = 2;

--- a/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/SketchupMaterialDescriptionPostprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/SketchupMaterialDescriptionPostprocessor.cs
@@ -1,12 +1,10 @@
-using System;
-using System.IO;
+﻿using System.IO;
 using UnityEngine;
 using UnityEditor.AssetImporters;
 
 namespace UnityEditor.Rendering.Universal
 {
-    [Obsolete("SketchupMaterialDescriptionPreprocessor is deprecated, consider creating a new AsserPostProcessor rather than overriding it.")]
-    public class SketchupMaterialDescriptionPreprocessor : AssetPostprocessor
+    class SketchupMaterialDescriptionPreprocessor : AssetPostprocessor
     {
         static readonly uint k_Version = 1;
         static readonly int k_Order = 2;

--- a/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/ThreeDSMaterialDescriptionPostprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/AssetPostProcessors/ThreeDSMaterialDescriptionPostprocessor.cs
@@ -1,12 +1,11 @@
-using System;
+﻿using System;
 using System.IO;
 using UnityEngine;
 using UnityEditor.AssetImporters;
 
 namespace UnityEditor.Rendering.Universal
 {
-    [Obsolete("ThreeDSMaterialDescriptionPreprocessor is deprecated, consider creating a new AsserPostProcessor rather than overriding it.")]
-    public class ThreeDSMaterialDescriptionPreprocessor : AssetPostprocessor
+    class ThreeDSMaterialDescriptionPreprocessor : AssetPostprocessor
     {
         static readonly uint k_Version = 1;
         static readonly int k_Order = 2;


### PR DESCRIPTION
### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR

Made URPs' MaterialDescriptionpreprocessors private as they're not meant to be overridden or part of public API.

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
