### PR TITLE
Avoid negative input to sqrt()

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/ACES.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/ACES.hlsl
@@ -316,6 +316,7 @@ half rgb_2_yc(half3 rgb)
     half g = rgb.y;
     half b = rgb.z;
     half k = b * (b - g) + g * (g - r) + r * (r - b);
+    k = max(k, 0.0h); // Clamp to avoid precision issue causing k < 0, making sqrt(k) undefined
 #if defined(SHADER_API_SWITCH)
     half chroma = k == 0.0 ? 0.0 : sqrt(k); // Fix NaN on Nintendo Switch (should not happen in theory).
 #else


### PR DESCRIPTION
This fixes a precision bug in ACES.hlsl resulting in rendering artifacts on Mali drivers newer than Bifrost/Valhall R21.

Before: 
![stock](https://user-images.githubusercontent.com/45175346/77652646-dc388a00-6f6e-11ea-9b3c-1abd2c7e270c.png)

After: ![fix](https://user-images.githubusercontent.com/45175346/77652633-d5117c00-6f6e-11ea-9684-e1b3b15b0931.png)

Summary:
- The calculation of `k` is not numerically robust when done in FP16 and might generate a negative value.
- This can be observed as rendering artifacts on Mali drivers newer than Bifrost/Valhall R21.
- This commit fixes this by by clamping `k` to [0, inf] before the `sqrt()`.
- On Mali-G77 the clamp compiles down to a free output modifier on the previous instruction, so there's no performance impact.