### PR TITLE
Enable

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Enable by default Cookie for Light Baking
+- Add warning if disabled and use Baking & Cookies
 - Ray tracing support for VR single-pass
 - Added sharpen filter shader parameter and UI for TemporalAA to control image quality instead of hardcoded value
 - Added frame settings option for custom post process and custom passes as well as custom color buffer format option.

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.Skin.cs
@@ -42,6 +42,7 @@ namespace UnityEditor.Rendering.HighDefinition
             public readonly GUIContent cookieTextureTypeError = new GUIContent("HDRP does not support the Cookie Texture type, only Default is supported.", EditorGUIUtility.IconContent("console.warnicon").image);
             public readonly string cookieNonPOT = "HDRP does not support non power of two cookie textures.";
             public readonly string cookieTooSmall = "Min texture size for cookies is 2x2 pixels.";
+            public readonly string cookieBaking = "Light Baking for cookies disabled on the Project Settings, .";
 
 
             // Additional light data

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightUI.cs
@@ -410,7 +410,7 @@ namespace UnityEditor.Rendering.HighDefinition
                         case AreaLightShape.Disc:
                             //draw the built-in area light control at the moment as everything is handled by built-in
                             serialized.settings.DrawArea();
-                            serialized.displayAreaLightEmissiveMesh.boolValue = false; //force deactivate emissive mesh for Disc (not supported) 
+                            serialized.displayAreaLightEmissiveMesh.boolValue = false; //force deactivate emissive mesh for Disc (not supported)
                             break;
                         case (AreaLightShape)(-1): //multiple different values
                             using (new EditorGUI.DisabledScope(true))
@@ -723,12 +723,12 @@ namespace UnityEditor.Rendering.HighDefinition
                     EditorGUI.indentLevel--;
                 }
 
-                ShowCookieTextureWarnings(serialized.settings.cookie);
+                ShowCookieTextureWarnings(serialized.settings.cookie, serialized.settings.isCompletelyBaked || serialized.settings.isBakedOrMixed);
             }
             else if (serialized.areaLightShape == AreaLightShape.Rectangle || serialized.areaLightShape == AreaLightShape.Disc)
             {
                 EditorGUILayout.ObjectField( serialized.areaLightCookie, s_Styles.areaLightCookie );
-                ShowCookieTextureWarnings(serialized.areaLightCookie.objectReferenceValue as Texture);
+                ShowCookieTextureWarnings(serialized.areaLightCookie.objectReferenceValue as Texture, serialized.settings.isCompletelyBaked || serialized.settings.isBakedOrMixed);
             }
 
             if (EditorGUI.EndChangeCheck())
@@ -738,7 +738,7 @@ namespace UnityEditor.Rendering.HighDefinition
             }
         }
 
-        static void ShowCookieTextureWarnings(Texture cookie)
+        static void ShowCookieTextureWarnings(Texture cookie, bool useBaking)
         {
             if (cookie == null)
                 return;
@@ -768,12 +768,14 @@ namespace UnityEditor.Rendering.HighDefinition
                 }
             }
 
+            if (useBaking && UnityEditor.EditorSettings.disableCookiesInLightmapper)
+                EditorGUILayout.HelpBox(s_Styles.cookieBaking, MessageType.Warning);
             if (cookie.width != cookie.height)
                 EditorGUILayout.HelpBox(s_Styles.cookieNonPOT, MessageType.Warning);
             if (cookie.width < LightCookieManager.k_MinCookieSize || cookie.height < LightCookieManager.k_MinCookieSize)
                 EditorGUILayout.HelpBox(s_Styles.cookieTooSmall, MessageType.Warning);
         }
-        
+
         static void DrawEmissionAdvancedContent(SerializedHDLight serialized, Editor owner)
         {
             HDLightType lightType = serialized.type;
@@ -809,7 +811,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
                 bool showSubArea = serialized.displayAreaLightEmissiveMesh.boolValue && !serialized.displayAreaLightEmissiveMesh.hasMultipleDifferentValues;
                 ++EditorGUI.indentLevel;
-                    
+
                 Rect lineRect = EditorGUILayout.GetControlRect();
                 ShadowCastingMode newCastShadow;
                 EditorGUI.showMixedValue = serialized.areaLightEmissiveMeshCastShadow.hasMultipleDifferentValues;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -103,6 +103,7 @@ namespace UnityEngine.Rendering.HighDefinition
         readonly XRSystem m_XRSystem;
 
         bool m_FrameSettingsHistoryEnabled = false;
+        bool m_DisableCookieForLightBaking = false;
 
         /// <summary>
         /// This functions allows the user to have an approximation of the number of rays that were traced for a given frame.
@@ -660,6 +661,9 @@ namespace UnityEngine.Rendering.HighDefinition
             GraphicsSettings.lightsUseLinearIntensity = true;
             GraphicsSettings.lightsUseColorTemperature = true;
 
+            m_DisableCookieForLightBaking = UnityEditor.EditorSettings.disableCookiesInLightmapper;
+            UnityEditor.EditorSettings.disableCookiesInLightmapper = false;
+
             GraphicsSettings.useScriptableRenderPipelineBatching = m_Asset.enableSRPBatcher;
 
             SupportedRenderingFeatures.active = new SupportedRenderingFeatures()
@@ -775,6 +779,8 @@ namespace UnityEngine.Rendering.HighDefinition
 
             // Reset srp batcher state just in case
             GraphicsSettings.useScriptableRenderPipelineBatching = false;
+
+            UnityEditor.EditorSettings.disableCookiesInLightmapper = m_DisableCookieForLightBaking;
 
             Lightmapping.ResetDelegate();
         }


### PR DESCRIPTION
Update Light Baking with Cookie
- If Project Settings > disable light cookies in baking && project use baking or mixed light with cookie show warning message
- For new project, enable light baking cookies by default.


**PR workflow guidelines**
* SRP ABV will start automatically on Yamato when you open your PR
* Changes to docs and md files will **not** trigger ABV jobs 
* Consider making use of **draft PRs** if you are not 100% sure that your PR is ready for review
* ABV will restart if you add a new commit to a branch with an open PR (hence why you should consider using draft PRs)
* Adding [skip ci] (case insensitive) to the title of PRs will stop any jobs being trigger automatically - you will need to open Yamato and find your branch to run ABV
* You can also add [skip ci] to commit messages to prevent CI from running on that push
* Add [cancel old ci] to your commit message if you've made changes you want to test and no longer need the previous jobs

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [X] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR
Update Light Baking with Cookie
- If Project Settings > disable light cookies in baking && project use baking or mixed light with cookie show warning message
- For new project, enable light baking cookies by default.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
