### PR TITLE
Reducing the number of variants for ray tracing when building a player

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added an alpha blend option for recursive rendering
 - Added support for stack lit for ray tracing effects.
 - Added support for hair for ray tracing effects.
+- Added a ray tracing mode option in the HDRP asset that allows to override and shader stripping.
 
 ### Fixed
 - Fix when rescale probe all direction below zero (1219246)
@@ -601,6 +602,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Hidden unsupported choice in emission in Materials
 - Temporal Anti aliasing improvements.
 - Optimized PrepareLightsForGPU (cost reduced by over 25%) and PrepareGPULightData (around twice as fast now).
+- Replaced the DIFFUSE_LIGHTING_ONLY multicompile by a uniform.
+- Removed the dynamic lightmap multicompile.
+- Remove the LOD cross fade multi compile for ray tracing.
 
 ## [7.1.1] - 2019-09-05
 

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDScreenSpaceReflectionEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/Reflection/HDScreenSpaceReflectionEditor.cs
@@ -100,25 +100,39 @@ namespace UnityEditor.Rendering.HighDefinition
                 PropertyField(m_LayerMask, EditorGUIUtility.TrTextContent("Layer Mask", "Layer mask used to include the objects for screen space reflection."));
                 PropertyField(m_RayLength, EditorGUIUtility.TrTextContent("Ray Length", "Controls the length of reflection rays."));
                 PropertyField(m_ClampValue, EditorGUIUtility.TrTextContent("Clamp Value", "Clamps the exposed intensity."));
-                PropertyField(m_Mode, EditorGUIUtility.TrTextContent("Mode", "Controls which version of the effect should be used."));
 
-                EditorGUI.indentLevel++;
-                switch (m_Mode.value.GetEnumValue<RayTracingMode>())
+                if (currentAsset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Both)
                 {
-                    case RayTracingMode.Performance:
+                    PropertyField(m_Mode, EditorGUIUtility.TrTextContent("Mode", "Controls which version of the effect should be used."));
+                    EditorGUI.indentLevel++;
+                    switch (m_Mode.value.GetEnumValue<RayTracingMode>())
                     {
-                        PropertyField(m_UpscaleRadius, EditorGUIUtility.TrTextContent("Upscale Radius", "Controls the size of the upscale radius."));
-                        PropertyField(m_FullResolution, EditorGUIUtility.TrTextContent("Full Resolution", "Enables full resolution mode."));
+                        case RayTracingMode.Performance:
+                            {
+                                PropertyField(m_UpscaleRadius, EditorGUIUtility.TrTextContent("Upscale Radius", "Controls the size of the upscale radius."));
+                                PropertyField(m_FullResolution, EditorGUIUtility.TrTextContent("Full Resolution", "Enables full resolution mode."));
+                            }
+                            break;
+                        case RayTracingMode.Quality:
+                            {
+                                PropertyField(m_SampleCount, EditorGUIUtility.TrTextContent("Sample Count", "Number of samples for reflections."));
+                                PropertyField(m_BounceCount, EditorGUIUtility.TrTextContent("Bounce Count", "Number of bounces for reflection rays."));
+                            }
+                            break;
                     }
-                    break;
-                    case RayTracingMode.Quality:
-                    {
-                        PropertyField(m_SampleCount, EditorGUIUtility.TrTextContent("Sample Count", "Number of samples for reflections."));
-                        PropertyField(m_BounceCount, EditorGUIUtility.TrTextContent("Bounce Count", "Number of bounces for reflection rays."));
-                    }
-                    break;
+                    EditorGUI.indentLevel--;
                 }
