### PR TITLE
Sg/export dependencies

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where shaders fail to compile due to `#pragma target` generation when your system locale uses commas instead of periods.
 - Fixed a compilation error when using Hybrid Renderer due to incorrect positioning of macros.
 - Fixed a bug with the `Transform` node where converting from `Absolute World` space in a sub graph causes invalid subscript errors. [1190813](https://issuetracker.unity3d.com/issues/shadergraph-invalid-subscript-errors-are-thrown-when-connecting-a-subgraph-with-transform-node-with-unlit-master-node)
+- Fixed a bug where depndencies were not getting included when exporting a shadergraph and subgraphs
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -17,12 +17,6 @@ namespace UnityEditor.ShaderGraph
     [ScriptedImporter(32, Extension, 3)]
     class ShaderGraphImporter : ScriptedImporter
     {
-        [Serializable]
-        private class ShaderGraphExportDependencies : ScriptableObject
-        {
-            public List<UnityEngine.Object> assetDependencies = new List<UnityEngine.Object>();
-        }
-
         public const string Extension = "shadergraph";
 
         public const string k_ErrorShader = @"
@@ -141,6 +135,13 @@ Shader ""Hidden/GraphErrorShader2""
             {
                 metadata.outputNodeTypeName = graph.outputNode.GetType().FullName;
             }
+            metadata.assetDependencies = new List<UnityEngine.Object>();
+            var deps = GatherDependenciesFromSourceFile(ctx.assetPath);
+            foreach(string dependency in deps)
+            {
+                metadata.assetDependencies.Add(AssetDatabase.LoadAssetAtPath(dependency, typeof(UnityEngine.Object)));
+            }
+
             ctx.AddObjectToAsset("Metadata", metadata);
 
             foreach (var sourceAssetDependencyPath in sourceAssetDependencyPaths.Distinct())
@@ -154,15 +155,6 @@ Shader ""Hidden/GraphErrorShader2""
 
                 ctx.DependsOnSourceAsset(sourceAssetDependencyPath);
             }
-
-            var exportDependencies = ScriptableObject.CreateInstance<ShaderGraphExportDependencies>();
-            exportDependencies.hideFlags = HideFlags.HideInHierarchy;
-            var deps = GatherDependenciesFromSourceFile(ctx.assetPath);
-            foreach(string dependency in deps)
-            {
-                exportDependencies.assetDependencies.Add(AssetDatabase.LoadAssetAtPath(dependency, typeof(UnityEngine.Object)));
-            }
-            ctx.AddObjectToAsset("Export Dependencies", exportDependencies);
         }
 
         internal static string GetShaderText(string path, out List<PropertyCollector.TextureInfo> configuredTextures, List<string> sourceAssetDependencyPaths, GraphData graph)

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -17,6 +17,12 @@ namespace UnityEditor.ShaderGraph
     [ScriptedImporter(32, Extension, 3)]
     class ShaderGraphImporter : ScriptedImporter
     {
+        [Serializable]
+        private class ShaderGraphExportDependencies : ScriptableObject
+        {
+            public List<UnityEngine.Object> assetDependencies = new List<UnityEngine.Object>();
+        }
+
         public const string Extension = "shadergraph";
 
         public const string k_ErrorShader = @"
@@ -148,6 +154,15 @@ Shader ""Hidden/GraphErrorShader2""
 
                 ctx.DependsOnSourceAsset(sourceAssetDependencyPath);
             }
+
+            var exportDependencies = ScriptableObject.CreateInstance<ShaderGraphExportDependencies>();
+            exportDependencies.hideFlags = HideFlags.HideInHierarchy;
+            var deps = GatherDependenciesFromSourceFile(ctx.assetPath);
+            foreach(string dependency in deps)
+            {
+                exportDependencies.assetDependencies.Add(AssetDatabase.LoadAssetAtPath(dependency, typeof(UnityEngine.Object)));
+            }
+            ctx.AddObjectToAsset("Export Dependencies", exportDependencies);
         }
 
         internal static string GetShaderText(string path, out List<PropertyCollector.TextureInfo> configuredTextures, List<string> sourceAssetDependencyPaths, GraphData graph)

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphMetadata.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphMetadata.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace UnityEditor.ShaderGraph
@@ -5,5 +6,6 @@ namespace UnityEditor.ShaderGraph
     class ShaderGraphMetadata : ScriptableObject
     {
         public string outputNodeTypeName;
+        public List<Object> assetDependencies;
     }
 }

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphImporter.cs
@@ -73,6 +73,16 @@ namespace UnityEditor.ShaderGraph
             Texture2D texture = Resources.Load<Texture2D>("Icons/sg_subgraph_icon@64");
             ctx.AddObjectToAsset("MainAsset", graphAsset, texture);
             ctx.SetMainObject(graphAsset);
+
+            var metadata = ScriptableObject.CreateInstance<ShaderGraphMetadata>();
+            metadata.hideFlags = HideFlags.HideInHierarchy;
+            metadata.assetDependencies = new List<UnityEngine.Object>();
+            var deps = GatherDependenciesFromSourceFile(ctx.assetPath);
+            foreach (string dependency in deps)
+            {
+                metadata.assetDependencies.Add(AssetDatabase.LoadAssetAtPath(dependency, typeof(UnityEngine.Object)));
+            }
+            ctx.AddObjectToAsset("Metadata", metadata);
         }
 
         static void ProcessSubGraph(SubGraphAsset asset, GraphData graph)

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphMetadata.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphMetadata.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityEditor.ShaderGraph
+{
+    class ShaderSubGraphMetadata : ScriptableObject
+    {
+        public List<Object> assetDependencies;
+    }
+}

--- a/com.unity.shadergraph/Editor/Importers/ShaderSubGraphMetadata.cs.meta
+++ b/com.unity.shadergraph/Editor/Importers/ShaderSubGraphMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0169c6aa153625741a0b332e73a43fb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### **Please read**
**PR workflow guidelines**
* SRP ABV will start automatically on Yamato when you open your PR
* Changes to docs and md files will **not** trigger ABV jobs 
* Consider making use of **draft PRs** if you are not 100% sure that your PR is ready for review
* ABV will restart if you add a new commit to a branch with an open PR (hence why you should consider using draft PRs)
* Adding [skip ci] (case insensitive) to the title of PRs will stop any jobs being trigger automatically - you will need to open Yamato and find your branch to run ABV
* You can also add [skip ci] to commit messages to prevent CI from running on that push
* Add [cancel old ci] to your commit message if you've made changes you want to test and no longer need the previous jobs

### Checklist for PR maker
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.

---
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing?
When exporting a shadergraph or subgraph with dependencies, the depended assets were not grabbed correctly. 
---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- Other: 
Reimported all files in the test project and tried exporting a few shadergraphs

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

---
### Comments to reviewers
Notes for the reviewers you have assigned.
