### PR TITLE
Expose Asset properties and add the option to turn off PP & volume updates globally, 

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ForwardRendererDataEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/ForwardRendererDataEditor.cs
@@ -14,6 +14,7 @@ namespace UnityEditor.Rendering.Universal
             public static readonly GUIContent OpaqueMask = new GUIContent("Default Layer Mask", "Controls which layers to globally include in the Custom Forward Renderer.");
             public static readonly GUIContent defaultStencilStateLabel = EditorGUIUtility.TrTextContent("Default Stencil State", "Configure stencil state for the opaque and transparent render passes.");
             public static readonly GUIContent shadowTransparentReceiveLabel = EditorGUIUtility.TrTextContent("Transparent Receive Shadows", "When disabled, none of the transparent objects will receive shadows.");
+            public static readonly GUIContent shouldUpdateVolumesLabel = EditorGUIUtility.TrTextContent("Should Update Volumes", "When disabled, none of the volumes will be updated for this renderer");
         }
 
         SerializedProperty m_OpaqueLayerMask;
@@ -22,6 +23,7 @@ namespace UnityEditor.Rendering.Universal
         SerializedProperty m_PostProcessData;
         SerializedProperty m_Shaders;
         SerializedProperty m_ShadowTransparentReceiveProp;
+        SerializedProperty m_ShouldUpdateVolumesProp;
 
         private void OnEnable()
         {
@@ -31,6 +33,7 @@ namespace UnityEditor.Rendering.Universal
             m_PostProcessData = serializedObject.FindProperty("postProcessData");
             m_Shaders = serializedObject.FindProperty("shaders");
             m_ShadowTransparentReceiveProp = serializedObject.FindProperty("m_ShadowTransparentReceive");
+            m_ShouldUpdateVolumesProp = serializedObject.FindProperty("m_ShouldUpdateVolumes");
         }
 
         public override void OnInspectorGUI()
@@ -48,6 +51,10 @@ namespace UnityEditor.Rendering.Universal
 
             EditorGUILayout.LabelField("Shadows", EditorStyles.boldLabel);
             EditorGUILayout.PropertyField(m_ShadowTransparentReceiveProp, Styles.shadowTransparentReceiveLabel);
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField("Volumes", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(m_ShouldUpdateVolumesProp, Styles.shouldUpdateVolumesLabel);
             EditorGUILayout.Space();
 
             EditorGUILayout.LabelField("Overrides", EditorStyles.boldLabel);

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
@@ -55,6 +55,7 @@ namespace UnityEditor.Rendering.Universal
             public static GUIContent supportsSoftShadows = EditorGUIUtility.TrTextContent("Soft Shadows", "If enabled pipeline will perform shadow filtering. Otherwise all lights that cast shadows will fallback to perform a single shadow sample.");
 
             // Post-processing
+            public static GUIContent postProcessEnabled = EditorGUIUtility.TrTextContent("Enabled", "Enables or disables postprocessing. This is a global setting which affects every camera and renderer.");
             public static GUIContent colorGradingMode = EditorGUIUtility.TrTextContent("Grading Mode", "Defines how color grading will be applied. Operators will react differently depending on the mode.");
             public static GUIContent colorGradingLutSize = EditorGUIUtility.TrTextContent("LUT size", "Sets the size of the internal and external color grading lookup textures (LUTs).");
             public static string colorGradingModeWarning = "HDR rendering is required to use the high dynamic range color grading mode. The low dynamic range will be used instead.";
@@ -130,6 +131,7 @@ namespace UnityEditor.Rendering.Universal
         SerializedProperty m_ShaderVariantLogLevel;
 
         LightRenderingMode selectedLightRenderingMode;
+        SerializedProperty m_PostProcessEnabled;
         SerializedProperty m_ColorGradingMode;
         SerializedProperty m_ColorGradingLutSize;
 
@@ -195,6 +197,7 @@ namespace UnityEditor.Rendering.Universal
 
             m_ShaderVariantLogLevel = serializedObject.FindProperty("m_ShaderVariantLogLevel");
 
+            m_PostProcessEnabled = serializedObject.FindProperty("m_PostProcessEnabled");
             m_ColorGradingMode = serializedObject.FindProperty("m_ColorGradingMode");
             m_ColorGradingLutSize = serializedObject.FindProperty("m_ColorGradingLutSize");
 
@@ -345,6 +348,7 @@ namespace UnityEditor.Rendering.Universal
 
                 EditorGUI.indentLevel++;
 
+                EditorGUILayout.PropertyField(m_PostProcessEnabled, Styles.postProcessEnabled);
                 EditorGUILayout.PropertyField(m_ColorGradingMode, Styles.colorGradingMode);
                 if (!isHdrOn && m_ColorGradingMode.intValue == (int)ColorGradingMode.HighDynamicRange)
                     EditorGUILayout.HelpBox(Styles.colorGradingModeWarning, MessageType.Warning);

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
@@ -55,7 +55,7 @@ namespace UnityEditor.Rendering.Universal
             public static GUIContent supportsSoftShadows = EditorGUIUtility.TrTextContent("Soft Shadows", "If enabled pipeline will perform shadow filtering. Otherwise all lights that cast shadows will fallback to perform a single shadow sample.");
 
             // Post-processing
-            public static GUIContent postProcessEnabled = EditorGUIUtility.TrTextContent("Enabled", "Enables or disables postprocessing. This is a global setting which affects every camera and renderer.");
+            public static GUIContent postProcessEnabled = EditorGUIUtility.TrTextContent("Enabled", "Enables or disables postprocessing. This is a global setting which affects all cameras and renderers.");
             public static GUIContent colorGradingMode = EditorGUIUtility.TrTextContent("Grading Mode", "Defines how color grading will be applied. Operators will react differently depending on the mode.");
             public static GUIContent colorGradingLutSize = EditorGUIUtility.TrTextContent("LUT size", "Sets the size of the internal and external color grading lookup textures (LUTs).");
             public static string colorGradingModeWarning = "HDR rendering is required to use the high dynamic range color grading mode. The low dynamic range will be used instead.";

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -495,11 +495,17 @@ namespace UnityEngine.Rendering.Universal
         public float cascade2Split
         {
             get { return m_Cascade2Split; }
+            set { m_Cascade2Split = Mathf.Clamp01(value); }
         }
 
         public Vector3 cascade4Split
         {
             get { return m_Cascade4Split; }
+            set {
+                m_Cascade4Split.x = Mathf.Clamp01(value.x);
+                m_Cascade4Split.y = Mathf.Clamp01(value.y);
+                m_Cascade4Split.z = Mathf.Clamp01(value.z);
+            }
         }
 
         public float shadowDepthBias
@@ -737,7 +743,7 @@ namespace UnityEngine.Rendering.Universal
 
         int ValidatePerObjectLights(int value)
         {
-            return System.Math.Max(0, System.Math.Min(value, UniversalRenderPipeline.maxPerObjectLights));
+            return Math.Max(0, Math.Min(value, UniversalRenderPipeline.maxPerObjectLights));
         }
 
         float ValidateRenderScale(float value)

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -448,21 +448,32 @@ namespace UnityEngine.Rendering.Universal
         public LightRenderingMode mainLightRenderingMode
         {
             get { return m_MainLightRenderingMode; }
+            set { m_MainLightRenderingMode = value; }
         }
 
         public bool supportsMainLightShadows
         {
             get { return m_MainLightShadowsSupported; }
+            set { m_MainLightShadowsSupported = value; }
         }
 
         public int mainLightShadowmapResolution
         {
             get { return (int)m_MainLightShadowmapResolution; }
+            set {
+                if (!Enum.IsDefined(typeof(ShadowResolution), value))
+                {
+                    Debug.LogError("The mainLightShadowmapResolution can not be set to \"" + value + "\". Options are 256, 512, 1024, 2048 and 4096");
+                    return;
+                }
+                m_MainLightShadowmapResolution = (ShadowResolution) value;
+            }
         }
 
         public LightRenderingMode additionalLightsRenderingMode
         {
             get { return m_AdditionalLightsRenderingMode; }
+            set { m_AdditionalLightsRenderingMode = value; }
         }
 
         public int maxAdditionalLightsCount
@@ -474,11 +485,20 @@ namespace UnityEngine.Rendering.Universal
         public bool supportsAdditionalLightShadows
         {
             get { return m_AdditionalLightShadowsSupported; }
+            set { m_AdditionalLightShadowsSupported = value; }
         }
 
         public int additionalLightsShadowmapResolution
         {
             get { return (int)m_AdditionalLightsShadowmapResolution; }
+            set {
+                if (!Enum.IsDefined(typeof(ShadowResolution), value))
+                {
+                    Debug.LogError("The additionalLightsShadowmapResolution can not be set to \"" + value + "\". Options are 256, 512, 1024, 2048 and 4096");
+                    return;
+                }
+                m_AdditionalLightsShadowmapResolution = (ShadowResolution)value;
+            }
         }
 
         public float shadowDistance
@@ -524,6 +544,7 @@ namespace UnityEngine.Rendering.Universal
         public bool supportsSoftShadows
         {
             get { return m_SoftShadowsSupported; }
+            set { m_SoftShadowsSupported = value; }
         }
 
         public bool supportsDynamicBatching

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -156,6 +156,7 @@ namespace UnityEngine.Rendering.Universal
         [SerializeField] PipelineDebugLevel m_DebugLevel = PipelineDebugLevel.Disabled;
 
         // Post-processing settings
+        [SerializeField] bool m_PostProcessEnabled = true;
         [SerializeField] ColorGradingMode m_ColorGradingMode = ColorGradingMode.LowDynamicRange;
         [SerializeField] int m_ColorGradingLutSize = 32;
 
@@ -551,6 +552,12 @@ namespace UnityEngine.Rendering.Universal
         {
             get { return m_UseSRPBatcher; }
             set { m_UseSRPBatcher = value; }
+        }
+
+        public bool postProcessEnabled
+        {
+            get { return m_PostProcessEnabled; }
+            set { m_PostProcessEnabled = value; }
         }
 
         public ColorGradingMode colorGradingMode

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
@@ -102,6 +102,8 @@ namespace UnityEngine.Rendering.Universal
             {
                 cameraStacking = true,
             };
+
+            shouldUpdateVolumes = data.shouldUpdateVolumes;
         }
 
         /// <inheritdoc />

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRendererData.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRendererData.cs
@@ -59,6 +59,7 @@ namespace UnityEngine.Rendering.Universal
         [SerializeField] LayerMask m_TransparentLayerMask = -1;
         [SerializeField] StencilStateData m_DefaultStencilState = new StencilStateData();
         [SerializeField] bool m_ShadowTransparentReceive = true;
