### PR TITLE
[Bugfix 1192259] Removed reliance on PlayerPrefs for material upgrading

### DIFF
--- a/TestProjects/UniversalGraphicsTest/ProjectSettings/UniversalRP_Settings.txt
+++ b/TestProjects/UniversalGraphicsTest/ProjectSettings/UniversalRP_Settings.txt
@@ -1,0 +1,1 @@
+{"m_Keys":["URP-material-upgrade-version"],"m_Values":["8.0.0"]}

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue with soft particles having dark blending when intersecting with scene geometry [case 1199812](https://issuetracker.unity3d.com/issues/urp-soft-particles-create-dark-blending-artefacts-when-intersecting-with-scene-geometry)
 - Fixed an issue with additive particles blending incorrectly [case 1215713](https://issuetracker.unity3d.com/issues/universal-render-pipeline-additive-particles-not-using-vertex-alpha)
 - Fixed an issue where camera preview window was missing in scene view. [case 1211971](https://issuetracker.unity3d.com/issues/scene-view-urp-camera-preview-window-is-missing-in-the-scene-view)
+- Fixed an issue where clearing player prefs caused a full reimport of all materials. [case 1192259](https://issuetracker.unity3d.com/product/unity/issues/guid/1192259/)
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Editor/EditorUtils.cs
+++ b/com.unity.render-pipelines.universal/Editor/EditorUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -24,6 +25,8 @@ namespace UnityEditor.Rendering.Universal
         public const int lwrpAssetCreateMenuPriorityGroup1 = CoreUtils.assetCreateMenuPriority1;
         public const int lwrpAssetCreateMenuPriorityGroup2 = CoreUtils.assetCreateMenuPriority1 + 50;
         public const int lwrpAssetCreateMenuPriorityGroup3 = lwrpAssetCreateMenuPriorityGroup2 + 50;
+
+        private const string SettingsFilePath = "/ProjectSettings/UniversalRP_Settings.txt";
 
         internal class Styles
         {
@@ -68,6 +71,51 @@ namespace UnityEditor.Rendering.Universal
                     }
                 }
             }
+        }
+
+        internal static void SetProjectValue(string key, string value)
+        {
+            var dict = ReadSettings();
+
+            if (dict != null && dict.ContainsKey(key))
+            {
+                dict[key] = value;
+            }
+            else
+            {
+                dict.Add(key, value);
+            }
+            WriteSettings(dict);
+        }
+
+        internal static string GetProjectValue(string key)
+        {
+            var dict = ReadSettings();
+            return (dict != null && dict.ContainsKey(key)) ? dict[key] : "null";
+        }
+
+        private static SerializedDictionary<string, string> ReadSettings()
+        {
+            if (!File.Exists(SettingsPath()))
+            {
+                File.WriteAllText(SettingsPath(), "");
+            }
+            var rawData = File.ReadAllText(SettingsPath());
+            if(rawData.Length == 0)
+                return new SerializedDictionary<string, string>();
+            return JsonUtility.FromJson(rawData, typeof(SerializedDictionary<string, string>)) as
+                SerializedDictionary<string, string>;
+        }
+
+        private static void WriteSettings(SerializedDictionary<string, string> data)
+        {
+            var outputData = JsonUtility.ToJson(data);
+            File.WriteAllText(SettingsPath(), outputData);
+        }
+
+        private static string SettingsPath()
+        {
+            return Application.dataPath.Remove(Application.dataPath.Length - 6) + SettingsFilePath;
         }
     }
 }

--- a/com.unity.render-pipelines.universal/Editor/MaterialPostprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/MaterialPostprocessor.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.Rendering.Universal
 
     class MaterialReimporter : Editor
     {
-        const string Key = "LWRP-material-upgrader";
+        const string Key = "URP-material-upgrade-version";
 
         // Upgrade materials only after we compiled shaders.
         // This fixes a case that caused ReloadAllNullIn to be called before shaders finished compiling.
@@ -31,18 +31,18 @@ namespace UnityEditor.Rendering.Universal
             //Check to see if the upgrader has been run for this project/LWRP version
             PackageManager.PackageInfo lwrpInfo = PackageManager.PackageInfo.FindForAssembly(Assembly.GetAssembly(typeof(UniversalRenderPipeline)));
             var lwrpVersion = lwrpInfo.version;
-            var curUpgradeVersion = PlayerPrefs.GetString(Key);
+            var curUpgradeVersion = EditorUtils.GetProjectValue(Key);
 
             if (curUpgradeVersion != lwrpVersion)
             {
-                string[] guids = AssetDatabase.FindAssets("t:material", null);
+                var guids = AssetDatabase.FindAssets("t:material", null);
 
                 foreach (var asset in guids)
                 {
                     var path = AssetDatabase.GUIDToAssetPath(asset);
                     AssetDatabase.ImportAsset(path);
                 }
-                PlayerPrefs.SetString(Key, lwrpVersion);
+                EditorUtils.SetProjectValue(Key, lwrpVersion);
             }
         }
     }


### PR DESCRIPTION
---
### Purpose of this PR
Universal now has a URP-settings.txt file in ProjectSettings much like HDRP, this will allow us to also store extra project based data in the future if needed.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
