### PR TITLE
Render pipeline editor settings refactor [ For Review/Discussion only for now ]

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Configuration.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Configuration.cs
@@ -355,8 +355,7 @@ namespace UnityEditor.Rendering.HighDefinition
         }
 
         bool IsHdrpAssetEditorResourcesCorrect()
-            => IsHdrpAssetUsedCorrect()
-            && HDRenderPipeline.defaultAsset.renderPipelineEditorResources != null;
+            => IsHdrpAssetUsedCorrect();
         void FixHdrpAssetEditorResources(bool fromAsyncUnused)
         {
             if (!IsHdrpAssetUsedCorrect())
@@ -366,9 +365,13 @@ namespace UnityEditor.Rendering.HighDefinition
             if (hdrpAsset == null)
                 return;
 
+
+            // TODO : handle this
+            /*
             hdrpAsset.renderPipelineEditorResources
                 = AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
             ResourceReloader.ReloadAllNullIn(HDRenderPipeline.defaultAsset.renderPipelineEditorResources, HDUtils.GetHDRenderPipelinePath());
+            */
         }
 
         bool IsSRPBatcherCorrect()

--- a/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Configuration.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Configuration.cs
@@ -360,18 +360,6 @@ namespace UnityEditor.Rendering.HighDefinition
         {
             if (!IsHdrpAssetUsedCorrect())
                 FixHdrpAssetUsed(fromAsync: false);
-
-            var hdrpAsset = HDRenderPipeline.defaultAsset;
-            if (hdrpAsset == null)
-                return;
-
-
-            // TODO : handle this
-            /*
-            hdrpAsset.renderPipelineEditorResources
-                = AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
-            ResourceReloader.ReloadAllNullIn(HDRenderPipeline.defaultAsset.renderPipelineEditorResources, HDUtils.GetHDRenderPipelinePath());
-            */
         }
 
         bool IsSRPBatcherCorrect()

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDAssetFactory.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDAssetFactory.cs
@@ -88,6 +88,9 @@ namespace UnityEditor.Rendering.HighDefinition
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, ScriptableObject.CreateInstance<DoCreateNewAssetHDRenderPipelineRayTracingResources>(), "New HDRenderPipelineRayTracingResources.asset", icon, null);
         }
 
+
+        // TODO remove completely
+        /*
         class DoCreateNewAssetHDRenderPipelineEditorResources : ProjectWindowCallback.EndNameEditAction
         {
             public override void Action(int instanceId, string pathName, string resourceFile)
@@ -109,5 +112,6 @@ namespace UnityEditor.Rendering.HighDefinition
             var icon = EditorGUIUtility.FindTexture("ScriptableObject Icon");
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, ScriptableObject.CreateInstance<DoCreateNewAssetHDRenderPipelineEditorResources>(), "New HDRenderPipelineEditorResources.asset", icon, null);
         }
+        */
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDAssetFactory.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDAssetFactory.cs
@@ -87,31 +87,5 @@ namespace UnityEditor.Rendering.HighDefinition
             var icon = EditorGUIUtility.FindTexture("ScriptableObject Icon");
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, ScriptableObject.CreateInstance<DoCreateNewAssetHDRenderPipelineRayTracingResources>(), "New HDRenderPipelineRayTracingResources.asset", icon, null);
         }
-
-
-        // TODO remove completely
-        /*
-        class DoCreateNewAssetHDRenderPipelineEditorResources : ProjectWindowCallback.EndNameEditAction
-        {
-            public override void Action(int instanceId, string pathName, string resourceFile)
-            {
-                var newAsset = CreateInstance<HDRenderPipelineEditorResources>();
-                newAsset.name = Path.GetFileName(pathName);
-
-                ResourceReloader.ReloadAllNullIn(newAsset, HDUtils.GetHDRenderPipelinePath());
-
-                AssetDatabase.CreateAsset(newAsset, pathName);
-                ProjectWindowUtil.ShowCreatedAsset(newAsset);
-            }
-        }
-
-        // Hide: User aren't suppose to have to create it.
-        //[MenuItem("Assets/Create/Rendering/High Definition Render Pipeline Editor Resources", priority = CoreUtils.assetCreateMenuPriority1)]
-        static void CreateRenderPipelineEditorResources()
-        {
-            var icon = EditorGUIUtility.FindTexture("ScriptableObject Icon");
-            ProjectWindowUtil.StartNameEditingIfProjectWindowExists(0, ScriptableObject.CreateInstance<DoCreateNewAssetHDRenderPipelineEditorResources>(), "New HDRenderPipelineEditorResources.asset", icon, null);
-        }
-        */
     }
 }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.Skin.cs
