### PR TITLE
Add custom pass opaque rendering error message

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for fog attenuation in path tracing.
 - Added a new debug panel for volumes
 - Added XR setting to control camera jitter for temporal effects
+- Added an error message in the DrawRenderers custom pass when rendering opaque objects with an HDRP asset in DeferredOnly mode.
 
 ### Fixed
 - Update documentation of HDRISky-Backplate, precise how to have Ambient Occlusion on the Backplate
@@ -472,7 +473,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed error in the console when switching shader to decal in the material UI.
 - Fixed an issue with refraction model and ray traced recursive rendering (case 1198578).
 - Fixed an issue where a dynamic sky changing any frame may not update the ambient probe.
-- Fixed cubemap thumbnail generation at project load time. 
+- Fixed cubemap thumbnail generation at project load time.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Documentation~/Custom-Pass.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Custom-Pass.md
@@ -198,6 +198,8 @@ Here is the list of all the defines you can enable
 
 Note that you can also override the depth state of the objects in your pass. This is especially useful when you're rendering objects that are not in the camera culling mask (they are only rendered in the custom pass). Because in these objects, opaque ones will be rendered in `Depth Equal` test which only works if they already are in the depth buffer. In this case you may want to override the depth test to `Less Equal`.
 
+**⚠️ Be careful when rendering Opaque objects if you're in deferred: All objects rendered within custom passes are rendered in Forward. It means that you'll need to set your HDRP settings Lit Shader Mode to 'Both' in case you encounter issues when building in release.**
+
 <a name="ScriptingAPI"></a>
 
 ## Scripting API

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/CustomPass/CustomPass.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/RenderPass/CustomPass/CustomPass.cs
@@ -375,6 +375,9 @@ namespace UnityEngine.Rendering.HighDefinition
         /// <param name="type">The custom pass render queue type.</param>
         /// <returns>Returns a render queue range compatible with a ScriptableRenderContext.DrawRenderers.</returns>
         protected RenderQueueRange GetRenderQueueRange(CustomPass.RenderQueueType type)
+            => GetRenderQueueRangeFromRenderQueueType(type);
+
+        internal static RenderQueueRange GetRenderQueueRangeFromRenderQueueType(RenderQueueType type)
         {
             switch (type)
             {


### PR DESCRIPTION
### Purpose of this PR
Add an error message in the DrawRenderers custom pass when rendering opaque objects in deferred only mode. Ignoring this error can lead to object not being present when you build your project because the Forward pass used to render the object in the custom pass have been striped during the build.

![CustomPassError](https://user-images.githubusercontent.com/6877923/77327681-deef7100-6d1b-11ea-863e-9395f3d017d4.gif)

Also updated the doc:
![image](https://user-images.githubusercontent.com/6877923/77327363-6e485480-6d1b-11ea-9f1a-3f14c3708b39.png)

