### PR TITLE
Hdrp /fix framesettingsoverridemask api

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Utilities/BitArray.cs
+++ b/com.unity.render-pipelines.core/Runtime/Utilities/BitArray.cs
@@ -41,6 +41,12 @@ namespace UnityEngine.Rendering
         /// </summary>
         /// <returns></returns>
         IBitArray BitNot();
+
+        /// <summary>
+        /// Affectation utility to deal with underneath type
+        /// </summary>
+        /// <param name="other">the IBitArray to copy content into this one. Must have same size.</param>
+        void AssignFrom(IBitArray other);
     }
 
     // /!\ Important for serialization:
@@ -163,6 +169,19 @@ namespace UnityEngine.Rendering
         /// </summary>
         /// <returns>Hashcode of the bit array.</returns>
         public override int GetHashCode() => 1768953197 + data.GetHashCode();
+
+        /// <summary>
+        /// Helper to convert from IBitArray 
+        /// </summary>
+        /// <param name="other">The IBitArray to copy data from</param>
+        /// <returns></returns>
+        public void AssignFrom(IBitArray other)
+        {
+            if (!(other.capacity == 8u))
+                throw new InvalidCastException();
+
+            data = ((BitArray8)other).data;
+        }
     }
 
     /// <summary>
@@ -282,6 +301,19 @@ namespace UnityEngine.Rendering
         /// </summary>
         /// <returns>Hashcode of the bit array.</returns>
         public override int GetHashCode() => 1768953197 + data.GetHashCode();
+        
+        /// <summary>
+        /// Helper to convert from IBitArray 
+        /// </summary>
+        /// <param name="other">The IBitArray to copy data from</param>
+        /// <returns></returns>
+        public void AssignFrom(IBitArray other)
+        {
+            if (!(other.capacity == 16u))
+                throw new InvalidCastException();
+
+            data = ((BitArray16)other).data;
+        }
     }
 
     /// <summary>
@@ -402,6 +434,19 @@ namespace UnityEngine.Rendering
         /// </summary>
         /// <returns>Hashcode of the bit array.</returns>
         public override int GetHashCode() => 1768953197 + data.GetHashCode();
+        
+        /// <summary>
+        /// Helper to convert from IBitArray 
+        /// </summary>
+        /// <param name="other">The IBitArray to copy data from</param>
+        /// <returns></returns>
+        public void AssignFrom(IBitArray other)
+        {
+            if (!(other.capacity == 32u))
+                throw new InvalidCastException();
+
+            data = ((BitArray32)other).data;
+        }
     }
 
     /// <summary>
@@ -521,6 +566,19 @@ namespace UnityEngine.Rendering
         /// </summary>
         /// <returns>Hashcode of the bit array.</returns>
         public override int GetHashCode() => 1768953197 + data.GetHashCode();
+
+        /// <summary>
+        /// Helper to convert from IBitArray 
+        /// </summary>
+        /// <param name="other">The IBitArray to copy data from</param>
+        /// <returns></returns>
+        public void AssignFrom(IBitArray other)
+        {
+            if (!(other.capacity == 64u))
+                throw new InvalidCastException();
+
+            data = ((BitArray64)other).data;
+        }
     }
 
     /// <summary>
@@ -656,6 +714,20 @@ namespace UnityEngine.Rendering
             hashCode = hashCode * -1521134295 + data1.GetHashCode();
             hashCode = hashCode * -1521134295 + data2.GetHashCode();
             return hashCode;
+        }
+        
+        /// <summary>
+        /// Helper to convert from IBitArray 
+        /// </summary>
+        /// <param name="other">The IBitArray to copy data from</param>
+        /// <returns></returns>
+        public void AssignFrom(IBitArray other)
+        {
+            if (!(other.capacity == 128u))
+                throw new InvalidCastException();
+
+            data1 = ((BitArray128)other).data1;
+            data2 = ((BitArray128)other).data2;
         }
     }
 
@@ -812,6 +884,22 @@ namespace UnityEngine.Rendering
             hashCode = hashCode * -1521134295 + data3.GetHashCode();
             hashCode = hashCode * -1521134295 + data4.GetHashCode();
             return hashCode;
