### PR TITLE
HDRP/alpha to mask

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeMasterNode.cs
@@ -229,6 +229,21 @@ namespace UnityEditor.Rendering.HighDefinition
                 Dirty(ModificationScope.Topological);
             }
         }
+        
+        [SerializeField]
+        bool m_AlphaToMask = false;
+
+        public ToggleData alphaToMask
+        {
+            get { return new ToggleData(m_AlphaToMask); }
+            set
+            {
+                if (m_AlphaToMask == value.isOn)
+                    return;
+                m_AlphaToMask = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
 
         [SerializeField]
         bool m_AlphaTestDepthPrepass;
@@ -717,6 +732,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 // Misc
                 new ConditionalField(Fields.AlphaTest,                              alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId)),
+                new ConditionalField(Fields.AlphaToMask,                            alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId) && alphaToMask.isOn),
                 new ConditionalField(HDFields.AlphaFog,                             surfaceType != SurfaceType.Opaque && transparencyFog.isOn),
                 new ConditionalField(HDFields.BlendPreserveSpecular,                surfaceType != SurfaceType.Opaque && blendPreserveSpecular.isOn),
                 new ConditionalField(HDFields.DisableDecals,                        !receiveDecals.isOn),
@@ -853,6 +869,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 surfaceType,
                 HDSubShaderUtilities.ConvertAlphaModeToBlendMode(alphaMode),
                 sortPriority,
+                alphaToMask.isOn,
                 zWrite.isOn,
                 transparentCullMode,
                 zTest,

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyeSettingsView.cs
@@ -116,26 +116,38 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
                 });
             });
 
-            if (m_Node.surfaceType == SurfaceType.Transparent && m_Node.alphaTest.isOn)
+            if (m_Node.alphaTest.isOn)
             {
                 ++indentLevel;
-                ps.Add(new PropertyRow(CreateLabel("Alpha Cutoff Depth Prepass", indentLevel)), (row) =>
+                ps.Add(new PropertyRow(CreateLabel("Alpha to Mask", indentLevel)), (row) =>
                 {
                     row.Add(new Toggle(), (toggle) =>
                     {
-                        toggle.value = m_Node.alphaTestDepthPrepass.isOn;
-                        toggle.OnToggleChanged(ChangeAlphaTestPrepass);
+                        toggle.value = m_Node.alphaToMask.isOn;
+                        toggle.OnToggleChanged(ChangeAlphaToMask);
                     });
                 });
+                
+                if (m_Node.surfaceType == SurfaceType.Transparent)
+                {
+                    ps.Add(new PropertyRow(CreateLabel("Alpha Cutoff Depth Prepass", indentLevel)), (row) =>
+                    {
+                        row.Add(new Toggle(), (toggle) =>
+                        {
+                            toggle.value = m_Node.alphaTestDepthPrepass.isOn;
+                            toggle.OnToggleChanged(ChangeAlphaTestPrepass);
+                        });
+                    });
 
-                ps.Add(new PropertyRow(CreateLabel("Alpha Cutoff Depth Postpass", indentLevel)), (row) =>
-                {
-                    row.Add(new Toggle(), (toggle) =>
+                    ps.Add(new PropertyRow(CreateLabel("Alpha Cutoff Depth Postpass", indentLevel)), (row) =>
                     {
-                        toggle.value = m_Node.alphaTestDepthPostpass.isOn;
-                        toggle.OnToggleChanged(ChangeAlphaTestPostpass);
+                        row.Add(new Toggle(), (toggle) =>
+                        {
+                            toggle.value = m_Node.alphaTestDepthPostpass.isOn;
+                            toggle.OnToggleChanged(ChangeAlphaTestPostpass);
+                        });
                     });
-                });
+                }
                 --indentLevel;
             }
 
@@ -324,6 +336,14 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
             ToggleData td = m_Node.alphaTest;
             td.isOn = evt.newValue;
             m_Node.alphaTest = td;
+        }
+        
+        void ChangeAlphaToMask(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Alpha to Mask Change");
+            ToggleData td = m_Node.alphaToMask;
+            td.isOn = evt.newValue;
+            m_Node.alphaToMask = td;
         }
 
         void ChangeAlphaTestPrepass(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricMasterNode.cs
@@ -234,6 +234,21 @@ namespace UnityEditor.Rendering.HighDefinition
                 Dirty(ModificationScope.Topological);
             }
         }
+        
+        [SerializeField]
+        bool m_AlphaToMask = false;
+
+        public ToggleData alphaToMask
+        {
+            get { return new ToggleData(m_AlphaToMask); }
+            set
+            {
+                if (m_AlphaToMask == value.isOn)
+                    return;
+                m_AlphaToMask = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
 
         [SerializeField]
         int m_SortPriority;
@@ -728,6 +743,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 // Misc
                 new ConditionalField(Fields.AlphaTest,                              alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId)),
+                new ConditionalField(Fields.AlphaToMask,                            alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId) && alphaToMask.isOn),
                 new ConditionalField(HDFields.AlphaFog,                             surfaceType != SurfaceType.Opaque && transparencyFog.isOn),
                 new ConditionalField(HDFields.BlendPreserveSpecular,                surfaceType != SurfaceType.Opaque && blendPreserveSpecular.isOn),
                 new ConditionalField(HDFields.DisableDecals,                        !receiveDecals.isOn),