-                EditorGUI.indentLevel--;
+                else if (currentAsset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Quality)
+                {
+                    PropertyField(m_SampleCount, EditorGUIUtility.TrTextContent("Sample Count", "Number of samples for reflections."));
+                    PropertyField(m_BounceCount, EditorGUIUtility.TrTextContent("Bounce Count", "Number of bounces for reflection rays."));
+                }
+                else
+                {
+                    PropertyField(m_UpscaleRadius, EditorGUIUtility.TrTextContent("Upscale Radius", "Controls the size of the upscale radius."));
+                    PropertyField(m_FullResolution, EditorGUIUtility.TrTextContent("Full Resolution", "Enables full resolution mode."));
+                }
+                
                 PropertyField(m_Denoise, EditorGUIUtility.TrTextContent("Denoise", "Enable denoising on the ray traced reflections."));
                 {
                     EditorGUI.indentLevel++;

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.Skin.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.Skin.cs
@@ -109,6 +109,7 @@ namespace UnityEditor.Rendering.HighDefinition
             public static readonly GUIContent supportTransparentDepthPrepass = EditorGUIUtility.TrTextContent("Transparent Depth Prepass", "When disabled, HDRP removes all transparent depth prepass Shader variants when you build for the Unity Player. This decreases build time.");
             public static readonly GUIContent supportTransparentDepthPostpass = EditorGUIUtility.TrTextContent("Transparent Depth Postpass", "When disabled, HDRP removes all transparent depth postpass Shader variants when you build for the Unity Player. This decreases build time.");
             public static readonly GUIContent supportRaytracing = EditorGUIUtility.TrTextContent("Realtime Raytracing (Preview)");
+            public static readonly GUIContent supportedRayTracingMode = EditorGUIUtility.TrTextContent("Supported Ray Tracing Mode (Preview)");
             public static readonly GUIContent rayTracingUnsupportedWarning = EditorGUIUtility.TrTextContent("Ray tracing is not supported on your device. Please refer to the documentation.");
             public static readonly GUIContent maximumLODLevel = EditorGUIUtility.TrTextContent("Maximum LOD Level");
             public static readonly GUIContent LODBias = EditorGUIUtility.TrTextContent("LOD Bias");

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/HDRenderPipelineUI.cs
@@ -845,10 +845,13 @@ namespace UnityEditor.Rendering.HighDefinition
             EditorGUILayout.PropertyField(serialized.renderPipelineSettings.supportRayTracing, Styles.supportRaytracing);
             using (new EditorGUI.DisabledScope(!serialized.renderPipelineSettings.supportRayTracing.boolValue))
             {
+                ++EditorGUI.indentLevel;
+                EditorGUILayout.PropertyField(serialized.renderPipelineSettings.supportedRayTracingMode, Styles.supportedRayTracingMode);
                 if (serialized.renderPipelineSettings.supportRayTracing.boolValue && !UnityEngine.SystemInfo.supportsRayTracing)
                 {
                     EditorGUILayout.HelpBox(Styles.rayTracingUnsupportedWarning.text, MessageType.Warning, wide: true);
                 }
+                --EditorGUI.indentLevel;
             }
 
             serialized.renderPipelineSettings.lodBias.ValueGUI<float>(Styles.LODBias);
@@ -964,6 +967,7 @@ namespace UnityEditor.Rendering.HighDefinition
             AppendSupport(builder, serialized.renderPipelineSettings.supportTransparentDepthPrepass, Styles.supportTransparentDepthPrepass);
             AppendSupport(builder, serialized.renderPipelineSettings.supportTransparentDepthPostpass, Styles.supportTransparentDepthPostpass);
             AppendSupport(builder, serialized.renderPipelineSettings.supportRayTracing, Styles.supportRaytracing);
+            AppendSupport(builder, serialized.renderPipelineSettings.supportedRayTracingMode, Styles.supportedRayTracingMode);
 
             EditorGUILayout.HelpBox(builder.ToString(), MessageType.Info, wide: true);
         }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/GlobalIlluminationEditor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/GlobalIlluminationEditor.cs
@@ -76,25 +76,38 @@ namespace UnityEditor.Rendering.HighDefinition
                     PropertyField(m_LayerMask);
                     PropertyField(m_RayLength);
                     PropertyField(m_ClampValue);
-                    PropertyField(m_Mode);
 
-                    EditorGUI.indentLevel++;
-                    switch (m_Mode.value.GetEnumValue<RayTracingMode>())
+                    if (currentAsset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Both)
                     {
-                        case RayTracingMode.Performance:
-                            {
-                                PropertyField(m_FullResolution);
-                                PropertyField(m_UpscaleRadius);
-                            }
-                            break;
-                        case RayTracingMode.Quality:
-                            {
-                                PropertyField(m_SampleCount);
-                                PropertyField(m_BounceCount);
-                            }
-                            break;
+                        PropertyField(m_Mode);
+                        EditorGUI.indentLevel++;
+                        switch (m_Mode.value.GetEnumValue<RayTracingMode>())
+                        {
+                            case RayTracingMode.Performance:
+                                {
+                                    PropertyField(m_FullResolution);
+                                    PropertyField(m_UpscaleRadius);
+                                }
+                                break;
+                            case RayTracingMode.Quality:
+                                {
+                                    PropertyField(m_SampleCount);
+                                    PropertyField(m_BounceCount);
+                                }
+                                break;
+                        }
+                        EditorGUI.indentLevel--;
                     }
