### PR TITLE
[Shader Graph][8.x.x] Minor Caching Improvements to Searcher

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -261,6 +261,11 @@ namespace UnityEditor.ShaderGraph.Drawing
                         item => (m_SearchWindowProvider as SearcherProvider).OnSearcherSelectEntry(item, c.screenMousePosition - editorWindow.position.position),
                         c.screenMousePosition - editorWindow.position.position, null);
                 };
+            m_GraphView.RegisterCallback<FocusInEvent>( evt =>
+            {
+                //regenerate entries when graph view is refocused, to propogate subgraph changes
+                m_SearchWindowProvider.regenerateEntries = true;
+            });
 
             m_EdgeConnectorListener = new EdgeConnectorListener(m_Graph, m_SearchWindowProvider, editorWindow);
 
@@ -562,6 +567,8 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
 
             previewManager.RenderPreviews();
+            if(m_Graph.addedInputs.Count() > 0 || m_Graph.removedInputs.Count() > 0)
+                m_SearchWindowProvider.regenerateEntries = true;
             m_BlackboardProvider.HandleGraphChanges();
             m_GroupHashSet.Clear();
 


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing? 
Backport of #5997 
Previously, the `Create Node` menu/searcher window regenerated an instance of every node on every load call. This makes minor improvements to the caching of entries to speed up the load of the searcher for the majority of calls. 
The searcher window will now only generate new entries when changes to properties or keywords are detected, or when the shader graph window is refocused (to account for subgraph changes). Only the first invoke after these changes are detected will lag, and every call after that will use a cache and load much faster.
More improvements can be made later as well but this speeds up 80% of the use of the searcher and is probably worth putting in for UX improvements. 
Issue link: [public](https://issuetracker.unity3d.com/product/unity/issues/guid/1209567/) [internal](https://fogbugz.unity3d.com/f/cases/1209567/)

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] Checked new UI names with UX convention
- [x] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 
- Rapidly opened and closed the searcher (using spacebar) and observed rapidly improved load times. 
- Added many properties, keywords, and nodes from the searcher entries to the graph to ensure there are no guid errors in the copy system. 
- Checked that when refocusing the window, adding, removing, or changing a property or keyword the next load did lag, but reflected the changes in the search entries. Every load after that remained fast. 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
