### PR TITLE
[Workaround] Fixed WMR crashes editor when entering play mode regression for 7.2.0

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -167,6 +167,7 @@ namespace UnityEngine.Rendering.Universal
 
 #if ENABLE_VR && ENABLE_XR_MODULE
         static List<XRDisplaySubsystem> xrDisplayList = new List<XRDisplaySubsystem>();
+        static bool xrSkipRender = false;
         internal void SetupXRStates()
         {
             SubsystemManager.GetInstances(xrDisplayList);
@@ -180,18 +181,18 @@ namespace UnityEngine.Rendering.Universal
                 if(display.GetRenderPassCount() == 0)
                 {
                     // Disable XR rendering if display contains 0 renderpass
-                    if(!display.disableLegacyRenderer)
+                    if(!xrSkipRender)
                     {
-                        display.disableLegacyRenderer = true;
+                        xrSkipRender = true;
                         Debug.Log("XR display is not ready. Skip XR rendering.");
                     }
                 }
                 else
                 {
                     // Enable XR rendering if display contains >0 renderpass
-                    if (display.disableLegacyRenderer)
+                    if (xrSkipRender)
                     {
-                        display.disableLegacyRenderer = false;
+                        xrSkipRender = false;
                         Debug.Log("XR display is ready. Start XR rendering.");
                     }
                 }
@@ -208,6 +209,8 @@ namespace UnityEngine.Rendering.Universal
             SetupPerFrameShaderConstants();
 #if ENABLE_VR && ENABLE_XR_MODULE
             SetupXRStates();
+            if(xrSkipRender)
+                return;
 #endif
 
             SortCameras(cameras);
@@ -272,7 +275,7 @@ namespace UnityEngine.Rendering.Universal
                 return;
             }
 
-            if (!camera.TryGetCullingParameters(IsStereoEnabled(camera), out var cullingParameters))
+            if (!camera.TryGetCullingParameters( IsStereoEnabled(camera), out var cullingParameters))
                 return;
 
             SetupPerCameraShaderConstants(cameraData);

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -275,7 +275,7 @@ namespace UnityEngine.Rendering.Universal
                 return;
             }
 
-            if (!camera.TryGetCullingParameters( IsStereoEnabled(camera), out var cullingParameters))
+            if (!camera.TryGetCullingParameters(IsStereoEnabled(camera), out var cullingParameters))
                 return;
 
             SetupPerCameraShaderConstants(cameraData);

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -7,6 +7,9 @@ using UnityEditor.Rendering.Universal;
 #endif
 using UnityEngine.Scripting.APIUpdating;
 using Lightmapping = UnityEngine.Experimental.GlobalIllumination.Lightmapping;
+#if ENABLE_VR && ENABLE_XR_MODULE
+using UnityEngine.XR;
+#endif
 
 namespace UnityEngine.Rendering.LWRP
 {
@@ -162,6 +165,34 @@ namespace UnityEngine.Rendering.Universal
             CameraCaptureBridge.enabled = false;
         }
 
+#if ENABLE_VR && ENABLE_XR_MODULE
+        static List<XRDisplaySubsystem> xrDisplayList = new List<XRDisplaySubsystem>();
+        internal void SetupXRStates()
+        {
+            SubsystemManager.GetInstances(xrDisplayList);
+
+            if (xrDisplayList.Count > 0)
+            {
+                if (xrDisplayList.Count > 1)
+                    throw new NotImplementedException("Only 1 XR display is supported.");
+
+                XRDisplaySubsystem display = xrDisplayList[0];
+                if(display.GetRenderPassCount() == 0)
+                {
+                    // Disable XR rendering if display contains 0 renderpass
+                    if(XRGraphics.enabled)
+                        display.disableLegacyRenderer = true;
+                }
+                else
+                {
+                    // Disable XR rendering if display contains >0 renderpass
+                    if (!XRGraphics.enabled)
+                        display.disableLegacyRenderer = false;
+                }
+            }
+        }
+#endif
+
         protected override void Render(ScriptableRenderContext renderContext, Camera[] cameras)
         {
             BeginFrameRendering(renderContext, cameras);
@@ -169,6 +200,9 @@ namespace UnityEngine.Rendering.Universal
             GraphicsSettings.lightsUseLinearIntensity = (QualitySettings.activeColorSpace == ColorSpace.Linear);
             GraphicsSettings.useScriptableRenderPipelineBatching = asset.useSRPBatcher;
             SetupPerFrameShaderConstants();
+#if ENABLE_VR && ENABLE_XR_MODULE
+            SetupXRStates();
+#endif
 
             SortCameras(cameras);
             for (int i = 0; i < cameras.Length; ++i)

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -185,7 +185,7 @@ namespace UnityEngine.Rendering.Universal
                 }
                 else
                 {
-                    // Disable XR rendering if display contains >0 renderpass
+                    // Enable XR rendering if display contains >0 renderpass
                     if (!XRGraphics.enabled)
                         display.disableLegacyRenderer = false;
                 }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -180,14 +180,20 @@ namespace UnityEngine.Rendering.Universal
                 if(display.GetRenderPassCount() == 0)
                 {
                     // Disable XR rendering if display contains 0 renderpass
-                    if(XRGraphics.enabled)
+                    if(!display.disableLegacyRenderer)
+                    {
                         display.disableLegacyRenderer = true;
+                        Debug.Log("XR display is not ready. Skip XR rendering.");
+                    }
                 }
                 else
                 {
                     // Enable XR rendering if display contains >0 renderpass
-                    if (!XRGraphics.enabled)
+                    if (display.disableLegacyRenderer)
+                    {
                         display.disableLegacyRenderer = false;
+                        Debug.Log("XR display is ready. Start XR rendering.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
- Fixed WMR crashes editor issue introduced in 7.2.0. 

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
- 7.2.0 has WMR crashes editor issue caused by culling system
   - This is a regression since we didn't see this in 7.1.8
- The issue is WMR returns zero'd projection/view matrix data for the first couple frames.
   - culling system used to be able to handle this, but 7.2.0 can't handle this anymore(editor crashes)
- Fix is disable URP rendering until WMR is ready to return valid data
- Trunk proper fix is here: https://ono.unity3d.com/unity/unity/pull-request/94762/_/xr/display/noop-frame
    - QA: please verify this workaround is compatible with the trunk fix above