### PR TITLE
[ShaderGraph] Fix: View Direction Node: World Space to be Normalized in URP

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/Varyings.hlsl
@@ -14,12 +14,12 @@ Varyings BuildVaryings(Attributes input)
     // Evaluate Vertex Graph
     VertexDescriptionInputs vertexDescriptionInputs = BuildVertexDescriptionInputs(input);
     VertexDescription vertexDescription = VertexDescriptionFunction(vertexDescriptionInputs);
-    
+
     // Assign modified vertex attributes
     input.positionOS = vertexDescription.VertexPosition;
     #if defined(VARYINGS_NEED_NORMAL_WS)
         input.normalOS = vertexDescription.VertexNormal;
-    #endif //FEATURES_GRAPH_NORMAL  
+    #endif //FEATURES_GRAPH_NORMAL
     #if defined(VARYINGS_NEED_TANGENT_WS)
         input.tangentOS.xyz = vertexDescription.VertexTangent.xyz;
     #endif //FEATURES GRAPH TANGENT
@@ -51,7 +51,7 @@ Varyings BuildVaryings(Attributes input)
 #ifdef VARYINGS_NEED_POSITION_WS
     output.positionWS = positionWS;
 #endif
-    
+
 #ifdef VARYINGS_NEED_NORMAL_WS
     output.normalWS = normalWS;			// normalized in TransformObjectToWorldNormal()
 #endif
@@ -92,7 +92,7 @@ Varyings BuildVaryings(Attributes input)
 #endif
 
 #ifdef VARYINGS_NEED_VIEWDIRECTION_WS
-    output.viewDirectionWS = _WorldSpaceCameraPos.xyz - positionWS;
+    output.viewDirectionWS = normalize(_WorldSpaceCameraPos.xyz - positionWS);
 #endif
 
 #ifdef VARYINGS_NEED_SCREENPOSITION

--- a/com.unity.shadergraph/Editor/Generation/Templates/BuildSurfaceDescriptionInputs.template.hlsl
+++ b/com.unity.shadergraph/Editor/Generation/Templates/BuildSurfaceDescriptionInputs.template.hlsl
@@ -28,7 +28,7 @@ SurfaceDescriptionInputs BuildSurfaceDescriptionInputs(Varyings input)
     $SurfaceDescriptionInputs.ObjectSpaceBiTangent:      output.ObjectSpaceBiTangent =        TransformWorldToObjectDir(output.WorldSpaceBiTangent);
     $SurfaceDescriptionInputs.ViewSpaceBiTangent:        output.ViewSpaceBiTangent =          TransformWorldToViewDir(output.WorldSpaceBiTangent);
     $SurfaceDescriptionInputs.TangentSpaceBiTangent:     output.TangentSpaceBiTangent =       float3(0.0f, 1.0f, 0.0f);
-    $SurfaceDescriptionInputs.WorldSpaceViewDirection:   output.WorldSpaceViewDirection =     input.viewDirectionWS; //TODO: by default normalized in HD, but not in universal
+    $SurfaceDescriptionInputs.WorldSpaceViewDirection:   output.WorldSpaceViewDirection =     input.viewDirectionWS;
     $SurfaceDescriptionInputs.ObjectSpaceViewDirection:  output.ObjectSpaceViewDirection =    TransformWorldToObjectDir(output.WorldSpaceViewDirection);
     $SurfaceDescriptionInputs.ViewSpaceViewDirection:    output.ViewSpaceViewDirection =      TransformWorldToViewDir(output.WorldSpaceViewDirection);
     $SurfaceDescriptionInputs.TangentSpaceViewDirection: float3x3 tangentSpaceTransform =     float3x3(output.WorldSpaceTangent,output.WorldSpaceBiTangent,output.WorldSpaceNormal);


### PR DESCRIPTION
**Summary:**

Fix for https://fogbugz.unity3d.com/f/cases/1217639/

---
**Manually Tested:**

* That the bug no longer reproduces
* That the other spaces seem fine in URP

---

(Always)
**Technical Risk:** 0.1/4
**Halo Effect:** 2/4 - I looked around but didn't see this effecting anything else

---
**Automation:**

* Test should fail, I'll grab those generated shaders and put them in test project (as I can't trust my own home machine to produce usable images)

---
**Yamato:**

https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline/tree/sg%252Ffix-view-direction-for-urp