### PR TITLE
Hdrp/custom pass aov

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a path tracing test to the test suite.
 - Added a warning and workaround instructions that appear when you enable XR single-pass after the first frame with the XR SDK.
 - Added the exposure sliders to the planar reflection probe preview
+- Added support for custom passes in the AOV API
 
 ### Fixed
 - Update documentation of HDRISky-Backplate, precise how to have Ambient Occlusion on the Backplate

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1988,7 +1988,7 @@ namespace UnityEngine.Rendering.HighDefinition
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforeRendering);
 
             // Push the custom pass buffer, in case it was requested in the AOVs
-            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforeRendering, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforeRendering, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
 
             // This is always false in forward and if it is true, is equivalent of saying we have a partial depth prepass.
             bool shouldRenderMotionVectorAfterGBuffer = RenderDepthPrepass(cullingResults, hdCamera, renderContext, cmd);
@@ -2024,7 +2024,7 @@ namespace UnityEngine.Rendering.HighDefinition
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.AfterOpaqueDepthAndNormal);
 
             // Push the custom pass buffer, in case it was requested in the AOVs
-            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferAfterOpaqueDepthAndNormal, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.AfterOpaqueDepthAndNormal, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
 
             // In both forward and deferred, everything opaque should have been rendered at this point so we can safely copy the depth buffer for later processing.
             GenerateDepthPyramid(hdCamera, cmd, FullScreenDebugMode.DepthPyramid);
@@ -2271,7 +2271,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforePreRefraction);
 
                 // Push the custom pass buffer, in case it was requested in the AOVs
-                aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforePreRefraction, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+                aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforePreRefraction, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
 
                 // Render pre refraction objects
                 RenderForwardTransparent(cullingResults, hdCamera, true, renderContext, cmd);
@@ -2295,7 +2295,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforeTransparent);
 
                 // Push the custom pass texture, if it was requested in the AOVs
-                aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforePostProcess, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+                aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforeTransparent, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
 
                 // Render all type of transparent forward (unlit, lit, complex (hair...)) to keep the sorting between transparent objects.
                 RenderForwardTransparent(cullingResults, hdCamera, false, renderContext, cmd);
@@ -2353,7 +2353,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
             // Push the camera and custom pass textures, in case they were requested in the AOVs
             aovRequest.PushCameraTexture(cmd, AOVBuffers.Color, hdCamera, m_CameraColorBuffer, aovBuffers);
-            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforePostProcess, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforePostProcess, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
 
             RenderTargetIdentifier postProcessDest = HDUtils.PostProcessIsFinalPass(hdCamera) ? target.id : m_IntermediateAfterPostProcessBuffer;
             RenderPostProcess(cullingResults, hdCamera, postProcessDest, renderContext, cmd);
@@ -2361,7 +2361,7 @@ namespace UnityEngine.Rendering.HighDefinition
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.AfterPostProcess);
 
             // Push the custom pass texture, in case it was requested in the AOVs
-            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferAfterPostProcess, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.AfterPostProcess, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
 
             // Copy and rescale depth buffer for XR devices
             if (hdCamera.xr.enabled && hdCamera.xr.copyDepth)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1854,8 +1854,9 @@ namespace UnityEngine.Rendering.HighDefinition
             }
 
             using (ListPool<RTHandle>.Get(out var aovBuffers))
+            using (ListPool<RTHandle>.Get(out var aovCustomPassBuffers))
             {
-                aovRequest.AllocateTargetTexturesIfRequired(ref aovBuffers);
+                aovRequest.AllocateTargetTexturesIfRequired(ref aovBuffers, ref aovCustomPassBuffers);
 
             // If we render a reflection view or a preview we should not display any debug information
             // This need to be call before ApplyDebugDisplaySettings()
@@ -1988,7 +1989,7 @@ namespace UnityEngine.Rendering.HighDefinition
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforeRendering);
 
             // Push the custom pass buffer, in case it was requested in the AOVs
-            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforeRendering, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforeRendering, m_CameraColorBuffer, m_CustomPassColorBuffer, aovCustomPassBuffers);
 
             // This is always false in forward and if it is true, is equivalent of saying we have a partial depth prepass.
             bool shouldRenderMotionVectorAfterGBuffer = RenderDepthPrepass(cullingResults, hdCamera, renderContext, cmd);
@@ -2024,7 +2025,7 @@ namespace UnityEngine.Rendering.HighDefinition
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.AfterOpaqueDepthAndNormal);
 
             // Push the custom pass buffer, in case it was requested in the AOVs