-                    EditorGUI.indentLevel--;
+                    else if (currentAsset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Quality)
+                    {
+                        PropertyField(m_SampleCount);
+                        PropertyField(m_BounceCount);
+                    }
+                    else
+                    {
+                        PropertyField(m_FullResolution);
+                        PropertyField(m_UpscaleRadius);
+                    }
 
                     PropertyField(m_Denoise);
                     {

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/RayTracingShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Raytracing/RayTracingShaderPreprocessor.cs
@@ -21,6 +21,18 @@ namespace UnityEditor.Rendering.HighDefinition
                     || snippet.passName == "SubSurfaceDXR")
                     return true;
             }
+            else
+            {
+                // If we only support Performance mode, we do not want the indirectDXR shader
+                if (hdrpAsset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Performance
+                    && snippet.passName == "IndirectDXR")
+                    return true;
+
+                // If we only support Quality mode, we do not want the indirectDXR shader
+                if (hdrpAsset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Quality
+                    && snippet.passName == "GBufferDXR")
+                    return true;
+            }
 
             return false;
         }

--- a/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedRenderPipelineSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/RenderPipeline/Settings/SerializedRenderPipelineSettings.cs
@@ -49,6 +49,7 @@ namespace UnityEditor.Rendering.HighDefinition
         public SerializedProperty supportDitheringCrossFade;
         public SerializedProperty supportTerrainHole;
         public SerializedProperty supportRayTracing;
+        public SerializedProperty supportedRayTracingMode;
         public SerializedProperty supportDistortion;
         public SerializedProperty supportTransparentBackface;
         public SerializedProperty supportTransparentDepthPrepass;
@@ -107,6 +108,7 @@ namespace UnityEditor.Rendering.HighDefinition
             supportTransparentDepthPostpass = root.Find((RenderPipelineSettings s) => s.supportTransparentDepthPostpass);
 
             supportRayTracing               = root.Find((RenderPipelineSettings s) => s.supportRayTracing);
+            supportedRayTracingMode         = root.Find((RenderPipelineSettings s) => s.supportedRayTracingMode);
 
             lightLoopSettings = new SerializedGlobalLightLoopSettings(root.Find((RenderPipelineSettings s) => s.lightLoopSettings));
             hdShadowInitParams = new SerializedHDShadowInitParameters(root.Find((RenderPipelineSettings s) => s.hdShadowInitParams));

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDKeywords.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDKeywords.cs
@@ -79,15 +79,6 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
                 scope = KeywordScope.Global,
             };
 
-            public static KeywordDescriptor DiffuseLightingOnly = new KeywordDescriptor()
-            {
-                displayName = "Diffuse Lighting Only",
-                referenceName = "DIFFUSE_LIGHTING_ONLY",
-                type = KeywordType.Boolean,
-                definition = KeywordDefinition.MultiCompile,
-                scope = KeywordScope.Global,
-            };
-
             public static KeywordDescriptor LightLayers = new KeywordDescriptor()
             {
                 displayName = "Light Layers",
@@ -257,6 +248,15 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
             { Descriptors.AlphaTest, new FieldCondition(Fields.AlphaTest, true) },
         };
 
+        public static KeywordCollection HDBaseNoCrossFade = new KeywordCollection
+        {
+            { Descriptors.SurfaceTypeTransparent },
+            { Descriptors.BlendMode },
+            { Descriptors.DoubleSided, new FieldCondition(HDFields.SubShader.Unlit, false) },
+            { Descriptors.FogOnTransparent },
+            { Descriptors.AlphaTest, new FieldCondition(Fields.AlphaTest, true) },
+        };
+
         public static KeywordCollection Lightmaps = new KeywordCollection
         {
             { Descriptors.Lightmap },
@@ -359,14 +359,13 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
 
         public static KeywordCollection RaytracingIndirect = new KeywordCollection
         {
-            { HDBase },
-            { Descriptors.DiffuseLightingOnly },
+            { HDBaseNoCrossFade },
             { Lightmaps },
         };
 
         public static KeywordCollection RaytracingGBufferForward = new KeywordCollection
         {
-            { HDBase },
+            { HDBaseNoCrossFade },
             { Lightmaps },
         };
     }

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/LayeredLit/LayeredLit.shader
@@ -890,7 +890,6 @@ Shader "HDRP/LayeredLit"
             #define SHADERPASS SHADERPASS_RAYTRACING_INDIRECT
 
             // multi compile that allows us to
-            #pragma multi_compile _ DIFFUSE_LIGHTING_ONLY
             #pragma multi_compile _ MULTI_BOUNCE_INDIRECT
 
             // We use the low shadow maps for raytracing
