### PR TITLE
[8.x.x Backport] Partial fix LookDev opened when CoreRP package reimported

### DIFF
--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+- Fixed issue when LookDev window is opened and the CoreRP Package is updated to a newer version.
 
 ## [8.0.0] - 2020-05-25
 

--- a/com.unity.render-pipelines.core/Editor/LookDev/DisplayWindow.cs
+++ b/com.unity.render-pipelines.core/Editor/LookDev/DisplayWindow.cs
@@ -205,8 +205,6 @@ namespace UnityEditor.Rendering.LookDev
 
         void OnEnable()
         {
-            Debug.Log("OnEnable");
-
             //Stylesheet             
             // Try to load stylesheet. Timing can be odd while upgrading packages (case 1219692).
             // In this case, it will be fixed in OnGUI. Though it can spawn error while reimporting assets.

--- a/com.unity.render-pipelines.core/Editor/LookDev/DisplayWindow.cs
+++ b/com.unity.render-pipelines.core/Editor/LookDev/DisplayWindow.cs
@@ -458,6 +458,9 @@ namespace UnityEditor.Rendering.LookDev
         Vector2 m_LastSecondViewSize = new Vector2();
         void IViewDisplayer.SetTexture(ViewCompositionIndex index, Texture texture)
         {
+            if (texture == null)
+                return;
+
             bool updated = false;
             switch (index)
             {

--- a/com.unity.render-pipelines.core/Editor/LookDev/DisplayWindow.cs
+++ b/com.unity.render-pipelines.core/Editor/LookDev/DisplayWindow.cs
@@ -200,8 +200,30 @@ namespace UnityEditor.Rendering.LookDev
             remove => OnUpdateRequestedInternal -= value;
         }
 
+        StyleSheet styleSheet = null;
+        StyleSheet styleSheetLight = null;
+
         void OnEnable()
         {
+            Debug.Log("OnEnable");
+
+            //Stylesheet             
+            // Try to load stylesheet. Timing can be odd while upgrading packages (case 1219692).
+            // In this case, it will be fixed in OnGUI. Though it can spawn error while reimporting assets.
+            // Waiting for filter on stylesheet (case 1228706) to remove last error.
+            if (styleSheet == null || styleSheet.Equals(null))
+            {
+                styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss);
+                if (styleSheet != null && !styleSheet.Equals(null))
+                    rootVisualElement.styleSheets.Add(styleSheet);
+            }
+            if (!EditorGUIUtility.isProSkin && styleSheetLight != null && !styleSheetLight.Equals(null))
+            {
+                styleSheetLight = AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss_personal_overload);
+                if (styleSheetLight != null && !styleSheetLight.Equals(null))
+                    rootVisualElement.styleSheets.Add(styleSheetLight);
+            }
+
             //Call the open function to configure LookDev
             // in case the window where open when last editor session finished.
             // (Else it will open at start and has nothing to display).
@@ -212,15 +234,6 @@ namespace UnityEditor.Rendering.LookDev
 
             // /!\ be sure to have a minSize that will allow a non negative sized viewport even with side panel open
             this.minSize = new Vector2(600, 400);
-
-            rootVisualElement.styleSheets.Add(
-                AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss));
-
-            if (!EditorGUIUtility.isProSkin)
-            {
-                rootVisualElement.styleSheets.Add(
-                    AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss_personal_overload));
-            }
 
             CreateToolbar();
 
@@ -592,6 +605,62 @@ namespace UnityEditor.Rendering.LookDev
             }
         }
 
-        void OnGUI() => OnUpdateRequestedInternal?.Invoke();
+        void OnGUI()
+        {
+            //Stylesheet             
+            // [case 1219692] if LookDev is open while reimporting CoreRP package,
+            // stylesheet can be null. In this case, we can have a null stylesheet
+            // registered as it got destroyed. Reloading it. As we cannot just 
+            // remove a null entry, we must filter and reconstruct the while list.
+            if (styleSheet == null || styleSheet.Equals(null)
+                || (!EditorGUIUtility.isProSkin && (styleSheetLight == null || styleSheetLight.Equals(null))))
+            {
+                // While (case 1228706) is still on going, we sill close and reopen the look dev.
+                // This will prevent spawning error at frame.
+                LookDev.Close();
+                LookDev.Open();
+                return;
+
+                // Following lines is the correct fix if UIElement filter garbage collected Stylesheet.
+
+                //System.Collections.Generic.List<StyleSheet> usedStyleSheets = new System.Collections.Generic.List<StyleSheet>();
+                //int currentCount = rootVisualElement.styleSheets.count;
+                //for (int i = 0; i < currentCount; ++i)
+                //{
+                //    StyleSheet sheet = rootVisualElement.styleSheets[i];
+                //    if (sheet != null && !sheet.Equals(null))
+                //        usedStyleSheets.Add(sheet);
+                //}
+                //rootVisualElement.styleSheets.Clear();
+                //foreach (StyleSheet sheet in usedStyleSheets)
+                //    rootVisualElement.styleSheets.Add(sheet);
+
+                //styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss);
+                //if (styleSheet != null && !styleSheet.Equals(null))
+                //{
+                //    rootVisualElement.styleSheets.Add(styleSheet);
+                //    if (!EditorGUIUtility.isProSkin)
+                //    {
+                //        rootVisualElement.styleSheets.Add(
+                //            AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss_personal_overload));
+                //    }
+                //}
+
+                //if (styleSheet == null || styleSheet.Equals(null))
+                //{
+                //    styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss);
+                //    if (styleSheet != null && !styleSheet.Equals(null))
+                //        rootVisualElement.styleSheets.Add(styleSheet);
+                //}
+                //if (!EditorGUIUtility.isProSkin && styleSheetLight != null && !styleSheetLight.Equals(null))
+                //{
+                //    styleSheetLight = AssetDatabase.LoadAssetAtPath<StyleSheet>(Style.k_uss_personal_overload);
+                //    if (styleSheetLight != null && !styleSheetLight.Equals(null))
+                //        rootVisualElement.styleSheets.Add(styleSheetLight);
+                //}
+            }
+
+            OnUpdateRequestedInternal?.Invoke();
+        }
     }
 }