-            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.AfterOpaqueDepthAndNormal, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.AfterOpaqueDepthAndNormal, m_CameraColorBuffer, m_CustomPassColorBuffer, aovCustomPassBuffers);
 
             // In both forward and deferred, everything opaque should have been rendered at this point so we can safely copy the depth buffer for later processing.
             GenerateDepthPyramid(hdCamera, cmd, FullScreenDebugMode.DepthPyramid);
@@ -2271,7 +2272,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforePreRefraction);
 
                 // Push the custom pass buffer, in case it was requested in the AOVs
-                aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforePreRefraction, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
+                aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforePreRefraction, m_CameraColorBuffer, m_CustomPassColorBuffer, aovCustomPassBuffers);
 
                 // Render pre refraction objects
                 RenderForwardTransparent(cullingResults, hdCamera, true, renderContext, cmd);
@@ -2295,7 +2296,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforeTransparent);
 
                 // Push the custom pass texture, if it was requested in the AOVs
-                aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforeTransparent, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
+                aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforeTransparent, m_CameraColorBuffer, m_CustomPassColorBuffer, aovCustomPassBuffers);
 
                 // Render all type of transparent forward (unlit, lit, complex (hair...)) to keep the sorting between transparent objects.
                 RenderForwardTransparent(cullingResults, hdCamera, false, renderContext, cmd);
@@ -2353,7 +2354,7 @@ namespace UnityEngine.Rendering.HighDefinition
 
             // Push the camera and custom pass textures, in case they were requested in the AOVs
             aovRequest.PushCameraTexture(cmd, AOVBuffers.Color, hdCamera, m_CameraColorBuffer, aovBuffers);
-            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforePostProcess, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.BeforePostProcess, m_CameraColorBuffer, m_CustomPassColorBuffer, aovCustomPassBuffers);
 
             RenderTargetIdentifier postProcessDest = HDUtils.PostProcessIsFinalPass(hdCamera) ? target.id : m_IntermediateAfterPostProcessBuffer;
             RenderPostProcess(cullingResults, hdCamera, postProcessDest, renderContext, cmd);
@@ -2361,7 +2362,7 @@ namespace UnityEngine.Rendering.HighDefinition
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.AfterPostProcess);
 
             // Push the custom pass texture, in case it was requested in the AOVs
-            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.AfterPostProcess, m_CameraColorBuffer, m_CustomPassColorBuffer, aovBuffers);
+            aovRequest.PushCustomPassTexture(cmd, CustomPassInjectionPoint.AfterPostProcess, m_CameraColorBuffer, m_CustomPassColorBuffer, aovCustomPassBuffers);
 
             // Copy and rescale depth buffer for XR devices
             if (hdCamera.xr.enabled && hdCamera.xr.copyDepth)
@@ -2447,7 +2448,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 RenderGizmos(cmd, camera, renderContext, GizmoSubset.PostImageEffects);
 #endif
 
-                aovRequest.Execute(cmd, aovBuffers, RenderOutputProperties.From(hdCamera));
+                aovRequest.Execute(cmd, aovBuffers, aovCustomPassBuffers, RenderOutputProperties.From(hdCamera));
             }
 
             // This is required so that all commands up to here are executed before EndCameraRendering is called for the user.

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -1987,6 +1987,9 @@ namespace UnityEngine.Rendering.HighDefinition
 
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforeRendering);
 
+            // Push the custom pass buffer, in case it was requested in the AOVs
+            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforeRendering, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+
             // This is always false in forward and if it is true, is equivalent of saying we have a partial depth prepass.
             bool shouldRenderMotionVectorAfterGBuffer = RenderDepthPrepass(cullingResults, hdCamera, renderContext, cmd);
             if (!shouldRenderMotionVectorAfterGBuffer)
@@ -2019,6 +2022,9 @@ namespace UnityEngine.Rendering.HighDefinition
 
             // After Depth and Normals/roughness including decals
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.AfterOpaqueDepthAndNormal);
+
+            // Push the custom pass buffer, in case it was requested in the AOVs
+            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferAfterOpaqueDepthAndNormal, hdCamera, m_CustomPassColorBuffer, aovBuffers);
 
             // In both forward and deferred, everything opaque should have been rendered at this point so we can safely copy the depth buffer for later processing.
             GenerateDepthPyramid(hdCamera, cmd, FullScreenDebugMode.DepthPyramid);
@@ -2264,6 +2270,9 @@ namespace UnityEngine.Rendering.HighDefinition
                 cmd.SetGlobalTexture(HDShaderIDs._ColorPyramidTexture, m_CameraColorBuffer);
                 RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforePreRefraction);
 
