### PR TITLE
Remove inefficient node dirty when graph first created

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -813,8 +813,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (m_FrameAllAfterLayout)
                 graphEditorView.graphView.FrameAll();
             m_FrameAllAfterLayout = false;
-            foreach (var node in m_GraphObject.graph.GetNodes<AbstractMaterialNode>())
-                node.Dirty(ModificationScope.Node);
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -534,14 +534,17 @@ namespace UnityEditor.ShaderGraph.Drawing
             if (m_GraphView == null)
                 return;
 
+            // moved this outside of the loop
+            IEnumerable<IShaderNodeView> theViews = m_GraphView.nodes.ToList().OfType<IShaderNodeView>();
+
             var dependentNodes = new List<AbstractMaterialNode>();
             NodeUtils.CollectNodesNodeFeedsInto(dependentNodes, inNode);
             foreach (var node in dependentNodes)
             {
-                var theViews = m_GraphView.nodes.ToList().OfType<IShaderNodeView>();
-                var viewsFound = theViews.Where(x => x.node.guid == node.guid).ToList();
-                foreach (var drawableNodeData in viewsFound)
-                    drawableNodeData.OnModified(scope);
+                // I think there is never more than one IShaderNodeView matching the guid of a node... is this correct?
+                var nodeView = theViews.FirstOrDefault(x => x.node.guid == node.guid);
+                if (nodeView != null)
+                    nodeView.OnModified(scope);
             }
         }
 


### PR DESCRIPTION
### **Please read**
**PR workflow guidelines**
* SRP ABV will start automatically on Yamato when you open your PR
* Changes to docs and md files will **not** trigger ABV jobs 
* Consider making use of **draft PRs** if you are not 100% sure that your PR is ready for review
* ABV will restart if you add a new commit to a branch with an open PR (hence why you should consider using draft PRs)
* Adding [skip ci] (case insensitive) to the title of PRs will stop any jobs being trigger automatically - you will need to open Yamato and find your branch to run ABV
* You can also add [skip ci] to commit messages to prevent CI from running on that push
* Add [cancel old ci] to your commit message if you've made changes you want to test and no longer need the previous jobs

### Checklist for PR maker
- [ ] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [ ] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---
### Purpose of this PR

Remove unnecessary node dirtying when a shadergraph is opened.
Somewhat improves the performance of the node dirtying code by removing node list construction from the inner loop.
Opening a large graph  goes from ~16 seconds to ~9 seconds.  (Other optimizations in separate PRs)

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
