### PR TITLE
[XR] Fix for XRSDK single-pass stereo mode incorrectly switch to multipass mode (case 1217120)

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where post processing disappeared when using custom renderers and SMAA or no AA
 - Fixed an issue with soft particles having dark blending when intersecting with scene geometry [case 1199812](https://issuetracker.unity3d.com/issues/urp-soft-particles-create-dark-blending-artefacts-when-intersecting-with-scene-geometry)
 - Fixed an issue with additive particles blending incorrectly [case 1215713](https://issuetracker.unity3d.com/issues/universal-render-pipeline-additive-particles-not-using-vertex-alpha)
+- Fixed XR SDK single-pass wrongly switching to multipass issue. Add query for XR SDK single-pass availability using XR SDK renderpass descriptors.
 
 ## [7.1.8] - 2020-01-20
 

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -460,16 +460,17 @@ namespace UnityEngine.Rendering.Universal
             InitializeAdditionalCameraData(camera, additionalCameraData, ref cameraData);
         }
 
+#if ENABLE_VR && ENABLE_XR_MODULE
+        static List<XR.XRDisplaySubsystem> displaySubsystemList = new List<XR.XRDisplaySubsystem>();
         static bool CanXRSDKUseSinglePass(Camera camera)
         {
-            List<XR.XRDisplaySubsystem> displayList = new List<XR.XRDisplaySubsystem>();
             XR.XRDisplaySubsystem display = null;
-            SubsystemManager.GetInstances(displayList);
+            SubsystemManager.GetInstances(displaySubsystemList);
 
-            if (displayList.Count > 0)
+            if (displaySubsystemList.Count > 0)
             {
                 XR.XRDisplaySubsystem.XRRenderPass renderPass;
-                display = displayList[0];
+                display = displaySubsystemList[0];
                 if (display.GetRenderPassCount() > 0)
                 {
                     display.GetRenderPass(0, out renderPass);
@@ -494,6 +495,7 @@ namespace UnityEngine.Rendering.Universal
             }
             return false;
         }
+#endif
 
         /// <summary>
         /// Initialize camera data settings common for all cameras in the stack. Overlay cameras will inherit


### PR DESCRIPTION
### Purpose of this PR 
Add query for XR SDK single-pass availability using XR SDK renderpass descriptors. This is a short-term fix for XR SDK single-pass stereo mode incorrectly switch to multipass mode ( case 1217120).

---
### Testing status
Tested locally on Oculus Quest and Rift with GLES/Vulkan with and without XRSDK.

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/2019.3%252Furp%252Fxrsdk-single-pass-query

---
### Comments to reviewers
Proper XR SDK shim fix will land in 2019.3.2.
