### PR TITLE
[8.x.x Backport] Fix fog density returning zero with an Unlit Master Node

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalUnlitSubShader.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalUnlitSubShader.cs
@@ -55,6 +55,7 @@ namespace UnityEditor.Rendering.Universal
                 "prefer_hlslcc gles",
                 "exclude_renderers d3d11_9x",
                 "target 2.0",
+                "multi_compile_fog",
                 "multi_compile_instancing",
             },
             keywords = new KeywordDescriptor[]

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [8.0.1] - 2020-05-25
 
 ### Fixed
-- Fix Changelog
+- Fixed a bug where fog density node always returns 0 in the shader preview window when connected to an Unlit Master node. 
 
 ## [8.0.0] - 2020-05-25
 


### PR DESCRIPTION
Purpose of this PR
Backport of #6008

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/8.x.x%252Fsg%252Ffix-fog-density-returning-zero