### PR TITLE
Universal/shader quality

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `[MainTexture]` and `[MainColor]` shader property attributes to URP shader properties. These will link script material.mainTextureOffset and material.color to `_BaseMap` and `_BaseColor` shader properties.
 - Added the option to specify the maximum number of visible lights. If you set a value, lights are sorted based on their distance from the Camera.
 - Added the option to control the transparent layer separately in the Forward Renderer.
+- Added the option to specify shader quality which is used by the shaders to know which features to use.
 
 ### Changed
 - Moved the icon that indicates the type of a Light 2D from the Inspector header to the Light Type field.

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
@@ -35,6 +35,7 @@ namespace UnityEditor.Rendering.Universal
             public static GUIContent hdrText = EditorGUIUtility.TrTextContent("HDR", "Controls the global HDR settings.");
             public static GUIContent msaaText = EditorGUIUtility.TrTextContent("Anti Aliasing (MSAA)", "Controls the global anti aliasing settings.");
             public static GUIContent renderScaleText = EditorGUIUtility.TrTextContent("Render Scale", "Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution. When VR is enabled, this is overridden by XRSettings.");
+            public static GUIContent shaderQualityText = EditorGUIUtility.TrTextContent("Shader Quality", "Controls the Shader features.");
 
             // Main light
             public static GUIContent mainLightRenderingModeText = EditorGUIUtility.TrTextContent("Main Light", "Main light is the brightest directional light.");
@@ -103,6 +104,7 @@ namespace UnityEditor.Rendering.Universal
         SerializedProperty m_HDR;
         SerializedProperty m_MSAA;
         SerializedProperty m_RenderScale;
+        SerializedProperty m_ShaderQuality;
 
         SerializedProperty m_MainLightRenderingModeProp;
         SerializedProperty m_MainLightShadowsSupportedProp;
@@ -170,6 +172,7 @@ namespace UnityEditor.Rendering.Universal
             m_HDR = serializedObject.FindProperty("m_SupportsHDR");
             m_MSAA = serializedObject.FindProperty("m_MSAA");
             m_RenderScale = serializedObject.FindProperty("m_RenderScale");
+            m_ShaderQuality = serializedObject.FindProperty("m_ShaderQuality");
 
             m_MainLightRenderingModeProp = serializedObject.FindProperty("m_MainLightRenderingMode");
             m_MainLightShadowsSupportedProp = serializedObject.FindProperty("m_MainLightShadowsSupported");
@@ -247,6 +250,7 @@ namespace UnityEditor.Rendering.Universal
                 EditorGUI.BeginDisabledGroup(XRGraphics.enabled);
                 m_RenderScale.floatValue = EditorGUILayout.Slider(Styles.renderScaleText, m_RenderScale.floatValue, UniversalRenderPipeline.minRenderScale, UniversalRenderPipeline.maxRenderScale);
                 EditorGUI.EndDisabledGroup();
+                EditorGUILayout.PropertyField(m_ShaderQuality, Styles.shaderQualityText);
                 EditorGUI.indentLevel--;
                 EditorGUILayout.Space();
                 EditorGUILayout.Space();

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -49,6 +49,13 @@ namespace UnityEngine.Rendering.Universal
         _8x = 8
     }
 