--- a/com.unity.render-pipelines.core/Editor/LookDev/LookDev.cs
+++ b/com.unity.render-pipelines.core/Editor/LookDev/LookDev.cs
@@ -90,12 +90,22 @@ namespace UnityEditor.Rendering.LookDev
                 InternalEditorUtility.SaveToSerializedFileAndForget(new[] { currentContext }, path, true);
         }
 
-        /// <summary>open the LookDev window</summary>
+        /// <summary>Open the LookDev window</summary>
         public static void Open()
         {
-            s_ViewDisplayer = EditorWindow.GetWindow<DisplayWindow>();
-            s_EnvironmentDisplayer = EditorWindow.GetWindow<DisplayWindow>();
+            var Window = EditorWindow.GetWindow<DisplayWindow>();
+            s_ViewDisplayer = Window;
+            s_EnvironmentDisplayer = Window;
             ConfigureLookDev(reloadWithTemporaryID: false);
+        }
+
+        /// <summary>Close the LookDev window</summary>
+        public static void Close()
+        {
+            (s_ViewDisplayer as EditorWindow)?.Close();
+            s_ViewDisplayer = null;
+            (s_EnvironmentDisplayer as EditorWindow)?.Close();
+            s_EnvironmentDisplayer = null;
         }
 
         [Callbacks.DidReloadScripts]
@@ -131,7 +141,7 @@ namespace UnityEditor.Rendering.LookDev
                     () => WaitingSRPReloadForConfiguringRenderer(maxAttempt, reloadWithTemporaryID, ++attemptNumber);
             else
             {
-                (s_ViewDisplayer as EditorWindow)?.Close();
+                Close();
 
                 throw new System.Exception("LookDev is not supported by this Scriptable Render Pipeline: "
                     + (RenderPipelineManager.currentPipeline == null ? "No SRP in use" : RenderPipelineManager.currentPipeline.ToString()));
@@ -148,8 +158,7 @@ namespace UnityEditor.Rendering.LookDev
 
         static void LinkViewDisplayer()
         {
-            EditorApplication.playModeStateChanged += state =>
-                (s_ViewDisplayer as EditorWindow)?.Close();
+            EditorApplication.playModeStateChanged += state => Close();
 
             s_ViewDisplayer.OnClosed += () =>
             {


### PR DESCRIPTION
### Purpose of this PR
Partly fix https://fogbugz.unity3d.com/f/cases/1219692/
Remaining issue should be fixed in https://fogbugz.unity3d.com/f/cases/1228706/

The issue happens when the LookDev window is open and user upgrade the CoreRP/HDRP package to a newer version.
Currently, doing this, will call OnEnable of the LookDev window as soon as the script is reimported and this happens at a time where the Stylesheet have not been reimported yet. So importing it in order to use it will cause issue later as you will have the one in the former version that will be garbage collected soon.
The first OnGUI is called at a time that the stylesheet is reimported but if we load the stylesheet at that time, the first frame of the window will not have any stylesheet (so no layout and wrong colors)

As this case is sufficiently a rare occurence, if it happens, the present fix will use the wrong stylesheet in OnEnable. This will cause potentially few issue in the console. But we now detect the stylesheet have been garbage collected and thus close and reopen the LookDev window in first OnGUI to stop the error at editor frame, and fully fix the window. 

The "remaining" issue linked need to be fixed on UIElement side to not try to use null Stylesheet. Once it is landed, it will be able to finish the fix.

---
### Testing status

**Manual Tests**:
- Other: Tested manually while migrating from package 7.1.8 to 7.2.1

---
### Comments to reviewers
