### PR TITLE
GetDefaultRenderer() test fix [Skip CI]

### DIFF
--- a/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs
+++ b/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs
@@ -1,8 +1,6 @@
 using NUnit.Framework;
-using System.Collections;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
-using UnityEngine.TestTools;
 
 public class UniversalProjectEditorTests
 {
@@ -14,12 +12,10 @@ public class UniversalProjectEditorTests
         GetUniversalAsset();
     }
 
-    [UnityTest]
-    public IEnumerator GetDefaultRenderer()
+    //[Test]
+    public void GetDefaultRenderer()
     {
         GetUniversalAsset();
-
-        yield return null;
 
         Assert.IsNotNull(currentAsset.scriptableRenderer, "Current ScriptableRenderer is null.");
     }

--- a/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs
+++ b/TestProjects/UniversalGraphicsTest/Assets/Test/Editor/UniversalProjectEditorTests.cs
@@ -1,6 +1,8 @@
 using NUnit.Framework;
+using System.Collections;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
+using UnityEngine.TestTools;
 
 public class UniversalProjectEditorTests
 {
@@ -12,10 +14,12 @@ public class UniversalProjectEditorTests
         GetUniversalAsset();
     }
 
-    [Test]
-    public void GetDefaultRenderer()
+    [UnityTest]
+    public IEnumerator GetDefaultRenderer()
     {
         GetUniversalAsset();
+
+        yield return null;
 
         Assert.IsNotNull(currentAsset.scriptableRenderer, "Current ScriptableRenderer is null.");
     }


### PR DESCRIPTION
### Purpose of this PR
Removing the GetDefaultRenderer() test for now. It needs to be redone.

---

**DONT FORGET TO ADD A CHANGELOG**

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---

### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 


**Yamato**:
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/universal%252Fgetrenderer-test-fix