+    public enum ShaderQuality
+    {
+        Low,
+        Medium,
+        High
+    }
+
     [MovedFrom("UnityEngine.Rendering.LWRP")] public enum Downsampling
     {
         None,
@@ -128,6 +135,7 @@ namespace UnityEngine.Rendering.Universal
         [SerializeField] bool m_SupportsHDR = false;
         [SerializeField] MsaaQuality m_MSAA = MsaaQuality.Disabled;
         [SerializeField] float m_RenderScale = 1.0f;
+        [SerializeField] ShaderQuality m_ShaderQuality = ShaderQuality.High;
         // TODO: Shader Quality Tiers
 
         // Main directional light Settings
@@ -522,6 +530,12 @@ namespace UnityEngine.Rendering.Universal
         {
             get { return m_RenderScale; }
             set { m_RenderScale = ValidateRenderScale(value); }
+        }
+
+        public ShaderQuality shaderQuality
+        {
+            get { return m_ShaderQuality; }
+            set { m_ShaderQuality = value; }
         }
 
         public LightRenderingMode mainLightRenderingMode

--- a/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ScriptableRenderer.cs
@@ -240,6 +240,8 @@ namespace UnityEngine.Rendering.Universal
 
             // Initialize Camera Render State
             SetCameraRenderState(cmd, ref cameraData);
+            // Initialize Shader Quality
+            SetShaderQuality(cmd, renderingData.shaderQuality);
             context.ExecuteCommandBuffer(cmd);
             cmd.Clear();
             
@@ -419,6 +421,28 @@ namespace UnityEngine.Rendering.Universal
             cmd.DisableShaderKeyword(ShaderKeywordStrings.SoftShadows);
             cmd.DisableShaderKeyword(ShaderKeywordStrings.MixedLightingSubtractive);
             cmd.DisableShaderKeyword(ShaderKeywordStrings.LinearToSRGBConversion);
+        }
+
+        void SetShaderQuality(CommandBuffer cmd, ShaderQuality shaderQuality)
+        {
+            if (shaderQuality == ShaderQuality.High)
+            {
+                cmd.DisableShaderKeyword("SHADER_QUALITY_LOW");
+                cmd.DisableShaderKeyword("SHADER_QUALITY_MEDIUM");
+                cmd.EnableShaderKeyword("SHADER_QUALITY_HIGH");
+            }
+            else if (shaderQuality == ShaderQuality.Medium)
+            {
+                cmd.DisableShaderKeyword("SHADER_QUALITY_LOW");
+                cmd.EnableShaderKeyword("SHADER_QUALITY_MEDIUM");
+                cmd.DisableShaderKeyword("SHADER_QUALITY_HIGH");
+            }
+            else if (shaderQuality == ShaderQuality.Low)
+            {
+                cmd.EnableShaderKeyword("SHADER_QUALITY_LOW");
+                cmd.DisableShaderKeyword("SHADER_QUALITY_MEDIUM");
+                cmd.DisableShaderKeyword("SHADER_QUALITY_HIGH");
+            }
         }
 
         internal void Clear(CameraRenderType cameraType)

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -628,6 +628,7 @@ namespace UnityEngine.Rendering.Universal
             InitializePostProcessingData(settings, out renderingData.postProcessingData);
             renderingData.supportsDynamicBatching = settings.supportsDynamicBatching;
             renderingData.perObjectData = GetPerObjectLightFlags(renderingData.lightData.additionalLightsCount);
+            renderingData.shaderQuality = settings.shaderQuality;
 
             bool isOffscreenCamera = cameraData.targetTexture != null && !cameraData.isSceneViewCamera;
             renderingData.resolveFinalTarget = requiresBlitToBackbuffer;

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -24,6 +24,7 @@ namespace UnityEngine.Rendering.Universal
         public PostProcessingData postProcessingData;
         public bool supportsDynamicBatching;
         public PerObjectData perObjectData;