@@ -13,7 +13,6 @@ namespace UnityEditor.Rendering.HighDefinition
             {
                 public static readonly GUIContent renderPipelineResourcesContent = EditorGUIUtility.TrTextContent("Render Pipeline Resources", "Set of resources that need to be loaded when creating stand alone");
                 public static readonly GUIContent renderPipelineRayTracingResourcesContent = EditorGUIUtility.TrTextContent("Render Pipeline Ray Tracing Resources", "Set of resources that need to be loaded when using ray tracing");
-                public static readonly GUIContent renderPipelineEditorResourcesContent = EditorGUIUtility.TrTextContent("Render Pipeline Editor Resources", "Set of resources that need to be loaded for working in editor");
                 public static readonly GUIContent shaderVariantLogLevel = EditorGUIUtility.TrTextContent("Shader Variant Log Level", "Controls the level logging in of shader variants information is outputted when a build is performed. Information appears in the Unity Console when the build finishes.");
             }
 

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -180,17 +180,6 @@ namespace UnityEditor.Rendering.HighDefinition
             if (hdrp != null && hdrp.rayTracingSupported)
                 EditorGUILayout.PropertyField(serialized.renderPipelineRayTracingResources, Styles.GeneralSection.renderPipelineRayTracingResourcesContent);
 
-
-            // TODO : Remove this section completely
-            /*
-            // Not serialized as editor only datas... Retrieve them in data
-            EditorGUI.showMixedValue = serialized.editorResourceHasMultipleDifferentValues;
-            EditorGUI.BeginChangeCheck();
-            var editorResources = EditorGUILayout.ObjectField(Styles.GeneralSection.renderPipelineEditorResourcesContent, serialized.firstEditorResources, typeof(HDRenderPipelineEditorResources), allowSceneObjects: false) as HDRenderPipelineEditorResources;
-            if (EditorGUI.EndChangeCheck())
-                serialized.SetEditorResource(editorResources);
-            */
-
             EditorGUI.showMixedValue = false;
             //EditorGUILayout.PropertyField(serialized.enableSRPBatcher, k_SRPBatcher);
             EditorGUILayout.PropertyField(serialized.shaderVariantLogLevel, Styles.GeneralSection.shaderVariantLogLevel);

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -180,14 +180,18 @@ namespace UnityEditor.Rendering.HighDefinition
             if (hdrp != null && hdrp.rayTracingSupported)
                 EditorGUILayout.PropertyField(serialized.renderPipelineRayTracingResources, Styles.GeneralSection.renderPipelineRayTracingResourcesContent);
 
+
+            // TODO : Remove this section completely
+            /*
             // Not serialized as editor only datas... Retrieve them in data
             EditorGUI.showMixedValue = serialized.editorResourceHasMultipleDifferentValues;
             EditorGUI.BeginChangeCheck();
             var editorResources = EditorGUILayout.ObjectField(Styles.GeneralSection.renderPipelineEditorResourcesContent, serialized.firstEditorResources, typeof(HDRenderPipelineEditorResources), allowSceneObjects: false) as HDRenderPipelineEditorResources;
             if (EditorGUI.EndChangeCheck())
                 serialized.SetEditorResource(editorResources);
-            EditorGUI.showMixedValue = false;
+            */
 
+            EditorGUI.showMixedValue = false;
             //EditorGUILayout.PropertyField(serialized.enableSRPBatcher, k_SRPBatcher);
             EditorGUILayout.PropertyField(serialized.shaderVariantLogLevel, Styles.GeneralSection.shaderVariantLogLevel);
         }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
@@ -21,32 +21,6 @@ namespace UnityEditor.Rendering.HighDefinition
         public SerializedFrameSettings defaultBakedOrCustomReflectionFrameSettings;
         public SerializedFrameSettings defaultRealtimeReflectionFrameSettings;
 
