### PR TITLE
Make public and document HDCamera.SetupGlobalParams

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added path tracing support for refraction and internal reflections.
 - Added support for Thin Refraction Model and Lit's Clear Coat in Path Tracing.
 - Added the Tint parameter to Sky Colored Fog.
+- Exposed `HDCamera.SetupGlobalParams`, enabling custom passes to set up global shader uniforms.
 
 ### Fixed
 - Update documentation of HDRISky-Backplate, precise how to have Ambient Occlusion on the Backplate
@@ -418,7 +419,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed shader graph and ray tracing after the shader target PR.
 - Fixed a bug in semi-transparent shadows (object further than the light casting shadows)
 - Fix state enabled of default volume profile when in package.
-- Fixed removal of MeshRenderer and MeshFilter on adding Light component. 
+- Fixed removal of MeshRenderer and MeshFilter on adding Light component.
 - Fixed Ray Traced SubSurface Scattering not working with ray traced area lights
 - Fixed Ray Traced SubSurface Scattering not working in forward mode.
 - Fixed a bug in debug light volumes.

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -549,8 +549,13 @@ namespace UnityEngine.Rendering.HighDefinition
             s_Cleanup.Clear();
         }
 
-        // Set up UnityPerView CBuffer.
-        internal void SetupGlobalParams(CommandBuffer cmd, int frameCount)
+        /// <summary>
+        /// Schedule the setup of Camera specific global shader variables. This function sets up view, projection and clipping planes global shader variables.
+        /// Additionally, if stereoSetup is set to true, and single-pass stereo is enabled, stereo-specific shader variables and state are configured.
+        /// </summary>
+        /// <param name="cmd">The CommandBuffer to schedule these commands on.</param>
+        /// <param name="frameCount"></param>
+        public void SetupGlobalParams(CommandBuffer cmd, int frameCount)
         {
             bool taaEnabled = frameSettings.IsEnabled(FrameSettingsField.Postprocess)
                 && antialiasing == AntialiasingMode.TemporalAntialiasing


### PR DESCRIPTION
### Purpose of this PR

Expose the `HDCamera.SetupGlobalParams` method. This is necessary for custom passes that modify the camera frustum or viewport.

### Testing status

**Manual Tests**: Tested with the `com.unity.picking` package.

### Comments to reviewers

I could use some help documenting the `frameCount` parameter, as well as validation that my description of the function is correct and complete.