### PR TITLE
[ShaderGraph][HD][8.x.x] Fix for Scene Depth node and Keywords

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDSubShaderUtilities.cs
@@ -841,6 +841,10 @@ namespace UnityEditor.Rendering.HighDefinition
 
             ShaderGenerator defines = new ShaderGenerator();
             {
+                defines.AddShaderChunk("// Shared Graph Keywords");
+                defines.AddShaderChunk(shaderKeywordDeclarations.ToString());
+                defines.AddShaderChunk(shaderKeywordPermutations.ToString());
+
                 defines.AddShaderChunk(string.Format("#define SHADERPASS {0}", pass.ShaderPassName), true);
                 if (pass.ExtraDefines != null)
                 {
@@ -893,10 +897,6 @@ namespace UnityEditor.Rendering.HighDefinition
                 foreach (var include in pass.Includes)
                     shaderPassIncludes.AddShaderChunk(include);
             }
-
-            defines.AddShaderChunk("// Shared Graph Keywords");
-            defines.AddShaderChunk(shaderKeywordDeclarations.ToString());
-            defines.AddShaderChunk(shaderKeywordPermutations.ToString());
 
             // build graph code
             var graph = new ShaderGenerator();

--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where adding a HDRP Master Node to a Shader Graph would softlock the Shader Graph.
 - Fixed a bug where the input fields sometimes didn't render properly. [1176268](https://issuetracker.unity3d.com/issues/shadergraph-input-fields-get-cut-off-after-minimizing-and-maximizing-become-unusable)
 - Fixed a bug with the `Transform` node where converting from `Absolute World` space in a sub graph causes invalid subscript errors. [1190813](https://issuetracker.unity3d.com/issues/shadergraph-invalid-subscript-errors-are-thrown-when-connecting-a-subgraph-with-transform-node-with-unlit-master-node)
+- Fixed a bug where `Scene Depth` nodes would stop working after adding a keyword on the blackboard. [1203333](https://issuetracker.unity3d.com/product/unity/issues/guid/1203333/)
 
 ## [8.0.1] - 2020-05-25
 


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
Fixes an issue where adding shader keywords to a graph would break the results of the Scene Depth node. [public link](https://issuetracker.unity3d.com/product/unity/issues/guid/1203333/) [internal link](https://fogbugz.unity3d.com/f/cases/1203333/)

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 
- Opened the Scene depth test scene in HDRP_tests project.
- Opened the graph and added a keyword.
- Ran the test and confirmed that results are now the same with or without a shader keyword present on the blackboard. 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
Not needed in master, targets already resolved the generation issue. 