### PR TITLE
Shader Graph: Fix for "Having Main Preview be Hidden can soft lock all Shader Graph windows"

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -285,15 +285,14 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void UpdateSubWindowsVisibility()
         {
-            if (m_UserViewSettings.isBlackboardVisible)
-                m_GraphView.Insert(m_GraphView.childCount, m_BlackboardProvider.blackboard);
-            else
-                m_BlackboardProvider.blackboard.RemoveFromHierarchy();
+            // Master Preview and Blackboard both need to keep their layouts when hidden in order to restore user preferences.
+            // Because of their differences we do this is different ways, for now. + Blackboard needs to be effectively removed when hidden to avoid bugs.
+            m_MasterPreviewView.visible = m_UserViewSettings.isPreviewVisible;
 
-            if (m_UserViewSettings.isPreviewVisible)
-                m_GraphView.Insert(m_GraphView.childCount, m_MasterPreviewView);
+            if (m_UserViewSettings.isBlackboardVisible)
+                m_BlackboardProvider.blackboard.style.display = DisplayStyle.Flex;
             else
-                m_MasterPreviewView.RemoveFromHierarchy();
+                m_BlackboardProvider.blackboard.style.display = DisplayStyle.None;
         }
 
         Action<Group, string> m_GraphViewGroupTitleChanged;


### PR DESCRIPTION
**Summary:**
* Fix for https://fogbugz.unity3d.com/f/cases/1214177/
* 7.x.x Backport version already merged
* This was delayed because I was looking into a better, cleaner, & more future proof fix for master. However it was decided that treating Master Preview and Blackboard differently is okay for now as one day, with Internal Inspector & Blackboard 2.0, we can enforce that these Sub Windows use the same base class then. Despite this being seemingly hacky, I've confirmed that it fixes all the bugs and gave it a full QA pass (which we already did for the backport...).

Backport:
https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/5984

---
**Manually Tested:**
* All the QAing done in #5630

---
**Technical Risk:** 1/4
**Halo Effect:** 2/4

---
**Notes to QA:**
* Already gave it my full QA pass

---
**Automation:**
See #5891

---
**Yamato:**
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fblackboard-toggle-fix