+                // Push the custom pass buffer, in case it was requested in the AOVs
+                aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforePreRefraction, hdCamera, m_CustomPassColorBuffer, aovBuffers);
+
                 // Render pre refraction objects
                 RenderForwardTransparent(cullingResults, hdCamera, true, renderContext, cmd);
 
@@ -2284,6 +2293,9 @@ namespace UnityEngine.Rendering.HighDefinition
 
                 // We don't have access to the color pyramid with transparent if rough refraction is disabled
                 RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforeTransparent);
+
+                // Push the custom pass texture, if it was requested in the AOVs
+                aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforePostProcess, hdCamera, m_CustomPassColorBuffer, aovBuffers);
 
                 // Render all type of transparent forward (unlit, lit, complex (hair...)) to keep the sorting between transparent objects.
                 RenderForwardTransparent(cullingResults, hdCamera, false, renderContext, cmd);
@@ -2339,16 +2351,17 @@ namespace UnityEngine.Rendering.HighDefinition
 
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforePostProcess);
 
+            // Push the camera and custom pass textures, in case they were requested in the AOVs
             aovRequest.PushCameraTexture(cmd, AOVBuffers.Color, hdCamera, m_CameraColorBuffer, aovBuffers);
-            if (m_CustomPassColorBuffer.IsValueCreated)
-            {
-                aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPass, hdCamera, m_CustomPassColorBuffer.Value, aovBuffers);
-            }
+            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferBeforePostProcess, hdCamera, m_CustomPassColorBuffer, aovBuffers);
 
             RenderTargetIdentifier postProcessDest = HDUtils.PostProcessIsFinalPass(hdCamera) ? target.id : m_IntermediateAfterPostProcessBuffer;
             RenderPostProcess(cullingResults, hdCamera, postProcessDest, renderContext, cmd);
 
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.AfterPostProcess);
+
+            // Push the custom pass texture, in case it was requested in the AOVs
+            aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPassBufferAfterPostProcess, hdCamera, m_CustomPassColorBuffer, aovBuffers);
 
             // Copy and rescale depth buffer for XR devices
             if (hdCamera.xr.enabled && hdCamera.xr.copyDepth)

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -2340,6 +2340,10 @@ namespace UnityEngine.Rendering.HighDefinition
             RenderCustomPass(renderContext, cmd, hdCamera, customPassCullingResults, CustomPassInjectionPoint.BeforePostProcess);
 
             aovRequest.PushCameraTexture(cmd, AOVBuffers.Color, hdCamera, m_CameraColorBuffer, aovBuffers);
+            if (m_CustomPassColorBuffer.IsValueCreated)
+            {
+                aovRequest.PushCameraTexture(cmd, AOVBuffers.CustomPass, hdCamera, m_CustomPassColorBuffer.Value, aovBuffers);
+            }
 
             RenderTargetIdentifier postProcessDest = HDUtils.PostProcessIsFinalPass(hdCamera) ? target.id : m_IntermediateAfterPostProcessBuffer;
             RenderPostProcess(cullingResults, hdCamera, postProcessDest, renderContext, cmd);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVBuffers.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVBuffers.cs
@@ -13,7 +13,17 @@ namespace UnityEngine.Rendering.HighDefinition
         Normals,
         /// <summary>Motion vectors buffer at the end of the frame.</summary>
         MotionVectors,
-        /// <summary>Custom pass buffer.</summary> 
-        CustomPass //TODO: all injection points
+        /// <summary>Custom pass buffer after the custom pass at "BeforeRendering" injection point is executed.</summary> 
+        CustomPassBufferBeforeRendering,
+        /// <summary>Custom pass buffer after the custom pass at "AfterOpaqueDepthAndNormal" injection point is executed.</summary> 
+        CustomPassBufferAfterOpaqueDepthAndNormal,
+        /// <summary>Custom pass buffer after the custom pass at "BeforePreRefraction" injection point is executed.</summary> 
+        CustomPassBufferBeforePreRefraction,
+        /// <summary>Custom pass buffer after the custom pass at "BeforeTransparent" injection point is executed.</summary> 
+        CustomPassBufferBeforeTransparent,
+        /// <summary>Custom pass buffer after the custom pass at "BeforePostProcess" injection point is executed.</summary> 
+        CustomPassBufferBeforePostProcess,
+        /// <summary>Custom pass buffer after the custom pass at "AfterPostProcess" injection point is executed.</summary> 
+        CustomPassBufferAfterPostProcess
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVBuffers.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVBuffers.cs
@@ -12,18 +12,25 @@ namespace UnityEngine.Rendering.HighDefinition
         /// <summary>Normals buffer at the end of the frame.</summary>
         Normals,
         /// <summary>Motion vectors buffer at the end of the frame.</summary>