@@ -868,6 +884,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 surfaceType,
                 HDSubShaderUtilities.ConvertAlphaModeToBlendMode(alphaMode),
                 sortPriority,
+                alphaToMask.isOn,
                 zWrite.isOn,
                 transparentCullMode,
                 zTest,

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricSettingsView.cs
@@ -116,6 +116,20 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
                 });
             });
 
+            if (m_Node.alphaTest.isOn)
+            {
+                ++indentLevel;
+                ps.Add(new PropertyRow(CreateLabel("Alpha to Mask", indentLevel)), (row) =>
+                {
+                    row.Add(new Toggle(), (toggle) =>
+                    {
+                        toggle.value = m_Node.alphaToMask.isOn;
+                        toggle.OnToggleChanged(ChangeAlphaToMask);
+                    });
+                });
+                --indentLevel;
+            }
+
             ps.Add(new PropertyRow(CreateLabel("Double-Sided", indentLevel)), (row) =>
             {
                 row.Add(new EnumField(DoubleSidedMode.Disabled), (field) =>
@@ -326,6 +340,14 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
             ToggleData td = m_Node.alphaTest;
             td.isOn = evt.newValue;
             m_Node.alphaTest = td;
+        }
+
+        void ChangeAlphaToMask(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Alpha to Mask Change");
+            ToggleData td = m_Node.alphaToMask;
+            td.isOn = evt.newValue;
+            m_Node.alphaToMask = td;
         }
 
         void ChangeDecal(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairMasterNode.cs
@@ -259,6 +259,21 @@ namespace UnityEditor.Rendering.HighDefinition
                 Dirty(ModificationScope.Topological);
             }
         }
+        
+        [SerializeField]
+        bool m_AlphaToMask = false;
+
+        public ToggleData alphaToMask
+        {
+            get { return new ToggleData(m_AlphaToMask); }
+            set
+            {
+                if (m_AlphaToMask == value.isOn)
+                    return;
+                m_AlphaToMask = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
 
         [SerializeField]
         bool m_AlphaTestDepthPrepass;
@@ -836,6 +851,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 // Misc
                 new ConditionalField(Fields.AlphaTest,                              alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId)),
+                new ConditionalField(Fields.AlphaToMask,                            alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId) && alphaToMask.isOn),
                 new ConditionalField(HDFields.AlphaTestShadow,                      alphaTest.isOn && alphaTestShadow.isOn && 
                                                                                         pass.pixelPorts.Contains(AlphaClipThresholdShadowSlotId)),
                 new ConditionalField(HDFields.AlphaTestPrepass,                     alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdDepthPrepassSlotId)),
@@ -987,6 +1003,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 surfaceType,
                 HDSubShaderUtilities.ConvertAlphaModeToBlendMode(alphaMode),
                 sortPriority,
+                alphaToMask.isOn,
                 zWrite.isOn,
                 transparentCullMode,
                 zTest,

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairSettingsView.cs
@@ -172,6 +172,15 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
                         toggle.OnToggleChanged(ChangeAlphaTestShadow);
                     });
                 });
+                
+                ps.Add(new PropertyRow(CreateLabel("Alpha to Mask", indentLevel)), (row) =>
+                {
+                    row.Add(new Toggle(), (toggle) =>
+                    {
+                        toggle.value = m_Node.alphaToMask.isOn;
+                        toggle.OnToggleChanged(ChangeAlphaToMask);
+                    });
+                });
                 --indentLevel;
             }
 
@@ -330,6 +339,14 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
             ToggleData td = m_Node.alphaTest;
             td.isOn = evt.newValue;
             m_Node.alphaTest = td;
+        }
+
+        void ChangeAlphaToMask(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Alpha to Mask Change");
+            ToggleData td = m_Node.alphaToMask;
+            td.isOn = evt.newValue;
+            m_Node.alphaToMask = td;
         }
 
         void ChangeAlphaTestPrepass(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitMasterNode.cs
@@ -786,6 +786,24 @@ namespace UnityEditor.Rendering.HighDefinition
         }
 
         [SerializeField]
+        bool m_AlphaToMask = false;
+
+        public ToggleData alphaToMask
+        {
+            get { return new ToggleData(m_AlphaToMask); }
+            set
+            {
+                if (m_AlphaToMask == value.isOn)
+                    return;
+
+                m_AlphaToMask = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+
+
+        [SerializeField]
         int m_MaterialNeedsUpdateHash = 0;
 
         int ComputeMaterialNeedsUpdateHash()
@@ -1131,6 +1149,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 // Misc
                 new ConditionalField(Fields.AlphaTest,                      alphaTest.isOn && pass.pixelPorts.Contains(AlphaThresholdSlotId)),
+                new ConditionalField(Fields.AlphaToMask,                    alphaTest.isOn && pass.pixelPorts.Contains(AlphaThresholdSlotId) && alphaToMask.isOn),
                 new ConditionalField(HDFields.AlphaTestShadow,              alphaTest.isOn && alphaTestShadow.isOn && 
                                                                                 pass.pixelPorts.Contains(AlphaThresholdShadowSlotId)),
                 new ConditionalField(HDFields.AlphaTestPrepass,             alphaTest.isOn && pass.pixelPorts.Contains(AlphaThresholdDepthPrepassSlotId)),
@@ -1289,6 +1308,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 surfaceType,
                 HDSubShaderUtilities.ConvertAlphaModeToBlendMode(alphaMode),
                 sortPriority,
+                alphaToMask.isOn,
                 zWrite.isOn,
                 transparentCullMode,
                 zTest,

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/HDLitSettingsView.cs
@@ -283,6 +283,15 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
                         toggle.OnToggleChanged(ChangeAlphaTestShadow);
                     });
                 });
