### PR TITLE
uv7 test

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added path tracing support for refraction and internal reflections.
 - Added support for Thin Refraction Model and Lit's Clear Coat in Path Tracing.
 - Added the Tint parameter to Sky Colored Fog.
+- Added 8 bone skinning support to linear blend skinning node
 
 ### Fixed
 - Update documentation of HDRISky-Backplate, precise how to have Ambient Occlusion on the Backplate

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -39,6 +39,8 @@ namespace UnityEditor.Rendering.HighDefinition
             [Semantic("TEXCOORD1")][Optional]       Vector4 uv1;
             [Semantic("TEXCOORD2")][Optional]       Vector4 uv2;
             [Semantic("TEXCOORD3")][Optional]       Vector4 uv3;
+            [Semantic("TEXCOORD4")][Optional]       Vector4 uv4;
+            [Semantic("TEXCOORD5")][Optional]       Vector4 uv5;
             [Semantic("BLENDWEIGHTS")][Optional]    Vector4 weights;
             [Semantic("BLENDINDICES")][Optional]    UInt32_4 indices;
             [Semantic("COLOR")][Optional]           Vector4 color;
@@ -82,6 +84,8 @@ namespace UnityEditor.Rendering.HighDefinition
                 new Dependency("VaryingsMeshToPS.texCoord1",        "AttributesMesh.uv1"),
                 new Dependency("VaryingsMeshToPS.texCoord2",        "AttributesMesh.uv2"),
                 new Dependency("VaryingsMeshToPS.texCoord3",        "AttributesMesh.uv3"),
+                new Dependency("VaryingsMeshToPS.texCoord4",        "AttributesMesh.uv4"),
+                new Dependency("VaryingsMeshToPS.texCoord5",        "AttributesMesh.uv5"),
                 new Dependency("VaryingsMeshToPS.color",            "AttributesMesh.color"),
                 new Dependency("VaryingsMeshToPS.instanceID",       "AttributesMesh.instanceID"),
             };
@@ -239,6 +243,8 @@ namespace UnityEditor.Rendering.HighDefinition
             [Optional] Vector4 uv1;
             [Optional] Vector4 uv2;
             [Optional] Vector4 uv3;
+            [Optional] Vector4 uv4;
+            [Optional] Vector4 uv5;
             [Optional] Vector4 VertexColor;
             [Optional] Vector3 TimeParameters;
             [Optional] Vector4 BoneWeights;
@@ -277,6 +283,8 @@ namespace UnityEditor.Rendering.HighDefinition
                 new Dependency("VertexDescriptionInputs.uv1",                       "AttributesMesh.uv1"),
                 new Dependency("VertexDescriptionInputs.uv2",                       "AttributesMesh.uv2"),
                 new Dependency("VertexDescriptionInputs.uv3",                       "AttributesMesh.uv3"),
+                new Dependency("VertexDescriptionInputs.uv4",                       "AttributesMesh.uv4"),
+                new Dependency("VertexDescriptionInputs.uv5",                       "AttributesMesh.uv5"),
                 new Dependency("VertexDescriptionInputs.VertexColor",               "AttributesMesh.color"),
 
                 new Dependency("VertexDescriptionInputs.BoneWeights",               "AttributesMesh.weights"),