-        // TODO : should be unused after refactor, remove.
-        /*
-        //RenderPipelineResources not always exist and thus cannot be serialized normally.
-        public bool editorResourceHasMultipleDifferentValues
-        {
-            get
-            {
-                var initialValue = firstEditorResources;
-                for (int index = 1; index < serializedObject.targetObjects.Length; ++index)
-                {
-                    if (initialValue != (serializedObject.targetObjects[index] as HDRenderPipelineAsset)?.renderPipelineEditorResources)
-                        return true;
-                }
-                return false;
-            }
-        }
-
-        public HDRenderPipelineEditorResources firstEditorResources
-            => (serializedObject.targetObjects[0] as HDRenderPipelineAsset)?.renderPipelineEditorResources;
-
-        public void SetEditorResource(HDRenderPipelineEditorResources value)
-        {
-            for (int index = 0; index < serializedObject.targetObjects.Length; ++index)
-                (serializedObject.targetObjects[index] as HDRenderPipelineAsset).renderPipelineEditorResources = value;
-        }
-        */
 
         public SerializedHDRenderPipelineAsset(SerializedObject serializedObject)
         {

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedHDRenderPipelineAsset.cs
@@ -21,6 +21,8 @@ namespace UnityEditor.Rendering.HighDefinition
         public SerializedFrameSettings defaultBakedOrCustomReflectionFrameSettings;
         public SerializedFrameSettings defaultRealtimeReflectionFrameSettings;
 
+        // TODO : should be unused after refactor, remove.
+        /*
         //RenderPipelineResources not always exist and thus cannot be serialized normally.
         public bool editorResourceHasMultipleDifferentValues
         {
@@ -44,6 +46,7 @@ namespace UnityEditor.Rendering.HighDefinition
             for (int index = 0; index < serializedObject.targetObjects.Length; ++index)
                 (serializedObject.targetObjects[index] as HDRenderPipelineAsset).renderPipelineEditorResources = value;
         }
+        */
 
         public SerializedHDRenderPipelineAsset(SerializedObject serializedObject)
         {

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -508,16 +508,6 @@ namespace UnityEngine.Rendering.HighDefinition
             }
 
 
-            // TODO Handle this...
-            /*
-            if (HDRenderPipeline.defaultAsset.renderPipelineEditorResources == null)
-                HDRenderPipeline.defaultAsset.renderPipelineEditorResources
-                    = UnityEditor.AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
-            ResourceReloader.ReloadAllNullIn(HDRenderPipeline.defaultAsset.renderPipelineEditorResources, HDUtils.GetHDRenderPipelinePath());
-            */
-            ////////////////////////
-
-
             // Upgrade the resources (re-import every references in RenderPipelineResources) if the resource version mismatches
             // It's done here because we know every HDRP assets have been imported before
             HDRenderPipeline.defaultAsset.renderPipelineResources?.UpgradeIfNeeded();

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -342,7 +342,6 @@ namespace UnityEngine.Rendering.HighDefinition
             //So in this case, the reloader would fail and the resources cannot be validated. So skip validation here.
             //The HDRenderPipeline will be reconstructed in a few frame which will fix this issue.
             if (HDRenderPipeline.defaultAsset.renderPipelineResources == null
-                || HDRenderPipeline.defaultAsset.renderPipelineEditorResources == null
                 || (m_RayTracingSupported && HDRenderPipeline.defaultAsset.renderPipelineRayTracingResources == null))
                 return;
             else
@@ -508,10 +507,16 @@ namespace UnityEngine.Rendering.HighDefinition
                 HDRenderPipeline.defaultAsset.renderPipelineRayTracingResources = null;
             }
 
+
+            // TODO Handle this...
+            /*
             if (HDRenderPipeline.defaultAsset.renderPipelineEditorResources == null)
                 HDRenderPipeline.defaultAsset.renderPipelineEditorResources
                     = UnityEditor.AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
             ResourceReloader.ReloadAllNullIn(HDRenderPipeline.defaultAsset.renderPipelineEditorResources, HDUtils.GetHDRenderPipelinePath());
+            */
+            ////////////////////////
+
 
             // Upgrade the resources (re-import every references in RenderPipelineResources) if the resource version mismatches
             // It's done here because we know every HDRP assets have been imported before

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineAsset.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using UnityEditorInternal;
 using UnityEngine.Serialization;
 using Utilities;
 
