### PR TITLE
[VFX] Fix AssetBundle test 

### DIFF
--- a/com.unity.testing.visualeffectgraph/Runtime/LoadVFXFromAssetBundle.cs
+++ b/com.unity.testing.visualeffectgraph/Runtime/LoadVFXFromAssetBundle.cs
@@ -7,30 +7,16 @@ namespace Unity.Testing.VisualEffectGraph
 {
     public class LoadVFXFromAssetBundle : MonoBehaviour
     {
-        public static string GetAssetBundleBasePath()
-        {
-            var basePath = System.IO.Directory.GetCurrentDirectory();
-
-            var args = System.Environment.GetCommandLineArgs();
-            for (int i = 0; i < args.Length; i++)
-            {
-                if (args[i].ToLower() == "-logfile" && i != args.Length - 1)
-                {
-                    var testResultID = "test-results";
-                    var logPath = args[i + 1];
-                    if (logPath.Contains(testResultID))
-                    {
-                        basePath = logPath.Substring(0, logPath.IndexOf(testResultID) + testResultID.Length);
-                    }
-                    break;
-                }
-            }
-            return System.IO.Path.Combine(basePath, "VFX_Bundle_Test");
-        }
-
         void Start()
         {
-            var basePath = GetAssetBundleBasePath();
+            var assetBundlePath = System.IO.File.ReadAllLines(Application.streamingAssetsPath + "/AssetBundlePath.txt");
+            if (assetBundlePath.Length < 1)
+            {
+                Debug.LogError("Unable to find bundle AssetBundlePath.txt");
+                return;
+            }
+
+            var basePath = assetBundlePath[0];
             var fullPath = System.IO.Path.Combine(basePath, "vfx_in_assetbundle");
             if (!System.IO.File.Exists(fullPath))
             {

--- a/com.unity.testing.visualeffectgraph/Tests/Runtime/Setup/SetupGraphicsTestCases.cs
+++ b/com.unity.testing.visualeffectgraph/Tests/Runtime/Setup/SetupGraphicsTestCases.cs
@@ -25,7 +25,26 @@ public class SetupGraphicsTestCases : IPrebuildSetup
         var fnRecompileIfNeeded = graph.GetType().GetMethod("RecompileIfNeeded");
         fnRecompileIfNeeded.Invoke(graph, new object[] { false, false });
     }
+    private static string GetAssetBundleBasePath()
+    {
+        var basePath = System.IO.Directory.GetCurrentDirectory();
 
+        var args = System.Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i].ToLower() == "-logfile" && i != args.Length - 1)
+            {
+                var testResultID = "test-results"; //Find a nice path for yamato output
+                var logPath = args[i + 1];
+                if (logPath.Contains(testResultID))
+                {
+                    basePath = logPath.Substring(0, logPath.IndexOf(testResultID) + testResultID.Length);
+                }
+                break;
+            }
+        }
+        return System.IO.Path.Combine(basePath, "VFX_Bundle_Test");
+    }
 
     public void Setup()
     {
@@ -49,11 +68,14 @@ public class SetupGraphicsTestCases : IPrebuildSetup
             EditorUtility.ClearProgressBar();
         }
 
-        var bundlePath = Unity.Testing.VisualEffectGraph.LoadVFXFromAssetBundle.GetAssetBundleBasePath();
+        var bundlePath = GetAssetBundleBasePath();
         if (!Directory.Exists(bundlePath))
         {
             Directory.CreateDirectory(bundlePath);
         }
         UnityEditor.BuildPipeline.BuildAssetBundles(bundlePath, UnityEditor.BuildAssetBundleOptions.None, UnityEditor.BuildTarget.StandaloneWindows64);
+        if (!Directory.Exists("Assets/StreamingAssets"))
+            Directory.CreateDirectory("Assets/StreamingAssets");
+        File.WriteAllText("Assets/StreamingAssets/AssetBundlePath.txt", bundlePath);
     }
 }


### PR DESCRIPTION
### Purpose of this PR
Fix asset bundle test preprocess.

There was an issue with base asset bundle path :
***Before***
Only based on logFile path, in standalone & editor.
***Now***
Still use logFile path to be able to retrieve the created asset bundle in artefact, only in editor, standalone uses the output path stored in Streaming asset (like https://github.com/Unity-Technologies/ScriptableRenderPipeline/blob/master/com.unity.testframework.graphics/Editor/CreateSceneListFileFromBuildSettings.cs#L11)

Tested locally, awaiting for yamato result (run several configuration to caught a potential instability).

It will require a backport to 8.x.x & 7.x.x