### PR TITLE
[9.x.x] Fix DepthTexture precision, macros in Core.hlsl and make URP shaders use DeclareDepthTexture.hlsl when sampling depth

### DIFF
--- a/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl
@@ -14,13 +14,13 @@
 #endif
 #endif
 
-// Shader Quality Tiers in Universal. 
+// Shader Quality Tiers in Universal.
 // SRP doesn't use Graphics Settings Quality Tiers.
 // We should expose shader quality tiers in the pipeline asset.
 // Meanwhile, it's forced to be:
 // High Quality: Non-mobile platforms or shader explicit defined SHADER_HINT_NICE_QUALITY
 // Medium: Mobile aside from GLES2
-// Low: GLES2 
+// Low: GLES2
 #if SHADER_HINT_NICE_QUALITY
 #define SHADER_QUALITY_HIGH
 #elif defined(SHADER_API_GLES)
@@ -54,11 +54,11 @@ VertexPositionInputs GetVertexPositionInputs(float3 positionOS)
     input.positionWS = TransformObjectToWorld(positionOS);
     input.positionVS = TransformWorldToView(input.positionWS);
     input.positionCS = TransformWorldToHClip(input.positionWS);
-    
+
     float4 ndc = input.positionCS * 0.5f;
     input.positionNDC.xy = float2(ndc.x, ndc.y * _ProjectionParams.x) + ndc.w;
     input.positionNDC.zw = input.positionCS.zw;
-        
+
     return input;
 }
 
@@ -124,12 +124,12 @@ half OutputAlpha(half outputAlpha)
 
 // A word on normalization of normals:
 // For better quality normals should be normalized before and after
-// interpolation. 
-// 1) In vertex, skinning or blend shapes might vary significantly the lenght of normal. 
+// interpolation.
+// 1) In vertex, skinning or blend shapes might vary significantly the lenght of normal.
 // 2) In fragment, because even outputting unit-length normals interpolation can make it non-unit.
-// 3) In fragment when using normal map, because mikktspace sets up non orthonormal basis. 
-// However we will try to balance performance vs quality here as also let users configure that as 
-// shader quality tiers. 
+// 3) In fragment when using normal map, because mikktspace sets up non orthonormal basis.
+// However we will try to balance performance vs quality here as also let users configure that as
+// shader quality tiers.
 // Low Quality Tier: Normalize either per-vertex or per-pixel depending if normalmap is sampled.
 // Medium Quality Tier: Always normalize per-vertex. Normalize per-pixel only if using normal map
 // High Quality Tier: Normalize in both vertex and pixel shaders.
@@ -143,7 +143,7 @@ real3 NormalizeNormalPerVertex(real3 normalWS)
 }
 
 real3 NormalizeNormalPerPixel(real3 normalWS)
