### PR TITLE
[7.2.1 Backport] Bugfix: Determining the number of maximum visible lights 

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- The check for maximum visible lights now checks if the platform is mobile or not.
+- The number of maximum visible lights is now determined by whether the platform is mobile or not.
 
 ## [7.2.0] - 2020-03-02
 

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- The check for maximum visible lights now checks if the platform is mobile or not.
+
 ## [7.2.0] - 2020-03-02
 
 ### Added

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -73,28 +73,13 @@ namespace UnityEngine.Rendering.Universal
         }
 
         // These limits have to match same limits in Input.hlsl
-        const int k_MaxVisibleAdditionalLightsSSBO  = 256;
-        const int k_MaxVisibleAdditionalLightsUBO   = 32;
+        const int k_MaxVisibleAdditionalLightsMobile    = 32;
+        const int k_MaxVisibleAdditionalLightsNonMobile = 256;
         public static int maxVisibleAdditionalLights
         {
             get
             {
-                // There are some performance issues by using SSBO in mobile.
-                // Also some GPUs don't supports SSBO in vertex shader.
-                if (RenderingUtils.useStructuredBuffer)
-                    return k_MaxVisibleAdditionalLightsSSBO;
-
-                // We don't use SSBO in D3D because we can't figure out without adding shader variants if platforms is D3D10.
-                // We don't use SSBO on Nintendo Switch as UBO path is faster.
-                // However here we use same limits as SSBO path.
-                var deviceType = SystemInfo.graphicsDeviceType;
-                if (deviceType == GraphicsDeviceType.Direct3D11 || deviceType == GraphicsDeviceType.Direct3D12 ||
-                    deviceType == GraphicsDeviceType.Switch)
-                    return k_MaxVisibleAdditionalLightsSSBO;
-
-                // We use less limits for mobile as some mobile GPUs have small SP cache for constants
-                // Using more than 32 might cause spilling to main memory.
-                return k_MaxVisibleAdditionalLightsUBO;
+                return (Application.isMobilePlatform) ? k_MaxVisibleAdditionalLightsMobile : k_MaxVisibleAdditionalLightsNonMobile;
             }
         }
 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
@@ -1,27 +1,19 @@
 #ifndef UNIVERSAL_INPUT_INCLUDED
 #define UNIVERSAL_INPUT_INCLUDED
 
-#define MAX_VISIBLE_LIGHTS_SSBO 256
-#define MAX_VISIBLE_LIGHTS_UBO  32
+#define MAX_VISIBLE_LIGHTS_MOBILE  32
+#define MAX_VISIBLE_LIGHTS_NON_MOBILE 256
+#define USE_STRUCTURED_BUFFER_FOR_LIGHT_DATA 0
+
+#define MAX_VISIBLE_LIGHTS_UBO  MAX_VISIBLE_LIGHTS_MOBILE
+#define MAX_VISIBLE_LIGHTS_SSBO MAX_VISIBLE_LIGHTS_NON_MOBILE
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderTypes.cs.hlsl"
 
-// There are some performance issues by using SSBO in mobile.
-// Also some GPUs don't supports SSBO in vertex shader.
-#if !defined(SHADER_API_MOBILE) && (defined(SHADER_API_METAL) || defined(SHADER_API_VULKAN) || defined(SHADER_API_PS4) || defined(SHADER_API_XBOXONE))
-    #define USE_STRUCTURED_BUFFER_FOR_LIGHT_DATA 0
-    #define MAX_VISIBLE_LIGHTS MAX_VISIBLE_LIGHTS_SSBO
-// We don't use SSBO in D3D because we can't figure out without adding shader variants if platforms is D3D10.
-// We don't use SSBO on Nintendo Switch as UBO path is faster.
-// However here we use same limits as SSBO path. 
-#elif defined(SHADER_API_D3D11) || defined(SHADER_API_SWITCH)
-    #define MAX_VISIBLE_LIGHTS MAX_VISIBLE_LIGHTS_SSBO
-    #define USE_STRUCTURED_BUFFER_FOR_LIGHT_DATA 0
-// We use less limits for mobile as some mobile GPUs have small SP cache for constants
-// Using more than 32 might cause spilling to main memory.
+#if defined(SHADER_API_MOBILE)
+    #define MAX_VISIBLE_LIGHTS MAX_VISIBLE_LIGHTS_MOBILE
 #else
-    #define MAX_VISIBLE_LIGHTS MAX_VISIBLE_LIGHTS_UBO
-    #define USE_STRUCTURED_BUFFER_FOR_LIGHT_DATA 0
+    #define MAX_VISIBLE_LIGHTS MAX_VISIBLE_LIGHTS_NON_MOBILE
 #endif
 
 struct InputData


### PR DESCRIPTION
### Purpose of this PR
This is a backport of a code change done in #5438 where the check for the maximum visible lights was changed to only look whether it's a mobile platform or not. 

Mobile platforms support 32 lights otherwise 256.

---

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---

### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline
