### PR TITLE
Fixed URP Terrain Depth pass not working in XR

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue with soft particles having dark blending when intersecting with scene geometry [case 1199812](https://issuetracker.unity3d.com/issues/urp-soft-particles-create-dark-blending-artefacts-when-intersecting-with-scene-geometry)
 - Fixed an issue with additive particles blending incorrectly [case 1215713](https://issuetracker.unity3d.com/issues/universal-render-pipeline-additive-particles-not-using-vertex-alpha)
 - Fixed an issue where camera preview window was missing in scene view. [case 1211971](https://issuetracker.unity3d.com/issues/scene-view-urp-camera-preview-window-is-missing-in-the-scene-view)
+- Fixed an issue where terrain depthOnly pass does not work for XR.
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -441,7 +441,7 @@ VaryingsLean DepthOnlyVertex(AttributesLean v)
 {
     VaryingsLean o = (VaryingsLean)0;
     UNITY_SETUP_INSTANCE_ID(v);
-	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
     TerrainInstancing(v.position, v.normalOS);
     o.clipPos = TransformObjectToHClip(v.position.xyz);
 #ifdef _ALPHATEST_ON		

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -386,10 +386,10 @@ struct AttributesLean
 {
     float4 position     : POSITION;
     float3 normalOS       : NORMAL;
-    UNITY_VERTEX_INPUT_INSTANCE_ID
 #ifdef _ALPHATEST_ON
 	float2 texcoord     : TEXCOORD0;
 #endif
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
 struct VaryingsLean
@@ -398,6 +398,7 @@ struct VaryingsLean
 #ifdef _ALPHATEST_ON		
     float2 texcoord     : TEXCOORD0;
 #endif
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 VaryingsLean ShadowPassVertex(AttributesLean v)
@@ -440,6 +441,7 @@ VaryingsLean DepthOnlyVertex(AttributesLean v)
 {
     VaryingsLean o = (VaryingsLean)0;
     UNITY_SETUP_INSTANCE_ID(v);
+	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
     TerrainInstancing(v.position, v.normalOS);
     o.clipPos = TransformObjectToHClip(v.position.xyz);
 #ifdef _ALPHATEST_ON		


### PR DESCRIPTION
### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR

Fixed URP Terrain depth pass not working for XR
Related to https://fogbugz.unity3d.com/f/cases/assign/1219278

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
- Added XR Macros to URP Terrain DepthOnly Pass