### PR TITLE
Makes material inspector work when the pipeline is not HDRP

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
@@ -643,7 +643,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 m_RenderingPassValues.Add((int)HDRenderQueue.OpaqueRenderQueue.AfterPostProcessing);
             }
 
-            if ((RenderPipelineManager.currentPipeline as HDRenderPipeline).rayTracingSupported)
+            if (RenderPipelineManager.currentPipeline != null && RenderPipelineManager.currentPipeline is HDRenderPipeline && (RenderPipelineManager.currentPipeline as HDRenderPipeline).rayTracingSupported)
             {
                 m_RenderingPassNames.Add("Raytracing");
                 m_RenderingPassValues.Add((int)HDRenderQueue.OpaqueRenderQueue.Raytracing);


### PR DESCRIPTION
This patch allows the inspector to work when the currently selected pipeline is not the HDRP. This allows those who are foolishly working with multiple pipelines in the same project, still able to inspect and edit materials that are designed for HDRP.

--
LICENSING: In-case any disclaimer is needed, I fully release any ownership or rights in this pull request, and release the changes into the public domain, the work may be used for any purpose commercial or non-commercial without any credit, royalties or other restriction. Where public domain is not possible, I release this under both the MIT license (copyright notice to read: Adam Frisby <adam@sinewavecompany.com> (c)2020.), and the Creative Commons CC0 license.
--

**DONT FORGET TO ADD A CHANGELOG**

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

We're working with compatibility between pipelines - having multiple pipelines loaded at once is part of our workflow.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 
- [x] Works for me!

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