@@ -972,7 +971,6 @@ Shader "HDRP/LayeredLit"
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
             #pragma multi_compile _ DYNAMICLIGHTMAP_ON
-            #pragma multi_compile _ DIFFUSE_LIGHTING_ONLY
 
             #define SHADERPASS SHADERPASS_RAYTRACING_GBUFFER
 
@@ -1035,7 +1033,6 @@ Shader "HDRP/LayeredLit"
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
             #pragma multi_compile _ DYNAMICLIGHTMAP_ON
-            #pragma multi_compile _ DIFFUSE_LIGHTING_ONLY
 
             #define SHADERPASS SHADERPASS_RAYTRACING_SUB_SURFACE
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
+++ b/com.unity.render-pipelines.high-definition/Runtime/Material/Lit/Lit.shader
@@ -296,9 +296,6 @@ Shader "HDRP/Lit"
 
     #pragma shader_feature_local _ADD_PRECOMPUTED_VELOCITY
 
-    // enable dithering LOD crossfade
-    #pragma multi_compile _ LOD_FADE_CROSSFADE
-
     //-------------------------------------------------------------------------------------
     // Define
     //-------------------------------------------------------------------------------------
@@ -355,12 +352,13 @@ Shader "HDRP/Lit"
             Cull Off
 
             HLSLPROGRAM
-
             #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
             //enable GPU instancing support
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             // Note: Require _ObjectId and _PassValue variables
 
@@ -405,6 +403,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #pragma multi_compile _ DEBUG_DISPLAY
             #pragma multi_compile _ LIGHTMAP_ON
@@ -454,6 +454,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             // Lightmap memo
             // DYNAMICLIGHTMAP_ON is used when we have an "enlighten lightmap" ie a lightmap updated at runtime by enlighten.This lightmap contain indirect lighting from realtime lights and realtime emissive material.Offline baked lighting(from baked material / light,
@@ -492,6 +494,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #define SHADERPASS SHADERPASS_SHADOWS
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
@@ -531,6 +535,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             // In deferred, depth only pass don't output anything.
             // In forward it output the normal buffer
@@ -581,6 +587,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #pragma multi_compile _ WRITE_NORMAL_BUFFER
             #pragma multi_compile _ WRITE_MSAA_DEPTH
@@ -628,6 +636,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #define SHADERPASS SHADERPASS_DISTORTION
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
@@ -666,6 +676,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #define SHADERPASS SHADERPASS_DEPTH_ONLY
             #define CUTOFF_TRANSPARENT_DEPTH_PREPASS
@@ -710,6 +722,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #pragma multi_compile _ DEBUG_DISPLAY
             #pragma multi_compile _ LIGHTMAP_ON
@@ -782,6 +796,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #pragma multi_compile _ DEBUG_DISPLAY
             #pragma multi_compile _ LIGHTMAP_ON
@@ -848,6 +864,8 @@ Shader "HDRP/Lit"
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
             #pragma multi_compile _ DOTS_INSTANCING_ON
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #define SHADERPASS SHADERPASS_DEPTH_ONLY
             #define CUTOFF_TRANSPARENT_DEPTH_POSTPASS
@@ -874,8 +892,9 @@ Shader "HDRP/Lit"
             ZTest LEqual // If the object have already been render in depth prepass, it will re-render to tag stencil
 
             HLSLPROGRAM
-
             #pragma only_renderers d3d11 ps4 xboxone vulkan metal switch
+            // enable dithering LOD crossfade
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
 
             #define SHADERPASS SHADERPASS_CONSTANT
             #include "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/Material.hlsl"
@@ -907,12 +926,10 @@ Shader "HDRP/Lit"
             #pragma multi_compile _ DEBUG_DISPLAY
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
-            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
 
             #define SHADERPASS SHADERPASS_RAYTRACING_INDIRECT
 
-            // multi compile that allows us to
-            #pragma multi_compile _ DIFFUSE_LIGHTING_ONLY
+            // multi compile that allows us to strip the recursive code
             #pragma multi_compile _ MULTI_BOUNCE_INDIRECT
 
             // We use the low shadow maps for raytracing
@@ -952,7 +969,6 @@ Shader "HDRP/Lit"
             #pragma multi_compile _ DEBUG_DISPLAY
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
-            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
 
             #define SHADERPASS SHADERPASS_RAYTRACING_FORWARD
 
@@ -993,8 +1009,6 @@ Shader "HDRP/Lit"
             #pragma multi_compile _ DEBUG_DISPLAY
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
-            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
-            #pragma multi_compile _ DIFFUSE_LIGHTING_ONLY
 
             #define SHADERPASS SHADERPASS_RAYTRACING_GBUFFER
 
