### PR TITLE
[7.2.x] Fixed for case 1218714.

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
@@ -96,7 +96,7 @@
 // - UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX
 #ifdef UNITY_STEREO_INSTANCING_ENABLED
 #if defined(SHADER_API_GLES3) || defined(SHADER_API_GLCORE)
-    #define DEFAULT_UNITY_VERTEX_OUTPUT_STEREO                          uint stereoTargetEyeIndexAsRTArrayIdx : SV_RenderTargetArrayIndex; uint stereoTargetEyeIndexAsBlendIdx0 : BLENDINDICES0;
+    #define DEFAULT_UNITY_VERTEX_OUTPUT_STEREO                          uint stereoTargetEyeIndexAsBlendIdx0 : BLENDINDICES0; uint stereoTargetEyeIndexAsRTArrayIdx : SV_RenderTargetArrayIndex; 
     #define DEFAULT_UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output)       output.stereoTargetEyeIndexAsRTArrayIdx = unity_StereoEyeIndex; output.stereoTargetEyeIndexAsBlendIdx0 = unity_StereoEyeIndex;
     #define DEFAULT_UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(input, output)  output.stereoTargetEyeIndexAsBlendIdx0 = input.stereoTargetEyeIndexAsBlendIdx0;
     #define DEFAULT_UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input)     unity_StereoEyeIndex = input.stereoTargetEyeIndexAsBlendIdx0;
@@ -109,7 +109,7 @@
         #define DEFAULT_UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(input, output)  output.stereoTargetEyeIndexAsBlendIdx0 = input.stereoTargetEyeIndexAsBlendIdx0;
         #define DEFAULT_UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input)     unity_StereoEyeIndex = input.stereoTargetEyeIndexAsBlendIdx0;        
     #else
-        #define DEFAULT_UNITY_VERTEX_OUTPUT_STEREO                          uint stereoTargetEyeIndexAsRTArrayIdx : SV_RenderTargetArrayIndex; uint stereoTargetEyeIndexAsBlendIdx0 : BLENDINDICES0;
+        #define DEFAULT_UNITY_VERTEX_OUTPUT_STEREO                          uint stereoTargetEyeIndexAsBlendIdx0 : BLENDINDICES0; uint stereoTargetEyeIndexAsRTArrayIdx : SV_RenderTargetArrayIndex; 
         #define DEFAULT_UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output)       output.stereoTargetEyeIndexAsRTArrayIdx = unity_StereoEyeIndex; output.stereoTargetEyeIndexAsBlendIdx0 = unity_StereoEyeIndex;
         #define DEFAULT_UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(input, output)  output.stereoTargetEyeIndexAsBlendIdx0 = input.stereoTargetEyeIndexAsBlendIdx0;
         #define DEFAULT_UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input)     unity_StereoEyeIndex = input.stereoTargetEyeIndexAsBlendIdx0;                

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -112,7 +112,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Prefab previews were incorrectly lit when you used the 2D Renderer.
 - Fixed an issue where the Light didn't update correctly when you deleted a Sprite that a Sprite 2D Light uses.
 - Fixed an issue where Cinemachine v2.4 couldn't be used together with Universal RP due to a circular dependency between the two packages.
-- Fixed Shader using Texture Arrays does not compile when building, prevents build [case 1218714]
+- Fixed an issue where Shaders that used Texture Arrays didn't compile at build time, which caused the build to fail.
 
 ## [7.1.2] - 2019-09-19
 ### Added

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -112,7 +112,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Prefab previews were incorrectly lit when you used the 2D Renderer.
 - Fixed an issue where the Light didn't update correctly when you deleted a Sprite that a Sprite 2D Light uses.
 - Fixed an issue where Cinemachine v2.4 couldn't be used together with Universal RP due to a circular dependency between the two packages.
-- Fixed an issue where Shaders that used Texture Arrays didn't compile at build time, which caused the build to fail.
+- Fixed an issue where Shaders that used Texture Arrays didn't compile at build time, which caused the build to fail. [case 1218714]
 
 ## [7.1.2] - 2019-09-19
 ### Added

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Prefab previews were incorrectly lit when you used the 2D Renderer.
 - Fixed an issue where the Light didn't update correctly when you deleted a Sprite that a Sprite 2D Light uses.
 - Fixed an issue where Cinemachine v2.4 couldn't be used together with Universal RP due to a circular dependency between the two packages.
+- Fixed Shader using Texture Arrays does not compile when building, prevents build [case 1218714]
 
 ## [7.1.2] - 2019-09-19
 ### Added

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/UniversalShaderGraphResources.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/UniversalShaderGraphResources.cs
@@ -83,11 +83,12 @@ namespace UnityEditor.Rendering.Universal
             uint instanceID;
             [Semantic("FRONT_FACE_SEMANTIC")][SystemGenerated][OverrideType("FRONT_FACE_TYPE")][PreprocessorIf("defined(SHADER_STAGE_FRAGMENT) && defined(VARYINGS_NEED_CULLFACE)")]
             bool cullFace;
+            [Semantic("BLENDINDICES0")]
+            [PreprocessorIf("(defined(UNITY_STEREO_MULTIVIEW_ENABLED)) || " +
+                                            "(defined(UNITY_STEREO_INSTANCING_ENABLED) && (defined(SHADER_API_GLES3) || defined(SHADER_API_GLCORE)))")]
+            uint stereoTargetEyeIndexAsBlendIdx0;
             [Semantic("SV_RenderTargetArrayIndex")] [PreprocessorIf("(defined(UNITY_STEREO_INSTANCING_ENABLED))")]
             uint stereoTargetEyeIndexAsRTArrayIdx;
-            [Semantic("BLENDINDICES0")] [PreprocessorIf("(defined(UNITY_STEREO_MULTIVIEW_ENABLED)) || " +
-                                                        "(defined(UNITY_STEREO_INSTANCING_ENABLED) && (defined(SHADER_API_GLES3) || defined(SHADER_API_GLCORE)))")]
-            uint stereoTargetEyeIndexAsBlendIdx0;
         };
 
         internal struct VertexDescriptionInputs


### PR DESCRIPTION
### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR

Fixed https://fogbugz.unity3d.com/f/cases/1218714/
And https://fogbugz.unity3d.com/f/cases/1201706
See https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/5219
Master PR: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/5914

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Fabien: there is a bug for this on build-in renderer too. That won't be fixed by this URP PR.
https://fogbugz.unity3d.com/f/cases/1187259
The issue is that in SPI shaders, BLENDINDICES0(likely becomes TEXCOORD due to shader cross-compile) is declared after SV_RenderTargetArrayIndex. This generates error.
This case is only happening for gl3 and glcore because of ifdef guard and is only happening when SV_RenderTargetArrayIndexis being used in frag shader stage because otherwise it is being optimized away.

I need to test this change for the latest unity trunk and latest SRP repo before making PR to SRP master.
I debugged this purely based on the error msg and platofrm config. I will need to dig in more into the shader graph repro and see why it triggered the bug.