@@ -379,6 +387,8 @@ namespace UnityEditor.Rendering.HighDefinition
             {
                 activeFields.AddAll("VertexDescriptionInputs.BoneWeights");
                 activeFields.AddAll("VertexDescriptionInputs.BoneIndices");
+                activeFields.AddAll("VertexDescriptionInputs.uv4");
+                activeFields.AddAll("VertexDescriptionInputs.uv5");
             }
 
             foreach (var channel in requirements.requiresMeshUVs.Distinct())

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/VertexAnimation.template.hlsl
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/VertexAnimation.template.hlsl
@@ -31,6 +31,8 @@ VertexDescriptionInputs AttributesMeshToVertexDescriptionInputs(AttributesMesh i
     $VertexDescriptionInputs.uv1:                       output.uv1 =                         input.uv1;
     $VertexDescriptionInputs.uv2:                       output.uv2 =                         input.uv2;
     $VertexDescriptionInputs.uv3:                       output.uv3 =                         input.uv3;
+    $VertexDescriptionInputs.uv4:                       output.uv4 =                         input.uv4;
+    $VertexDescriptionInputs.uv5:                       output.uv5 =                         input.uv5;
     $VertexDescriptionInputs.VertexColor:               output.VertexColor =                 input.color;
     $VertexDescriptionInputs.BoneWeights:               output.BoneWeights =                 input.weights;
     $VertexDescriptionInputs.BoneIndices:               output.BoneIndices =                 input.indices;

--- a/com.unity.shadergraph/Editor/Data/Nodes/Vertex Skinning/LinearBlendSkinningNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Vertex Skinning/LinearBlendSkinningNode.cs
@@ -1,12 +1,39 @@
 using UnityEngine;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Internal;
+using UnityEditor.ShaderGraph.Drawing.Controls;
 
 namespace UnityEditor.ShaderGraph
 {
     [Title("Vertex Skinning", "Linear Blend Skinning")]
     class LinearBlendSkinningNode : AbstractMaterialNode, IGeneratesBodyCode, IGeneratesFunction, IMayRequireVertexSkinning, IMayRequirePosition, IMayRequireNormal, IMayRequireTangent
     {
+
+        public enum BoneCountType
+        {
+            PerVerteBoneCount4,
+            PerVerteBoneCount8
+        };
+
+        [SerializeField]
+        private BoneCountType m_BoneCountType = BoneCountType.PerVerteBoneCount4;
+
+        [EnumControl("BoneCount")]
+        public BoneCountType boneCountType
+        {
+            get { return m_BoneCountType; }
+            set
+            {
+                if (m_BoneCountType == value)
+                    return;
+
+                m_BoneCountType = value;
+                Dirty(ModificationScope.Graph);
+
+                ValidateNode();
+            }
+        }
+
         public const int kPositionSlotId = 0;
         public const int kNormalSlotId = 1;
         public const int kTangentSlotId = 2;
@@ -77,15 +104,33 @@ namespace UnityEditor.ShaderGraph
             sb.AppendLine("$precision3 {0} = 0;", GetVariableNameForSlot(kTangentOutputSlotId));
             if (generationMode == GenerationMode.ForReals)
             {
-                sb.AppendLine("{0}(IN.BoneIndices, (int)(({1})), IN.BoneWeights, {2}, {3}, {4}, {5}, {6}, {7});",
-                    GetFunctionName(),
-                    GetSlotValue(kSkinMatricesOffsetSlotId, generationMode),
-                    GetSlotValue(kPositionSlotId, generationMode),
-                    GetSlotValue(kNormalSlotId, generationMode),
-                    GetSlotValue(kTangentSlotId, generationMode),
-                    GetVariableNameForSlot(kPositionOutputSlotId),
-                    GetVariableNameForSlot(kNormalOutputSlotId),
-                    GetVariableNameForSlot(kTangentOutputSlotId));
+                if(m_BoneCountType == BoneCountType.PerVerteBoneCount8)
+                {
+                    // the first 4 bones were normalized assuming bone count was 4, so we need to denormalize them back to original values
+                    // this should be done in the post processor, but right now there is a bug in mesh API when trying to set bone weights on a mesh imported with custom bone count per vertex setting
+                    sb.AppendLine("$precision1 denormalizeScale = 1.0f - (IN.uv5.x + IN.uv5.y + IN.uv5.z + IN.uv5.w);");                
+                    sb.AppendLine("{0}(IN.BoneIndices, IN.uv4, (int)(({1})), IN.BoneWeights * denormalizeScale, IN.uv5, {2}, {3}, {4}, {5}, {6}, {7});",
+                        GetFunctionName(),
+                        GetSlotValue(kSkinMatricesOffsetSlotId, generationMode),
+                        GetSlotValue(kPositionSlotId, generationMode),
+                        GetSlotValue(kNormalSlotId, generationMode),
+                        GetSlotValue(kTangentSlotId, generationMode),
+                        GetVariableNameForSlot(kPositionOutputSlotId),
+                        GetVariableNameForSlot(kNormalOutputSlotId),
+                        GetVariableNameForSlot(kTangentOutputSlotId));
+                }
+                else
+                {
+                    sb.AppendLine("{0}(IN.BoneIndices, (int)(({1})), IN.BoneWeights, {2}, {3}, {4}, {5}, {6}, {7});",
+                        GetFunctionName(),
+                        GetSlotValue(kSkinMatricesOffsetSlotId, generationMode),
+                        GetSlotValue(kPositionSlotId, generationMode),
+                        GetSlotValue(kNormalSlotId, generationMode),
+                        GetSlotValue(kTangentSlotId, generationMode),
+                        GetVariableNameForSlot(kPositionOutputSlotId),
+                        GetVariableNameForSlot(kNormalOutputSlotId),
+                        GetVariableNameForSlot(kTangentOutputSlotId));
+                }
             }
         }
 
@@ -97,12 +142,21 @@ namespace UnityEditor.ShaderGraph
             });
             registry.ProvideFunction(GetFunctionName(), sb =>
             {
-                sb.AppendLine("void {0}(uint4 indices, int indexOffset, $precision4 weights, $precision3 positionIn, $precision3 normalIn, $precision3 tangentIn, out $precision3 positionOut, out $precision3 normalOut, out $precision3 tangentOut)",
-                    GetFunctionName());
+                if(m_BoneCountType == BoneCountType.PerVerteBoneCount8)
+                {
+                    sb.AppendLine("void {0}(uint4 indices, uint4 indices4_8, int indexOffset, $precision4 weights, $precision4 weights4_8, $precision3 positionIn, $precision3 normalIn, $precision3 tangentIn, out $precision3 positionOut, out $precision3 normalOut, out $precision3 tangentOut)",
+                        GetFunctionName());
+                }
+                else
+                {
+                    sb.AppendLine("void {0}(uint4 indices, int indexOffset, $precision4 weights, $precision3 positionIn, $precision3 normalIn, $precision3 tangentIn, out $precision3 positionOut, out $precision3 normalOut, out $precision3 tangentOut)",
+                        GetFunctionName());            
+                }
                 sb.AppendLine("{");
                 using (sb.IndentScope())
                 {
-                    sb.AppendLine("for (int i = 0; i < 4; i++)");
+                    sb.AppendLine("int i;");
+                    sb.AppendLine("for (i = 0; i < 4; i++)");
                     sb.AppendLine("{");
                     using (sb.IndentScope())
                     {
@@ -116,6 +170,23 @@ namespace UnityEditor.ShaderGraph
                         sb.AppendLine("tangentOut += ttransformed * weights[i];");
                     }
                     sb.AppendLine("}");
+                    if(m_BoneCountType == BoneCountType.PerVerteBoneCount8)
+                    {
+                        sb.AppendLine("for (i = 0; i < 4; i++)");
+                        sb.AppendLine("{");
+                        using (sb.IndentScope())
+                        {
+                            sb.AppendLine("$precision3x4 skinMatrix = _SkinMatrices[indices4_8[i] + indexOffset];");
+                            sb.AppendLine("$precision3 vtransformed = mul(skinMatrix, $precision4(positionIn, 1));");
+                            sb.AppendLine("$precision3 ntransformed = mul(skinMatrix, $precision4(normalIn, 0));");
+                            sb.AppendLine("$precision3 ttransformed = mul(skinMatrix, $precision4(tangentIn, 0));");
+                            sb.AppendLine("");
+                            sb.AppendLine("positionOut += vtransformed * weights4_8[i];");
+                            sb.AppendLine("normalOut += ntransformed * weights4_8[i];");
+                            sb.AppendLine("tangentOut += ttransformed * weights4_8[i];");
+                        }
+                        sb.AppendLine("}");
+                    }
                 }
                 sb.AppendLine("}");
             });


### PR DESCRIPTION
use uv4,5 for the extra boneindices/weights streams

Update CHANGELOG.md

move model post processor to shader graph asset post processor, remove unnecessary interpolators

add comment

**DONT FORGET TO ADD A CHANGELOG**

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
