### PR TITLE
7.x.x Platforms Fixes

### DIFF
--- a/TestProjects/ShaderGraph/ProjectSettings/UnityConnectSettings.asset
+++ b/TestProjects/ShaderGraph/ProjectSettings/UnityConnectSettings.asset
@@ -17,7 +17,7 @@ UnityConnectSettings:
     m_Enabled: 0
     m_TestMode: 0
   UnityAnalyticsSettings:
-    m_Enabled: 1
+    m_Enabled: 0
     m_InitializeOnStartup: 1
     m_TestMode: 0
     m_TestEventUrl: 

--- a/TestProjects/UniversalGraphicsTest/Packages/manifest.json
+++ b/TestProjects/UniversalGraphicsTest/Packages/manifest.json
@@ -13,7 +13,7 @@
     "com.unity.test-framework": "1.1.5",
     "com.unity.testframework.graphics": "file:../../../com.unity.testframework.graphics",
     "com.unity.ugui": "1.0.0",
-    "com.unity.xr.legacyinputhelpers": "2.0.4",
+    "com.unity.xr.legacyinputhelpers": "1.3.11",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
### Purpose of this PR
Two minor fixes for platforms, specifically:
- Disabled Analytics in the ShaderGraph test project
- Changed XR Legacy Input Helpers package in the UniversalGraphicsTest project to version 1.3.11 (2.x has XR namespace errors on some platforms)

---
### Testing status

**Manual Tests**: What did you do?
- Was able to manually begin Test Runner for Universal and ShaderGraph tests on certain platforms (was blocked, previously)

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)
- Triggered tests on the SRP Private repository, see Yamato

**Yamato**:
https://yamato.cds.internal.unity3d.com/jobs/339-ScriptableRenderPipelinePrivate/tree/7.x.x%252Fplatforms

---
### Comments to reviewers
Very minor updates that shouldn't have any effect on other targets.
