### PR TITLE
Update Ray-Tracing documentation typo

### DIFF
--- a/com.unity.render-pipelines.high-definition/Documentation~/Ray-Traced-Reflections.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Ray-Traced-Reflections.md
@@ -61,7 +61,7 @@ Alongside the standard properties, Unity exposes extra properties depending on t
 | ------------------------- | ------------------------------------------------------------ |
 | **Ray Tracing**           | Makes HDRP use ray tracing to process screen-space reflections. Enabling this exposes properties that you can use to adjust the quality of ray-traced reflections. |
 | **Minimum Smoothness**    | Controls the minimum smoothness value for a pixel at which HDRP processes ray-traced reflections. If the smoothness value of the pixel is lower than this value, HDRP falls back to the next available reflection method in the [reflection hierarchy](Reflection-in-HDRP.html#ReflectionHierarchy). |
-| **Smoothness Fade Start** | This feature has not been implemented yet and currently does nothing. Ray tracing in HDRP is experimental so some features have not been implemented yet. |
+| **Smoothness Fade Start** | Controls the smoothness value at which the smoothness controlled fade out starts. The fade is in the range [Min Smoothness, Smoothness Fade Start]. |
 | **Reflect Sky**           | Enable this feature to specify to HDRP that it should use the sky as a fall-back for ray-traced reflections when a ray doesn't find an intersection. |
 | **LayerMask**             | Defines the layers that HDRP processes this ray-traced effect for. |
 | **Ray Length**            | Controls the length of the rays that HDRP uses for ray tracing. If a ray doesn't find an intersection, then the ray returns the color of the sky if Reflect Sky is enabled, or black if not. |

--- a/com.unity.render-pipelines.high-definition/Documentation~/Ray-Traced-Shadows.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Ray-Traced-Shadows.md
@@ -29,7 +29,7 @@ Finally, to make HDRP process ray-traced shadows for your Directional, Point, or
 
 1. Under the Shadow Map fold-out in the Shadows section, click the Enable checkbox.
 2. Also in the Shadow Map foldout, enable Ray-Traced Shadows. For Directional Lights, you need to enable Screen Space Shadows to access this property.
-3. To change the behavior of the shadows, edit the properties under Ray-Traced Shadows .
+3. To change the behavior of the shadows, edit the properties under Ray-Traced Shadows.
 
 <a name="DirectionalLight"></a>
 
@@ -47,7 +47,7 @@ Ray-traced shadows offer an alternative to the cascade shadow map that Direction
 
 ![](Images/RayTracedShadows3.png)
 
-**Ray raced Directional Light shadows (Sun Angle = 0.53, the angle of the Sun as seen from Earth)**
+**Ray-traced Directional Light shadows (Sun Angle = 0.53, the angle of the Sun as seen from Earth)**
 
 Ray-traced shadows allow for transparent and transmissive GameObjects, lit by Directional Lights, to cast colored shadows.
 
@@ -73,7 +73,7 @@ Ray-traced shadows allow for transparent and transmissive GameObjects, lit by Di
 
 ## Point And Spot Light
 
-Ray-traced shadows offer an alternative to the shadow map that Point and Spot Lights use for opaque GameObjects. HDRP still evaluates the lighting of a Point Light as coming from a single point in space (the light is [punctual](Glossary.html#PunctualLights)), but it evaluates the shadowing as if the light was coming from the surface of a sphere. On the other side, HDRP evaluates the lighting of a Spot Light as coming from a single point in space, but it evaluates the shadowing as if the light was coming from the surface of a cone.
+Ray-traced shadows offer an alternative to the shadow map that Point and Spot Lights use for opaque GameObjects. HDRP still evaluates the lighting of a Point Light as coming from a single point in space (the light is [punctual](Glossary.md#punctual-lights)), but it evaluates the shadowing as if the light was coming from the surface of a sphere. On the other side, HDRP evaluates the lighting of a Spot Light as coming from a single point in space, but it evaluates the shadowing as if the light was coming from the surface of a cone.
 
 ![](Images/RayTracedShadows4.png)
 
@@ -91,11 +91,11 @@ Ray-traced shadows offer the possibility of semi-transparent shadows for Point L
 
 ![](Images/RayTracedShadows11.png)
 
-**Ray-traced Point Light shadows with emi-transparent shadows**
+**Ray-traced Point Light shadows with semi-transparent shadows**
 
 ![](Images/RayTracedShadows12.png)
 
-**Ray-traced Point Light shadows without emi-transparent shadows**
+**Ray-traced Point Light shadows without semi-transparent shadows**
 
 ### Properties
 

--- a/com.unity.render-pipelines.high-definition/Documentation~/Ray-Tracing-Debug.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Ray-Tracing-Debug.md
@@ -16,6 +16,6 @@ The High Definition Render Pipeline (HDRP) includes the [Render Pipeline Debug w
 | **SSAO**                    | When [Ray-Traced Ambient Occlusion](Ray-Traced-Ambient-Occlusion.html) is active, this displays the screen space buffer that holds the ambient occlusion. |
 | **Screen Space Reflection** | When [Ray-Traced Reflections](Ray-Traced-Reflections.html) are active, this displays the ray-traced reflections. |
 | **Contact Shadows** 		  | When [Ray-Traced Contact Shadows](Ray-Traced-Contact-Shadows.html) are active, this displays the ray-traced contact shadows. |
-| **Screen Space Shadows**    | When screen space shadows are active, this displays the set of screen space shadows. If you select this option, Unity exposes the **Screen Space Shadow Index** slider that allows you to change the currently active shadows. |
+| **Screen Space Shadows**    | When screen space shadows are active, this displays the set of screen space shadows. If you select this option, Unity exposes the **Screen Space Shadow Index** slider that allows you to change the currently active shadows. Area lights shadows take two channels. |
 | **Indirect Diffuse**        | When [Ray-Traced Global Illumination](Ray-Traced-Global-Illumination.html) is active, this displays a screen space buffer that holds the indirect diffuse lighting. |
 | **Light Cluster**           | This displays the cluster using a debug view that allows you to see the regions of the Scene where light density is higher, and potentially more resource-intensive to evaluate. |


### PR DESCRIPTION
### Purpose of this PR
This PR corrects a few typos and update about the RTX documentation : 
- Typo corrections and link in "ray-traced shadows"
- Smoothness fade start implementation in "ray-traced reflections"
- Fact that area lights shadows take two channels in "ray-traced debug"