### PR TITLE
[8.x.x Backport] Bugfix 1226530: Missing shadows on terrains when no cascades are selected

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -124,6 +124,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a Null ref when trying to remove a missing Renderer Feature from the Forward Renderer. [case 1196651](https://issuetracker.unity3d.com/product/unity/issues/guid/1196651/)
 - Fixed data serialization issue when adding a Renderer Feature to teh Forward Renderer. [case 1214779](https://issuetracker.unity3d.com/product/unity/issues/guid/1214779/)
 - Fixed an issue where Shaders that used Texture Arrays and FrontFace didn't compile at build time, which caused the build to fail.
+- Fixed an issue with shadows not appearing on terrains when no cascades were selected [case 1226530](https://issuetracker.unity3d.com/issues/urp-no-shadows-on-terrain-when-cascades-is-set-to-no-cascades-in-render-pipeline-asset-settings)
 
 ## [7.1.1] - 2019-09-05
 ### Upgrade Guide

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/TerrainLitPasses.hlsl
@@ -96,7 +96,7 @@ void InitializeInputData(Varyings IN, half3 normalTS, out InputData input)
     input.viewDirectionWS = viewDirWS;
 
 #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
-    input.shadowCoord = input.shadowCoord;
+    input.shadowCoord = IN.shadowCoord;
 #elif defined(MAIN_LIGHT_CALCULATE_SHADOWS)
     input.shadowCoord = TransformWorldToShadowCoord(input.positionWS);
 #else
@@ -164,7 +164,7 @@ void SplatmapMix(float4 uvMainAndLM, float4 uvSplat01, float4 uvSplat23, inout h
 
     // avoid risk of NaN when normalizing.
 #if HAS_HALF
-    nrm.z += 0.01h;     
+    nrm.z += 0.01h;
 #else
     nrm.z += 1e-5f;
 #endif
@@ -395,7 +395,7 @@ struct AttributesLean
 struct VaryingsLean
 {
     float4 clipPos      : SV_POSITION;
-#ifdef _ALPHATEST_ON		
+#ifdef _ALPHATEST_ON
     float2 texcoord     : TEXCOORD0;
 #endif
 };
@@ -418,11 +418,11 @@ VaryingsLean ShadowPassVertex(AttributesLean v)
 #endif
 
 	o.clipPos = clipPos;
-	
-#ifdef _ALPHATEST_ON		
+
+#ifdef _ALPHATEST_ON
 	o.texcoord = v.texcoord;
-#endif	
-	
+#endif
+
 	return o;
 }
 
@@ -430,7 +430,7 @@ half4 ShadowPassFragment(VaryingsLean IN) : SV_TARGET
 {
 #ifdef _ALPHATEST_ON
 	ClipHoles(IN.texcoord);
-#endif	
+#endif
     return 0;
 }
 
@@ -442,9 +442,9 @@ VaryingsLean DepthOnlyVertex(AttributesLean v)
     UNITY_SETUP_INSTANCE_ID(v);
     TerrainInstancing(v.position, v.normalOS);
     o.clipPos = TransformObjectToHClip(v.position.xyz);
-#ifdef _ALPHATEST_ON		
+#ifdef _ALPHATEST_ON
 	o.texcoord = v.texcoord;
-#endif	
+#endif
 	return o;
 }
 


### PR DESCRIPTION
### Purpose of this PR
Backport of #6261 

Fixing issue [1226530](https://issuetracker.unity3d.com/issues/urp-no-shadows-on-terrain-when-cascades-is-set-to-no-cascades-in-render-pipeline-asset-settings)

Shadows were missing on terrains when no cascades were selected. The reason was a simple typo in the terrain shader.

---

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-2019.3` label. After you backport the PR, the label changes to `backported-2019.3`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---

### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/8.x.x%252Funiversal%252Fbugfix%252F1226530-terrain-shadows/.yamato%252Fupm-ci-abv.yml%2523all_project_ci_fast-2020.1/1646887/job