### PR TITLE
Fx for Fogbugz 1214609 - HDRP Wizard addively increases the Light

### DIFF
--- a/com.unity.render-pipelines.high-definition/Documentation~/Render-Pipeline-Wizard.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Render-Pipeline-Wizard.md
@@ -102,5 +102,5 @@ When upgrading a project from the built-in render pipeline to HDRP, you need to 
 
 - **Upgrade Project Materials to High Definition Materials**: Upgrades every Material in your Unity Project to HDRP Materials.
 - **Upgrade Selected Materials to High Definition Materials**: Upgrades every Material currently selected to HDRP Materials.
-- **Upgrade Unity Builtin Scene Light Intensity for High Definition**: Upgrades each Light in the current Scene to HDRP compatible intensity values.
+- **Multiply Unity Builtin Directional Light Intensity to match High Definition**: Multiply intensity of each Directional Light in the current Scene to match HDRP compatible intensity values. Caution: This script should be executed only once.
 

--- a/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Window.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/DefaultScene/HDWizard.Window.cs
@@ -41,7 +41,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
             public const string migrateAllButton = "Upgrade Project Materials to High Definition Materials";
             public const string migrateSelectedButton = "Upgrade Selected Materials to High Definition Materials";
-            public const string migrateLights = "Upgrade Unity Builtin Scene Light Intensity for High Definition";
+            public const string migrateLights = "Multiply Unity Builtin Directional Light Intensity to match High Definition";
             public const string migrateMaterials = "Upgrade HDRP Materials to Latest Version";
 
             public const string hdrpVersionLast = "You are using High-Definition Render Pipeline lastest {0} version."; //{0} will be replaced when displayed by the version number.

--- a/com.unity.render-pipelines.high-definition/Editor/Upgraders/UpgradeStandardShaderMaterials.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Upgraders/UpgradeStandardShaderMaterials.cs
@@ -33,12 +33,13 @@ namespace UnityEditor.Rendering.HighDefinition
             MaterialUpgrader.UpgradeSelection(GetHDUpgraders(), "Upgrade to HD Material");
         }
 
-        [MenuItem("Edit/Render Pipeline/Upgrade Unity Builtin Scene Light Intensity for High Definition", priority = CoreUtils.editMenuPriority2)]
+        [MenuItem("Edit/Render Pipeline/Multiply Unity Builtin Directional Light Intensity to match High Definition", priority = CoreUtils.editMenuPriority2)]
         internal static void UpgradeLights()
         {
             Light[] lights = Light.GetLights(LightType.Directional, 0);
             foreach (var l in lights)
             {
+                Undo.RecordObject(l, "Light intensity x PI");
                 l.intensity *= Mathf.PI;
             }
         }


### PR DESCRIPTION
# Purpose of this PR
Fix for Fogbugz 1214609 - HDRP Wizard addively increases the Light intesity instead of setting it

- Rename "Upgrade Unity Builtin Scene Light Intensity for High Definition" script to "Multiply Unity Builtin Directional Light Intensity to match High Definition" to be less confusing
- Add undo support for the convert light command

Manual testing

https://fogbugz.unity3d.com/f/cases/1214609/

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in devloper mode, you have a button at end of resources that check the pathes)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