+
+                ps.Add(new PropertyRow(CreateLabel("Alpha to Mask", indentLevel)), (row) =>
+                {
+                    row.Add(new Toggle(), (toggle) =>
+                    {
+                        toggle.value = m_Node.alphaToMask.isOn;
+                        toggle.OnToggleChanged(ChangeAlphaToMask);
+                    });
+                });
                 --indentLevel;
             }
 
@@ -685,6 +694,14 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
             ToggleData td = m_Node.supportLodCrossFade;
             td.isOn = evt.newValue;
             m_Node.supportLodCrossFade = td;
+        }
+
+        void ChangeAlphaToMask(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Alpha to Mask Change");
+            ToggleData td = m_Node.alphaToMask;
+            td.isOn = evt.newValue;
+            m_Node.alphaToMask = td;
         }
 
         void ChangeZWrite(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitMasterNode.cs
@@ -360,6 +360,21 @@ namespace UnityEditor.Rendering.HighDefinition
                 Dirty(ModificationScope.Topological);
             }
         }
+        
+        [SerializeField]
+        bool m_AlphaToMask = false;
+
+        public ToggleData alphaToMask
+        {
+            get { return new ToggleData(m_AlphaToMask); }
+            set
+            {
+                if (m_AlphaToMask == value.isOn)
+                    return;
+                m_AlphaToMask = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
 
         [SerializeField]
         int m_SortPriority;
@@ -1453,6 +1468,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 // Misc
                 new ConditionalField(Fields.AlphaTest,                      alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId)),
+                new ConditionalField(Fields.AlphaToMask,                    alphaTest.isOn && pass.pixelPorts.Contains(AlphaClipThresholdSlotId) && alphaToMask.isOn),
                 new ConditionalField(HDFields.AlphaFog,                     surfaceType != SurfaceType.Opaque && transparencyFog.isOn),
                 new ConditionalField(HDFields.BlendPreserveSpecular,        surfaceType != SurfaceType.Opaque && blendPreserveSpecular.isOn),
                 new ConditionalField(HDFields.EnergyConservingSpecular,     energyConservingSpecular.isOn),
@@ -1722,6 +1738,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 surfaceType,
                 HDSubShaderUtilities.ConvertAlphaModeToBlendMode(alphaMode),
                 sortPriority,
+                alphaToMask.isOn,
                 zWrite.isOn,
                 transparentCullMode,
                 zTest,

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitSettingsView.cs
@@ -159,6 +159,20 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
                 });
             });
 
