### PR TITLE
Hdrp/fix emissive mesh on lights

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -149,6 +149,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed the broken ShaderGraph preview when creating a new Lit graph.
 - Fix indentation issue in preset of LayeredLit material.
 - Fixed wrong build error message when building for android on mac.
+- Fix MeshFilter and MeshRenderer removed automatically when adding light component.
 
 ### Changed
 - Hide unused LOD settings in Quality Settings legacy window.

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.Migration.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/Light/HDAdditionalLightData.Migration.cs
@@ -22,6 +22,7 @@ namespace UnityEngine.Rendering.HighDefinition
             RemoveAdditionalShadowData,
             AreaLightShapeTypeLogicIsolation,
             PCSSUIUpdate,
+            MoveEmissionMesh,
         }
 
         /// <summary>
@@ -141,8 +142,12 @@ namespace UnityEngine.Rendering.HighDefinition
                 {
                     // The min filter size is now in the [0..1] range when user facing
                     data.minFilterSize = data.minFilterSize * 1000.0f;
+                }),
+                MigrationStep.New(Version.MoveEmissionMesh, (HDAdditionalLightData data) =>
+                {
+                    CoreUtils.Destroy(data.GetComponent<MeshFilter>());
+                    CoreUtils.Destroy(data.GetComponent<MeshRenderer>());
                 })
-
             );
 #pragma warning restore 0618, 0612
 


### PR DESCRIPTION
### Purpose of this PR
Fix issue where MeshRenderer and MeshFilter were removed when adding Light component.
( https://fogbugz.unity3d.com/f/cases/1207148/ )

Note:
Now they are in a sub GameObject that is not editable in editor. This GameObject is hiden while light type is not Area.

---
### Testing status
Manualy tested all light type and the Display Emissive Mesh checkbox.
Tested also the coherency while moving and rotating and scaling the area light.

---
### Comments to reviewers
