### PR TITLE
Add comment on building of prev VP with no translation

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -953,6 +953,7 @@ namespace UnityEngine.Rendering.HighDefinition
             Matrix4x4 noTransViewMatrix = gpuView;
             if (ShaderConfig.s_CameraRelativeRendering == 0)
             {
+                // In case we are not camera relative, gpuView contains the camera translation component at this stage, so we need to remove it.
                 noTransViewMatrix.SetColumn(3, new Vector4(0, 0, 0, 1));
 
             }


### PR DESCRIPTION
Added a comment on why we remove the translation component when computing the prev VP matrix with no translation