### PR TITLE
Use 2-component edge texture for SMAA on Mali

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
@@ -49,6 +49,7 @@ namespace UnityEngine.Rendering.Universal.Internal
         const int k_MaxPyramidSize = 16;
         readonly GraphicsFormat m_DefaultHDRFormat;
         bool m_UseRGBM;
+        readonly GraphicsFormat m_SMAAEdgeFormat;
         readonly GraphicsFormat m_GaussianCoCFormat;
         Matrix4x4 m_PrevViewProjM = Matrix4x4.identity;
         bool m_ResetHistory;
@@ -91,6 +92,12 @@ namespace UnityEngine.Rendering.Universal.Internal
                     : GraphicsFormat.R8G8B8A8_UNorm;
                 m_UseRGBM = true;
             }
+
+            // Only two components are needed for edge render texture, but on some vendors four components may be faster.
+            if (SystemInfo.IsFormatSupported(GraphicsFormat.R8G8_UNorm, FormatUsage.Render) && SystemInfo.graphicsDeviceVendor.ToLowerInvariant().Contains("arm"))
+                m_SMAAEdgeFormat = GraphicsFormat.R8G8_UNorm;
+            else
+                m_SMAAEdgeFormat = GraphicsFormat.R8G8B8A8_UNorm;
 
             if (SystemInfo.IsFormatSupported(GraphicsFormat.R16_UNorm, FormatUsage.Linear | FormatUsage.Render))
                 m_GaussianCoCFormat = GraphicsFormat.R16_UNorm;
@@ -458,7 +465,7 @@ namespace UnityEngine.Rendering.Universal.Internal
                 stencil = m_Depth.Identifier();
                 tempDepthBits = 0;
             }
-            cmd.GetTemporaryRT(ShaderConstants._EdgeTexture, GetStereoCompatibleDescriptor(m_Descriptor.width, m_Descriptor.height, GraphicsFormat.R8G8B8A8_UNorm, tempDepthBits), FilterMode.Point);
+            cmd.GetTemporaryRT(ShaderConstants._EdgeTexture, GetStereoCompatibleDescriptor(m_Descriptor.width, m_Descriptor.height, m_SMAAEdgeFormat, tempDepthBits), FilterMode.Point);
             cmd.GetTemporaryRT(ShaderConstants._BlendTexture, GetStereoCompatibleDescriptor(m_Descriptor.width, m_Descriptor.height, GraphicsFormat.R8G8B8A8_UNorm), FilterMode.Point);
 
             // Prepare for manual blit


### PR DESCRIPTION
---
### Purpose of this PR

The SMAA edge texture only requires 2 components, but using 4 may be
faster on some vendors (SMAA authors mention it is faster on Nvidia).
2 components is faster on Mali, so make sure 2 components is used
when running on a Mali device but keep 4 components for other vendors.

---
### Testing status

Measurements were done in the URP default template scene with SMAA on
medium settings and all other post-processing effects turned off on a
Mali G-76.

| Counter | Change (error) |
| --- | --- |
| Mali Core Internal Bus Write Beats: Tile buffer internal | -12.6% (+-2.3%) |
| Mali Core Tiles (CRC): Killed tiles | +16.1% (+-2.3%) |
| Mali External Bus Accesses: Write transaction | -10.9% (+-2.3%) |
| Mali External Bus Beats: Write beat | -10.8% (+-2.3%) |
| Mali External Bus Outstanding Writes: 0-25% | -14.8% (+-2.1%) |
| Mali L2 Cache Lookups: Write lookup | -10.2% (+-3.2%) |

---
### Comments to reviewers
Notes for the reviewers you have assigned.