+        [SerializeField] bool m_ShouldUpdateVolumes = true;
 
         protected override ScriptableRenderer Create()
         {
@@ -79,6 +80,8 @@ namespace UnityEngine.Rendering.Universal
         public StencilStateData defaultStencilState => m_DefaultStencilState;
 
         public bool shadowTransparentReceive => m_ShadowTransparentReceive;
+
+        public bool shouldUpdateVolumes => m_ShouldUpdateVolumes;
 
         protected override void OnEnable()
         {

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -94,6 +94,8 @@ namespace UnityEngine.Rendering.Universal
         /// </summary>
         public RenderingFeatures supportedRenderingFeatures { get; set; } = new RenderingFeatures();
 
+        public bool shouldUpdateVolumes { get; set; }
+
         static class RenderPassBlock
         {
             // Executes render passes that are inputs to the main rendering

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -319,7 +319,7 @@ namespace UnityEngine.Rendering.Universal
                 }
             }
 
-
+            anyPostProcessingEnabled &= asset.postProcessEnabled;
             bool isStackedRendering = lastActiveOverlayCameraIndex != -1;
 
             BeginCameraRendering(context, baseCamera);
@@ -603,6 +603,7 @@ namespace UnityEngine.Rendering.Universal
 
             // Disables post if GLes2
             cameraData.postProcessEnabled &= SystemInfo.graphicsDeviceType != GraphicsDeviceType.OpenGLES2;
+            cameraData.postProcessEnabled &= settings.postProcessEnabled;
 
             cameraData.requiresDepthTexture |= cameraData.isSceneViewCamera || CheckPostProcessForDepth(cameraData);
         }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -365,6 +365,17 @@ namespace UnityEngine.Rendering.Universal
 
         static void UpdateVolumeFramework(Camera camera, UniversalAdditionalCameraData additionalCameraData)
         {
+            // We only disable volume updates if the user has specifically disabled it in the renderer
+            bool shouldUpdateVolumes = camera.cameraType == CameraType.SceneView
+                || additionalCameraData == null
+                || additionalCameraData.scriptableRenderer == null
+                || additionalCameraData.scriptableRenderer.shouldUpdateVolumes;
+
+            if (!shouldUpdateVolumes)
+            {
+                return;
+            }
+
             // Default values when there's no additional camera data available
             LayerMask layerMask = 1; // "Default"
             Transform trigger = camera.transform;
@@ -375,6 +386,7 @@ namespace UnityEngine.Rendering.Universal
                 trigger = additionalCameraData.volumeTrigger != null
                     ? additionalCameraData.volumeTrigger
                     : trigger;
+
             }
             else if (camera.cameraType == CameraType.SceneView)
             {


### PR DESCRIPTION
### Purpose of this PR
This PR does three things:

1. Exposes various settings to users. Such as
1.1. Main Light Rendering Mode
1.2. Main Light Shadow Casting
1.3. Main Light Shadow Resolution
1.4. Additional Light Rendering Mode
1.5. Additional Light Shadow Casting
1.6. Additional Light Shadow Resolution
1.7. Soft Shadows

2. Adds the option to turn on/off Post Processing globally
3. Adds the option to turn on/off Volume updating per-renderer

---


### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---

### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
