### PR TITLE
[Shader Graph] Fix Various Property Duplication Issues

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -86,6 +86,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug where shaders fail to compile due to `#pragma target` generation when your system locale uses commas instead of periods.
 - Fixed a compilation error when using Hybrid Renderer due to incorrect positioning of macros.
 - Fixed a bug with the `Transform` node where converting from `Absolute World` space in a sub graph causes invalid subscript errors. [1190813](https://issuetracker.unity3d.com/issues/shadergraph-invalid-subscript-errors-are-thrown-when-connecting-a-subgraph-with-transform-node-with-unlit-master-node)
+- Fixed an issue where Blackboard properties would not duplicate with `Precision` or `Hybrid Instancing` options. 
+- Fixed an issue where `Texture` properties on the Blackboard would not duplicate with the same `Mode` settings. 
+- Fixed an issue where `Keywords` on the Blackboard would not duplicate with the same `Default` value.
 
 ## [7.1.1] - 2019-09-05
 ### Added

--- a/com.unity.shadergraph/Editor/Data/Graphs/BooleanShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/BooleanShaderProperty.cs
@@ -46,7 +46,8 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/ColorShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ColorShaderProperty.cs
@@ -63,7 +63,9 @@ namespace UnityEditor.ShaderGraph.Internal
                 displayName = displayName,
                 hidden = hidden,
                 value = value,
-                colorMode = colorMode
+                colorMode = colorMode,
+                precision = precision,
+                gpuInstanced = gpuInstanced,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/CubemapShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/CubemapShaderProperty.cs
@@ -67,7 +67,8 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/GradientShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/GradientShaderProperty.cs
@@ -97,7 +97,8 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Matrix2ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Matrix2ShaderProperty.cs
@@ -45,7 +45,8 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Matrix3ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Matrix3ShaderProperty.cs
@@ -46,7 +46,8 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Matrix4ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Matrix4ShaderProperty.cs
@@ -43,7 +43,9 @@ namespace UnityEditor.ShaderGraph
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
+                gpuInstanced = gpuInstanced,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/SamplerStateShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SamplerStateShaderProperty.cs
@@ -60,7 +60,8 @@ namespace UnityEditor.ShaderGraph
                 displayName = displayName,
                 hidden = hidden,
                 overrideReferenceName = overrideReferenceName,
-                value = value
+                value = value,
+                precision = precision,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/ShaderKeyword.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/ShaderKeyword.cs
@@ -196,7 +196,8 @@ namespace UnityEditor.ShaderGraph
                 keywordType = keywordType,
                 keywordDefinition = keywordDefinition,
                 keywordScope = keywordScope,
-                entries = entries
+                entries = entries,
+                value = value,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DArrayShaderProperty.cs
@@ -65,7 +65,8 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture2DShaderProperty.cs
@@ -78,7 +78,9 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                defaultType = defaultType,
+                precision = precision,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Texture3DShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Texture3DShaderProperty.cs
@@ -65,7 +65,8 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector1ShaderProperty.cs
@@ -148,7 +148,9 @@ namespace UnityEditor.ShaderGraph.Internal
                 rangeValues = rangeValues,
                 enumType = enumType,
                 enumNames = enumNames,
-                enumValues = enumValues
+                enumValues = enumValues,
+                precision = precision,
+                gpuInstanced = gpuInstanced,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector2ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector2ShaderProperty.cs
@@ -38,7 +38,9 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
+                gpuInstanced = gpuInstanced,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector3ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector3ShaderProperty.cs
@@ -39,7 +39,9 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
+                gpuInstanced = gpuInstanced,
             };
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Graphs/Vector4ShaderProperty.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/Vector4ShaderProperty.cs
@@ -41,7 +41,9 @@ namespace UnityEditor.ShaderGraph.Internal
             {
                 displayName = displayName,
                 hidden = hidden,
-                value = value
+                value = value,
+                precision = precision,
+                gpuInstanced = gpuInstanced,
             };
         }
     }


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing? 
This fixes three bugs with duplication of properties and keywords on the blackboard: 
- Precision was note copied 
- Hybrid Instancing default was not copied 
- Texture properties did not copy default `Mode` 
- Keywords did not copy default value

https://fogbugz.unity3d.com/f/cases/1213638/
https://fogbugz.unity3d.com/f/cases/1213640/
https://fogbugz.unity3d.com/f/cases/1213641/

---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] Checked new UI names with UX convention
- [x] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [x] C# and shader warnings (supress shader cache to see them)
- Other: 
Created a new graph. Created a property of every type, changed every option from the default value, ensure that all changes are transferred to a duplicated copy of the property. Confirm with CTRL+C/CTRL+V, CTRL+D, and Right Click -> Duplicate, as well as undo and redo. 

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
