### PR TITLE
Shader Graph: Fix for Blackboard Location Restoring

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -995,9 +995,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             blackboardRect.width = Mathf.Clamp(blackboardRect.width, 160f, m_GraphView.contentContainer.layout.width);
             blackboardRect.height = Mathf.Clamp(blackboardRect.height, 160f, m_GraphView.contentContainer.layout.height);
 
-            // Make sure that the positionining is on screen.
-            blackboardRect.x = Mathf.Clamp(blackboardRect.x, 0f, Mathf.Max(1f, m_GraphView.contentContainer.layout.width - blackboardRect.width - blackboardRect.width));
-            blackboardRect.y = Mathf.Clamp(blackboardRect.y, 0f, Mathf.Max(1f, m_GraphView.contentContainer.layout.height - blackboardRect.height - blackboardRect.height));
+            // Make sure that the positioning is on screen.
+            blackboardRect.x = Mathf.Clamp(blackboardRect.x, 0f, Mathf.Max(0f, m_GraphView.contentContainer.layout.width - blackboardRect.width));
+            blackboardRect.y = Mathf.Clamp(blackboardRect.y, 0f, Mathf.Max(0f, m_GraphView.contentContainer.layout.height - blackboardRect.height));
 
             // Set the processed blackboard layout.
             m_BlackboardProvider.blackboard.SetPosition(blackboardRect);


### PR DESCRIPTION
**Summary:**

Fix for an unreported bug where, if the user prefers the Blackboard to be at the right side of bottom of the Shader Graph window, it would not properly return to that location upon closing & reopening the graph.

---
**Manually Tested:**

* All the Blackboard Locations!
* Resizing window before and after, closing an reopening, toggling off and on, ect.
* Fails automated test without this, passes with

---
**Technical Risk:** 0/4
**Halo Effect:** 0/4

---
**Notes to QA:**
* This got my full pass and also has automation on the way (that I've confirmed works), personally I'd say you don't have to do a QA pass on this & can just approve for awareness.

---
**Automation:**
See #5891

---
**Yamato:**
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fblackboard-loc-remember-fix