@@ -79,23 +81,7 @@ namespace UnityEngine.Rendering.HighDefinition
             set => m_DefaultLookDevProfile = value;
         }
 
-        HDRenderPipelineEditorResources m_RenderPipelineEditorResources;
-
-        internal HDRenderPipelineEditorResources renderPipelineEditorResources
-        {
-            get
-            {
-                //there is no clean way to load editor resources without having it serialized
-                // - impossible to load them at deserialization
-                // - constructor only called at asset creation
-                // - cannot rely on OnEnable
-                //thus fallback with lazy init for them
-                if (m_RenderPipelineEditorResources == null || m_RenderPipelineEditorResources.Equals(null))
-                    m_RenderPipelineEditorResources = UnityEditor.AssetDatabase.LoadAssetAtPath<HDRenderPipelineEditorResources>(HDUtils.GetHDRenderPipelinePath() + "Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset");
-                return m_RenderPipelineEditorResources;
-            }
-            set { m_RenderPipelineEditorResources = value; }
-        }
+        internal HDRenderPipelineEditorResources renderPipelineEditorResources => HDRenderPipelineEditorResources.GetInstance();
 #endif
 
         // To be able to turn on/off FrameSettings properties at runtime for debugging purpose without affecting the original one
@@ -256,50 +242,50 @@ namespace UnityEngine.Rendering.HighDefinition
 #if UNITY_EDITOR
         /// <summary>HDRP default material.</summary>
         public override Material defaultMaterial
-            => renderPipelineEditorResources?.materials.defaultDiffuseMat;
+            => renderPipelineEditorResources.materials.defaultDiffuseMat;
 
         // call to GetAutodeskInteractiveShaderXXX are only from within editor
         /// <summary>HDRP default autodesk interactive shader.</summary>
         public override Shader autodeskInteractiveShader
-            => renderPipelineEditorResources?.shaderGraphs.autodeskInteractive;
+            => renderPipelineEditorResources.shaderGraphs.autodeskInteractive;
 
         /// <summary>HDRP default autodesk interactive transparent shader.</summary>
         public override Shader autodeskInteractiveTransparentShader
-            => renderPipelineEditorResources?.shaderGraphs.autodeskInteractiveTransparent;
+            => renderPipelineEditorResources.shaderGraphs.autodeskInteractiveTransparent;
 
         /// <summary>HDRP default autodesk interactive masked shader.</summary>
         public override Shader autodeskInteractiveMaskedShader
-            => renderPipelineEditorResources?.shaderGraphs.autodeskInteractiveMasked;
+            => renderPipelineEditorResources.shaderGraphs.autodeskInteractiveMasked;
 
         /// <summary>HDRP default terrain detail lit shader.</summary>
         public override Shader terrainDetailLitShader
-            => renderPipelineEditorResources?.shaders.terrainDetailLitShader;
+            => renderPipelineEditorResources.shaders.terrainDetailLitShader;
 
         /// <summary>HDRP default terrain detail grass shader.</summary>
         public override Shader terrainDetailGrassShader
-            => renderPipelineEditorResources?.shaders.terrainDetailGrassShader;
+            => renderPipelineEditorResources.shaders.terrainDetailGrassShader;
 
         /// <summary>HDRP default terrain detail grass billboard shader.</summary>
         public override Shader terrainDetailGrassBillboardShader
-            => renderPipelineEditorResources?.shaders.terrainDetailGrassBillboardShader;
+            => renderPipelineEditorResources.shaders.terrainDetailGrassBillboardShader;
 
         // Note: This function is HD specific
         /// <summary>HDRP default Decal material.</summary>
         public Material GetDefaultDecalMaterial()
-            => renderPipelineEditorResources?.materials.defaultDecalMat;
+            => renderPipelineEditorResources.materials.defaultDecalMat;
 
         // Note: This function is HD specific
         /// <summary>HDRP default mirror material.</summary>
         public Material GetDefaultMirrorMaterial()