+            if (m_Node.alphaTest.isOn)
+            {
+                ++indentLevel;
+                ps.Add(new PropertyRow(CreateLabel("Alpha to Mask", indentLevel)), (row) =>
+                {
+                    row.Add(new Toggle(), (toggle) =>
+                    {
+                        toggle.value = m_Node.alphaToMask.isOn;
+                        toggle.OnToggleChanged(ChangeAlphaToMask);
+                    });
+                });
+                --indentLevel;
+            }
+
             ps.Add(new PropertyRow(CreateLabel("Double-Sided", indentLevel)), (row) =>
             {
                 row.Add(new EnumField(DoubleSidedMode.Disabled), (field) =>
@@ -698,6 +712,14 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
             ToggleData td = m_Node.alphaTest;
             td.isOn = evt.newValue;
             m_Node.alphaTest = td;
+        }
+
+        void ChangeAlphaToMask(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Alpha to Mask Change");
+            ToggleData td = m_Node.alphaToMask;
+            td.isOn = evt.newValue;
+            m_Node.alphaToMask = td;
         }
 
         void ChangeReceiveDecals(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/UIBlocks/SurfaceOptionUIBlock.cs
@@ -25,7 +25,8 @@ namespace UnityEditor.Rendering.HighDefinition
             BackThenFrontRendering      = 1 << 7,
             ReceiveSSR                  = 1 << 8,
             ShowAfterPostProcessPass    = 1 << 9,
-            Unlit                       = Surface | BlendMode | DoubleSided | DoubleSidedNormalMode | AlphaCutoff | AlphaCutoffShadowThreshold | AlphaCutoffThreshold | BackThenFrontRendering | ShowAfterPostProcessPass,
+            AlphaToMask                 = 1 << 10,
+            Unlit                       = Surface | BlendMode | DoubleSided | DoubleSidedNormalMode | AlphaCutoff | AlphaCutoffShadowThreshold | AlphaCutoffThreshold | BackThenFrontRendering | ShowAfterPostProcessPass | AlphaToMask,
             Lit                         = All,
             All                         = ~0,
         }
@@ -52,6 +53,7 @@ namespace UnityEditor.Rendering.HighDefinition
             public static GUIContent alphaCutoffShadowText = new GUIContent("Shadow Threshold", "Controls the threshold for shadow pass alpha clipping.");
             public static GUIContent alphaCutoffPrepassText = new GUIContent("Prepass Threshold", "Controls the threshold for transparent depth prepass alpha clipping.");
             public static GUIContent alphaCutoffPostpassText = new GUIContent("Postpass Threshold", "Controls the threshold for transparent depth postpass alpha clipping.");
+            public static GUIContent alphaToMaskText = new GUIContent("Alpha To Mask", "When enabled, HDRP processes Alpha To Mask for this Material.");
             public static GUIContent transparentDepthPostpassEnableText = new GUIContent("Transparent Depth Postpass", "When enabled, HDRP renders a depth postpass for transparent objects. This improves post-processing effects like depth of field.");
             public static GUIContent transparentDepthPrepassEnableText = new GUIContent("Transparent Depth Prepass", "When enabled, HDRP renders a depth prepass for transparent GameObjects. This improves sorting.");
             public static GUIContent transparentBackfaceEnableText = new GUIContent("Back Then Front Rendering", "When enabled, HDRP renders the back face and then the front face, in two separate draw calls, to better sort transparent meshes.");
@@ -115,6 +117,8 @@ namespace UnityEditor.Rendering.HighDefinition
         const string kAlphaCutoffPrepass = "_AlphaCutoffPrepass";
         MaterialProperty alphaCutoffPostpass = null;
         const string kAlphaCutoffPostpass = "_AlphaCutoffPostpass";
+        MaterialProperty alphaToMask = null;
+        const string kAlphaToMask = "_AlphaToMask";
         MaterialProperty transparentDepthPrepassEnable = null;
         const string kTransparentDepthPrepassEnable = "_TransparentDepthPrepassEnable";
         MaterialProperty transparentDepthPostpassEnable = null;
@@ -273,6 +277,7 @@ namespace UnityEditor.Rendering.HighDefinition
             alphaCutoffShadow = FindProperty(kAlphaCutoffShadow);
             alphaCutoffPrepass = FindProperty(kAlphaCutoffPrepass);
             alphaCutoffPostpass = FindProperty(kAlphaCutoffPostpass);
+            alphaToMask = FindProperty(kAlphaToMask);
             transparentDepthPrepassEnable = FindProperty(kTransparentDepthPrepassEnable);
             transparentDepthPostpassEnable = FindProperty(kTransparentDepthPostpassEnable);
 
@@ -400,6 +405,12 @@ namespace UnityEditor.Rendering.HighDefinition
                     }
                 }
 
+                if ((m_Features & Features.AlphaToMask) != 0)
+                {
+                    if (alphaToMask != null)
+                        materialEditor.ShaderProperty(alphaToMask, Styles.alphaToMaskText);
+                }
+
                 // With transparent object and few specific materials like Hair, we need more control on the cutoff to apply
                 // This allow to get a better sorting (with prepass), better shadow (better silhouettes fidelity) etc...
                 if (surfaceTypeValue == SurfaceType.Transparent)
@@ -416,7 +427,13 @@ namespace UnityEditor.Rendering.HighDefinition
                 }
                 EditorGUI.indentLevel--;
             }
-            
+            else if ((m_Features & Features.AlphaToMask) != 0)
+            {
+                if (alphaToMask != null)
+                    alphaToMask.floatValue = 0.0f;
+            }
+
+
             // Update the renderqueue when we change the alphaTest
             if (EditorGUI.EndChangeCheck())
             {

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/BaseUnlitGUI.cs
@@ -19,6 +19,9 @@ namespace UnityEditor.Rendering.HighDefinition
             bool alphaTestEnable = material.HasProperty(kAlphaCutoffEnabled) && material.GetFloat(kAlphaCutoffEnabled) > 0.0f;
             CoreUtils.SetKeyword(material, "_ALPHATEST_ON", alphaTestEnable);
 
+            bool alphaToMaskEnable = alphaTestEnable && material.HasProperty(kAlphaToMask) && material.GetFloat(kAlphaToMask) > 0.0f;
+            CoreUtils.SetKeyword(material, "_ALPHATOMASK_ON", alphaToMaskEnable);
+
             SurfaceType surfaceType = material.GetSurfaceType();
             CoreUtils.SetKeyword(material, "_SURFACE_TYPE_TRANSPARENT", surfaceType == SurfaceType.Transparent);
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitMasterNode.cs
@@ -205,6 +205,22 @@ namespace UnityEditor.Rendering.HighDefinition
         }
 
         [SerializeField]
+        bool m_AlphaToMask = false;
+
+        public ToggleData alphaToMask
+        {
+            get { return new ToggleData(m_AlphaToMask); }
+            set
+            {
+                if (m_AlphaToMask == value.isOn)
+                    return;
+
+                m_AlphaToMask = value.isOn;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
         int m_SortPriority;
 
         public int sortPriority
@@ -415,6 +431,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 
                 // Misc
                 new ConditionalField(Fields.AlphaTest,                      alphaTest.isOn && pass.pixelPorts.Contains(AlphaThresholdSlotId)),
+                new ConditionalField(Fields.AlphaToMask,                    alphaTest.isOn && pass.pixelPorts.Contains(AlphaThresholdSlotId) && alphaToMask.isOn),
                 new ConditionalField(HDFields.AlphaFog,                     surfaceType != SurfaceType.Opaque && transparencyFog.isOn),
                 new ConditionalField(Fields.VelocityPrecomputed,            addPrecomputedVelocity.isOn),
                 new ConditionalField(HDFields.EnableShadowMatte,            enableShadowMatte.isOn),
@@ -542,6 +559,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 surfaceType,
                 HDSubShaderUtilities.ConvertAlphaModeToBlendMode(alphaMode),
                 sortPriority,
+                alphaTest.isOn,
                 zWrite.isOn,
                 transparentCullMode,
                 zTest,

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Unlit/ShaderGraph/HDUnlitSettingsView.cs
@@ -208,6 +208,20 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
                 });
             });
 
