### PR TITLE
Fixes about alpha clipping, plus preview mode when PT is on.

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -412,6 +412,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue with MipRatio debug mode showing _DebugMatCapTexture not being set.
 - Fixed missing initialization of input params in Blit for VR.
 - Fix Inf source in LTC for area lights.
+- Fixed alpha clipping test (comparison was '>', now '>=')
+- Fixed preview camera (eg. shader graph preview) when path tracing is on
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl
@@ -123,7 +123,7 @@ void DoAlphaTest(float alpha, float alphaCutoff)
 // This function is the alternative version used for ray tracing
 void DoAlphaTest(float alpha, float alphaCutoff, out bool alphaTestResult)
 {
-    alphaTestResult = alpha > alphaCutoff;
+    alphaTestResult = alpha >= alphaCutoff;
 }
 //-----------------------------------------------------------------------------
 // LoD Fade

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -2026,7 +2026,8 @@ namespace UnityEngine.Rendering.HighDefinition
                 RenderDebugViewMaterial(cullingResults, hdCamera, renderContext, cmd);
             }
             else if (hdCamera.frameSettings.IsEnabled(FrameSettingsField.RayTracing) &&
-                     hdCamera.volumeStack.GetComponent<PathTracing>().enable.value)
+                     hdCamera.volumeStack.GetComponent<PathTracing>().enable.value &&
+                     hdCamera.camera.cameraType != CameraType.Preview)
             {
                 // Update the light clusters that we need to update
                 BuildRayTracingLightCluster(cmd, hdCamera);
@@ -3957,7 +3958,7 @@ namespace UnityEngine.Rendering.HighDefinition
             CoreUtils.SetKeyword(cmd, "DEBUG_DISPLAY", debugDisplayEnabledOrSceneLightingDisabled);
 
             // Setting this all the time due to a strange bug that either reports a (globally) bound texture as not bound or where SetGlobalTexture doesn't behave as expected.
-            // As a workaround we bind it regardless of debug display. Eventually with 
+            // As a workaround we bind it regardless of debug display. Eventually with
             cmd.SetGlobalTexture(HDShaderIDs._DebugMatCapTexture, defaultResources.textures.matcapTex);
 
             if (debugDisplayEnabledOrSceneLightingDisabled ||

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl
@@ -32,14 +32,14 @@
 
 #if defined(SHADER_STAGE_RAY_TRACING)
 // FXC Supports the naïve "recursive" concatenation, while DXC and C do not https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
-// However, FXC does not support the proper pattern (the one bellow), so we only override it in the case of ray tracing subshaders for the moment. 
+// However, FXC does not support the proper pattern (the one bellow), so we only override it in the case of ray tracing subshaders for the moment.
 // Note that this should be used for all shaders when DX12 used DXC for vert/frag shaders (which it does not for the moment)
 #undef MERGE_NAME
 #define MERGE_NAME_CONCAT(Name, ...) Name ## __VA_ARGS__
 #define MERGE_NAME(X, Y) MERGE_NAME_CONCAT(X, Y)
 
 #define RAY_TRACING_OPTIONAL_PARAMETERS , IntersectionVertex intersectionVertex, RayCone rayCone, out bool alphaTestResult
-#define GENERIC_ALPHA_TEST(alphaValue, alphaCutoffValue) DoAlphaTest(alphaValue, alphaCutoffValue, alphaTestResult); if (!alphaTestResult) {alphaTestResult = false; return;}
+#define GENERIC_ALPHA_TEST(alphaValue, alphaCutoffValue) DoAlphaTest(alphaValue, alphaCutoffValue, alphaTestResult); if (!alphaTestResult) { return; }
 #define RAY_TRACING_OPTIONAL_ALPHA_TEST_PASS alphaTestResult = true;
 #else
 #define RAY_TRACING_OPTIONAL_PARAMETERS


### PR DESCRIPTION
* Fixed alpha clipping test (comparison was '>', now '>=')
* Removed unnecessary assignment in alpha test macro
* Fixed preview camera (eg. shader graph preview) when path tracing is on
