### PR TITLE
DOC-1532 Fixed the "wrong" quotation marks. [Skip CI]

### DIFF
--- a/com.unity.render-pipelines.universal/Documentation~/camera-stacking.md
+++ b/com.unity.render-pipelines.universal/Documentation~/camera-stacking.md
@@ -9,7 +9,7 @@ A Camera Stack consists of a [Base Camera](camera-types-and-render-type.md#base-
 
  URP performs several optimizations within a Camera, including rendering order optimizations to reduce overdraw. However, when you use a Camera Stack, you effectively define the order in which those Cameras are rendered. You must therefore be careful not to order the Cameras in a way that causes excessive overdraw. For more information on overdraw in URP, see [Advanced information](cameras-advanced.md).
 
-<a name=”adding-a-camera-to-a-camera-stack”></a>
+<a name="adding-a-camera-to-a-camera-stack"></a>
 ## Adding a Camera to a Camera Stack
 
 ![Adding a Camera to a Camera Stack](Images/camera-stack-add-camera.png)


### PR DESCRIPTION
### Purpose of this PR
Fixed the "wrong" quotation marks in the Camera Stacking documentation. 