+        public ShaderQuality shaderQuality;
 
         /// <summary>
         /// True if post-processing effect is enabled while rendering the camera stack.

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
@@ -5,33 +5,7 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Version.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
-
-#if !defined(SHADER_HINT_NICE_QUALITY)
-#if defined(SHADER_API_MOBILE) || defined(SHADER_API_SWITCH)
-#define SHADER_HINT_NICE_QUALITY 0
-#else
-#define SHADER_HINT_NICE_QUALITY 1
-#endif
-#endif
-
-// Shader Quality Tiers in Universal. 
-// SRP doesn't use Graphics Settings Quality Tiers.
-// We should expose shader quality tiers in the pipeline asset.
-// Meanwhile, it's forced to be:
-// High Quality: Non-mobile platforms or shader explicit defined SHADER_HINT_NICE_QUALITY
-// Medium: Mobile aside from GLES2
-// Low: GLES2 
-#if SHADER_HINT_NICE_QUALITY
-#define SHADER_QUALITY_HIGH
-#elif defined(SHADER_API_GLES)
-#define SHADER_QUALITY_LOW
-#else
-#define SHADER_QUALITY_MEDIUM
-#endif
-
-#ifndef BUMP_SCALE_NOT_SUPPORTED
-#define BUMP_SCALE_NOT_SUPPORTED !SHADER_HINT_NICE_QUALITY
-#endif
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQuality.hlsl"
 
 struct VertexPositionInputs
 {

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl
@@ -100,7 +100,7 @@ half3 SampleNormalTS(float2 uv, float3 blendUv, TEXTURE2D_PARAM(bumpMap, sampler
 {
 #if defined(_NORMALMAP)
     half4 n = BlendTexture(TEXTURE2D_ARGS(bumpMap, sampler_bumpMap), uv, blendUv);
-    #if BUMP_SCALE_NOT_SUPPORTED
+    #if !BUMP_SCALE
         return UnpackNormal(n);
     #else
         return UnpackNormalScale(n, scale);

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQuality.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQuality.hlsl
@@ -1,0 +1,28 @@
+#ifndef UNIVERSAL_SHADER_OPTIONS_INCLUDED
+#define UNIVERSAL_SHADER_OPTIONS_INCLUDED
+
+//#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderOptions.hlsl"
+//use in some shader to compile properly:
+//#pragma multi_compile SHADER_OPTIONS_LOW SHADER_OPTIONS_MEDIUM SHADER_OPTIONS_HIGH
+
+#if !defined (SHADER_QUALITY_LOW) && !defined (SHADER_QUALITY_MEDIUM) && !defined (SHADER_QUALITY_HIGH)
+#if defined(SHADER_API_MOBILE) || defined(SHADER_API_SWITCH)
+#if defined(SHADER_API_GLES)
+#define SHADER_QUALITY_LOW
+#else
+#define SHADER_QUALITY_MEDIUM
+#endif
+#else
+#define SHADER_QUALITY_HIGH
+#endif
+#endif
+
+#if defined (SHADER_QUALITY_LOW)
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl"
+#elif defined (SHADER_QUALITY_MEDIUM)
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl"
+#elif defined (SHADER_QUALITY_HIGH)
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.hlsl"
+#endif
+#endif
+

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQuality.hlsl.meta
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQuality.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 16592ca35decb9b43a60d95b45591665
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs
@@ -1,0 +1,10 @@
+namespace UnityEngine.Rendering.Universal
+{
+    [GenerateHLSL(PackingRules.Exact, false, false, false, 1, true)]
+    public struct ShaderOptionsHigh
+    {
+        public static int reflectionProbe = 1;
+        public static int blendReflectionProbe = 1;
+        public static int bumpScale = 1;
+    }
+}

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs
@@ -6,5 +6,6 @@ namespace UnityEngine.Rendering.Universal
         public static int reflectionProbe = 1;
         public static int blendReflectionProbe = 1;
         public static int bumpScale = 1;
+        public static int fadeShadows = 1;
     }
 }

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.hlsl
@@ -1,0 +1,15 @@
+//
+// This file was automatically generated. Please don't edit by hand.
+//
+
+#ifndef SHADERQUALITYHIGH_CS_HLSL
+#define SHADERQUALITYHIGH_CS_HLSL
+//
+// UnityEngine.Rendering.Universal.ShaderOptionsHigh:  static fields
+//
+#define REFLECTION_PROBE (1)
+#define BLEND_REFLECTION_PROBE (1)
+#define BUMP_SCALE (1)
+
+
+#endif

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.hlsl
@@ -10,6 +10,7 @@
 #define REFLECTION_PROBE (1)
 #define BLEND_REFLECTION_PROBE (1)
 #define BUMP_SCALE (1)
+#define FADE_SHADOWS (1)
 
 
 #endif

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.hlsl.meta
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1ace303d5430a394c88fabde89758745
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.meta
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityHigh.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b96137f40788c5748bbaaaa786137940
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs
@@ -1,0 +1,10 @@
+namespace UnityEngine.Rendering.Universal
+{
+    [GenerateHLSL(PackingRules.Exact, false, false, false, 1, true)]
+    public struct ShaderOptionsLow
+    {
+        public static int reflectionProbe = 0;
+        public static int blendReflectionProbe = 0;
+        public static int bumpScale = 0;
+    }
+}

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs
@@ -3,7 +3,7 @@ namespace UnityEngine.Rendering.Universal
     [GenerateHLSL(PackingRules.Exact, false, false, false, 1, true)]
     public struct ShaderOptionsLow
     {
-        public static int reflectionProbe = 0;
+        public static int reflectionProbe = 1;
         public static int blendReflectionProbe = 0;
         public static int bumpScale = 0;
     }

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs
@@ -6,5 +6,6 @@ namespace UnityEngine.Rendering.Universal
         public static int reflectionProbe = 1;
         public static int blendReflectionProbe = 0;
         public static int bumpScale = 0;
+        public static int fadeShadows = 0;
     }
 }

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl
@@ -1,0 +1,15 @@
+//
+// This file was automatically generated. Please don't edit by hand.
+//
+
+#ifndef SHADERQUALITYLOW_CS_HLSL
+#define SHADERQUALITYLOW_CS_HLSL
+//
+// UnityEngine.Rendering.Universal.ShaderOptionsLow:  static fields
+//
+#define REFLECTION_PROBE (0)
+#define BLEND_REFLECTION_PROBE (0)
+#define BUMP_SCALE (0)
+
+
+#endif

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl
@@ -7,7 +7,7 @@
 //
 // UnityEngine.Rendering.Universal.ShaderOptionsLow:  static fields
 //
