### PR TITLE
Shader Graph quick fix for unreported Keyword bug

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -845,7 +845,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     case ShaderKeyword keyword:
                     {
                         // This could be from another graph, in which case we add a copy of the ShaderInput to this graph.
-                        if (graph.properties.FirstOrDefault(k => k.guid == keyword.guid) == null)
+                        if (graph.keywords.FirstOrDefault(k => k.guid == keyword.guid) == null)
                         {
                             var copy = (ShaderKeyword)keyword.Copy();
                             graph.SanitizeGraphInputName(copy);


### PR DESCRIPTION
**Summary:**

Fixed an unreported bug where dragging keywords in GV would create a duplicate of the keyword on the blackboard.

---
**Manually Tested:**

* Adding Keywords & Properties of various types/modes to the graph via dragging
* Also across graphs

---
**Technical Risk:** 0/4
**Halo Effect:** 0/4

---
**Notes to QA:**
* I have already tested and would say that this is one of those fixes that you don't need to test at all. Added you nonetheless for awareness/habit.

---
**Yamato:**
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fyour-branch-dude