@@ -1058,8 +1072,6 @@ Shader "HDRP/Lit"
             #pragma multi_compile _ DEBUG_DISPLAY
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ DIRLIGHTMAP_COMBINED
-            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
-            #pragma multi_compile _ DIFFUSE_LIGHTING_ONLY
 
             #define SHADERPASS SHADERPASS_RAYTRACING_SUB_SURFACE
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -720,6 +720,7 @@ namespace UnityEngine.Rendering.HighDefinition
         // Deferred Lighting
         public static readonly int _RaytracingLitBufferRW           = Shader.PropertyToID("_RaytracingLitBufferRW");
         public static readonly int _RaytracingDiffuseRay            = Shader.PropertyToID("_RaytracingDiffuseRay");
+        public static readonly int _RayTracingDiffuseLightingOnly   = Shader.PropertyToID("_RayTracingDiffuseLightingOnly");
 
         // Ray binning
         public static readonly int _RayBinResult                    = Shader.PropertyToID("_RayBinResult");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingDeferredLightLoop.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingDeferredLightLoop.cs
@@ -231,7 +231,7 @@ namespace UnityEngine.Rendering.HighDefinition
             cmd.SetRayTracingTextureParam(parameters.gBufferRaytracingRT, HDShaderIDs._SkyTexture, buffers.skyTexture);
 
             // Only compute diffuse lighting if required
-            CoreUtils.SetKeyword(cmd, "DIFFUSE_LIGHTING_ONLY", parameters.diffuseLightingOnly);
+            cmd.SetGlobalInt(HDShaderIDs._RayTracingDiffuseLightingOnly, parameters.diffuseLightingOnly ? 1 : 0);
             CoreUtils.SetKeyword(cmd, "MULTI_BOUNCE_INDIRECT", false);
 
             // All rays are diffuse if we are evaluating diffuse lighting only
@@ -253,9 +253,6 @@ namespace UnityEngine.Rendering.HighDefinition
                 cmd.SetRayTracingIntParams(parameters.gBufferRaytracingRT, "_RaytracingHalfResolution", parameters.halfResolution ? 1 : 0);
                 cmd.DispatchRays(parameters.gBufferRaytracingRT, m_RayGenGBuffer, widthResolution, heightResolution, (uint)parameters.viewCount);
             }
-
-            // Disable the diffuse lighting only flag
-            CoreUtils.SetKeyword(cmd, "DIFFUSE_LIGHTING_ONLY", false);
 
             // Now let's do the deferred shading pass on the samples
             int currentKernel = parameters.deferredRaytracingCS.FindKernel(parameters.halfResolution ? "RaytracingDeferredHalf" : "RaytracingDeferred");

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingIndirectDiffuse.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingIndirectDiffuse.cs
@@ -56,18 +56,30 @@ namespace UnityEngine.Rendering.HighDefinition
 
             GlobalIllumination giSettings = hdCamera.volumeStack.GetComponent<GlobalIllumination>();
 
-            switch (giSettings.mode.value)
+            // Based on what the asset supports, follow the volume or force the right mode.
+            if (m_Asset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Both)
             {
-                case RayTracingMode.Performance:
+                switch (giSettings.mode.value)
                 {
-                    RenderIndirectDiffusePerformance(hdCamera, cmd, renderContext, frameCount);
+                    case RayTracingMode.Performance:
+                    {
+                        RenderIndirectDiffusePerformance(hdCamera, cmd, renderContext, frameCount);
+                    }
+                    break;
+                    case RayTracingMode.Quality:
+                    {
+                        RenderIndirectDiffuseQuality(hdCamera, cmd, renderContext, frameCount);
+                    }
+                    break;
                 }
-                break;
-                case RayTracingMode.Quality:
-                {
-                    RenderIndirectDiffuseQuality(hdCamera, cmd, renderContext, frameCount);
-                }
-                break;
+            }
+            else if (m_Asset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Quality)
+            {
+                RenderIndirectDiffuseQuality(hdCamera, cmd, renderContext, frameCount);
+            }
+            else
+            {
+                RenderIndirectDiffusePerformance(hdCamera, cmd, renderContext, frameCount);
             }
 
             // Bind the indirect diffuse texture (for forward materials)
@@ -324,13 +336,12 @@ namespace UnityEngine.Rendering.HighDefinition
 
             // Only use the shader variant that has multi bounce if the bounce count > 1
             CoreUtils.SetKeyword(cmd, "MULTI_BOUNCE_INDIRECT", giSettings.bounceCount.value > 1);
