### PR TITLE
Hdrp /fix light prefab infinite reload on inspector gui

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -421,6 +421,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed MSAA Buffers allocation when lit shader mode is set to "deferred only".
 - Fixed invalid cast for realtime reflection probes (case 1220504)
 - Fixed invalid game view rendering when disabling all cameras in the scene (case 1105163)
+- Fixed infinite reload loop while displaying Light's Shadow's Link Light Layer in Inspector of Prefab Asset.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightEditor.cs
@@ -92,11 +92,9 @@ namespace UnityEditor.Rendering.HighDefinition
         {
             // UX team decided that we should always show component in inspector.
             // However already authored scene save this settings, so force the component to be visible
-            // var flags = hide ? HideFlags.HideInInspector : HideFlags.None;
-            var flags = HideFlags.None;
-
             foreach (var t in m_SerializedHDLight.serializedObject.targetObjects)
-                ((HDAdditionalLightData)t).hideFlags = flags;
+                if (((HDAdditionalLightData)t).hideFlags == HideFlags.HideInInspector)
+                    ((HDAdditionalLightData)t).hideFlags = HideFlags.None;
         }
 
         protected override void OnSceneGUI()

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
@@ -1028,7 +1028,8 @@ namespace UnityEditor.Rendering.HighDefinition
         {
             // If we're not in decoupled mode for light layers, we sync light with shadow layers:
             foreach (Light target in owner.targets)
-                target.renderingLayerMask = serialized.lightlayersMask.intValue;
+                if (target.renderingLayerMask != serialized.lightlayersMask.intValue)
+                    target.renderingLayerMask = serialized.lightlayersMask.intValue;
         }
 
         static void DrawContactShadowsContent(SerializedHDLight serialized, Editor owner)


### PR DESCRIPTION
### Purpose of this PR
Fix https://fogbugz.unity3d.com/f/cases/1221237/ : 
Infinite reload loop of Prefab Asset containing a Light Component displaying the Link Light Layer option.
Also add potential other infinite loop with really old prefab while making their HDAdditionalLightData be visible again.

---
### Testing status

**Manual Tests**: 
- Other: 
  - Check with @alelievr  that this cause no regression on Link Light Layer
  - Checked manually with problematic asset given by Kim Hutchinson (Issue produce before but not after this fix)

---
### Comments to reviewers
This bug only occures on 2019.3 but can be an optimisation for 2020.x.
It is productible with 7.2.x/release