### PR TITLE
[8.x.x Backport] Shader Graph fix for dragging keywords in the graph

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -1232,8 +1232,8 @@ namespace UnityEditor.Rendering.HighDefinition
             );
 
             // All these properties values will be patched with the material keyword update
-            collector.AddIntProperty("_StencilRef", stencilRef); 
-            collector.AddIntProperty("_StencilWriteMask", stencilWriteMask); 
+            collector.AddIntProperty("_StencilRef", stencilRef);
+            collector.AddIntProperty("_StencilWriteMask", stencilWriteMask);
             // Depth prepass
             collector.AddIntProperty("_StencilRefDepth", stencilRefDepth); // Nothing
             collector.AddIntProperty("_StencilWriteMaskDepth", stencilWriteMaskDepth); // StencilUsage.TraceReflectionRay
@@ -1244,8 +1244,8 @@ namespace UnityEditor.Rendering.HighDefinition
             collector.AddIntProperty("_StencilRefDistortionVec", (int)StencilUsage.DistortionVectors);
             collector.AddIntProperty("_StencilWriteMaskDistortionVec", (int)StencilUsage.DistortionVectors);
             // Gbuffer
-            collector.AddIntProperty("_StencilWriteMaskGBuffer", stencilWriteMaskGBuffer); 
-            collector.AddIntProperty("_StencilRefGBuffer", stencilRefGBuffer); 
+            collector.AddIntProperty("_StencilWriteMaskGBuffer", stencilWriteMaskGBuffer);
+            collector.AddIntProperty("_StencilRefGBuffer", stencilRefGBuffer);
             collector.AddIntProperty("_ZTestGBuffer", 4);
 
             collector.AddToggleProperty(kUseSplitLighting, splitLighting);
@@ -1357,7 +1357,7 @@ namespace UnityEditor.Rendering.HighDefinition
         public static System.Collections.Generic.List<HDRenderQueue.RenderQueueType> GetRenderingPassList(bool opaque, bool needAfterPostProcess)
         {
             // We can't use RenderPipelineManager.currentPipeline here because this is called before HDRP is created by SG window
-            bool supportsRayTracing = HDRenderPipeline.GatherRayTracingSupport(HDRenderPipeline.currentAsset.currentPlatformRenderPipelineSettings);
+            bool supportsRayTracing = HDRenderPipeline.currentAsset && HDRenderPipeline.GatherRayTracingSupport(HDRenderPipeline.currentAsset.currentPlatformRenderPipelineSettings);
             var result = new System.Collections.Generic.List<HDRenderQueue.RenderQueueType>();
             if (opaque)
             {

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialGraphView.cs
@@ -845,7 +845,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     case ShaderKeyword keyword:
                     {
                         // This could be from another graph, in which case we add a copy of the ShaderInput to this graph.
-                        if (graph.properties.FirstOrDefault(k => k.guid == keyword.guid) == null)
+                        if (graph.keywords.FirstOrDefault(k => k.guid == keyword.guid) == null)
                         {
                             var copy = (ShaderKeyword)keyword.Copy();
                             graph.SanitizeGraphInputName(copy);


### PR DESCRIPTION
Backport of #5863 

---

Yamato:
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/8.x.x%252Fsg%252Fkeyword-drag-fix