### PR TITLE
Remove agent/command sections from virtual jobs

### DIFF
--- a/.yamato/upm-ci-abv.yml
+++ b/.yamato/upm-ci-abv.yml
@@ -32,16 +32,10 @@ testplatforms:
 {% for editor in editors %}
 all_project_ci_{{ editor.version }}:
   name: _ABV for SRP repository - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for project in projects %}
     - path: .yamato/upm-ci-{{ project.name | downcase }}.yml#All_{{ project.name }}_{{ editor.version }}
@@ -128,16 +122,10 @@ smoke_test_{{ testplatform.name }}_{{ editor.version }}:
 
 all_smoke_tests_{{ editor.version }}:
   name: All Smoke Tests - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for testplatform in testplatforms %}   
   - path: .yamato/upm-ci-abv.yml#smoke_test_{{ testplatform.name }}_{{ editor.version }}
@@ -148,16 +136,10 @@ all_smoke_tests_{{ editor.version }}:
 {% for editor in editors %}
 trunk_verification_{{ editor.version }}:
   name: Trunk verification - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
     {% for project in projects %}  
     {% for testplatform in testplatforms %}

--- a/.yamato/upm-ci-hdrp.yml
+++ b/.yamato/upm-ci-hdrp.yml
@@ -198,16 +198,10 @@ linux_apis:
 
 All_{{ project.name }}_{{ editor.version }}:
   name: All {{ project.name }} CI - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for platform in platforms %}
   {% for testplatform in testplatforms %}

--- a/.yamato/upm-ci-hdrp_dxr.yml
+++ b/.yamato/upm-ci-hdrp_dxr.yml
@@ -75,16 +75,10 @@ win_apis:
 
 All_{{ project.name }}:
   name: All {{ project.name }} CI
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for platform in platforms %}
   {% for testplatform in testplatforms %}

--- a/.yamato/upm-ci-hdrp_standalone.yml
+++ b/.yamato/upm-ci-hdrp_standalone.yml
@@ -198,16 +198,10 @@ Build_{{ project.name }}_Win_{{ win_api.name }}_Player_{{ editor.version }}:
 
 All_{{ project.name }}_{{ editor.version }}:
   name: All {{ project.name }} CI - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for platform in platforms %}
   {% for testplatform in testplatforms %}

--- a/.yamato/upm-ci-shadergraph.yml
+++ b/.yamato/upm-ci-shadergraph.yml
@@ -359,16 +359,10 @@ Build_{{ project.name }}_OSX_OpenGLCore_Player_{{ editor.version }}:
 
 All_{{ project.name }}_{{ editor.version }}:
   name: All {{ project.name }} CI - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for platform in platforms %}
   {% for testplatform in testplatforms %}

--- a/.yamato/upm-ci-shadergraph_stereo.yml
+++ b/.yamato/upm-ci-shadergraph_stereo.yml
@@ -132,16 +132,10 @@ Build_{{ project.name }}_Win_Player_{{ editor.version }}:
 
 All_{{ project.name }}_{{ editor.version }}:
   name: All {{ project.name }} CI - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for platform in platforms %}
   {% for testplatform in testplatforms %}

--- a/.yamato/upm-ci-universal.yml
+++ b/.yamato/upm-ci-universal.yml
@@ -440,16 +440,10 @@ Build_{{ project.name }}_Android_{{ android_api.name }}_{{ editor.version }}:
 
 All_{{ project.name }}_{{ editor.version }}:
   name: All {{ project.name }} CI - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for platform in platforms %}
   {% for testplatform in testplatforms %}

--- a/.yamato/upm-ci-universal_stereo.yml
+++ b/.yamato/upm-ci-universal_stereo.yml
@@ -132,16 +132,10 @@ Build_{{ project.name }}_Win_Player_{{ editor.version }}:
 
 All_{{ project.name }}_{{ editor.version }}:
   name: All {{ project.name }} CI - {{ editor.version }}
-  agent:
-    type: Unity::VM
-    image: cds-ops/ubuntu-18.04-agent:stable
-    flavor: b1.small
   {% if editor.version == 'CUSTOM-REVISION' %}
   variables:
     CUSTOM_REVISION: custom_revision_not_set
   {% endif %}
-  commands:
-    - dir
   dependencies:
   {% for platform in platforms %}
   {% for testplatform in testplatforms %}


### PR DESCRIPTION
### Purpose of this PR
Reduce the load on Yamato distribution slightly by no longer requiring an actual agent for the virtual jobs.
---
### Testing status
Not relevant; change to CI config only.
---
### Comments to reviewers
Notes for the reviewers you have assigned.
