### PR TITLE
[ShaderGraph] Fix: Matrix Related Nodes preview

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Basic/MultiplyNode.cs
@@ -34,10 +34,7 @@ namespace UnityEditor.ShaderGraph
 
         MultiplyType m_MultiplyType;
 
-        public override bool hasPreview
-        {
-            get { return m_MultiplyType != MultiplyType.Matrix; }
-        }
+        public override bool hasPreview => true;
 
         string GetFunctionHeader()
         {

--- a/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixDeterminantNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Math/Matrix/MatrixDeterminantNode.cs
@@ -11,6 +11,7 @@ namespace UnityEditor.ShaderGraph
             name = "Matrix Determinant";
         }
 
+        public override bool hasPreview => false;
 
         protected override MethodInfo GetFunctionToConvert()
         {


### PR DESCRIPTION
**Summary:**

Fix for https://fogbugz.unity3d.com/f/cases/1209948/
Stumbled across the problem when looking at something else so decided to fix the Prio 4 real quick

---
**Implementation Notes:**

* Dynamically removing and adding previews for the same type of Node is not supported with our given AbstractMaterialNode. It would require a larger refactor, but that's not worth it for fixing this minor bug case. As such all Nodes should always have a preview, or always lack one. In this case of Multiply we obviously want previews (Attempting to display a matrix doesn't result in any bugs - just a black matrix).
* Removed the preview from MatrixDeterminantNode to be consistent with the other Matrix nodes.

---
**Manually Tested:**

* That the bug no longer reproduces.

---
**Technical Risk:** 0/4 - Can't affect anything else
**Halo Effect:** 0/4 - Can't affect anything else

---
**Yamato:**

https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Fyour-branch-dude
