### PR TITLE
Bitangent computation in pixel shader [Don't Merge]

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl
@@ -177,8 +177,16 @@ real3 UnpackNormalAG(real4 packedNormal, real scale = 1.0)
 {
     real3 normal;
     normal.xy = packedNormal.ag * 2.0 - 1.0;
-    normal.xy *= scale;
     normal.z = sqrt(1.0 - saturate(dot(normal.xy, normal.xy)));
+
+	// must scale after reconstruction of normal.z which also
+	// mirrors UnpackNormalRGB(). This does imply normal is not returned
+	// as a unit length vector but doesn't need it since it will get normalized after TBN transformation.
+	// If we ever need to blend contributions with built-in shaders for URP
+	// then we should consider using UnpackDerivativeNormalAG() instead like
+	// HDRP does since derivatives do not use renormalization and unlike tangent space
+	// normals allow you to blend, accumulate and scale contributions correctly.
+	normal.xy *= scale;
     return normal;
 }
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
@@ -146,6 +146,9 @@ real3 TransformTangentToWorld(real3 dirTS, real3x3 tangentToWorld)
     return mul(dirTS, tangentToWorld);
 }
 
+// This function does the exact inverse of TransformTangentToWorld() and is
+// also decribed within comments in mikktspace.h and it follows implicitly
+// from the scalar triple product (google it).
 real3 TransformWorldToTangent(real3 dirWS, real3x3 tangentToWorld)
 {
     // Note matrix is in row major convention with left multiplication as it is build on the fly
@@ -162,10 +165,10 @@ real3 TransformWorldToTangent(real3 dirWS, real3x3 tangentToWorld)
 	float sgn = determinant<0.0 ? (-1.0) : 1.0;
 
 	// inverse transposed but scaled by determinant
+	// Will remove transpose part by using matrix as the first arg in the mul() below
+	// this makes it the exact inverse of what TransformTangentToWorld() does.
 	real3x3 matTBN_I_T = real3x3(col0, col1, col2);
 
-	// remove transpose part by using matrix as the first arg in mul()
-	// this makes it the exact inverse of what TransformTangentToWorld() does.
 	return SafeNormalize( sgn * mul(matTBN_I_T, dirWS) );
 }
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
@@ -179,7 +179,12 @@ real3 TransformTangentToObject(real3 dirTS, real3x3 tangentToWorld)
 real3 TransformObjectToTangent(real3 dirOS, real3x3 tangentToWorld)
 {
     // Note matrix is in row major convention with left multiplication as it is build on the fly
-	float3 normalWS = TransformObjectToWorldNormal(dirOS);
+
+	// corresponds to TransformObjectToWorldNormal(dirOS) but without the SafeNormalize() since 
+	// this is done at the end in TransformWorldToTangent().
+	float3 normalWS = mul(dirOS, (float3x3)GetWorldToObjectMatrix());
+
+	// transform from world to tangent
 	return TransformWorldToTangent(normalWS, tangentToWorld);
 }
 

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -96,7 +96,7 @@ Varyings LitPassVertex(Attributes input)
 
     output.uv = TRANSFORM_TEX(input.texcoord, _BaseMap);
 
-	output.normalWS = NormalizeNormalPerVertex(normalInput.normalWS);
+	output.normalWS = normalInput.normalWS;	// already normalized from normal transform to WS.
     output.viewDirWS = viewDirWS;
 #ifdef _NORMALMAP
 	real sign = input.tangentOS.w * GetOddNegativeScale();


### PR DESCRIPTION
### Purpose of this PR
 This PR changes bitangent generation for all URP stock shaders to be `per-fragment` and consistent between HDRP and ShaderGraph. This way developers will have a unified normal map generation workflows for all the new render pipelines.

Before:
`bi-tangent when computing normal maps per-pixel`
![image (1)](https://user-images.githubusercontent.com/7453395/76766010-9f62db00-6797-11ea-9828-ec49d4106c31.png)

Now:
`bi-tangent when computing normal maps per-pixel`
![image (2)](https://user-images.githubusercontent.com/7453395/76766001-9c67ea80-6797-11ea-8e5a-6cce8bf3bd4a.png)

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
 We need to evaluate performance impact on low end platforms.