-{ 
+{
 #if defined(SHADER_QUALITY_HIGH) || defined(_NORMALMAP)
     return normalize(normalWS);
 #else
@@ -215,14 +215,14 @@ half3 MixFog(real3 fragColor, real fogFactor)
 
     #define SLICE_ARRAY_INDEX   unity_StereoEyeIndex
 
-    #define TEXTURE2D_X                 TEXTURE2D_ARRAY
-    #define TEXTURE2D_X_PARAM           TEXTURE2D_ARRAY_PARAM
-    #define TEXTURE2D_X_ARGS            TEXTURE2D_ARRAY_ARGS
-    #define TEXTURE2D_X_HALF            TEXTURE2D_ARRAY_HALF
-    #define TEXTURE2D_X_FLOAT           TEXTURE2D_ARRAY_FLOAT
+    #define TEXTURE2D_X(textureName)                                        TEXTURE2D_ARRAY(textureName)
+    #define TEXTURE2D_X_PARAM(textureName, samplerName)                     TEXTURE2D_ARRAY_PARAM(textureName, samplerName)
+    #define TEXTURE2D_X_ARGS(textureName, samplerName)                      TEXTURE2D_ARRAY_ARGS(textureName, samplerName)
+    #define TEXTURE2D_X_HALF(textureName)                                   TEXTURE2D_ARRAY_HALF(textureName)
+    #define TEXTURE2D_X_FLOAT(textureName)                                  TEXTURE2D_ARRAY_FLOAT(textureName)
 
     #define LOAD_TEXTURE2D_X(textureName, unCoord2)                         LOAD_TEXTURE2D_ARRAY(textureName, unCoord2, SLICE_ARRAY_INDEX)
-    #define LOAD_TEXTURE2D_X_LOD(textureName, unCoord2, lod)                LOAD_TEXTURE2D_ARRAY_LOD(textureName, unCoord2, SLICE_ARRAY_INDEX, lod)    
+    #define LOAD_TEXTURE2D_X_LOD(textureName, unCoord2, lod)                LOAD_TEXTURE2D_ARRAY_LOD(textureName, unCoord2, SLICE_ARRAY_INDEX, lod)
     #define SAMPLE_TEXTURE2D_X(textureName, samplerName, coord2)            SAMPLE_TEXTURE2D_ARRAY(textureName, samplerName, coord2, SLICE_ARRAY_INDEX)
     #define SAMPLE_TEXTURE2D_X_LOD(textureName, samplerName, coord2, lod)   SAMPLE_TEXTURE2D_ARRAY_LOD(textureName, samplerName, coord2, SLICE_ARRAY_INDEX, lod)
     #define GATHER_TEXTURE2D_X(textureName, samplerName, coord2)            GATHER_TEXTURE2D_ARRAY(textureName, samplerName, coord2, SLICE_ARRAY_INDEX)
@@ -233,21 +233,21 @@ half3 MixFog(real3 fragColor, real fogFactor)
 #else
 
     #define SLICE_ARRAY_INDEX       0
+    
+    #define TEXTURE2D_X(textureName)                                        TEXTURE2D(textureName)
+    #define TEXTURE2D_X_PARAM(textureName, samplerName)                     TEXTURE2D_PARAM(textureName, samplerName)
+    #define TEXTURE2D_X_ARGS(textureName, samplerName)                      TEXTURE2D_ARGS(textureName, samplerName)
+    #define TEXTURE2D_X_HALF(textureName)                                   TEXTURE2D_HALF(textureName)
+    #define TEXTURE2D_X_FLOAT(textureName)                                  TEXTURE2D_FLOAT(textureName)
 
-    #define TEXTURE2D_X                 TEXTURE2D
-    #define TEXTURE2D_X_PARAM           TEXTURE2D_PARAM
-    #define TEXTURE2D_X_ARGS            TEXTURE2D_ARGS
-    #define TEXTURE2D_X_HALF            TEXTURE2D_HALF
-    #define TEXTURE2D_X_FLOAT           TEXTURE2D_FLOAT
-
-    #define LOAD_TEXTURE2D_X            LOAD_TEXTURE2D
-    #define LOAD_TEXTURE2D_X_LOD        LOAD_TEXTURE2D_LOD
-    #define SAMPLE_TEXTURE2D_X          SAMPLE_TEXTURE2D
-    #define SAMPLE_TEXTURE2D_X_LOD      SAMPLE_TEXTURE2D_LOD
-    #define GATHER_TEXTURE2D_X          GATHER_TEXTURE2D
-    #define GATHER_RED_TEXTURE2D_X      GATHER_RED_TEXTURE2D
-    #define GATHER_GREEN_TEXTURE2D_X    GATHER_GREEN_TEXTURE2D
-    #define GATHER_BLUE_TEXTURE2D_X     GATHER_BLUE_TEXTURE2D
+    #define LOAD_TEXTURE2D_X(textureName, unCoord2)                         LOAD_TEXTURE2D(textureName, unCoord2)
+    #define LOAD_TEXTURE2D_X_LOD(textureName, unCoord2, lod)                LOAD_TEXTURE2D_LOD(textureName, unCoord2, lod)
+    #define SAMPLE_TEXTURE2D_X(textureName, samplerName, coord2)            SAMPLE_TEXTURE2D(textureName, samplerName, coord2)
+    #define SAMPLE_TEXTURE2D_X_LOD(textureName, samplerName, coord2, lod)   SAMPLE_TEXTURE2D_LOD(textureName, samplerName, coord2, lod)
+    #define GATHER_TEXTURE2D_X(textureName, samplerName, coord2)            GATHER_TEXTURE2D(textureName, samplerName, coord2)
+    #define GATHER_RED_TEXTURE2D_X(textureName, samplerName, coord2)        GATHER_RED_TEXTURE2D(textureName, samplerName, coord2)
+    #define GATHER_GREEN_TEXTURE2D_X(textureName, samplerName, coord2)      GATHER_GREEN_TEXTURE2D(textureName, samplerName, coord2)
+    #define GATHER_BLUE_TEXTURE2D_X(textureName, samplerName, coord2)       GATHER_BLUE_TEXTURE2D(textureName, samplerName, coord2)
 
 #endif
 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl
@@ -2,7 +2,7 @@
 #define UNITY_DECLARE_DEPTH_TEXTURE_INCLUDED
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
-TEXTURE2D_X(_CameraDepthTexture);
+TEXTURE2D_X_FLOAT(_CameraDepthTexture);
 SAMPLER(sampler_CameraDepthTexture);
 
 float SampleSceneDepth(float2 uv)

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl
@@ -4,9 +4,8 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl"
-
-TEXTURE2D_X(_CameraDepthTexture); SAMPLER(sampler_CameraDepthTexture);
-TEXTURE2D_X(_CameraOpaqueTexture); SAMPLER(sampler_CameraOpaqueTexture);
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareOpaqueTexture.hlsl"
 
 // Pre-multiplied alpha helper
 #if defined(_ALPHAPREMULTIPLY_ON)

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/BokehDepthOfField.shader
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/BokehDepthOfField.shader
@@ -11,6 +11,7 @@ Shader "Hidden/Universal Render Pipeline/BokehDepthOfField"
         #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 
         // Do not change this without changing PostProcessPass.PrepareBokehKernel()
         #define SAMPLE_COUNT            42
@@ -22,8 +23,6 @@ Shader "Hidden/Universal Render Pipeline/BokehDepthOfField"
         TEXTURE2D_X(_MainTex);
         TEXTURE2D_X(_DofTexture);
         TEXTURE2D_X(_FullCoCTexture);
-
-        TEXTURE2D_X_FLOAT(_CameraDepthTexture);
 
         float4 _MainTex_TexelSize;
         float4 _DofTexture_TexelSize;
@@ -293,7 +292,7 @@ Shader "Hidden/Universal Render Pipeline/BokehDepthOfField"
             ENDHLSL
         }
     }
