### PR TITLE
- Avoid building the mip chain a second time for SSR for transparent objects.

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -598,6 +598,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed a few resources used by ray tracing shaders to be global resources (using register space1) for improved CPU performance.
 - All custom pass volumes are now executed for one injection point instead of the first one.
 - Hidden unsupported choice in emission in Materials
+- Avoid building the mip chain a second time for SSR for transparent objects.
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ScreenSpaceLighting/ScreenSpaceReflections.compute
@@ -8,6 +8,8 @@
 #pragma kernel ScreenSpaceReflectionsTracing      SSR_TRACE
 #pragma kernel ScreenSpaceReflectionsReprojection SSR_REPROJECT
 
+#pragma multi_compile _ DEPTH_SOURCE_NOT_FROM_MIP_CHAIN
+
 // Tweak parameters.
 // #define DEBUG
 #define SSR_TRACE_BEHIND_OBJECTS
@@ -38,6 +40,12 @@
 
 #ifdef DEBUG
     RW_TEXTURE2D(float4, _SsrDebugTexture);
+#endif
+
+// Given that for transparent objects we do not trace in a depth buffer that contains them 
+// we need a seperate texture for the mip chain and for the depth source
+#ifdef DEPTH_SOURCE_NOT_FROM_MIP_CHAIN
+TEXTURE2D_X(_DepthTexture);
 #endif
 
 #ifdef SSR_TRACE
@@ -121,7 +129,12 @@ void ScreenSpaceReflectionsTracing(uint3 groupId          : SV_GroupID,
     }
 
     float2 positionNDC = positionSS * _ScreenSize.zw + (0.5 * _ScreenSize.zw); // Should we precompute the half-texel bias? We seem to use it a lot.
+
+#ifdef DEPTH_SOURCE_NOT_FROM_MIP_CHAIN
+    float  deviceDepth = LOAD_TEXTURE2D_X(_DepthTexture, positionSS).r;
+#else
     float  deviceDepth = LOAD_TEXTURE2D_X(_CameraDepthTexture, positionSS).r;
+#endif
 
     bool killRay = deviceDepth == UNITY_RAW_FAR_CLIP_VALUE;
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.LightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.LightLoop.cs
@@ -241,6 +241,7 @@ namespace UnityEngine.Rendering.HighDefinition
         class RenderSSRPassData
         {
             public RenderSSRParameters parameters;
+            public TextureHandle depthBuffer;
             public TextureHandle depthPyramid;
             public TextureHandle colorPyramid;
             public TextureHandle stencilBuffer;
@@ -254,6 +255,7 @@ namespace UnityEngine.Rendering.HighDefinition
                                         HDCamera            hdCamera,
                                     TextureHandle   normalBuffer,
                                     TextureHandle   motionVectorsBuffer,
+                                    TextureHandle   depthBuffer,
                                     TextureHandle   depthPyramid,
                                     TextureHandle   stencilBuffer,
                                     TextureHandle   clearCoatMask)
@@ -282,7 +284,8 @@ namespace UnityEngine.Rendering.HighDefinition
 
                     var colorPyramid = renderGraph.ImportTexture(hdCamera.GetPreviousFrameRT((int)HDCameraFrameHistoryType.ColorBufferMipChain));
 
-                    passData.parameters = PrepareSSRParameters(hdCamera);
+                    passData.parameters = PrepareSSRParameters(hdCamera, true);
+                    passData.depthBuffer = builder.ReadTexture(depthBuffer);
                     passData.depthPyramid = builder.ReadTexture(depthPyramid);
                     passData.colorPyramid = builder.ReadTexture(colorPyramid);
                     passData.stencilBuffer = builder.ReadTexture(stencilBuffer);
@@ -305,6 +308,7 @@ namespace UnityEngine.Rendering.HighDefinition
                     {
                         var res = context.resources;
                         RenderSSR(data.parameters,
+                                    res.GetTexture(data.depthBuffer),
                                     res.GetTexture(data.depthPyramid),
                                     res.GetTexture(data.hitPointsTexture),
                                     res.GetTexture(data.stencilBuffer),

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.RenderGraph.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.RenderGraph.cs
@@ -75,6 +75,7 @@ namespace UnityEngine.Rendering.HighDefinition
                                                               hdCamera,
                                                               prepassOutput.resolvedNormalBuffer,
                                                               prepassOutput.resolvedMotionVectorsBuffer,
+                                                              prepassOutput.depthBuffer,
                                                               prepassOutput.depthPyramidTexture,
                                                               prepassOutput.stencilBuffer,
                                                               clearCoatMask);


### PR DESCRIPTION
Currently for transparentSSR, we are rebuilding the mip-chain which is expensive (and not useful). By using the post transparentDepthPrepass depth buffer for building the ray and the previous mip chain (without transparents) to ray marche we get a better result and cheaper.

The transparent SSR test is still green. Transparent SSR was not working for render graph, so I did not make it work.