### PR TITLE
Apply surface tint even if no texture is present

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/PhysicallyBasedSky/PhysicallyBasedSky.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/PhysicallyBasedSky/PhysicallyBasedSky.shader
@@ -137,8 +137,9 @@ Shader "Hidden/HDRP/Sky/PbrSky"
 
                                 color *= SampleCookie2D(uv, light.surfaceTextureScaleOffset);
                                 // color *= SAMPLE_TEXTURE2D_ARRAY(_CookieTextures, s_linear_clamp_sampler, uv, light.surfaceTextureIndex).rgb;
-                                color *= light.surfaceTint;
                             }
+                            
+                            color *= light.surfaceTint;
                         }
                         else // Flare region.
                         {


### PR DESCRIPTION
### Purpose of this PR
Apply surface tint even if no texture is present

---
### Testing status

**Manual Tests**: Not yet
**Yamato**: https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

---
### Comments to reviewers
Forgot the changelog.
