### PR TITLE
[Shader Graph][7.x.x] Fix Position Node upgrader

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-Version Updated
-The version number for this package has increased due to a version update of a related graphics package.
+### Fixed
+- Fixed a bug where the `Position` node would change coordinate spaces from `World` to `Absolute World` when shaders recompile. [1184617](https://issuetracker.unity3d.com/product/unity/issues/guid/1184617/)
 
 ## [7.3.0] - 2020-03-11
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -80,6 +80,12 @@ namespace UnityEditor.ShaderGraph
             set { m_Name = value; }
         }
 
+        public int nodeVersion 
+        {
+            get { return m_NodeVersion; }
+            set { m_NodeVersion = value; }
+        }
+
         protected virtual string documentationPage => name;
         public virtual string documentationURL => NodeUtils.GetDocumentationString(documentationPage);
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.ShaderGraph
         private string m_Name;
 
         [SerializeField]
-        protected int m_NodeVersion;
+        private int m_NodeVersion;
 
         [SerializeField]
         private DrawState m_DrawState;
@@ -80,7 +80,7 @@ namespace UnityEditor.ShaderGraph
             set { m_Name = value; }
         }
 
-        public int nodeVersion 
+        protected int nodeVersion 
         {
             get { return m_NodeVersion; }
             set { m_NodeVersion = value; }

--- a/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -80,12 +80,6 @@ namespace UnityEditor.ShaderGraph
             set { m_Name = value; }
         }
 
-        protected int nodeVersion 
-        {
-            get { return m_NodeVersion; }
-            set { m_NodeVersion = value; }
-        }
-
         protected virtual string documentationPage => name;
         public virtual string documentationURL => NodeUtils.GetDocumentationString(documentationPage);
 
@@ -216,6 +210,7 @@ namespace UnityEditor.ShaderGraph
         {
             m_DrawState.expanded = true;
             m_Guid = Guid.NewGuid();
+            m_NodeVersion = GetCompiledNodeVersion();
             version = 0;
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/PositionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/PositionNode.cs
@@ -21,6 +21,7 @@ namespace UnityEditor.ShaderGraph
         {
             name = "Position";
             precision = Precision.Float;
+            nodeVersion = 1;
             UpdateNodeAfterDeserialization();
         }
 

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/PositionNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Geometry/PositionNode.cs
@@ -21,7 +21,6 @@ namespace UnityEditor.ShaderGraph
         {
             name = "Position";
             precision = Precision.Float;
-            nodeVersion = 1;
             UpdateNodeAfterDeserialization();
         }
 


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing? 
backport #6343 
Fixed an issue where new Position nodes added to graphs would always be "upgraded", causing the coordinate space drop down to switch from World to Absolute World when entering play mode or restarting the project. 

[public link](https://issuetracker.unity3d.com/product/unity/issues/guid/1184617/)
[internal link](https://fogbugz.unity3d.com/f/cases/1184617/)

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 
Previous repro behavior: 
- Create a new graph, add a Position node. leave the coordinate space on default World. Save graph.
- Enter and exit playmode to force shader compilation. 
- Open the graph, observe that World has been automatically set to Absolute World. 

Fix behavior: 
- Create a new graph, add a Position node. leave the coordinate space on default World. Save graph.
- Enter and exit playmode to force shader compilation. 
- Open the graph, observe that the coordinate space has not changed.  

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
This was initially intended to be an upgrader for the position node when Absolute World space was added. Because HDRP uses different values, the intent was that any existing graphs would maintain the same output even though the entry changed. The node version was never set properly and it caused the Position node to always run through the upgrader no matter what. 
Any graphs with the Position node already in use should not see any change in behavior. This only applies to newly created Position nodes after this fix is merged. 