### PR TITLE
 Added Logic to Inject render pass to base renderer

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Made MaterialDescriptionPreprocessors private.
 - UniversalRenderPipelineAsset no longer supports presets [case 1197020](https://issuetracker.unity3d.com/issues/urp-reset-functionality-does-not-work-on-preset-of-universalrenderpipelineassets)
 - The number of maximum visible lights is now determined by whether the platform is mobile or not.
+- Custom renderers can now support `ScriptableRendererFeatures` by calling `base.Setup` in their `Setup` method.
 
 ### Fixed
 - Fixed an issue where linear to sRGB conversion occurred twice on certain Android devices.

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
@@ -118,6 +118,9 @@ namespace UnityEngine.Rendering.Universal
         /// <inheritdoc />
         public override void Setup(ScriptableRenderContext context, ref RenderingData renderingData)
         {
+            // Injects render passes into the active render pass queue.
+            base.Setup(context, ref renderingData);
+            
             Camera camera = renderingData.cameraData.camera;
             ref CameraData cameraData = ref renderingData.cameraData;
             RenderTextureDescriptor cameraTargetDescriptor = renderingData.cameraData.cameraTargetDescriptor;
@@ -201,17 +204,6 @@ namespace UnityEngine.Rendering.Universal
 
             ConfigureCameraTarget(m_ActiveCameraColorAttachment.Identifier(), m_ActiveCameraDepthAttachment.Identifier());
 
-            for (int i = 0; i < rendererFeatures.Count; ++i)
-            {
-                rendererFeatures[i].AddRenderPasses(this, ref renderingData);
-            }
-
-            int count = activeRenderPassQueue.Count;
-            for (int i = count - 1; i >= 0; i--)
-            {
-                if(activeRenderPassQueue[i] == null)
-                    activeRenderPassQueue.RemoveAt(i);
-            }
             bool hasPassesAfterPostProcessing = activeRenderPassQueue.Find(x => x.renderPassEvent == RenderPassEvent.AfterRendering) != null;
 
             if (mainLightShadows)

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -190,13 +190,27 @@ namespace UnityEngine.Rendering.Universal
 
         /// <summary>
         /// Configures the render passes that will execute for this renderer.
-        /// This method is called per-camera every frame.
+        /// This method is called per-camera.
         /// </summary>
         /// <param name="context">Use this render context to issue any draw commands during execution.</param>
         /// <param name="renderingData">Current render state information.</param>
         /// <seealso cref="ScriptableRenderPass"/>
         /// <seealso cref="ScriptableRendererFeature"/>
-        public abstract void Setup(ScriptableRenderContext context, ref RenderingData renderingData);
+        public virtual void Setup(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            for (int i = 0; i < rendererFeatures.Count; ++i)
+            {
+                rendererFeatures[i].AddRenderPasses(this, ref renderingData);
+            }
+            
+            // Remove null render passes from the list
+            int count = activeRenderPassQueue.Count;
+            for (int i = count - 1; i >= 0; i--)
+            {
+                if(activeRenderPassQueue[i] == null)
+                    activeRenderPassQueue.RemoveAt(i);
+            }
+        }
 
         /// <summary>
         /// Override this method to implement the lighting setup for the renderer. You can use this to


### PR DESCRIPTION
### Purpose of this PR
- ScriptableRenderer.Setup now implements logic to inject custom render passes.
- Any renderer from URP now only need to call `base.Setup()` in order to support ScriptableRendererFeatures.

### Testing status

**Manual Tests**: What did you do?
- [x ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: No automated testing required. Renderers already test the logic.

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?
