### PR TITLE
Added Time range to Sample Gradient Node

### DIFF
--- a/com.unity.shadergraph/Documentation~/Sample-Gradient-Node.md
+++ b/com.unity.shadergraph/Documentation~/Sample-Gradient-Node.md
@@ -9,7 +9,7 @@ Samples a **Gradient** given the input of **Time**. Returns a **Vector 4** color
 | Name        | Direction           | Type  | Binding | Description |
 |:------------ |:-------------|:-----|:---|:---|
 | Gradient      | Input | Gradient | None | Gradient to sample |
-| Time      | Input | Vector 1 | None | Point at which to sample gradient |
+| Time      | Input | Vector 1 | None | Point at which to sample gradient (0.0–1.0) |
 | Out | Output      |    Vector 4 | None | Output value as Vector4 |
 
 ## Generated Code Example


### PR DESCRIPTION
**DONT FORGET TO ADD A CHANGELOG**

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.
N/A: docs update only
---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Added Time range (0.0–1.0) to Sample Gradient Node documentation.
---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: N/A

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers? No

---
### Comments to reviewers
https://fogbugz.unity3d.com/f/cases/1138602
