### PR TITLE
Dxc compatibility

### DIFF
--- a/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/2x_Lighting/2004_AnimatedCookie/AnimatedCookie_Shader2.shader
+++ b/TestProjects/HDRP_Tests/Assets/GraphicTests/Scenes/2x_Lighting/2004_AnimatedCookie/AnimatedCookie_Shader2.shader
@@ -129,7 +129,7 @@ Shader "HDRenderPipeline/GraphicTests/2004_AnimatedCookie_AnimMat2"
                 if (_StarsAnim[frame*STAR_COL*STAR_ROW + uv.y*STAR_ROW +uv.x]) c = 1;
             }
 
-            float4 frag(v2f_customrendertexture IN) : COLOR
+            float4 frag(v2f_customrendertexture IN) : SV_Target
             {
                 float4 c = float4(12.0/255.0, 65.0/255.0, 121.0/255.0, 1); // background color
 

--- a/com.unity.render-pipelines.core/CHANGELOG.md
+++ b/com.unity.render-pipelines.core/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Replaced calls to deprecated PlayerSettings.virtualRealitySupported property.
 - Enable RWTexture2D, RWTexture2DArray, RWTexture3D in gles 3.1
 - Updated macros to be compatible with the new shader preprocessor.
+- Updated shaders to be compatible with Microsoft's DXC.
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -663,6 +663,45 @@ uint GetMipCount(Texture2D tex)
 // ----------------------------------------------------------------------------
 // Texture format sampling
 // ----------------------------------------------------------------------------
+#if defined(UNITY_COMPILER_DXC) && !defined(DXC_SAMPLER_COMPATIBILITY)
+#define DXC_SAMPLER_COMPATIBILITY 1
+struct sampler1D            { Texture1D t; SamplerState s; };
+struct sampler2D            { Texture2D t; SamplerState s; };
+struct sampler3D            { Texture3D t; SamplerState s; };
+struct samplerCUBE          { TextureCube t; SamplerState s; };
+
+float4 tex1D(sampler1D x, float v)              { return x.t.Sample(x.s, v); }
+float4 tex2D(sampler2D x, float2 v)             { return x.t.Sample(x.s, v); }
+float4 tex3D(sampler3D x, float3 v)             { return x.t.Sample(x.s, v); }
+float4 texCUBE(samplerCUBE x, float3 v)         { return x.t.Sample(x.s, v); }
+
+float4 tex1Dbias(sampler1D x, in float4 t)              { return x.t.SampleBias(x.s, t.x, t.w); }
+float4 tex2Dbias(sampler2D x, in float4 t)              { return x.t.SampleBias(x.s, t.xy, t.w); }
+float4 tex3Dbias(sampler3D x, in float4 t)              { return x.t.SampleBias(x.s, t.xyz, t.w); }
+float4 texCUBEbias(samplerCUBE x, in float4 t)          { return x.t.SampleBias(x.s, t.xyz, t.w); }
+
+float4 tex1Dlod(sampler1D x, in float4 t)           { return x.t.SampleLevel(x.s, t.x, t.w); }
+float4 tex2Dlod(sampler2D x, in float4 t)           { return x.t.SampleLevel(x.s, t.xy, t.w); }
+float4 tex3Dlod(sampler3D x, in float4 t)           { return x.t.SampleLevel(x.s, t.xyz, t.w); }
+float4 texCUBElod(samplerCUBE x, in float4 t)       { return x.t.SampleLevel(x.s, t.xyz, t.w); }
+
+float4 tex1Dgrad(sampler1D x, float t, float dx, float dy)              { return x.t.SampleGrad(x.s, t, dx, dy); }
+float4 tex2Dgrad(sampler2D x, float2 t, float2 dx, float2 dy)           { return x.t.SampleGrad(x.s, t, dx, dy); }
+float4 tex3Dgrad(sampler3D x, float3 t, float3 dx, float3 dy)           { return x.t.SampleGrad(x.s, t, dx, dy); }
+float4 texCUBEgrad(samplerCUBE x, float3 t, float3 dx, float3 dy)       { return x.t.SampleGrad(x.s, t, dx, dy); }
+
+float4 tex1D(sampler1D x, float t, float dx, float dy)              { return x.t.SampleGrad(x.s, t, dx, dy); }
+float4 tex2D(sampler2D x, float2 t, float2 dx, float2 dy)           { return x.t.SampleGrad(x.s, t, dx, dy); }
+float4 tex3D(sampler3D x, float3 t, float3 dx, float3 dy)           { return x.t.SampleGrad(x.s, t, dx, dy); }
+float4 texCUBE(samplerCUBE x, float3 t, float3 dx, float3 dy)       { return x.t.SampleGrad(x.s, t, dx, dy); }
+
+float4 tex1Dproj(sampler1D s, in float2 t)              { return tex1D(s, t.x / t.y); }
+float4 tex1Dproj(sampler1D s, in float4 t)              { return tex1D(s, t.x / t.w); }
+float4 tex2Dproj(sampler2D s, in float3 t)              { return tex2D(s, t.xy / t.z); }
+float4 tex2Dproj(sampler2D s, in float4 t)              { return tex2D(s, t.xy / t.w); }
+float4 tex3Dproj(sampler3D s, in float4 t)              { return tex3D(s, t.xyz / t.w); }
+float4 texCUBEproj(samplerCUBE s, in float4 t)          { return texCUBE(s, t.xyz / t.w); }
+#endif
 
 float2 DirectionToLatLongCoordinate(float3 unDir)
 {

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -197,8 +197,8 @@
 #define LODDitheringTransition ERROR_ON_UNSUPPORTED_FUNCTION(LODDitheringTransition)
 #endif
 
-// On everything but GCN consoles we error on cross-lane operations
-#ifndef PLATFORM_SUPPORTS_WAVE_INTRINSICS
+// On everything but GCN consoles or DXC compiled shaders we error on cross-lane operations
+#if !defined(PLATFORM_SUPPORTS_WAVE_INTRINSICS) && !defined(UNITY_COMPILER_DXC)
 #define WaveActiveAllTrue ERROR_ON_UNSUPPORTED_FUNCTION(WaveActiveAllTrue)
 #define WaveActiveAnyTrue ERROR_ON_UNSUPPORTED_FUNCTION(WaveActiveAnyTrue)
 #define WaveGetLaneIndex ERROR_ON_UNSUPPORTED_FUNCTION(WaveGetLaneIndex)

--- a/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
@@ -335,10 +335,21 @@
         #define CALL_MERGE_UNITY_BUILTINS_INDEX(X)  MERGE_UNITY_BUILTINS_INDEX(X)
         #ifdef MODIFY_MATRIX_FOR_CAMERA_RELATIVE_RENDERING
             #define UNITY_MATRIX_M      ApplyCameraTranslationToMatrix(UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_ObjectToWorldArray))
-            #define UNITY_MATRIX_I_M    ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray))
+            //#define UNITY_MATRIX_I_M    ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray))
+            #ifdef UNITY_ASSUME_UNIFORM_SCALING
+                #define UNITY_MATRIX_I_M  ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(unity_Builtins1, unity_WorldToObjectArray))
+            #else
+                #define UNITY_MATRIX_I_M  ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_WorldToObjectArray))
+            #endif
         #else
             #define UNITY_MATRIX_M      UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_ObjectToWorldArray)
-            #define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray)
+
+            //#define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray)
+            #ifdef UNITY_ASSUME_UNIFORM_SCALING
+                #define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(unity_Builtins1, unity_WorldToObjectArray)
+            #else
+                #define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_WorldToObjectArray)
+            #endif
         #endif
     #endif
 

--- a/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/UnityInstancing.hlsl
@@ -335,21 +335,10 @@
         #define CALL_MERGE_UNITY_BUILTINS_INDEX(X)  MERGE_UNITY_BUILTINS_INDEX(X)
         #ifdef MODIFY_MATRIX_FOR_CAMERA_RELATIVE_RENDERING
             #define UNITY_MATRIX_M      ApplyCameraTranslationToMatrix(UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_ObjectToWorldArray))
-            //#define UNITY_MATRIX_I_M    ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray))
-            #ifdef UNITY_ASSUME_UNIFORM_SCALING
-                #define UNITY_MATRIX_I_M  ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(unity_Builtins1, unity_WorldToObjectArray))
-            #else
-                #define UNITY_MATRIX_I_M  ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_WorldToObjectArray))
-            #endif
+            #define UNITY_MATRIX_I_M    ApplyCameraTranslationToInverseMatrix(UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray))
         #else
             #define UNITY_MATRIX_M      UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_ObjectToWorldArray)
-
-            //#define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray)
-            #ifdef UNITY_ASSUME_UNIFORM_SCALING
-                #define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(unity_Builtins1, unity_WorldToObjectArray)
-            #else
-                #define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(unity_Builtins0, unity_WorldToObjectArray)
-            #endif
+            #define UNITY_MATRIX_I_M    UNITY_ACCESS_INSTANCED_PROP(CALL_MERGE_UNITY_BUILTINS_INDEX(UNITY_WORLDTOOBJECTARRAY_CB), unity_WorldToObjectArray)
         #endif
     #endif
 

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -407,6 +407,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue with MipRatio debug mode showing _DebugMatCapTexture not being set.
 - Fixed missing initialization of input params in Blit for VR.
 - Fix Inf source in LTC for area lights.
+- Fixed reliance on atan2 undefined behavior in motion vector debug shader.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled
@@ -491,6 +492,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Transform result from CIE XYZ to sRGB color space in EvalSensitivity for iridescence.
 - Hide the Probes section in the Renderer editos because it was unused.
 - Moved BeginCameraRendering callback right before culling.
+- Updated shaders to be compatible with Microsoft's DXC.
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugFullScreen.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugFullScreen.shader
@@ -241,6 +241,11 @@ Shader "Hidden/HDRP/DebugFullScreen"
                         d = 1.0 - saturate(d);
                     }
 
+                    // Explicitly handling the case where mv == float2(0, 0) as atan2(mv.x, mv.y) above would be atan2(0,0) which
+                    // is undefined and in practice can be incosistent between compilers (e.g. NaN on FXC and ~pi/2 on DXC)
+                    if(!any(mv))
+                        color = float3(0, 0, 0);
+
                     return float4(color + d.xxx, 1.0);
                 }
                 if (_FullScreenDebugMode == FULLSCREENDEBUGMODE_COLOR_LOG)

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl
@@ -204,7 +204,7 @@ DecalSurfaceData GetDecalSurfaceData(PositionInputs posInput, inout float alpha)
 {
     uint mask = 0;
     // the code in the macros, gets moved inside the conditionals by the compiler
-    FETCH_DBUFFER(DBuffer, _DBufferTexture, posInput.positionSS);
+    FETCH_DBUFFER(DBuffer, _DBufferTexture, int2(posInput.positionSS.xy));
 
 #if defined(_SURFACE_TYPE_TRANSPARENT) && defined(HAS_LIGHTLOOP)  // forward transparent using clustered decals
     uint decalCount, decalStart;
@@ -258,7 +258,7 @@ DecalSurfaceData GetDecalSurfaceData(PositionInputs posInput, inout float alpha)
 
         if (!fastPath)
         {
-            // If we are not in fast path, v_lightIdx is not scalar, so we need to query the Min value across the wave. 
+            // If we are not in fast path, v_lightIdx is not scalar, so we need to query the Min value across the wave.
             s_decalIdx = WaveActiveMin(v_decalIdx);
             // If WaveActiveMin returns 0xffffffff it means that all lanes are actually dead, so we can safely ignore the loop and move forward.
             // This could happen as an helper lane could reach this point, hence having a valid v_lightIdx, but their values will be ignored by the WaveActiveMin

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/ShaderVariablesDecal.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/ShaderVariablesDecal.hlsl
@@ -10,7 +10,7 @@ TEXTURE2D(_DecalAtlas2D);
 SAMPLER(_trilinear_clamp_sampler_DecalAtlas2D);
 
 #ifdef PLATFORM_SUPPORTS_BUFFER_ATOMICS_IN_PIXEL_SHADER
-RWStructuredBuffer<uint> _DecalPropertyMaskBuffer;
+RWStructuredBuffer<uint> _DecalPropertyMaskBuffer : register(u4);
 StructuredBuffer<uint> _DecalPropertyMaskBufferSRV;
 #endif
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl
@@ -1773,9 +1773,9 @@ IndirectLighting EvaluateBSDF_ScreenspaceRefraction(LightLoopContext lightLoopCo
     refractionOffsetMultiplier *= (hitLinearDepth > posInput.linearDepth);
 
     float2 samplingPositionNDC = lerp(posInput.positionNDC, hit.positionNDC, refractionOffsetMultiplier);
-    float3 preLD = SAMPLE_TEXTURE2D_X_LOD(_ColorPyramidTexture, s_trilinear_clamp_sampler,
-                                        // Offset by half a texel to properly interpolate between this pixel and its mips
+    float3 preLD = SAMPLE_TEXTURE2D_X_LOD(_ColorPyramidTexture, s_trilinear_clamp_sampler, \
                                         samplingPositionNDC * _ColorPyramidScale.xy, preLightData.transparentSSMipLevel).rgb;
+                                        // Offset by half a texel to properly interpolate between this pixel and its mips
 
     // Inverse pre-exposure
     preLD *= GetInverseCurrentExposureMultiplier();

--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/TemporalAntiAliasing.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/TemporalAntiAliasing.shader
@@ -23,7 +23,7 @@ Shader "Hidden/HDRP/TemporalAntialiasing"
 
         TEXTURE2D_X(_InputTexture);
         TEXTURE2D_X(_InputHistoryTexture);
-        RW_TEXTURE2D_X(CTYPE, _OutputHistoryTexture);
+        RW_TEXTURE2D_X(CTYPE, _OutputHistoryTexture) : register(u1);
 
         struct Attributes
         {

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ResolveStencilBuffer.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ResolveStencilBuffer.compute
@@ -84,9 +84,13 @@ void KERNEL_NAME(uint3 groupId          : SV_GroupID,
 
 #endif
 
+    //This temp is needed outside the if(isFirstThread) condition to workaround a DXC DXIL codegen
+    // issue https://github.com/microsoft/DirectXShaderCompiler/issues/2743 until it's fixed
+    uint perThreadCoarseStencilValue = coarseStencilValue;
+
     if (isFirstThread)
     {
         uint addressIndex = Get1DAddressFromPixelCoord(groupId.xy, _CoarseStencilBufferSize.xy, groupId.z);
-        _CoarseStencilBuffer[addressIndex] = coarseStencilValue;
+        _CoarseStencilBuffer[addressIndex] = perThreadCoarseStencilValue;
     }
 }

--- a/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/TextureXR.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/TextureXR.hlsl
@@ -63,7 +63,7 @@
     #define TEXTURE2D_X_UINT(textureName)                                    Texture2DArray<uint> textureName
     #define TEXTURE2D_X_UINT2(textureName)                                   Texture2DArray<uint2> textureName
     #define TEXTURE2D_X_UINT4(textureName)                                   Texture2DArray<uint4> textureName
-    #define TEXTURE2D_X_MSAA(type, textureName)                              Texture2DMSArray<type> textureName
+    #define TEXTURE2D_X_MSAA(type, textureName)                              Texture2DMSArray<type, 1> textureName
 
     #define RW_TEXTURE2D_X(type, textureName)                                RW_TEXTURE2D_ARRAY(type, textureName)
     #define LOAD_TEXTURE2D_X(textureName, unCoord2)                          LOAD_TEXTURE2D_ARRAY(textureName, unCoord2, SLICE_ARRAY_INDEX)
@@ -90,7 +90,7 @@
     #define TEXTURE2D_X_UINT(textureName)                                    Texture2D<uint> textureName
     #define TEXTURE2D_X_UINT2(textureName)                                   Texture2D<uint2> textureName
     #define TEXTURE2D_X_UINT4(textureName)                                   Texture2D<uint4> textureName
-    #define TEXTURE2D_X_MSAA(type, textureName)                              Texture2DMS<type> textureName
+    #define TEXTURE2D_X_MSAA(type, textureName)                              Texture2DMS<type, 1> textureName
 
     #define RW_TEXTURE2D_X                                                   RW_TEXTURE2D
     #define LOAD_TEXTURE2D_X                                                 LOAD_TEXTURE2D

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Made MaterialDescriptionPreprocessors private.
 - UniversalRenderPipelineAsset no longer supports presets [case 1197020](https://issuetracker.unity3d.com/issues/urp-reset-functionality-does-not-work-on-preset-of-universalrenderpipelineassets)
 - The number of maximum visible lights is now determined by whether the platform is mobile or not.
+- Updated shaders to be compatible with Microsoft's DXC.
 
 ### Fixed
 - Fixed an issue where linear to sRGB conversion occurred twice on certain Android devices.

--- a/com.unity.render-pipelines.universal/ShaderLibrary/MetaInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/MetaInput.hlsl
@@ -51,11 +51,8 @@ half4 MetaFragment(MetaInput input)
     {
         res = half4(input.Albedo, 1.0);
 
-        // d3d9 shader compiler doesn't like NaNs and infinity.
-        unity_OneOverOutputBoost = saturate(unity_OneOverOutputBoost);
-
         // Apply Albedo Boost from LightmapSettings.
-        res.rgb = clamp(PositivePow(res.rgb, unity_OneOverOutputBoost), 0, unity_MaxOutputValue);
+        res.rgb = clamp(PositivePow(res.rgb, saturate(unity_OneOverOutputBoost)), 0, unity_MaxOutputValue);
     }
     if (unity_MetaFragmentControl.y)
     {

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7Input.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7Input.hlsl
@@ -7,9 +7,6 @@
     #define GEOM_TYPE_BRANCH
 #endif
 
-#ifdef GEOM_TYPE_BRANCH_DETAIL
-    sampler2D _DetailTex;
-#endif
 
 #if defined(GEOM_TYPE_FROND) || defined(GEOM_TYPE_LEAF) || defined(GEOM_TYPE_FACING_LEAF)
 #define SPEEDTREE_ALPHATEST
@@ -22,5 +19,9 @@
 #endif
 
 #include "SpeedTree7CommonInput.hlsl"
+
+#ifdef GEOM_TYPE_BRANCH_DETAIL
+    sampler2D _DetailTex;
+#endif
 
 #endif


### PR DESCRIPTION
---
### Purpose of this PR
- To make SRP shaders compatible with the DirectX shader compiler.
- Fix a usage of `atan2` which was relying on undefined behavior (in this PR only because it was looking differently with DXC).


---
### Testing status

**Manual Tests**: 
- QA inspected HDRP_Tests project for differences/errors with and w/o DXC

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

---
### Comments to reviewers

- All shaders should produce the same results as they did before this PR with the existing compilers  ( DebugFullScreen.shader might be an exception as now it's explicitly assigned a black output color when motion vectors are zero so test images could potentially have minor differences)
- As far as we know only 1 shader has incorrect output with DXC `com.unity.render-pipelines.high-definition\Runtime\Lighting\LightLoop\Deferred.compute` which compiles but has no planar reflections due to a bug in DXC itself (reported here https://github.com/microsoft/DirectXShaderCompiler/issues/2772)