### PR TITLE
Fix Asset Bundle test

### DIFF
--- a/com.unity.testing.visualeffectgraph/Runtime/LoadVFXFromAssetBundle.cs
+++ b/com.unity.testing.visualeffectgraph/Runtime/LoadVFXFromAssetBundle.cs
@@ -7,16 +7,11 @@ namespace Unity.Testing.VisualEffectGraph
 {
     public class LoadVFXFromAssetBundle : MonoBehaviour
     {
+        public static string s_AssetBundlePath = "Assets/StreamingAssets/VFX_Bundle_Test";
+
         void Start()
         {
-            var assetBundlePath = System.IO.File.ReadAllLines(Application.streamingAssetsPath + "/AssetBundlePath.txt");
-            if (assetBundlePath.Length < 1)
-            {
-                Debug.LogError("Unable to find bundle AssetBundlePath.txt");
-                return;
-            }
-
-            var basePath = assetBundlePath[0];
+            var basePath = s_AssetBundlePath;
             var fullPath = System.IO.Path.Combine(basePath, "vfx_in_assetbundle");
             if (!System.IO.File.Exists(fullPath))
             {

--- a/com.unity.testing.visualeffectgraph/Runtime/LoadVFXFromAssetBundle.cs
+++ b/com.unity.testing.visualeffectgraph/Runtime/LoadVFXFromAssetBundle.cs
@@ -7,11 +7,11 @@ namespace Unity.Testing.VisualEffectGraph
 {
     public class LoadVFXFromAssetBundle : MonoBehaviour
     {
-        public static string s_AssetBundlePath = "Assets/StreamingAssets/VFX_Bundle_Test";
+        public static string s_AssetBundleName = "VFX_Bundle_Test";
 
         void Start()
         {
-            var basePath = s_AssetBundlePath;
+            var basePath = System.IO.Path.Combine(Application.streamingAssetsPath, s_AssetBundleName);
             var fullPath = System.IO.Path.Combine(basePath, "vfx_in_assetbundle");
             if (!System.IO.File.Exists(fullPath))
             {

--- a/com.unity.testing.visualeffectgraph/Tests/Runtime/Setup/SetupGraphicsTestCases.cs
+++ b/com.unity.testing.visualeffectgraph/Tests/Runtime/Setup/SetupGraphicsTestCases.cs
@@ -10,31 +10,6 @@ using UnityEngine.VFX;
 // can be used directly instead.
 public class SetupGraphicsTestCases : IPrebuildSetup
 {
-    public static void RebuildVisualEffectAsset(VisualEffectAsset vfx)
-    {
-    }
-
-    private static string GetAssetBundleBasePath()
-    {
-        var basePath = System.IO.Directory.GetCurrentDirectory();
-
-        var args = System.Environment.GetCommandLineArgs();
-        for (int i = 0; i < args.Length; i++)
-        {
-            if (args[i].ToLower() == "-logfile" && i != args.Length - 1)
-            {
-                var testResultID = "test-results"; //Find a nice path for yamato output
-                var logPath = args[i + 1];
-                if (logPath.Contains(testResultID))
-                {
-                    basePath = logPath.Substring(0, logPath.IndexOf(testResultID) + testResultID.Length);
-                }
-                break;
-            }
-        }
-        return System.IO.Path.Combine(basePath, "VFX_Bundle_Test");
-    }
-
     public void Setup()
     {
         UnityEditor.TestTools.Graphics.SetupGraphicsTestCases.Setup();
@@ -46,37 +21,17 @@ public class SetupGraphicsTestCases : IPrebuildSetup
             foreach (var guid in vfxAssetsGuid)
             {
                 string assetPath = AssetDatabase.GUIDToAssetPath(guid);
-                var vfxAsset = AssetDatabase.LoadAssetAtPath<VisualEffectAsset>(assetPath);
-                if (vfxAsset != null)
-                {
-                    var vfxName = Path.GetFileName(AssetDatabase.GUIDToAssetPath(guid));
-                    EditorUtility.DisplayProgressBar("Recompiling Asset Bundle VFX : " + vfxName, "Asset Bundle", 0);
-                    RebuildVisualEffectAsset(vfxAsset);
-                }
+                AssetDatabase.ImportAsset(assetPath);
             }
             EditorUtility.ClearProgressBar();
         }
 
-        var bundlePath = GetAssetBundleBasePath();
+        var bundlePath = Unity.Testing.VisualEffectGraph.LoadVFXFromAssetBundle.s_AssetBundlePath;
         if (!Directory.Exists(bundlePath))
         {
             Directory.CreateDirectory(bundlePath);
         }
-        BuildTarget target = UnityEditor.BuildTarget.NoTarget;
-
-#if UNITY_STANDALONE_OSX
-        target = UnityEditor.BuildTarget.StandaloneOSX;
-#elif UNITY_STANDALONE_LINUX
-        target = UnityEditor.BuildTarget.StandaloneLinux64;
-#elif UNITY_STANDALONE_WIN
-        target = UnityEditor.BuildTarget.StandaloneWindows64;
-#else
-        Debug.LogError("Unable to choose the correct target while building AssetBundle");
-#endif
-
+        BuildTarget target = UnityEditor.EditorUserBuildSettings.activeBuildTarget;
         UnityEditor.BuildPipeline.BuildAssetBundles(bundlePath, UnityEditor.BuildAssetBundleOptions.None, target);
-        if (!Directory.Exists("Assets/StreamingAssets"))
-            Directory.CreateDirectory("Assets/StreamingAssets");
-        File.WriteAllText("Assets/StreamingAssets/AssetBundlePath.txt", bundlePath);
     }
 }

--- a/com.unity.testing.visualeffectgraph/Tests/Runtime/Setup/SetupGraphicsTestCases.cs
+++ b/com.unity.testing.visualeffectgraph/Tests/Runtime/Setup/SetupGraphicsTestCases.cs
@@ -26,7 +26,7 @@ public class SetupGraphicsTestCases : IPrebuildSetup
             EditorUtility.ClearProgressBar();
         }
 
-        var bundlePath = Unity.Testing.VisualEffectGraph.LoadVFXFromAssetBundle.s_AssetBundlePath;
+        var bundlePath = "Assets/StreamingAssets/" + Unity.Testing.VisualEffectGraph.LoadVFXFromAssetBundle.s_AssetBundleName;
         if (!Directory.Exists(bundlePath))
         {
             Directory.CreateDirectory(bundlePath);


### PR DESCRIPTION
### Purpose of this PR
Fix asset bundle test for dedicated platform test execution :
- Use UnityEditor.EditorUserBuildSettings.activeBuildTarget instead of compilation define
- Output assetBundle directly in streaming asset

### Comments to reviewers
I was outputting the generated AssetBundle into output log folder to easily retrieve it from artefact, but, in the end, I never used this functionality and it prevents correct execution of VFX test project in real (PS4/X1) platform.

I'm awaiting for yamato before adding any reviewer, tested locally on URP project.

*Update* : Yamato is green