-#define REFLECTION_PROBE (0)
+#define REFLECTION_PROBE (1)
 #define BLEND_REFLECTION_PROBE (0)
 #define BUMP_SCALE (0)
 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl
@@ -10,6 +10,7 @@
 #define REFLECTION_PROBE (1)
 #define BLEND_REFLECTION_PROBE (0)
 #define BUMP_SCALE (0)
+#define FADE_SHADOWS (0)
 
 
 #endif

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl.meta
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 74842f8dbb29dfc4c8e6e1983045ad57
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.meta
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityLow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0f2a1547ad085240b822fce11cfeb47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs
@@ -4,7 +4,7 @@ namespace UnityEngine.Rendering.Universal
     public struct ShaderOptionsMedium
     {
         public static int reflectionProbe = 1;
-        public static int blendReflectionProbe = 0;
+        public static int blendReflectionProbe = 1;
         public static int bumpScale = 0;
     }
 }

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs
@@ -1,0 +1,10 @@
+namespace UnityEngine.Rendering.Universal
+{
+    [GenerateHLSL(PackingRules.Exact, false, false, false, 1, true)]
+    public struct ShaderOptionsMedium
+    {
+        public static int reflectionProbe = 1;
+        public static int blendReflectionProbe = 0;
+        public static int bumpScale = 0;
+    }
+}

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs
@@ -6,5 +6,6 @@ namespace UnityEngine.Rendering.Universal
         public static int reflectionProbe = 1;
         public static int blendReflectionProbe = 1;
         public static int bumpScale = 0;
+        public static int fadeShadows = 1;
     }
 }

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl
@@ -8,7 +8,7 @@
 // UnityEngine.Rendering.Universal.ShaderOptionsMedium:  static fields
 //
 #define REFLECTION_PROBE (1)
-#define BLEND_REFLECTION_PROBE (0)
+#define BLEND_REFLECTION_PROBE (1)
 #define BUMP_SCALE (0)
 
 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl
@@ -1,0 +1,15 @@
+//
+// This file was automatically generated. Please don't edit by hand.
+//
+
+#ifndef SHADERQUALITYMEDIUM_CS_HLSL
+#define SHADERQUALITYMEDIUM_CS_HLSL
+//
+// UnityEngine.Rendering.Universal.ShaderOptionsMedium:  static fields
+//
+#define REFLECTION_PROBE (1)
+#define BLEND_REFLECTION_PROBE (0)
+#define BUMP_SCALE (0)
+
+
+#endif

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl
@@ -10,6 +10,7 @@
 #define REFLECTION_PROBE (1)
 #define BLEND_REFLECTION_PROBE (1)
 #define BUMP_SCALE (0)
+#define FADE_SHADOWS (1)
 
 
 #endif

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl.meta
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a4063663be96b7449bc8e0153957ef7e
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.meta
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderQualityMedium.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8bffdfce7533c242a69f2b5ac6de8c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl
@@ -49,7 +49,7 @@ half3 SampleNormal(float2 uv, TEXTURE2D_PARAM(bumpMap, sampler_bumpMap), half sc
 {
 #ifdef _NORMALMAP
     half4 n = SAMPLE_TEXTURE2D(bumpMap, sampler_bumpMap, uv);
-    #if BUMP_SCALE_NOT_SUPPORTED
+    #if !BUMP_SCALE
         return UnpackNormal(n);
     #else
         return UnpackNormalScale(n, scale);

--- a/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/UnityInput.hlsl
@@ -106,6 +106,7 @@ float4 unity_ProbesOcclusion;
 // Reflection Probe 0 block feature
 // HDR environment map decode instructions
 real4 unity_SpecCube0_HDR;
+real4 unity_SpecCube1_HDR;
 
 // Lightmap block feature
 float4 unity_LightmapST;
@@ -200,7 +201,10 @@ real4 unity_ShadowColor;
 
 // Unity specific
 TEXTURECUBE(unity_SpecCube0);
+TEXTURECUBE(unity_SpecCube1);
 SAMPLER(samplerunity_SpecCube0);
+SAMPLER(samplerunity_SpecCube1);
+real4 unity_SpecCube0_BoxMin;
 
 // Main lightmap
 TEXTURE2D(unity_Lightmap);

--- a/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -104,6 +104,7 @@ Shader "Universal Render Pipeline/Lit"
             #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile _ _SHADOWS_SOFT
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
+            #pragma multi_compile SHADER_QUALITY_LOW SHADER_QUALITY_MEDIUM SHADER_QUALITY_HIGH
 
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
@@ -71,7 +71,7 @@ void InitializeInputData(SpeedTreeVertexOutput input, half3 normalTS, out InputD
         inputData.viewDirectionWS = input.viewDirWS;
     #endif
 
-    #if SHADER_HINT_NICE_QUALITY
+    #if defined (SHADER_QUALITY_HIGH)
         inputData.viewDirectionWS = SafeNormalize(inputData.viewDirectionWS);
     #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
@@ -278,7 +278,7 @@ void InitializeInputData(SpeedTreeFragmentInput input, half3 normalTS, out Input
     inputData.viewDirectionWS = input.interpolated.viewDirWS;
 #endif
 
-#if SHADER_HINT_NICE_QUALITY
+#if defined (SHADER_QUALITY_HIGH)
     inputData.viewDirectionWS = SafeNormalize(inputData.viewDirectionWS);
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
@@ -68,7 +68,7 @@ void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData o
 
     output.normalWS = NormalizeNormalPerPixel(output.normalWS);
 
-#if SHADER_HINT_NICE_QUALITY
+#if defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 
@@ -103,7 +103,7 @@ VaryingsParticle ParticlesLitVertex(AttributesParticle input)
     VertexNormalInputs normalInput = GetVertexNormalInputs(input.normal, input.tangent);
     half3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
 
-#if !SHADER_HINT_NICE_QUALITY
+#if !defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLit.shader
@@ -123,7 +123,7 @@ Shader "Universal Render Pipeline/Particles/Simple Lit"
 
             #pragma vertex ParticlesLitVertex
             #pragma fragment ParticlesLitFragment
-            #define BUMP_SCALE_NOT_SUPPORTED 1
+            #define BUMP_SCALE 0
 
             #include "Packages/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitInput.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitForwardPass.hlsl"

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesSimpleLitForwardPass.hlsl
@@ -69,7 +69,7 @@ void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData o
 
     output.normalWS = NormalizeNormalPerPixel(output.normalWS);
 
-#if SHADER_HINT_NICE_QUALITY
+#if defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 
@@ -103,7 +103,7 @@ VaryingsParticle ParticlesLitVertex(AttributesParticle input)
     VertexPositionInputs vertexInput = GetVertexPositionInputs(input.vertex.xyz);
     VertexNormalInputs normalInput = GetVertexNormalInputs(input.normal, input.tangent);
     half3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
-#if !SHADER_HINT_NICE_QUALITY
+#if !defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
@@ -64,7 +64,7 @@ void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData o
 
     output.normalWS = NormalizeNormalPerPixel(output.normalWS);
 
-#if SHADER_HINT_NICE_QUALITY
+#if defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 
@@ -97,7 +97,7 @@ VaryingsParticle vertParticleUnlit(AttributesParticle input)
     output.color = input.color;
 
     half3 viewDirWS = GetCameraPositionWS() - vertexInput.positionWS;
-#if !SHADER_HINT_NICE_QUALITY
+#if !defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/SimpleLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/SimpleLit.shader
@@ -95,7 +95,7 @@ Shader "Universal Render Pipeline/Simple Lit"
 
             #pragma vertex LitPassVertexSimple
             #pragma fragment LitPassFragmentSimple
-            #define BUMP_SCALE_NOT_SUPPORTED 1
+            #define BUMP_SCALE 0
 
             #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl"

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -87,7 +87,7 @@ void InitializeInputData(Varyings IN, half3 normalTS, out InputData input)
     SH = IN.vertexSH;
 #endif
 
-#if SHADER_HINT_NICE_QUALITY
+#if defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 
@@ -262,7 +262,7 @@ Varyings SplatmapVert(Attributes v)
 #endif
 
     half3 viewDirWS = GetCameraPositionWS() - Attributes.positionWS;
-#if !SHADER_HINT_NICE_QUALITY
+#if !defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
@@ -41,7 +41,7 @@ void InitializeInputData(GrassVertexOutput input, out InputData inputData)
     inputData.positionWS = input.posWSShininess.xyz;
 
     half3 viewDirWS = input.viewDir;
-#if SHADER_HINT_NICE_QUALITY
+#if defined (SHADER_QUALITY_HIGH)
     viewDirWS = SafeNormalize(viewDirWS);
 #endif
 

--- a/com.unity.shadergraph/ShaderGraphLibrary/ShaderVariables.hlsl
+++ b/com.unity.shadergraph/ShaderGraphLibrary/ShaderVariables.hlsl
@@ -133,6 +133,7 @@ CBUFFER_START(UnityPerDraw : register(b0))
 
     // HDR environment map decode instructions
     half4 unity_SpecCube0_HDR;
+    half4 unity_SpecCube1_HDR;
 CBUFFER_END
 
 #if defined(USING_STEREO_MATRICES)
@@ -223,7 +224,10 @@ TEXTURE2D(unity_DynamicDirectionality);
 
 // Default reflection probe
 TEXTURECUBE(unity_SpecCube0);
+TEXTURECUBE(unity_SpecCube1);
 SAMPLER(samplerunity_SpecCube0);
+SAMPLER(samplerunity_SpecCube1);
+real4 unity_SpecCube0_BoxMin;
 
 // We can have shadowMask only if we have lightmap, so no sampler
 TEXTURE2D(unity_ShadowMask);


### PR DESCRIPTION
**DONT FORGET TO ADD A CHANGELOG**

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
The purpose of this PR is to ensure easier manageable shader features.
An example for this could be for the future feature blending reflection probes.
Which some platforms should not support then the URP can simply change the shader quality.

---
### Testing status

**Manual Tests**: What did you do?
Build player for Windows 10 x86_64, which worked as expected.

- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
