### PR TITLE
Fix texture curve destroy (the return II)

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed copy/pasting of Volume Components when loading a new scene
 - Fix LookDev issue when adding a GameObject containing a Volume into the LookDev's view.
 - Fixed duplicated entry for com.unity.modules.xr in the runtime asmdef file
+- Fixed the texture curve being destroyed from another thread than main (case 1211754)
 
 ### Changed
 - Restored usage of ENABLE_VR to fix compilation errors on some platforms.

--- a/com.unity.render-pipelines.core/Runtime/Utilities/TextureCurve.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/TextureCurve.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.Rendering
     /// A wrapper around <c>AnimationCurve</c> to automatically bake it into a texture.
     /// </summary>
     [Serializable]
-    public class TextureCurve : IDisposable
+    public class TextureCurve
     {
         const int k_Precision = 128; // Edit LutBuilder3D if you change this value
         const float k_Step = 1f / k_Precision;
@@ -78,23 +78,9 @@ namespace UnityEngine.Rendering
         }
 
         /// <summary>
-        /// Finalizer.
+        /// Releases the internal texture resource.
         /// </summary>
-        ~TextureCurve()
-        {
-            ReleaseUnityResources();
-        }
-
-        /// <summary>
-        /// Cleans up the internal texture resource.
-        /// </summary>
-        public void Dispose()
-        {
-            ReleaseUnityResources();
-            GC.SuppressFinalize(this);
-        }
-
-        void ReleaseUnityResources()
+        public void Release()
         {
             CoreUtils.Destroy(m_Texture);
             m_Texture = null;
@@ -127,17 +113,18 @@ namespace UnityEngine.Rendering
         /// <returns>A 128x1 texture.</returns>
         public Texture2D GetTexture()
         {
+            if (m_Texture == null)
+            {
+                m_Texture = new Texture2D(k_Precision, 1, GetTextureFormat(), false, true);
+                m_Texture.name = "CurveTexture";
+                m_Texture.hideFlags = HideFlags.HideAndDontSave;
+                m_Texture.filterMode = FilterMode.Bilinear;
+                m_Texture.wrapMode = TextureWrapMode.Clamp;
+                m_IsTextureDirty = true;
+            }
+
             if (m_IsTextureDirty)
             {
-                if (m_Texture == null)
-                {
-                    m_Texture = new Texture2D(k_Precision, 1, GetTextureFormat(), false, true);
-                    m_Texture.name = "CurveTexture";
-                    m_Texture.hideFlags = HideFlags.HideAndDontSave;
-                    m_Texture.filterMode = FilterMode.Bilinear;
-                    m_Texture.wrapMode = TextureWrapMode.Clamp;
-                }
-
                 var pixels = new Color[k_Precision];
 
                 for (int i = 0; i < pixels.Length; i++)
@@ -253,6 +240,8 @@ namespace UnityEngine.Rendering
         /// <param name="overrideState">The initial override state for the parameter.</param>
         public TextureCurveParameter(TextureCurve value, bool overrideState = false)
             : base(value, overrideState) { }
+
+        public override void Release() => m_Value.Release();
 
         // TODO: TextureCurve interpolation
     }

--- a/com.unity.render-pipelines.core/Runtime/Volume/VolumeComponent.cs
+++ b/com.unity.render-pipelines.core/Runtime/Volume/VolumeComponent.cs
@@ -209,5 +209,19 @@ namespace UnityEngine.Rendering
                 return hash;
             }
         }
+
+        /// <summary>
+        /// Unity calls this method before the object is destroyed. 
+        /// </summary>
+        protected virtual void OnDestroy() => Release();
+
+        /// <summary>
+        /// Releases all the allocated resources.
+        /// </summary>
+        public void Release()
+        {
+            for (int i = 0; i < parameters.Count; i++)
+                parameters[i].Release();
+        }
     }
 }

--- a/com.unity.render-pipelines.core/Runtime/Volume/VolumeParameter.cs
+++ b/com.unity.render-pipelines.core/Runtime/Volume/VolumeParameter.cs
@@ -103,6 +103,11 @@ namespace UnityEngine.Rendering
             return type.BaseType != null
                 && IsObjectParameter(type.BaseType);
         }
+
+        /// <summary>
+        /// Override this method to free all allocated resources
+        /// </summary>
+        public virtual void Release() {}
     }
 
     /// <summary>

--- a/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyManager.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Sky/SkyManager.cs
@@ -337,6 +337,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 m_CachedSkyContexts[i].Cleanup();
 
             m_StaticLightingSky.Cleanup();
+            lightingOverrideVolumeStack.Dispose();
 
 #if UNITY_EDITOR
             CoreUtils.Destroy(m_DefaultPreviewSky);


### PR DESCRIPTION
### Purpose of this PR
Fix again https://fogbugz.unity3d.com/f/cases/1185012/ and https://fogbugz.unity3d.com/f/cases/1211754/

This PR is basically the same thing as #6015 which got reverted because it was breaking all our graphic tests.

Apparently the texture in the TextureCurve class is destroyed when a new scene is loaded which was breaking the color grading post process and gave a black every time we ran more than one test.

### Testing status
I ran the HDRP graphic tests locally an found no issue.
Also ran the Universal graphic test and the texture curve finalizer error is gone.

### Comments to reviewers
I have absolutely no clue why does the texture within the TextureCurve class gets destroyed when a new scene is loaded but that works for now and i already spent too much time figuring out why :(