+        }
+
+        /// <summary>
+        /// Helper to convert from IBitArray 
+        /// </summary>
+        /// <param name="other">The IBitArray to copy data from</param>
+        /// <returns></returns>
+        public void AssignFrom(IBitArray other)
+        {
+            if (!(other.capacity == 256u))
+                throw new InvalidCastException();
+
+            data1 = ((BitArray256)other).data1;
+            data2 = ((BitArray256)other).data2;
+            data3 = ((BitArray256)other).data3;
+            data4 = ((BitArray256)other).data4;
         }
     }
 

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -572,6 +572,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Renamed "Environment" to "Reflection Probes" in tile/cluster debug menu.
 - Utilities namespace is obsolete, moved its content to UnityEngine.Rendering (case 1204677)
 - Obsolete Utilities namespace was removed, instead use UnityEngine.Rendering (case 1204677)
+- Deprecate the FrameSettingsOverridingMask.mask and introduce accessor, in order to be able to expend it later if needed.
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.Migration.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.Migration.cs
@@ -200,7 +200,7 @@ namespace UnityEngine.Rendering.HighDefinition
             }
 
             // OverrideMask
-            newFrameSettingsOverrideMask.mask = new BitArray128();
+            newFrameSettingsOverrideMask.ResetMask();
             Array values = Enum.GetValues(typeof(ObsoleteFrameSettingsOverrides));
             foreach (ObsoleteFrameSettingsOverrides val in values)
             {
@@ -209,97 +209,97 @@ namespace UnityEngine.Rendering.HighDefinition
                     switch(val)
                     {
                         case ObsoleteFrameSettingsOverrides.Shadow:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ShadowMaps] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ShadowMaps, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.ContactShadow:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ContactShadows] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ContactShadows, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.ShadowMask:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.Shadowmask] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.Shadowmask, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.SSR:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.SSR] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.SSR, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.SSAO:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.SSAO] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.SSAO, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.SubsurfaceScattering:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.SubsurfaceScattering] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.SubsurfaceScattering, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.Transmission:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.Transmission] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.Transmission, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.AtmosphericScaterring:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.AtmosphericScattering] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.AtmosphericScattering, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.Volumetrics:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.Volumetrics] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.Volumetrics, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.ReprojectionForVolumetrics:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ReprojectionForVolumetrics] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ReprojectionForVolumetrics, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.LightLayers:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.LightLayers] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.LightLayers, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.ShaderLitMode:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.LitShaderMode] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.LitShaderMode, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.DepthPrepassWithDeferredRendering:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.DepthPrepassWithDeferredRendering] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.DepthPrepassWithDeferredRendering, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.TransparentPrepass:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.TransparentPrepass] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.TransparentPrepass, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.MotionVectors:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.MotionVectors] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.MotionVectors, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.ObjectMotionVectors:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ObjectMotionVectors] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ObjectMotionVectors, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.Decals:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.Decals] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.Decals, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.RoughRefraction:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.Refraction] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.Refraction, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.TransparentPostpass:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.TransparentPostpass] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.TransparentPostpass, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.Distortion:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.Distortion] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.Distortion, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.Postprocess:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.Postprocess] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.Postprocess, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.OpaqueObjects:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.OpaqueObjects] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.OpaqueObjects, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.TransparentObjects:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.TransparentObjects] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.TransparentObjects, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.MSAA:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.MSAA] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.MSAA, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.ExposureControl:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ExposureControl] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ExposureControl, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.AsyncCompute:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.AsyncCompute] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.AsyncCompute, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.LightListAsync:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.LightListAsync] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.LightListAsync, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.SSRAsync:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.SSRAsync] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.SSRAsync, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.SSAOAsync:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.SSAOAsync] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.SSAOAsync, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.ContactShadowsAsync:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ContactShadowsAsync] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ContactShadowsAsync, true);
                             break;
                         case ObsoleteFrameSettingsOverrides.VolumeVoxelizationsAsync:
-                            newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.VolumeVoxelizationsAsync] = true;
+                            newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.VolumeVoxelizationsAsync, true);
                             break;
                         default:
                             throw new ArgumentException("Unknown ObsoleteFrameSettingsOverride, was " + val);
@@ -317,22 +317,22 @@ namespace UnityEngine.Rendering.HighDefinition
                         switch (val)
                         {
                             case ObsoleteLightLoopSettingsOverrides.TileAndCluster:
-                                newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.DeferredTile] = true;
+                                newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.DeferredTile, true);
                                 break;
                             case ObsoleteLightLoopSettingsOverrides.BigTilePrepass:
-                                newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.BigTilePrepass] = true;
+                                newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.BigTilePrepass, true);
                                 break;
                             case ObsoleteLightLoopSettingsOverrides.ComputeLightEvaluation:
-                                newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ComputeLightEvaluation] = true;
+                                newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ComputeLightEvaluation, true);
                                 break;
                             case ObsoleteLightLoopSettingsOverrides.ComputeLightVariants:
-                                newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ComputeLightVariants] = true;
+                                newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ComputeLightVariants, true);
                                 break;
                             case ObsoleteLightLoopSettingsOverrides.ComputeMaterialVariants:
-                                newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.ComputeMaterialVariants] = true;
+                                newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.ComputeMaterialVariants, true);
                                 break;
                             case ObsoleteLightLoopSettingsOverrides.FptlForForwardOpaque:
-                                newFrameSettingsOverrideMask.mask[(int)FrameSettingsField.FPTLForForwardOpaque] = true;
+                                newFrameSettingsOverrideMask.SetBitFor(FrameSettingsField.FPTLForForwardOpaque, true);
                                 break;
                             default:
                                 throw new ArgumentException("Unknown ObsoleteLightLoopSettingsOverrides");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettings.cs
@@ -321,8 +321,85 @@ namespace UnityEngine.Rendering.HighDefinition
     public struct FrameSettingsOverrideMask
     {
         /// <summary>Mask of overridden values.</summary>
+        [Obsolete("This will be removed in future version. Please use IsOverriding/SetOverriding instead.")]
         [SerializeField]
-        public BitArray128 mask;
+        public BitArray128 mask; //remove public for 9.x.x
+
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+        internal IBitArray bitMask => mask;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        internal void ResetMask()
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+            => mask = new BitArray128();
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// <summary>Get stored overriding mask's data for this field.</summary>
+        /// </summary>
+        /// <param name="field">Requested field.</param>
+        /// <returns>True if the field is enabled.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+        public bool GetBitFor(FrameSettingsField field) => mask[(uint)field];
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// <summary>Set stored overriding mask's data for this field.</summary>
+        /// </summary>
+        /// <param name="field">Requested field.</param>
+        /// <param name="value">State to set to the field.</param>
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+        public void SetBitFor(FrameSettingsField field, bool value) => mask[(uint)field] = value;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+
+        /// <summary>
+        /// Equality operator.
+        /// </summary>
+        /// <param name="a">First FrameSettingsOverrideMask.</param>
+        /// <param name="b">Second FrameSettingsOverrideMask.</param>
+        /// <returns>True if both settings are equal.</returns>
+        public static bool operator ==(FrameSettingsOverrideMask a, FrameSettingsOverrideMask b)
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+            => a.mask == b.mask;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        /// Inequality operator.
+        /// </summary>
+        /// <param name="a">First FrameSettingsOverrideMask.</param>
+        /// <param name="b">Second FrameSettingsOverrideMask.</param>
+        /// <returns>True if settings are not equal.</returns>
+        public static bool operator !=(FrameSettingsOverrideMask a, FrameSettingsOverrideMask b)
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+            => a.mask != b.mask;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+
+
+        /// <summary>
+        /// Equality operator.
+        /// </summary>
+        /// <param name="obj">FrameSettingsOverrideMask to compare to.</param>
+        /// <returns>True if both settings are equal.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is FrameSettingsOverrideMask overrideMask)
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+                return mask == overrideMask.mask;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the hash code of the FrameSettingsOverrideMask.
+        /// </summary>
+        /// <returns>Hash code of the FrameSettingsOverrideMask.</returns>
+        public override int GetHashCode()
+#pragma warning disable CS0618 // Type or member is obsolete      //remove for 9.x.x
+            => 1694694097 + mask.GetHashCode();
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     /// <summary>Per renderer and per frame settings.</summary>
@@ -606,22 +683,22 @@ namespace UnityEngine.Rendering.HighDefinition
         internal static void Override(ref FrameSettings overriddenFrameSettings, FrameSettings overridingFrameSettings, FrameSettingsOverrideMask frameSettingsOverideMask)
         {
             //quick override of all booleans
-            overriddenFrameSettings.bitDatas = (overridingFrameSettings.bitDatas & frameSettingsOverideMask.mask) | (~frameSettingsOverideMask.mask & overriddenFrameSettings.bitDatas);
+            overriddenFrameSettings.bitDatas.AssignFrom(overridingFrameSettings.bitDatas.BitAnd(frameSettingsOverideMask.bitMask).BitOr(frameSettingsOverideMask.bitMask.BitNot().BitAnd(overriddenFrameSettings.bitDatas)));
 
             //other overrides
-            if (frameSettingsOverideMask.mask[(uint) FrameSettingsField.LODBias])
+            if (frameSettingsOverideMask.GetBitFor(FrameSettingsField.LODBias))
                 overriddenFrameSettings.lodBias = overridingFrameSettings.lodBias;
-            if (frameSettingsOverideMask.mask[(uint) FrameSettingsField.LODBiasMode])
+            if (frameSettingsOverideMask.GetBitFor(FrameSettingsField.LODBiasMode))
                 overriddenFrameSettings.lodBiasMode = overridingFrameSettings.lodBiasMode;
-            if (frameSettingsOverideMask.mask[(uint) FrameSettingsField.LODBiasQualityLevel])
+            if (frameSettingsOverideMask.GetBitFor(FrameSettingsField.LODBiasQualityLevel))
                 overriddenFrameSettings.lodBiasQualityLevel = overridingFrameSettings.lodBiasQualityLevel;
-            if (frameSettingsOverideMask.mask[(uint) FrameSettingsField.MaximumLODLevel])
+            if (frameSettingsOverideMask.GetBitFor(FrameSettingsField.MaximumLODLevel))
                 overriddenFrameSettings.maximumLODLevel = overridingFrameSettings.maximumLODLevel;
-            if (frameSettingsOverideMask.mask[(uint) FrameSettingsField.MaximumLODLevelMode])
+            if (frameSettingsOverideMask.GetBitFor(FrameSettingsField.MaximumLODLevelMode))
                 overriddenFrameSettings.maximumLODLevelMode = overridingFrameSettings.maximumLODLevelMode;
-            if (frameSettingsOverideMask.mask[(uint) FrameSettingsField.MaximumLODLevelQualityLevel])
+            if (frameSettingsOverideMask.GetBitFor(FrameSettingsField.MaximumLODLevelQualityLevel))
                 overriddenFrameSettings.maximumLODLevelQualityLevel = overridingFrameSettings.maximumLODLevelQualityLevel;
-            if (frameSettingsOverideMask.mask[(uint) FrameSettingsField.MaterialQualityLevel])
+            if (frameSettingsOverideMask.GetBitFor(FrameSettingsField.MaterialQualityLevel))
                 overriddenFrameSettings.materialQuality = overridingFrameSettings.materialQuality;
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettingsHistory.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/FrameSettingsHistory.cs
@@ -149,7 +149,7 @@ namespace UnityEngine.Rendering.HighDefinition
             if (historyContainer.hasCustomFrameSettings)
             {
                 FrameSettings.Override(ref aggregatedFrameSettings, historyContainer.frameSettings, historyContainer.frameSettingsMask);
-                updatedComponent = history.customMask.mask != historyContainer.frameSettingsMask.mask;
+                updatedComponent = history.customMask != historyContainer.frameSettingsMask;
                 history.customMask = historyContainer.frameSettingsMask;
             }
             history.overridden = aggregatedFrameSettings;


### PR DESCRIPTION
### Purpose of this PR
Currently the public API make us unable to expend the FrameSettings size if we run out of space.
The modification in this PR deprecate the access to the visible element BitArray128. It introduce two new accessor for user to use instead:
    public struct FrameSettingsOverrideMask
    {
        public bool GetBitFor(FrameSettingsField field);
        public void SetBitFor(FrameSettingsField field, bool value);
    }
This also add utility to directly compare struct FrameSettingsOverrideMask to another one.
And finally, the IBitArray utility is completed to be able to perform the masking operation when aggregating regardless the king of BitArray used. Sadly we cannot yet add operator in Interface (will be available in C#8 so we must add the implementation for each case inside all the BitArrays.

Current project will have an warning regarding that they use an obsolete field. So this is only for HDRP/staging for now.
When the obsolete periode is over (for 9.x.x ?) we should only change the visibility of the FrameSettingsOverrideMask to be private, and remove the pragma removing the warning inside the FrameSettingsOverrideMask struct.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- Other: 
     - regarding the change, either they totally broke the pipeline, or it will works

---
### Comments to reviewers
Note: Not sure it is at no risk regarding the performance though. 