-            => renderPipelineEditorResources?.materials.defaultMirrorMat;
+            => renderPipelineEditorResources.materials.defaultMirrorMat;
 
         /// <summary>HDRP default particles material.</summary>
         public override Material defaultParticleMaterial
-            => renderPipelineEditorResources?.materials.defaultParticleMat;
+            => renderPipelineEditorResources.materials.defaultParticleMat;
 
         /// <summary>HDRP default terrain material.</summary>
         public override Material defaultTerrainMaterial
-            => renderPipelineEditorResources?.materials.defaultTerrainMat;
+            => renderPipelineEditorResources.materials.defaultTerrainMat;
 
         // Array structure that allow us to manipulate the set of defines that the HD render pipeline needs
         List<string> defineArray = new List<string>();

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineEditorResources.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipelineEditorResources.cs
@@ -1,33 +1,35 @@
 #if UNITY_EDITOR //file must be in realtime assembly folder to be found in HDRPAsset
 using System;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Experimental;
+using UnityEditorInternal;
 
 namespace UnityEngine.Rendering.HighDefinition
 {
     [HelpURL(Documentation.baseURL + Documentation.version + Documentation.subURL + "HDRP-Asset" + Documentation.endURL)]
     public partial class HDRenderPipelineEditorResources : ScriptableObject
     {
-        [Reload("Editor/DefaultScene/DefaultSceneRoot.prefab")]
+        public static readonly string k_SettingsFromPackagePath = "Packages/com.unity.render-pipelines.high-definition/Editor/RenderPipelineResources/HDRenderPipelineEditorResources.asset";
+        public static readonly string k_SettingsPath = "ProjectSettings/HDRenderPipelineEditorResources.asset";
+
         public GameObject defaultScene;
-        [Reload("Editor/DefaultDXRScene/DefaultSceneRoot.prefab")]
+        
         public GameObject defaultDXRScene;
-        [Reload("Editor/DefaultScene/Sky and Fog Settings Profile.asset")]
+        
         public VolumeProfile defaultSkyAndFogProfile;
-        [Reload("Editor/DefaultDXRScene/Sky and Fog Settings Profile.asset")]
+        
         public VolumeProfile defaultDXRSkyAndFogProfile;
-        [Reload("Editor/DefaultDXRScene/DXR Settings.asset")]
+        
         public VolumeProfile defaultDXRSettings;
-        [Reload(new[]
-        {
-            "Runtime/RenderPipelineResources/Skin Diffusion Profile.asset",
-            "Runtime/RenderPipelineResources/Foliage Diffusion Profile.asset"
-        })]
+        
         [SerializeField]
         internal DiffusionProfileSettings[] defaultDiffusionProfileSettingsList;
         
         [Reload("Editor/RenderPipelineResources/DefaultSettingsVolumeProfile.asset")]
         public VolumeProfile defaultSettingsVolumeProfile;
 
-        [Serializable, ReloadGroup]
+        [Serializable]
         public sealed class ShaderResources
         {
             public Shader terrainDetailLitShader;
@@ -35,41 +37,38 @@ namespace UnityEngine.Rendering.HighDefinition
             public Shader terrainDetailGrassBillboardShader;
         }
 
-        [Serializable, ReloadGroup]
+        [Serializable]
         public sealed class MaterialResources
         {
             // Defaults
-            [Reload("Runtime/RenderPipelineResources/Material/DefaultHDMaterial.mat")]
+            
             public Material defaultDiffuseMat;
-            [Reload("Runtime/RenderPipelineResources/Material/DefaultHDMirrorMaterial.mat")]
+            
             public Material defaultMirrorMat;
-            [Reload("Runtime/RenderPipelineResources/Material/DefaultHDDecalMaterial.mat")]
+            
             public Material defaultDecalMat;
-            [Reload("Runtime/RenderPipelineResources/Material/DefaultHDParticleMaterial.mat")]
+            
             public Material defaultParticleMat;
-            [Reload("Runtime/RenderPipelineResources/Material/DefaultHDTerrainMaterial.mat")]
+            
             public Material defaultTerrainMat;
-            [Reload("Editor/RenderPipelineResources/Materials/GUITextureBlit2SRGB.mat")]
+            
             public Material GUITextureBlit2SRGB;
         }
 
-        [Serializable, ReloadGroup]
+        [Serializable]
         public sealed class TextureResources
         {
         }
 
-        [Serializable, ReloadGroup]
+        [Serializable]
         public sealed class ShaderGraphResources
         {
-            [Reload("Runtime/RenderPipelineResources/ShaderGraph/AutodeskInteractive.ShaderGraph")]
             public Shader autodeskInteractive;
-            [Reload("Runtime/RenderPipelineResources/ShaderGraph/AutodeskInteractiveMasked.ShaderGraph")]
             public Shader autodeskInteractiveMasked;
-            [Reload("Runtime/RenderPipelineResources/ShaderGraph/AutodeskInteractiveTransparent.ShaderGraph")]
             public Shader autodeskInteractiveTransparent;
         }
 
-        [Serializable, ReloadGroup]
+        [Serializable]
         public sealed class LookDevResources
         {
             [Reload("Editor/RenderPipelineResources/DefaultLookDevProfile.asset")]
@@ -81,24 +80,107 @@ namespace UnityEngine.Rendering.HighDefinition
         public TextureResources textures;
         public ShaderGraphResources shaderGraphs;
         public LookDevResources lookDev;
-    }
-    
-    [UnityEditor.CustomEditor(typeof(HDRenderPipelineEditorResources))]
-    class HDRenderPipelineEditorResourcesEditor : UnityEditor.Editor
-    {
-        public override void OnInspectorGUI()
+
+        private static HDRenderPipelineEditorResources _instance;
+        private static SerializedObject _instanceSerializedObject;
+
+        internal static SerializedObject getSerializedObject()
         {
-            DrawDefaultInspector();
-
-            // Add a "Reload All" button in inspector when we are in developer's mode
-            if (UnityEditor.EditorPrefs.GetBool("DeveloperMode")
-                && GUILayout.Button("Reload All"))
+            if (_instanceSerializedObject == null)
             {
-                foreach(var field in typeof(HDRenderPipelineEditorResources).GetFields())
-                    field.SetValue(target, null);
+                if (_instance == null)
+                    _instance = GetInstance();
 
-                ResourceReloader.ReloadAllNullIn(target, HDUtils.GetHDRenderPipelinePath());
+                _instanceSerializedObject = new SerializedObject(_instance);
             }
+
+            return _instanceSerializedObject;
+        }
+
+        public static HDRenderPipelineEditorResources GetInstance()
+        {
+            if (_instance != null)
+                return _instance;
+
+            var objects = InternalEditorUtility.LoadSerializedFileAndForget(k_SettingsPath);
+            if (objects.Length > 0)
+            {
+                _instance = objects.First() as HDRenderPipelineEditorResources;
+            }
+            else
+            {
+                // UniversalRenderPipelineEditorResources was deleted or moved, regenerate it from package.
+                objects = InternalEditorUtility.LoadSerializedFileAndForget(k_SettingsFromPackagePath);
+                if (objects.Length > 0)
+                {
+                    _instance = objects.First() as HDRenderPipelineEditorResources;
+                    SaveSettings();
+                }
+                else
+                {
+                    //Was removed from package or other error, generate one from scratch ??
+                }
+
+                // custom dependencies should also be updated here.
+            }
+
+            return _instance;
+        }
+
+        public static void SaveSettings()
+        {
+            InternalEditorUtility.SaveToSerializedFileAndForget(new Object[] { _instance }, k_SettingsPath, true);
+        }
+    }
+
+    static class HDRenderPipelineEditorResourcesIMGUIRegister
+    {
+        private static readonly string defaultMaterialAssetImportDependency = "DefaultMaterialAssetImportDependency";
+
+        [SettingsProvider]
+        public static SettingsProvider CreateRenderPipelineEditorResourcesProvider()
+        {
+            var provider = new SettingsProvider("Project/HDRP", SettingsScope.Project)
+            {
+                label = "HDRP Editor Resources",
+                // Create the SettingsProvider and initialize its drawing (IMGUI) function in place:
+                guiHandler = (searchContext) =>
+                {
+
+                    var settings = HDRenderPipelineEditorResources.getSerializedObject();
+                    
+                    var diffuseMaterialProp = settings.FindProperty("materials.defaultDiffuseMat");
+                    EditorGUI.BeginChangeCheck();
+                    EditorGUILayout.PropertyField(diffuseMaterialProp);
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        settings.ApplyModifiedProperties();
+                        HDRenderPipelineEditorResources.SaveSettings();
+                        if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(diffuseMaterialProp.objectReferenceValue, out var guid, out long fileID))
+                        {
+                            var hash = Hash128.Compute(guid + "_" + fileID);
+                            AssetDatabaseExperimental.RegisterCustomDependency(defaultMaterialAssetImportDependency, hash);
+                            AssetDatabase.Refresh();
+                        }
+                    }
+
+                    EditorGUILayout.PropertyField(settings.FindProperty("materials.defaultParticleMat"));
+                    EditorGUILayout.PropertyField(settings.FindProperty("shaderGraphs.autodeskInteractive"));
+                    EditorGUILayout.PropertyField(settings.FindProperty("shaderGraphs.autodeskInteractiveTransparent"));
+                    EditorGUILayout.PropertyField(settings.FindProperty("shaderGraphs.autodeskInteractiveMasked"));
+                    // And so on...
+
+                    /*
+                    if (settings.hasModifiedProperties)
+                    {
+                        settings.ApplyModifiedProperties();
+                        HDRenderPipelineEditorResources.SaveSettings();
+                    }
+                    */
+                }
+            };
+
+            return provider;
         }
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -239,15 +239,6 @@ namespace UnityEngine.Rendering.Universal
             }
         }
 