-        
+
     // SM3.5 fallbacks - needed because of the use of Gather
     SubShader
     {

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/CameraMotionBlur.shader
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/CameraMotionBlur.shader
@@ -11,9 +11,9 @@ Shader "Hidden/Universal Render Pipeline/CameraMotionBlur"
         #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Random.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 
         TEXTURE2D_X(_MainTex);
-        TEXTURE2D_X_FLOAT(_CameraDepthTexture);
 
         float4x4 _ViewProjM;
         float4x4 _PrevViewProjM;

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/GaussianDepthOfField.shader
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/GaussianDepthOfField.shader
@@ -14,13 +14,12 @@ Shader "Hidden/Universal Render Pipeline/GaussianDepthOfField"
         #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Filtering.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 
         TEXTURE2D_X(_MainTex);
         TEXTURE2D_X(_ColorTexture);
         TEXTURE2D_X(_FullCoCTexture);
         TEXTURE2D_X(_HalfCoCTexture);
-
-        TEXTURE2D_X_FLOAT(_CameraDepthTexture);
 
         float4 _MainTex_TexelSize;
         float4 _ColorTexture_TexelSize;
@@ -73,7 +72,7 @@ Shader "Hidden/Universal Render Pipeline/GaussianDepthOfField"
         {
             UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
             float2 uv = UnityStereoTransformScreenSpaceTex(input.uv);
-	    
+
             float depth = LOAD_TEXTURE2D_X(_CameraDepthTexture, _MainTex_TexelSize.zw * uv).x;
             depth = LinearEyeDepth(depth, _ZBufferParams);
             half coc = (depth - FarStart) / (FarEnd - FarStart);

--- a/com.unity.render-pipelines.universal/Shaders/Utils/ScreenSpaceShadows.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/ScreenSpaceShadows.shader
@@ -18,13 +18,7 @@ Shader "Hidden/Universal Render Pipeline/ScreenSpaceShadows"
         #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
         #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
-
-#if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
-        TEXTURE2D_ARRAY_FLOAT(_CameraDepthTexture);
-#else
-        TEXTURE2D_FLOAT(_CameraDepthTexture);
-#endif
-        SAMPLER(sampler_CameraDepthTexture);
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 
         struct Attributes
         {


### PR DESCRIPTION
### Purpose of this PR
In this PR I'm doing three things:

1. Making sure we have high precision on our depth texture in DeclareDepthTexture.hlsl
2. Adding parameters to our "TEXTURE_X" macros in Core.hlsl  
3. Making sure URP shaders are including DeclareDepthTexture.hlsl instead of declaring the depth texture themselves.

---

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---

### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/universal%252Fshader-fix-depth-and-macros
