### PR TITLE
Sg/fix quotations in property names

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where shaders fail to compile due to `#pragma target` generation when your system locale uses commas instead of periods.
 - Fixed a compilation error when using Hybrid Renderer due to incorrect positioning of macros.
 - Fixed a bug with the `Transform` node where converting from `Absolute World` space in a sub graph causes invalid subscript errors. [1190813](https://issuetracker.unity3d.com/issues/shadergraph-invalid-subscript-errors-are-thrown-when-connecting-a-subgraph-with-transform-node-with-unlit-master-node)
+- Fixed a bug where adding a " to a property display name would cause shader compilation errors and show all nodes as broken
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Documentation~/Blackboard.md
+++ b/com.unity.shadergraph/Documentation~/Blackboard.md
@@ -11,6 +11,6 @@ You can move the Blackboard anywhere in the [Shader Graph Window](Shader-Graph-W
 
 To create a new Property or Keyword, click the **Add (+)** button on the Blackboard's title bar, and select a Property or Keyword type.
 
-To reorder items listed on the Blackboard, drag and drop them. To delete items, use the Delete key on Windows, or the Command + Backspace key combination on OS X. To rename an item, double-click on its name, and enter a new name. Drag Properties and Keywords from the Blackboard to the graph to create a corresponding node.
+To reorder items listed on the Blackboard, drag and drop them. To delete items, use the Delete key on Windows, or the Command + Backspace key combination on OS X. To rename an item, double-click on its name, and enter a new name (note: quotation marks in display names will get stripped and replaced with underscores). Drag Properties and Keywords from the Blackboard to the graph to create a corresponding node.
 
 For a full list of Property types, see [Property Types](Property-Types).

--- a/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/GraphUtil.cs
@@ -249,6 +249,8 @@ namespace UnityEditor.ShaderGraph
         /// </returns>
         internal static string SanitizeName(IEnumerable<string> existingNames, string duplicateFormat, string name)
         {
+            //.shader files are not cool with " in the middle of a property name (eg.  Vector1_81B203C2("fo"o"o", Float) = 0)
+            name = name.Replace("\"", "_");
             if (!existingNames.Contains(name))
                 return name;
 


### PR DESCRIPTION
…eak the shadergraph, but get sanitized out

### **Please read**
**PR workflow guidelines**
* SRP ABV will start automatically on Yamato when you open your PR
* Changes to docs and md files will **not** trigger ABV jobs 
* Consider making use of **draft PRs** if you are not 100% sure that your PR is ready for review
* ABV will restart if you add a new commit to a branch with an open PR (hence why you should consider using draft PRs)
* Adding [skip ci] (case insensitive) to the title of PRs will stop any jobs being trigger automatically - you will need to open Yamato and find your branch to run ABV
* You can also add [skip ci] to commit messages to prevent CI from running on that push
* Add [cancel old ci] to your commit message if you've made changes you want to test and no longer need the previous jobs

### Checklist for PR maker
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [x] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
If you use a " in a property name on a shadergraph, all nodes show errors and the graph breaks 
https://fogbugz.unity3d.com/f/cases/1221258/
---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Checked new UI names with UX convention

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