+            if (m_Node.alphaTest.isOn)
+            {
+                ++indentLevel;
+                ps.Add(new PropertyRow(CreateLabel("Alpha to Mask", indentLevel)), (row) =>
+                {
+                    row.Add(new Toggle(), (toggle) =>
+                    {
+                        toggle.value = m_Node.alphaToMask.isOn;
+                        toggle.OnToggleChanged(ChangeAlphaToMask);
+                    });
+                });
+                --indentLevel;
+            }
+
             ps.Add(new PropertyRow(CreateLabel("Add Precomputed Velocity", indentLevel)), (row) =>
             {
                 row.Add(new Toggle(), (toggle) =>
@@ -355,6 +369,14 @@ namespace UnityEditor.Rendering.HighDefinition.Drawing
             ToggleData td = m_Node.alphaTest;
             td.isOn = evt.newValue;
             m_Node.alphaTest = td;
+        }
+
+        void ChangeAlphaToMask(ChangeEvent<bool> evt)
+        {
+            m_Node.owner.owner.RegisterCompleteObjectUndo("Alpha to Mask Change");
+            ToggleData td = m_Node.alphaToMask;
+            td.isOn = evt.newValue;
+            m_Node.alphaToMask = td;
         }
 
         void ChangeAddPrecomputedVelocity(ChangeEvent<bool> evt)

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDKeywords.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDKeywords.cs
@@ -264,6 +264,15 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 definition = KeywordDefinition.ShaderFeature,
                 scope = KeywordScope.Local
             };
+
+            public static KeywordDescriptor AlphaToMask = new KeywordDescriptor()
+            {
+                displayName = "Alpha To Mask",
+                referenceName = "_ALPHATOMASK_ON",
+                type = KeywordType.Boolean,
+                definition = KeywordDefinition.ShaderFeature,
+                scope = KeywordScope.Local
+            };
         }
         public static KeywordCollection HDBase = new KeywordCollection
         {
@@ -342,7 +351,14 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             { Descriptors.AlphaTest, new FieldCondition(Fields.AlphaTest, true) },
         };
 
-        public static KeywordCollection HDDepthMotionVectors = new KeywordCollection
+        public static KeywordCollection HDDepthForwardOnly = new KeywordCollection
+        {
+            { HDBase },
+            { Descriptors.WriteMsaaDepth },
+            { Descriptors.AlphaToMask, new FieldCondition(Fields.AlphaToMask, true) },
+        };
+
+        public static KeywordCollection HDMotionVectors = new KeywordCollection
         {
             { HDBase },
             { Descriptors.WriteMsaaDepth },
@@ -364,7 +380,15 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             { Descriptors.Decals },
         };
 
-        public static KeywordCollection HDLitDepthMotionVectors = new KeywordCollection
+        public static KeywordCollection HDLitDepthOnly = new KeywordCollection
+        {
+            { HDBase },
+            { Descriptors.WriteMsaaDepth },
+            { Descriptors.WriteNormalBuffer },
+            { Descriptors.AlphaToMask, new FieldCondition(Fields.AlphaToMask, true) },
+        };
+
+        public static KeywordCollection HDLitMotionVectors = new KeywordCollection
         {
             { HDBase },
             { Descriptors.WriteMsaaDepth },
@@ -382,7 +406,14 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             { Descriptors.LightList, new FieldCondition(Fields.SurfaceOpaque, true) },
         };
 
