### PR TITLE
Handled targetTexture dimension not compatible with XR case. [case 1198052]

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where MSAA isn't applied until eye textures are relocated by changing their resolution. [case 1197958](https://issuetracker.unity3d.com/issues/oculus-quest-oculus-go-urp-msaa-isnt-applied-until-eye-textures-are-relocated-by-changing-their-resolution)
 - Fixed an issue where camera stacking didn't work properly inside prefab mode. [case 1220509](https://issuetracker.unity3d.com/issues/urp-cannot-assign-overlay-cameras-to-a-camera-stack-while-in-prefab-mode)
 - Fixed the definition of `mad()` in SMAA shader for OpenGL.
+- Fixed an issue where rendering into RenderTexture with Single Pass Instanced renders both eyes overlapping.
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -183,8 +183,7 @@ namespace UnityEngine.Rendering.Universal
             bool isGameCamera = IsGameCamera(camera);
             bool isCompatWithXRDimension = true;
 #if ENABLE_VR && ENABLE_VR_MODULE
-            isCompatWithXRDimension = camera.targetTexture ?
-                camera.targetTexture.dimension == UnityEngine.XR.XRSettings.deviceEyeTextureDimension : true;
+            isCompatWithXRDimension &= (camera.targetTexture ? camera.targetTexture.dimension == UnityEngine.XR.XRSettings.deviceEyeTextureDimension : true);
 #endif
             return XRGraphics.enabled && isGameCamera && (camera.stereoTargetEye == StereoTargetEyeMask.Both) && isCompatWithXRDimension;
         }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -181,7 +181,12 @@ namespace UnityEngine.Rendering.Universal
                 throw new ArgumentNullException("camera");
 
             bool isGameCamera = IsGameCamera(camera);
-            return XRGraphics.enabled && isGameCamera && (camera.stereoTargetEye == StereoTargetEyeMask.Both);
+            bool isCompatWithXRDimension = true;
+#if ENABLE_VR && ENABLE_VR_MODULE
+            isCompatWithXRDimension = camera.targetTexture ?
+                camera.targetTexture.dimension == UnityEngine.XR.XRSettings.deviceEyeTextureDimension : true;
+#endif
+            return XRGraphics.enabled && isGameCamera && (camera.stereoTargetEye == StereoTargetEyeMask.Both) && isCompatWithXRDimension;
         }
 
         /// <summary>


### PR DESCRIPTION
### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR

https://fogbugz.unity3d.com/f/cases/1198052/

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Note: this hides SPI mode rendering things overlapped in URP when rendering to texture2D: we disable XR in that case. SPI requires targetTexture to be texArr type.

Although the current logic makes sense, it **DOES NOT** have parity with the legacy renderer. Legacy renderer disables XR if targetTexture is being used. We can't do it in URP as URP uses targetTexture in cameraStack and XR needs to support cameraStack in SPI/Multiview. 