### PR TITLE
Reverted QualitySettings change in xr.

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
@@ -423,6 +423,12 @@ namespace UnityEngine.Rendering.Universal
                 msaaSampleCountHasChanged = true;
             }
 
+            // There's no exposed API to control how a backbuffer is created with MSAA
+            // By settings antiAliasing we match what the amount of samples in camera data with backbuffer
+            // We only do this for the main camera and this only takes effect in the beginning of next frame.
+            // This settings should not be changed on a frame basis so that's fine.
+            QualitySettings.antiAliasing = msaaSamples;
+
             if (stereo && msaaSampleCountHasChanged)
                 XR.XRDevice.UpdateEyeTextureMSAASetting();
 #endif


### PR DESCRIPTION
### Purpose of this PR
 Reverted change that caused regression in XR.
 Regression was introduced in this PR: #6093, the impact of this revert is that although it will fix the regression in XR, the following issue will not be fixed for XR: [case 1195272](https://issuetracker.unity3d.com/issues/lwrp-the-anti-alias-quality-settings-value-is-changing-without-user-interaction)

I have another PR to properly expose MSAA settings to SRP land. This might fix all paths. 

---
### Testing status
**Manual Tests**: Fix already validated and identified by @DennisDeRykeUnity while testing a backport PR to 7.x.x. 

---
### Comments to reviewers
 It's not known at this time why XR needs the QualitySettings change even though it updates the Eye texture MSAA settings just after the QualitySettings call. 

 For XR team, you could validate if the issue is only reproduced in 2019.3, then this PR would not be necessary.