-        MotionVectors,
-        /// <summary>Custom pass buffer after the custom pass at "BeforeRendering" injection point is executed.</summary> 
-        CustomPassBufferBeforeRendering,
-        /// <summary>Custom pass buffer after the custom pass at "AfterOpaqueDepthAndNormal" injection point is executed.</summary> 
-        CustomPassBufferAfterOpaqueDepthAndNormal,
-        /// <summary>Custom pass buffer after the custom pass at "BeforePreRefraction" injection point is executed.</summary> 
-        CustomPassBufferBeforePreRefraction,
-        /// <summary>Custom pass buffer after the custom pass at "BeforeTransparent" injection point is executed.</summary> 
-        CustomPassBufferBeforeTransparent,
-        /// <summary>Custom pass buffer after the custom pass at "BeforePostProcess" injection point is executed.</summary> 
-        CustomPassBufferBeforePostProcess,
-        /// <summary>Custom pass buffer after the custom pass at "AfterPostProcess" injection point is executed.</summary> 
-        CustomPassBufferAfterPostProcess
+        MotionVectors
+    }
+
+
+    public struct CustomPassAOVBuffers
+    {
+        public enum OutputType
+        {
+            CustomPassBuffer,
+            Camera
+        }
+
+        public CustomPassInjectionPoint injectionPoint;
+        public OutputType outputType;
+
+        public CustomPassAOVBuffers(CustomPassInjectionPoint ip, OutputType ot)
+        {
+            injectionPoint = ip;
+            outputType = ot;
+        }
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVBuffers.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVBuffers.cs
@@ -12,6 +12,8 @@ namespace UnityEngine.Rendering.HighDefinition
         /// <summary>Normals buffer at the end of the frame.</summary>
         Normals,
         /// <summary>Motion vectors buffer at the end of the frame.</summary>
-        MotionVectors
+        MotionVectors,
+        /// <summary>Custom pass buffer.</summary> 
+        CustomPass //TODO: all injection points
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestBuilder.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestBuilder.cs
@@ -34,20 +34,22 @@ namespace UnityEngine.Rendering.HighDefinition
         /// <param name="bufferAllocator">An allocator for each buffer.</param>
         /// <param name="includedLightList">If non null, only these lights will be rendered, if none, all lights will be rendered.</param>
         /// <param name="aovBuffers">A list of buffers to use.</param>
+        /// <param name="customPassAovBuffers">A list of custom passes to captured.</param>
+        /// <param name="customPassbufferAllocator">An allocator for each custom pass buffer.</param>
         /// <param name="callback">A callback that can use the requested buffers once the rendering has completed.</param>
         /// <returns></returns>
         public AOVRequestBuilder Add(
             AOVRequest settings,
             AOVRequestBufferAllocator bufferAllocator,
-            AOVRequestCustomPassBufferAllocator customPassbufferAllocator,
             List<GameObject> includedLightList,
             AOVBuffers[] aovBuffers,
             CustomPassAOVBuffers[] customPassAovBuffers,
+            AOVRequestCustomPassBufferAllocator customPassbufferAllocator,
             FramePassCallbackEx callback
         )
         {
             (m_AOVRequestDataData ?? (m_AOVRequestDataData = ListPool<AOVRequestData>.Get())).Add(
-                new AOVRequestData(settings, bufferAllocator, customPassbufferAllocator, includedLightList, aovBuffers, customPassAovBuffers, callback));
+                new AOVRequestData(settings, bufferAllocator, includedLightList, aovBuffers, customPassAovBuffers, customPassbufferAllocator, callback));
             return this;
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestBuilder.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestBuilder.cs
@@ -43,7 +43,7 @@ namespace UnityEngine.Rendering.HighDefinition
             List<GameObject> includedLightList,
             AOVBuffers[] aovBuffers,
             CustomPassAOVBuffers[] customPassAovBuffers,
-            FramePassCallback callback
+            FramePassCallbackEx callback
         )
         {
             (m_AOVRequestDataData ?? (m_AOVRequestDataData = ListPool<AOVRequestData>.Get())).Add(

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestBuilder.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestBuilder.cs
@@ -29,6 +29,28 @@ namespace UnityEngine.Rendering.HighDefinition
             return this;
         }
 
+        /// <summary>Add a AOV request.</summary>
+        /// <param name="settings">Settings to use for this frame pass.</param>
+        /// <param name="bufferAllocator">An allocator for each buffer.</param>
+        /// <param name="includedLightList">If non null, only these lights will be rendered, if none, all lights will be rendered.</param>
+        /// <param name="aovBuffers">A list of buffers to use.</param>
+        /// <param name="callback">A callback that can use the requested buffers once the rendering has completed.</param>
+        /// <returns></returns>
+        public AOVRequestBuilder Add(
+            AOVRequest settings,
+            AOVRequestBufferAllocator bufferAllocator,
+            AOVRequestCustomPassBufferAllocator customPassbufferAllocator,
+            List<GameObject> includedLightList,
+            AOVBuffers[] aovBuffers,
+            CustomPassAOVBuffers[] customPassAovBuffers,
+            FramePassCallback callback
+        )
+        {
+            (m_AOVRequestDataData ?? (m_AOVRequestDataData = ListPool<AOVRequestData>.Get())).Add(
+                new AOVRequestData(settings, bufferAllocator, customPassbufferAllocator, includedLightList, aovBuffers, customPassAovBuffers, callback));
+            return this;
+        }
+
         /// <summary>Build the frame passes. Allocated resources will be transferred to the returned value.</summary>
         /// <returns>The built collection.</returns>
         public AOVRequestDataCollection Build()

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestData.cs
@@ -111,6 +111,20 @@ namespace UnityEngine.Rendering.HighDefinition
             HDUtils.BlitCameraTexture(cmd, source, targets[index]);
         }
 