-            // Run the computation
-            CoreUtils.SetKeyword(cmd, "DIFFUSE_LIGHTING_ONLY", true);
 
+            // Run the computation
+            cmd.SetGlobalInt(HDShaderIDs._RayTracingDiffuseLightingOnly, 1);
             cmd.DispatchRays(indirectDiffuseRT, m_RayGenIndirectDiffuseIntegrationName, (uint)widthResolution, (uint)heightResolution, (uint)hdCamera.viewCount);
 
             // Disable the keywords we do not need anymore
-            CoreUtils.SetKeyword(cmd, "DIFFUSE_LIGHTING_ONLY", false);
             CoreUtils.SetKeyword(cmd, "MULTI_BOUNCE_INDIRECT", false);
 
             using (new ProfilingScope(cmd, ProfilingSampler.Get(HDProfileId.RaytracingFilterIndirectDiffuse)))

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingReflection.cs
@@ -28,18 +28,30 @@ namespace UnityEngine.Rendering.HighDefinition
         {
             ScreenSpaceReflection reflectionSettings = hdCamera.volumeStack.GetComponent<ScreenSpaceReflection>();
 
-            switch (reflectionSettings.mode.value)
+            // Based on what the asset supports, follow the volume or force the right mode.
+            if (m_Asset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Both)
             {
-                case RayTracingMode.Performance:
+                switch (reflectionSettings.mode.value)
                 {
-                    RenderReflectionsPerformance(hdCamera, cmd, outputTexture, renderContext, frameCount);
+                    case RayTracingMode.Performance:
+                    {
+                        RenderReflectionsPerformance(hdCamera, cmd, outputTexture, renderContext, frameCount);
+                    }
+                    break;
+                    case RayTracingMode.Quality:
+                    {
+                        RenderReflectionsQuality(hdCamera, cmd, outputTexture, renderContext, frameCount);
+                    }
+                    break;
                 }
-                break;
-                case RayTracingMode.Quality:
-                {
-                    RenderReflectionsQuality(hdCamera, cmd, outputTexture, renderContext, frameCount);
-                }
-                break;
+            }
+            else if (m_Asset.currentPlatformRenderPipelineSettings.supportedRayTracingMode == RenderPipelineSettings.SupportedRayTracingMode.Quality)
+            {
+                RenderReflectionsQuality(hdCamera, cmd, outputTexture, renderContext, frameCount);
+            }
+            else
+            {
+                RenderReflectionsPerformance(hdCamera, cmd, outputTexture, renderContext, frameCount);
             }
         }
 
@@ -315,7 +327,7 @@ namespace UnityEngine.Rendering.HighDefinition
                 CoreUtils.SetKeyword(cmd, "MULTI_BOUNCE_INDIRECT", settings.bounceCount.value > 1);
 
                 // We are not in the diffuse only case
-                CoreUtils.SetKeyword(cmd, "DIFFUSE_LIGHTING_ONLY", false);
+                cmd.SetGlobalInt(HDShaderIDs._RayTracingDiffuseLightingOnly, 0);
 
                 // Run the computation
                 cmd.DispatchRays(reflectionShader, m_RayGenIntegrationName, (uint)hdCamera.actualWidth, (uint)hdCamera.actualHeight, (uint)hdCamera.viewCount);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/Shaders/ShaderVariablesRaytracing.hlsl
@@ -35,6 +35,8 @@ GLOBAL_CBUFFER_START(UnityRayTracingGlobals, UNITY_RAY_TRACING_GLOBAL_CBUFFER_RE
 	// Path tracing parameters
 	int _RaytracingMinRecursion;
 	int _RaytracingMaxRecursion;
+	// Ray traced indirect diffuse data
+	int _RayTracingDiffuseLightingOnly;
 CBUFFER_END
 
 RW_TEXTURE2D_ARRAY(uint, _RayCountTexture);

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/RenderPipelineSettings.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Settings/RenderPipelineSettings.cs
@@ -59,6 +59,19 @@ namespace UnityEngine.Rendering.HighDefinition
             R11G11B10 = GraphicsFormat.B10G11R11_UFloatPack32,
         }
 