-        //[MenuItem("Assets/Create/Rendering/Universal Pipeline Editor Resources", priority = CoreUtils.assetCreateMenuPriority1)]
-        static void CreateUniversalPipelineEditorResources()
-        {
-            var instance = CreateInstance<UniversalRenderPipelineEditorResources>();
-            ResourceReloader.ReloadAllNullIn(instance, packagePath);
-            AssetDatabase.CreateAsset(instance, string.Format("Assets/{0}.asset", typeof(UniversalRenderPipelineEditorResources).Name));
-        }
-
-      
         UniversalRenderPipelineEditorResources editorResources => UniversalRenderPipelineEditorResources.GetInstance();
 #endif
 


### PR DESCRIPTION
**DONT FORGET TO ADD A CHANGELOG**

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
The current RenderPipelineEditorResources system causes problems with some asset importers, specifically when assets are imported when Unity starts ( when upgrading or after deleting the Library folder for instance).
AssetDatabase.LoadAssetAtPath() returns null in this case, so importers that need to fetch a resource from RenderPipelineEditorResources at that point can't find it.
The symptoms of this problem are :
- The modelImporter falls back to the Legacy Render Pipeline's default material When MaterialImportMode == None
- SpeedTree always fall back to the Legacy Render Pipeline's speedTree shaders.
- AutodeskInteractive materials are falling back to the legacy render pipeline default shader.
- Maybe more ? Terrain, particles maybe ?
Those issues affect both URP and HDRP and must have been present for quite a while..

Moreover, there are unresolved import dependencies on those resources. For instance when the 'Lit material' in UniversalRenderPipelineEditorResources is changed, Model importers that depend on it should be reimported automatically to make sure they remain deterministic.

Also, the current implementation does not seem ideal because it's unclear which RenderPipelineEditorResources asset is actually used and they can be moved or deleted, etc... Moving those to the ProjectSettings with the proposed implementation ensures that there's only one instance in a specific and immutable location.

Finally, from a UX standpoint (in my opinion, of course that's debatable), it seems more logical to find those settings in the Project Settings window.

This PR fixes the issues enumerated above ( including https://fogbugz.unity3d.com/f/cases/1141488/ for reference ) and I did not have any issue when adding new fields in RenderPipelineEditorResources and simulating a package upgrade.

One remaining issue is the migration of existing projects where users did change the values in RenderPipelineEditorResources, those changes do not transfer to the new version. This does not seem to be an issue in HDRP but can be a problem for URP users.

I tried several ways to fix those issues ( well, actually this one https://fogbugz.unity3d.com/f/cases/1141488/ ) and that is so far the only workable solution I found so please don't discard it too hastily :) Thanks for your feedback !

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