+        internal void PushCameraTexture(
+            CommandBuffer cmd,
+            AOVBuffers aovBufferId,
+            HDCamera camera,
+            Lazy<RTHandle> source,
+            List<RTHandle> targets
+        )
+        {
+            if (!source.IsValueCreated)
+                return;
+
+            PushCameraTexture(cmd, aovBufferId, camera, source.Value, targets);
+        }
+
         class PushCameraTexturePassData
         {
             public int                  requestIndex;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestData.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/AOV/AOVRequestData.cs
@@ -93,14 +93,15 @@ namespace UnityEngine.Rendering.HighDefinition
         /// <param name="lightFilter">If null, all light will be rendered, if not, only those light will be rendered.</param>
         /// <param name="requestedAOVBuffers">The requested buffers for the callback.</param>
         /// <param name="customPassAOVBuffers">The custom pass buffers that will be captured.</param>
+        /// <param name="customPassBufferAllocator">Buffer allocators to use for custom passes.</param>
         /// <param name="callback">The callback to execute.</param>
         public AOVRequestData(
             AOVRequest settings,
             AOVRequestBufferAllocator bufferAllocator,
-            AOVRequestCustomPassBufferAllocator customPassBufferAllocator,
             List<GameObject> lightFilter,
             AOVBuffers[] requestedAOVBuffers,
             CustomPassAOVBuffers[] customPassAOVBuffers,
+            AOVRequestCustomPassBufferAllocator customPassBufferAllocator,
             FramePassCallbackEx callback
         )
         {
@@ -113,7 +114,6 @@ namespace UnityEngine.Rendering.HighDefinition
             m_Callback = null;
             m_CallbackEx = callback;
         }
-
 
         /// <summary>Allocate texture if required.</summary>
         /// <param name="textures">A buffer of texture ready to use.</param>


### PR DESCRIPTION
[Draft PR to get some feedback on the API]

### Purpose of this PR
This PR exposes the results of custom passes to the AOV API. Since the desired output might be the result of multiple custom passes, AOVs are recorded after all passes of an injection point are executed. The API allows you to output either the custom pass buffer or the camera buffer.

An example use-case for this is to generate Object IDs with a custom pass, output them with the AOV API and record them with the unity recorder.

![image](https://user-images.githubusercontent.com/15788420/77154561-3b445d80-6a9c-11ea-9c64-2cf5b15e9efd.png)

---
### Testing status
For testing I have used the standard HDRP template scene, I setup a custom pass to generate Object IDs and then I have used a slightly modified AOV recorder to record the results.

You can find the test scene (with the Object ID pass) here:
https://drive.google.com/open?id=1jE1S_Uqor8-gNK-wSrzPFPEoyTwZKq5P
(you will have to change the paths in packages/manifest.json) 

And the modified AOV recorder here:
https://drive.google.com/open?id=1zOYm8BSj-Az6KrcBclNWM-qqP6TvVf1r