+        /// <summary>
+        /// Supported Ray Tracing Mode.
+        /// </summary>
+        public enum SupportedRayTracingMode
+        {
+            /// <summary>Performance mode only.</summary>
+            Performance = 1 << 0,
+            /// <summary>Quality mode only.</summary>
+            Quality = 1 << 1,
+            /// <summary>Both Performance and Quality modes.</summary>
+            Both = Performance | Quality
+        }
+
         internal static RenderPipelineSettings NewDefault() => new RenderPipelineSettings()
         {
             supportShadowMask = true,
@@ -91,6 +104,7 @@ namespace UnityEngine.Rendering.HighDefinition
             lightingQualitySettings = GlobalLightingQualitySettings.NewDefault(),
 
             supportRayTracing = false,
+            supportedRayTracingMode = SupportedRayTracingMode.Both,
             lodBias = new FloatScalableSetting(new[] { 1.0f, 1, 1 }, ScalableSettingSchemaId.With3Levels),
             maximumLODLevel = new IntScalableSetting(new[] { 0, 0, 0 }, ScalableSettingSchemaId.With3Levels),
             lightLayerName0 = "Light Layer default",
@@ -187,6 +201,8 @@ namespace UnityEngine.Rendering.HighDefinition
         public bool supportTerrainHole;
         /// <summary>Support ray tracing.</summary>
         public bool supportRayTracing;
+        /// <summary>Support ray tracing mode.</summary>
+        public SupportedRayTracingMode supportedRayTracingMode;
 
         /// <summary>Global light loop settings.</summary>
         public GlobalLightLoopSettings lightLoopSettings;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingGBuffer.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingGBuffer.hlsl
@@ -30,10 +30,11 @@ void ClosestHitGBuffer(inout RayIntersectionGBuffer rayIntersectionGbuffer : SV_
     GetSurfaceAndBuiltinData(fragInput, viewWS, posInput, surfaceData, builtinData, currentVertex, rayIntersectionGbuffer.cone, isVisible);
 
     // Sometimes, we only  want to use the diffuse when we compute the indirect diffuse
-    #ifdef DIFFUSE_LIGHTING_ONLY
-    builtinData.bakeDiffuseLighting = float3(0.0, 0.0, 0.0);
-    builtinData.backBakeDiffuseLighting = float3(0.0, 0.0, 0.0);
-    #endif
+    if (_RayTracingDiffuseLightingOnly)
+    {
+        builtinData.bakeDiffuseLighting = float3(0.0, 0.0, 0.0);
+        builtinData.backBakeDiffuseLighting = float3(0.0, 0.0, 0.0);
+    }
 
     // First we pack the data into the standard bsdf data
     StandardBSDFData standardLitData;

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingIndirect.hlsl
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/ShaderPass/ShaderPassRaytracingIndirect.hlsl
@@ -34,14 +34,15 @@ void ClosestHitMain(inout RayIntersection rayIntersection : SV_RayPayload, Attri
     GetSurfaceAndBuiltinData(fragInput, viewWS, posInput, surfaceData, builtinData, currentVertex, rayIntersection.cone, isVisible);
 
     // Compute the bsdf data
-    BSDFData bsdfData =  ConvertSurfaceDataToBSDFData(posInput.positionSS, surfaceData);
+    BSDFData bsdfData = ConvertSurfaceDataToBSDFData(posInput.positionSS, surfaceData);
 
 #ifdef HAS_LIGHTLOOP
     // We do not want to use the diffuse when we compute the indirect diffuse
-    #ifdef DIFFUSE_LIGHTING_ONLY
-    builtinData.bakeDiffuseLighting = float3(0.0, 0.0, 0.0);
-    builtinData.backBakeDiffuseLighting = float3(0.0, 0.0, 0.0);
-    #endif
+    if (_RayTracingDiffuseLightingOnly)
+    {
+        builtinData.bakeDiffuseLighting = float3(0.0, 0.0, 0.0);
+        builtinData.backBakeDiffuseLighting = float3(0.0, 0.0, 0.0);
+    }
 
     // Compute the prelight data
     PreLightData preLightData = GetPreLightData(viewWS, posInput, bsdfData);
@@ -57,9 +58,17 @@ void ClosestHitMain(inout RayIntersection rayIntersection : SV_RayPayload, Attri
         sample.x = GetBNDSequenceSample(rayIntersection.pixelCoord, rayIntersection.sampleIndex, rayIntersection.remainingDepth * 2);
         sample.y = GetBNDSequenceSample(rayIntersection.pixelCoord, rayIntersection.sampleIndex, rayIntersection.remainingDepth * 2 + 1);
 
-        #ifdef DIFFUSE_LIGHTING_ONLY
-        // Importance sample with a cosine lobe
-        float3 sampleDir = SampleHemisphereCosine(sample.x, sample.y, surfaceData.normalWS);
+        float3 sampleDir;
+        if (_RayTracingDiffuseLightingOnly)
+        {
+            sampleDir = SampleHemisphereCosine(sample.x, sample.y, surfaceData.normalWS);
+        }
+        else
+        {
+            float roughness = PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness);
+            float NdotL, NdotH, VdotH;
+            SampleGGXDir(sample, viewWS, fragInput.tangentToWorld, roughness, sampleDir, NdotL, NdotH, VdotH);
+        }
 
         // Create the ray descriptor for this pixel
         RayDesc rayDescriptor;
@@ -82,50 +91,26 @@ void ClosestHitMain(inout RayIntersection rayIntersection : SV_RayPayload, Attri
         reflectedIntersection.cone.spreadAngle = rayIntersection.cone.spreadAngle;
         reflectedIntersection.cone.width = rayIntersection.cone.width;
 
+        bool launchRay = true;
+        if (!_RayTracingDiffuseLightingOnly)
+            launchRay = dot(sampleDir, surfaceData.normalWS) > 0.0;
+
         // Evaluate the ray intersection
-        TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACINGRENDERERFLAG_OPAQUE, 0, 1, 0, rayDescriptor, reflectedIntersection);
+        if (launchRay)
+            TraceRay(_RaytracingAccelerationStructure
+                        , RAY_FLAG_CULL_BACK_FACING_TRIANGLES
+                        , _RayTracingDiffuseLightingOnly ? RAYTRACINGRENDERERFLAG_GLOBAL_ILLUMINATION : RAYTRACINGRENDERERFLAG_REFLECTION
+                        , 0, 1, 0, rayDescriptor, reflectedIntersection);
 
         // Contribute to the pixel
-        builtinData.bakeDiffuseLighting = reflectedIntersection.color;
-        #else
-        // Importance sample the direction using GGX
-        float3 sampleDir = float3(0.0, 0.0, 0.0);
-        float roughness = PerceptualSmoothnessToRoughness(surfaceData.perceptualSmoothness);
-        float NdotL, NdotH, VdotH;
-        SampleGGXDir(sample, viewWS, fragInput.tangentToWorld, roughness, sampleDir, NdotL, NdotH, VdotH);
-
-        // If the sample is under the surface
-        if (dot(sampleDir, surfaceData.normalWS) > 0.0)
+        if (_RayTracingDiffuseLightingOnly)
+            builtinData.bakeDiffuseLighting = reflectedIntersection.color;
+        else
         {
-            // Build the reflected ray
-            RayDesc reflectedRay;
-            reflectedRay.Origin = pointWSPos + surfaceData.normalWS * _RaytracingRayBias;
-            reflectedRay.Direction = sampleDir;
-            reflectedRay.TMin = 0;
-            reflectedRay.TMax = _RaytracingRayMaxLength;
-
-            // Create and init the RayIntersection structure for this
-            RayIntersection reflectedIntersection;
-            reflectedIntersection.color = float3(0.0, 0.0, 0.0);
-            reflectedIntersection.incidentDirection = reflectedRay.Direction;
-            reflectedIntersection.origin = reflectedRay.Origin;
-            reflectedIntersection.t = -1.0f;
-            reflectedIntersection.remainingDepth = rayIntersection.remainingDepth + 1;
-            reflectedIntersection.pixelCoord = rayIntersection.pixelCoord;
-            reflectedIntersection.sampleIndex = rayIntersection.sampleIndex;
-
-            // In order to achieve filtering for the textures, we need to compute the spread angle of the pixel
-            reflectedIntersection.cone.spreadAngle = rayIntersection.cone.spreadAngle;
-            reflectedIntersection.cone.width = rayIntersection.cone.width;
-
-            // Evaluate the ray intersection
-            TraceRay(_RaytracingAccelerationStructure, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, RAYTRACINGRENDERERFLAG_OPAQUE, 0, 1, 0, reflectedRay, reflectedIntersection);
-
-            // Override the transmitted color
+            // Override the reflected color
             reflected = reflectedIntersection.color;
             reflectedWeight = 1.0;
         }
-        #endif
     }
     #endif
     


### PR DESCRIPTION
- Replaced the DIFFUSE_LIGHTING_ONLY multicompile by a uniform.
- Removed the dynamic lightmap multicompile (was un-used, but still induced a lot of shader compilation)
- Removed the LOD cross fade multi compile for ray tracing (was un-used, but still induced a lot of shader compilation)
- Added a ray tracing mode option in the HDRP asset that allows to override and shader stripping.

When in something else than both, volume components only display the current configuration parameters for indirect diffuse and reflection.

![image](https://user-images.githubusercontent.com/42026998/77781356-b803a880-7055-11ea-9e3c-00f0d3b6bf96.png)


DXR tests are still green locally.