-        public static KeywordCollection HDDepthMotionVectorsNoNormal = new KeywordCollection
+        public static KeywordCollection HDDepthNoNormal = new KeywordCollection
+        {
+            { HDBase },
+            { Descriptors.WriteMsaaDepth },
+            { Descriptors.AlphaToMask, new FieldCondition(Fields.AlphaToMask, true) },
+        };
+
+        public static KeywordCollection HDMotionVectorsNoNormal = new KeywordCollection
         {
             { HDBase },
             { Descriptors.WriteMsaaDepth },

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDPasses.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDPasses.cs
@@ -448,7 +448,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 fieldDependencies = HDFieldDependencies.Default,
                 renderStates = HDRenderStates.HDDepthForwardOnly,
                 pragmas = HDPragmas.DotsInstancedInV2Only,
-                keywords = HDKeywords.HDDepthMotionVectors,
+                keywords = HDKeywords.HDDepthForwardOnly,
                 includes = HDIncludes.UnlitDepthOnly,
 
                 // Custom Template
@@ -473,7 +473,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 fieldDependencies = HDFieldDependencies.Default,
                 renderStates = HDRenderStates.HDUnlitMotionVectors,
                 pragmas = HDPragmas.DotsInstancedInV2Only,
-                keywords = HDKeywords.HDDepthMotionVectors,
+                keywords = HDKeywords.HDMotionVectors,
                 includes = HDIncludes.UnlitMotionVectors,
 
                 // Custom Template
@@ -655,7 +655,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDDepthOnly,
                 pragmas = HDPragmas.DotsInstancedInV1AndV2,
                 defines = HDDefines.ShaderGraphRaytracingHigh,
-                keywords = HDKeywords.HDLitDepthMotionVectors,
+                keywords = HDKeywords.HDLitDepthOnly,
                 includes = HDIncludes.LitDepthOnly,
 
                 // Custom Template
@@ -681,7 +681,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDMotionVectors,
                 pragmas = HDPragmas.DotsInstancedInV1AndV2,
                 defines = HDDefines.ShaderGraphRaytracingHigh,
-                keywords = HDKeywords.HDLitDepthMotionVectors,
+                keywords = HDKeywords.HDLitMotionVectors,
                 includes = HDIncludes.LitMotionVectors,
 
                 // Custom Template
@@ -912,7 +912,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDDepthOnly,
                 pragmas = HDPragmas.InstancedRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDDepthNoNormal,
                 includes = HDIncludes.EyeDepthOnly,
 
                 // Custom Template
@@ -938,7 +938,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDMotionVectors,
                 pragmas = HDPragmas.InstancedRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDMotionVectorsNoNormal,
                 includes = HDIncludes.EyeMotionVectors,
 
                 // Custom Template
@@ -1068,7 +1068,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDDepthOnly,
                 pragmas = HDPragmas.InstancedRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDDepthNoNormal,
                 includes = HDIncludes.FabricDepthOnly,
 
                 // Custom Template
@@ -1094,7 +1094,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDMotionVectors,
                 pragmas = HDPragmas.InstancedRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDMotionVectorsNoNormal,
                 includes = HDIncludes.FabricMotionVectors,
 
                 // Custom Template
@@ -1221,10 +1221,10 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 structs = HDStructCollections.Default,
                 requiredFields = HDRequiredFields.LitFull,
                 fieldDependencies = HDFieldDependencies.Default,
-                renderStates = HDRenderStates.HairDepthOnly,
+                renderStates = HDRenderStates.HDDepthOnly,
                 pragmas = HDPragmas.InstancedRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDDepthNoNormal,
                 includes = HDIncludes.HairDepthOnly,
 
                 // Custom Template
@@ -1250,7 +1250,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HairMotionVectors,
                 pragmas = HDPragmas.InstancedRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDMotionVectorsNoNormal,
                 includes = HDIncludes.HairMotionVectors,
 
                 // Custom Template
@@ -1463,7 +1463,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDDepthOnly,
                 pragmas = HDPragmas.DotsInstancedInV2OnlyRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDDepthNoNormal,
                 includes = HDIncludes.StackLitDepthOnly,
 
                 // Custom Template
@@ -1489,7 +1489,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 renderStates = HDRenderStates.HDMotionVectors,
                 pragmas = HDPragmas.DotsInstancedInV2OnlyRenderingLayer,
                 defines = HDDefines.DepthMotionVectors,
-                keywords = HDKeywords.HDDepthMotionVectorsNoNormal,
+                keywords = HDKeywords.HDMotionVectorsNoNormal,
                 includes = HDIncludes.StackLitMotionVectors,
 
                 // Custom Template

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDRenderStates.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDRenderStates.cs
@@ -11,6 +11,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             public static readonly string dstBlend = "[_DstBlend]";
             public static readonly string alphaSrcBlend = "[_AlphaSrcBlend]";
             public static readonly string alphaDstBlend = "[_AlphaDstBlend]";
+            public static readonly string alphaToMask = "[_AlphaToMask]";
             public static readonly string cullMode = "[_CullMode]";
             public static readonly string cullModeForward = "[_CullModeForward]";
             public static readonly string zTestDepthEqualForOpaque = "[_ZTestDepthEqualForOpaque]";
@@ -138,6 +139,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             { RenderState.Cull(Uniforms.cullMode) },
             { RenderState.ZWrite(ZWrite.On) },
             { RenderState.ColorMask("ColorMask 0 0") },
+            { RenderState.AlphaToMask(Uniforms.alphaToMask), new FieldCondition(Fields.AlphaToMask, true) },
             { RenderState.Stencil(new StencilDescriptor()
             {
                 WriteMask = Uniforms.stencilWriteMaskDepth,
@@ -167,19 +169,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
         {
             { RenderState.Cull(Uniforms.cullMode) },
             { RenderState.ZWrite(ZWrite.On) },
-            { RenderState.Stencil(new StencilDescriptor()
-            {
-                WriteMask = Uniforms.stencilWriteMaskDepth,
-                Ref = Uniforms.stencilRefDepth,
-                Comp = "Always",
-                Pass = "Replace",
-            }) },
-        };
-
-        public static RenderStateCollection HairDepthOnly = new RenderStateCollection
-        {
-            { RenderState.Cull(Uniforms.cullMode) },
-            { RenderState.ZWrite(ZWrite.On) },
+            { RenderState.AlphaToMask(Uniforms.alphaToMask), new FieldCondition(Fields.AlphaToMask, true) },
             { RenderState.Stencil(new StencilDescriptor()
             {
                 WriteMask = Uniforms.stencilWriteMaskDepth,

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -97,7 +97,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
         public static void AddBlendingStatesShaderProperties(
             PropertyCollector collector, SurfaceType surface, BlendMode blend, int sortingPriority,
-            bool zWrite, TransparentCullMode transparentCullMode, CompareFunction zTest,
+            bool alphaToMask, bool zWrite, TransparentCullMode transparentCullMode, CompareFunction zTest,
             bool backThenFrontRendering, bool fogOnTransparent)
         {
             collector.AddFloatProperty("_SurfaceType", (int)surface);
@@ -108,6 +108,7 @@ namespace UnityEditor.Rendering.HighDefinition
             collector.AddFloatProperty("_DstBlend", 0.0f);
             collector.AddFloatProperty("_AlphaSrcBlend", 1.0f);
             collector.AddFloatProperty("_AlphaDstBlend", 0.0f);
+            collector.AddToggleProperty("_AlphaToMask", alphaToMask);
             collector.AddToggleProperty(kZWrite, (surface == SurfaceType.Transparent) ? zWrite : true);
             collector.AddToggleProperty(kTransparentZWrite, zWrite);
             collector.AddFloatProperty("_CullMode", (int)CullMode.Back);

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -150,6 +150,7 @@ Shader "HDRP/Lit"
         [HideInInspector] _DstBlend("__dst", Float) = 0.0
         [HideInInspector] _AlphaSrcBlend("__alphaSrc", Float) = 1.0
         [HideInInspector] _AlphaDstBlend("__alphaDst", Float) = 0.0
+        [HideInInspector][ToggleUI]_AlphaToMask("__alphaToMask", Float) = 1
         [HideInInspector][ToggleUI] _ZWrite("__zw", Float) = 1.0
         [HideInInspector][ToggleUI] _TransparentZWrite("_TransparentZWrite", Float) = 0.0
         [HideInInspector] _CullMode("__cullmode", Float) = 2.0
@@ -234,6 +235,7 @@ Shader "HDRP/Lit"
     //-------------------------------------------------------------------------------------
 
     #pragma shader_feature_local _ALPHATEST_ON
+    #pragma shader_feature_local _ALPHATOMASK_ON
     #pragma shader_feature_local _DEPTHOFFSET_ON
     #pragma shader_feature_local _DOUBLESIDED_ON
     #pragma shader_feature_local _ _VERTEX_DISPLACEMENT _PIXEL_DISPLACEMENT
@@ -506,6 +508,7 @@ Shader "HDRP/Lit"
             Tags{ "LightMode" = "DepthOnly" }
 
             Cull[_CullMode]
+            AlphaToMask [_AlphaToMask]
 
             // To be able to tag stencil with disableSSR information for forward
             Stencil

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/SharedRTManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/SharedRTManager.cs
@@ -126,8 +126,8 @@ namespace UnityEngine.Rendering.HighDefinition
             if (frameSettings.IsEnabled(FrameSettingsField.MSAA))
             {
                 Debug.Assert(m_MSAASupported);
-                m_RTIDs2[0] = m_NormalMSAART.nameID;
-                m_RTIDs2[1] = m_DepthAsColorMSAART.nameID;
+                m_RTIDs2[0] = m_DepthAsColorMSAART.nameID;
+                m_RTIDs2[1] = m_NormalMSAART.nameID;
                 return m_RTIDs2;
             }
             else

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -947,6 +947,7 @@ namespace UnityEngine.Rendering.HighDefinition
         public const string kZTestGBuffer = "_ZTestGBuffer";
         public const string kZTestDepthEqualForOpaque = "_ZTestDepthEqualForOpaque";
         public const string kBlendMode = "_BlendMode";
+        public const string kAlphaToMask = "_AlphaToMask";
         public const string kEnableFogOnTransparent = "_EnableFogOnTransparent";
         public const string kDistortionDepthTest = "_DistortionDepthTest";
         public const string kDistortionEnable = "_DistortionEnable";

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassDepthOnly.hlsl
@@ -25,14 +25,13 @@ PackedVaryingsToPS VertTesselation(VaryingsToDS input)
 #endif // TESSELLATION_ON
 
 void Frag(  PackedVaryingsToPS packedInput
-            #ifdef WRITE_NORMAL_BUFFER
-            , out float4 outNormalBuffer : SV_Target0
-                #ifdef WRITE_MSAA_DEPTH
-                , out float1 depthColor : SV_Target1
+            #ifdef WRITE_MSAA_DEPTH
+                , out float4 depthColor : SV_Target0
+                #ifdef WRITE_NORMAL_BUFFER
+                , out float4 outNormalBuffer : SV_Target1
                 #endif
-            #elif defined(WRITE_MSAA_DEPTH) // When only WRITE_MSAA_DEPTH is define and not WRITE_NORMAL_BUFFER it mean we are Unlit and only need depth, but we still have normal buffer binded
+            #elif defined(WRITE_NORMAL_BUFFER)
             , out float4 outNormalBuffer : SV_Target0
-            , out float1 depthColor : SV_Target1
             #elif defined(SCENESELECTIONPASS)
             , out float4 outColor : SV_Target0
             #endif
@@ -63,18 +62,24 @@ void Frag(  PackedVaryingsToPS packedInput
     outputDepth = posInput.deviceDepth;
 #endif
 
+#ifdef WRITE_MSAA_DEPTH
+    // In case we are rendering in MSAA, reading the an MSAA depth buffer is way too expensive. To avoid that, we export the depth to a color buffer
+    depthColor = float4(packedInput.vmesh.positionCS.z, 0, 0, 1.0);
+    //depthColor.a = saturate(depthColor.a);
+    
+#ifdef _ALPHATOMASK_ON
+    SurfaceDescriptionInputs inputs;
+    ZERO_INITIALIZE(SurfaceDescriptionInputs, inputs);
+    SurfaceDescription surface = SurfaceDescriptionFunction(inputs);
+    
+    depthColor.a = builtinData.opacity;
+    depthColor.a = saturate((depthColor.a - surface.AlphaClipThreshold) / max(fwidth(depthColor.a), 0.0001) + 0.5);
+#endif
+#endif
+
 #ifdef WRITE_NORMAL_BUFFER
     EncodeIntoNormalBuffer(ConvertSurfaceDataToNormalData(surfaceData), posInput.positionSS, outNormalBuffer);
-    #ifdef WRITE_MSAA_DEPTH
-    // In case we are rendering in MSAA, reading the an MSAA depth buffer is way too expensive. To avoid that, we export the depth to a color buffer
-    depthColor = packedInput.vmesh.positionCS.z;
-    #endif
-#elif defined(WRITE_MSAA_DEPTH) // When we are MSAA depth only without normal buffer
-    // Due to the binding order of these two render targets, we need to have them both declared
-    outNormalBuffer = float4(0.0, 0.0, 0.0, 1.0);
-    // In case we are rendering in MSAA, reading the an MSAA depth buffer is way too expensive. To avoid that, we export the depth to a color buffer
-    depthColor = packedInput.vmesh.positionCS.z;
-#elif defined(SCENESELECTIONPASS)
+#elif !defined(WRITE_MSAA_DEPTH) && defined(SCENESELECTIONPASS)
     // We use depth prepass for scene selection in the editor, this code allow to output the outline correctly
     outColor = float4(_ObjectId, _PassValue, 1.0, 1.0);
 #endif

--- a/com.unity.shadergraph/Editor/Generation/Descriptors/RenderStateDescriptor.cs
+++ b/com.unity.shadergraph/Editor/Generation/Descriptors/RenderStateDescriptor.cs
@@ -11,6 +11,7 @@
         ColorMask,
         ZClip,
         Stencil,
+        AlphaToMask,
     }
 
     [GenerationAPI]
@@ -40,6 +41,7 @@
         public static RenderStateDescriptor ZWrite(string value) => new RenderStateDescriptor { type = RenderStateType.ZWrite, value = $"ZWrite {value}" };
         public static RenderStateDescriptor ZClip(string value) => new RenderStateDescriptor { type = RenderStateType.ZClip, value = $"ZClip {value}" };
         public static RenderStateDescriptor ColorMask(string value) => new RenderStateDescriptor { type = RenderStateType.ColorMask, value = $"{value}" };
+        public static RenderStateDescriptor AlphaToMask(string value) => new RenderStateDescriptor { type = RenderStateType.AlphaToMask, value = $"AlphaToMask {value}" };
         public static RenderStateDescriptor Stencil(StencilDescriptor value) => new RenderStateDescriptor { type = RenderStateType.Stencil, value = value.ToShaderString() };
     }
 }

--- a/com.unity.shadergraph/Editor/Generation/TargetResources/Fields.cs
+++ b/com.unity.shadergraph/Editor/Generation/TargetResources/Fields.cs
@@ -29,6 +29,7 @@
         public static FieldDescriptor NormalDropOffWS =       new FieldDescriptor(string.Empty, "NormalDropOffWS", "_NORMAL_DROPOFF_WS 1");
         public static FieldDescriptor IsPreview =             new FieldDescriptor(string.Empty, "isPreview", "SHADERGRAPH_PREVIEW");
         public static FieldDescriptor LodCrossFade =          new FieldDescriptor(string.Empty, "LodCrossFade", "_LODCROSSFADE 1");
+        public static FieldDescriptor AlphaToMask =           new FieldDescriptor(string.Empty, "AlphaToMask", "_ALPHATOMASK_ON 1");
 #endregion
     }
 }


### PR DESCRIPTION
### **Please read**
**PR workflow guidelines**
* SRP ABV will start automatically when you open your PR
* Changes to docs and md files will **not** trigger ABV jobs 
* Consider making use of **draft PRs** if you are not 100% sure that your PR is ready for review
* ABV will restart if you add a new commit to a branch with an open PR (hence why you should consider using draft PRs)
* Adding [skip ci] (case insensitive) to the title of PRs will stop any jobs being trigger automatically - you will need to open Yamato and find your branch to run ABV

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
New option to enable Alpha To Mask in some shader graph master nodes (Hair, Fabric, Lit, Unlit, Eye) and in the default Lit shader. The option appears only when Alpha Clipping is enabled.

The purpose of alpha to mask (or alpha to coverage) is to be able to use MSAA on alpha clipped materials. It only works when MSAA is enabled and the camera is in forward mode.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
