### PR TITLE
Fix issue of debug display variant with shader graph not compiling

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Material/Decal/ShaderGraph/DecalPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Decal/ShaderGraph/DecalPass.template
@@ -47,10 +47,6 @@ Pass
     $features.graphVertex:                  #define HAVE_MESH_MODIFICATION
     $splice(GraphDefines)
 
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #endif
-
     $splice(HybridV1InjectedBuiltinProperties)
 
     // Includes

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Eye/ShaderGraph/EyePass.template
@@ -58,9 +58,7 @@ Pass
         #define OUTPUT_SPLIT_LIGHTING
     #endif
 
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #else
+    #ifndef DEBUG_DISPLAY
         // In case of opaque we don't want to perform the alpha test, it is done in depth prepass and we use depth equal for ztest (setup from UI)
         // Don't do it with debug display mode as it is possible there is no depth prepass in this case
         #if !defined(_SURFACE_TYPE_TRANSPARENT) && defined(_ALPHATEST)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Fabric/ShaderGraph/FabricPass.template
@@ -57,9 +57,7 @@ Pass
     $features.graphVertex:              #define HAVE_MESH_MODIFICATION
     $splice(GraphDefines)
 
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #else
+    #ifndef DEBUG_DISPLAY
         // In case of opaque we don't want to perform the alpha test, it is done in depth prepass and we use depth equal for ztest (setup from UI)
         // Don't do it with debug display mode as it is possible there is no depth prepass in this case
         #if !defined(_SURFACE_TYPE_TRANSPARENT) && defined(_ALPHATEST)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Hair/ShaderGraph/HairPass.template
@@ -56,9 +56,7 @@ Pass
     $features.graphVertex:              #define HAVE_MESH_MODIFICATION
     $splice(GraphDefines)
 
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #else
+    #ifndef DEBUG_DISPLAY
         // In case of opaque we don't want to perform the alpha test, it is done in depth prepass and we use depth equal for ztest (setup from UI)
         // Don't do it with debug display mode as it is possible there is no depth prepass in this case
         #if !defined(_SURFACE_TYPE_TRANSPARENT) && defined(_ALPHATEST)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/LitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/Lit/ShaderGraph/LitPass.template
@@ -67,9 +67,7 @@ Pass
     $features.graphVertex:              #define HAVE_MESH_MODIFICATION
     $splice(GraphDefines)
 
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #else
+    #ifndef DEBUG_DISPLAY
         // In case of opaque we don't want to perform the alpha test, it is done in depth prepass and we use depth equal for ztest (setup from UI)
         // Don't do it with debug display mode as it is possible there is no depth prepass in this case
         #if !defined(_SURFACE_TYPE_TRANSPARENT) && defined(_ALPHATEST)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/PBRPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/PBR/ShaderGraph/PBRPass.template
@@ -53,9 +53,7 @@ Pass
     $features.graphVertex:                  #define HAVE_MESH_MODIFICATION
     $splice(GraphDefines)
 
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #else
+    #ifndef DEBUG_DISPLAY
         // In case of opaque we don't want to perform the alpha test, it is done in depth prepass and we use depth equal for ztest (setup from UI)
         // Don't do it with debug display mode as it is possible there is no depth prepass in this case
         #if !defined(_SURFACE_TYPE_TRANSPARENT) && defined(_ALPHATEST)

--- a/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/StackLit/ShaderGraph/StackLitPass.template
@@ -202,9 +202,7 @@ Pass
     $features.graphVertex:                  #define HAVE_MESH_MODIFICATION
     $splice(GraphDefines)
 
-    #ifdef DEBUG_DISPLAY
-        #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-    #else
+    #ifndef DEBUG_DISPLAY
         // In case of opaque we don't want to perform the alpha test, it is done in depth prepass and we use depth equal for ztest (setup from UI)
         // Don't do it with debug display mode as it is possible there is no depth prepass in this case
         #if !defined(_SURFACE_TYPE_TRANSPARENT) && defined(_ALPHATEST)

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDIncludes.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDIncludes.cs
@@ -17,6 +17,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
         const string kMaterialUtilities = "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl";
         const string kDecalUtilities = "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Decal/DecalUtilities.hlsl";
         //pre graph material includes
+        const string kDebugDisplay = "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl";
         const string kUnlit = "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Unlit/Unlit.hlsl";
         const string kLit = "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.hlsl";
         const string kEye = "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Eye/Eye.hlsl";
@@ -80,6 +81,7 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             { kShaderVariables, IncludeLocation.Pregraph },
             { kFragInputs, IncludeLocation.Pregraph },
             { kShaderPass, IncludeLocation.Pregraph },
