### PR TITLE
Removing three scenes 107 & 119 & 125 from EditorBuildSettings [Skip CI]

### DIFF
--- a/TestProjects/UniversalGraphicsTest/ProjectSettings/EditorBuildSettings.asset
+++ b/TestProjects/UniversalGraphicsTest/ProjectSettings/EditorBuildSettings.asset
@@ -203,18 +203,12 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/105_TransparentReceiveShadows.unity
     guid: 6d72a4ab29e211149914e8a46ba9d1cf
-  - enabled: 0
-    path: Assets/Scenes/107_DepthPrepass.unity
-    guid: 12bed04065c037743845d8a5970cb5d0
   - enabled: 1
     path: Assets/Scenes/108_MoveCamera.unity
     guid: 5365b5739a6ca3c40bd03dc1ee5cb3c6
   - enabled: 1
     path: Assets/Scenes/109_URPShadersAlphaOutput.unity
     guid: 0a89803a0d2352245a452c202f9a67d1
-  - enabled: 1
-    path: Assets/Scenes/119_CameraToRTWithViewportRect.unity
-    guid: c7b61419ee9382545afe530714fda0c2
   - enabled: 1
     path: Assets/Scenes/120_RenderUICustomRendererNoPP.unity
     guid: 40c4ce99a7711204d978b31395d890b4
@@ -224,7 +218,4 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/122_RenderUICustomRendererFXAA.unity
     guid: 9fc0d4010bbf28b4594072e72b8655ab
-  - enabled: 0
-    path: Assets/Scenes/125_CameraStackingVolumes.unity
-    guid: 9173c5ffc1365594aa9b927c4cd84c54
   m_configObjects: {}


### PR DESCRIPTION
### Purpose of this PR
We're currently not able to properly test Scene 119 so I'm removing it from the editor build settings as it was causing test failures on Yamato.

I also removed scenes 107 & 125 as they were disabled in the settings.