+            { kDebugDisplay, IncludeLocation.Pregraph },            
             { kMaterial, IncludeLocation.Pregraph },
         };
         public static IncludeCollection CoreUtility = new IncludeCollection

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugBlitQuad.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugBlitQuad.shader
@@ -20,7 +20,6 @@ Shader "Hidden/HDRP/DebugBlitQuad"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
 
             TEXTURE2D(_InputTexture);
             SAMPLER(sampler_InputTexture);

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugBlitQuad.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugBlitQuad.shader
@@ -20,6 +20,8 @@ Shader "Hidden/HDRP/DebugBlitQuad"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
+            #define DEBUG_DISPLAY
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
 
             TEXTURE2D(_InputTexture);
             SAMPLER(sampler_InputTexture);

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugColorPicker.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugColorPicker.shader
@@ -20,7 +20,7 @@ Shader "Hidden/HDRP/DebugColorPicker"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.cs.hlsl"
+            #define DEBUG_DISPLAY
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
 
             TEXTURE2D(_DebugColorPickerTexture);

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl
@@ -1,3 +1,5 @@
+#ifdef DEBUG_DISPLAY // Guard define here to be compliant with how shader graph generate code for include
+
 #ifndef UNITY_DEBUG_DISPLAY_INCLUDED
 #define UNITY_DEBUG_DISPLAY_INCLUDED
 
@@ -273,3 +275,5 @@ bool ShouldFlipDebugTexture()
 }
 
 #endif
+
+#endif // DEBUG_DISPLAY

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplayLatlong.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplayLatlong.shader
@@ -20,7 +20,6 @@ Shader "Hidden/HDRP/DebugDisplayLatlong"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
 
             TEXTURECUBE_ARRAY(_InputCubemap);
             SAMPLER(sampler_InputCubemap);

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplayLatlong.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplayLatlong.shader
@@ -20,6 +20,8 @@ Shader "Hidden/HDRP/DebugDisplayLatlong"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
+            #define DEBUG_DISPLAY
+            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
 
             TEXTURECUBE_ARRAY(_InputCubemap);
             SAMPLER(sampler_InputCubemap);

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugFullScreen.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugFullScreen.shader
@@ -22,7 +22,7 @@ Shader "Hidden/HDRP/DebugFullScreen"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.cs.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.cs.hlsl"
+            #define DEBUG_DISPLAY
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Builtin/BuiltinData.hlsl"
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugLightVolumes.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugLightVolumes.shader
@@ -70,7 +70,6 @@ Shader "Hidden/HDRP/DebugLightVolumes"
 
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-            #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
 
             TEXTURE2D_X(_BlitTexture);
             SamplerState sampler_PointClamp;

--- a/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugViewTiles.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugViewTiles.shader
@@ -31,6 +31,7 @@ Shader "Hidden/HDRP/DebugViewTiles"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/Lighting.hlsl"
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
 
+            #define DEBUG_DISPLAY
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
 
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Lighting/LightLoop/LightLoopDef.hlsl"

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Builtin/BuiltinData.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Builtin/BuiltinData.hlsl
@@ -11,9 +11,6 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl" // Require for GetIndexColor auto generated
 #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Builtin/BuiltinData.cs.hlsl"
 
-#include "Packages/com.unity.render-pipelines.high-definition/Runtime/ShaderLibrary/ShaderVariables.hlsl"
-#include "Packages/com.unity.render-pipelines.high-definition/Runtime/Debug/DebugDisplay.hlsl"
-
 //-----------------------------------------------------------------------------
 // helper macro
 //-----------------------------------------------------------------------------
@@ -83,11 +80,13 @@ void GetBuiltinDataDebug(uint paramId, BuiltinData builtinData, PositionInputs p
     case DEBUGVIEW_BUILTIN_BUILTINDATA_DISTORTION:
         result = float3((builtinData.distortion / (abs(builtinData.distortion) + 1) + 1) * 0.5, 0.5);
         break;
+#ifdef DEBUG_DISPLAY
     case DEBUGVIEW_BUILTIN_BUILTINDATA_RENDERING_LAYERS:
         // Only 8 first rendering layers are currently in use (used by light layers)
         // This mode shows only those layers
 
         uint stripeSize = 8;
+
         int lightLayers = (builtinData.renderingLayers & _DebugLightLayersMask) & 0xFF;
         uint layerId = 0, layerCount = countbits(lightLayers);
 
@@ -102,6 +101,7 @@ void GetBuiltinDataDebug(uint paramId, BuiltinData builtinData, PositionInputs p
             }
         }
         break;
+#endif
     }
 }
 


### PR DESCRIPTION
### Purpose of this PR
Shader graph debug mode was not working anymore after shader target refefactor. But we haven't noticed it. This PR fix it.

Note to QA: could you check if this fix this issue on Mac:
https://fogbugz.unity3d.com/f/cases/1227510/ ?

thanks


---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
