### PR TITLE
 Fix Editor Gizmos/Grid not working.

### DIFF
--- a/com.unity.render-pipelines.universal/Runtime/Passes/SceneViewDepthCopy.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/SceneViewDepthCopy.cs
@@ -6,6 +6,8 @@ namespace UnityEngine.Rendering.Universal
 
         Material m_CopyDepthMaterial;
         const string m_ProfilerTag = "Copy Depth for Scene View";
+        int m_ScaleBiasId = Shader.PropertyToID("_ScaleBiasRT");
+
 
         public SceneViewDepthCopyPass(RenderPassEvent evt, Material copyDepthMaterial)
         {
@@ -35,7 +37,21 @@ namespace UnityEngine.Rendering.Universal
             cmd.EnableShaderKeyword(ShaderKeywordStrings.DepthNoMsaa);
             cmd.DisableShaderKeyword(ShaderKeywordStrings.DepthMsaa2);
             cmd.DisableShaderKeyword(ShaderKeywordStrings.DepthMsaa4);
-            cmd.Blit(source.Identifier(), BuiltinRenderTextureType.CameraTarget, m_CopyDepthMaterial);
+            cmd.DisableShaderKeyword(ShaderKeywordStrings.DepthMsaa8);
+            // Blit has logic to flip projection matrix when rendering to render texture.
+            // Currently the y-flip is handled in CopyDepthPass.hlsl by checking _ProjectionParams.x
+            // If you replace this Blit with a Draw* that sets projection matrix double check
+            // to also update shader.
+            // scaleBias.x = flipSign
+            // scaleBias.y = scale
+            // scaleBias.z = bias
+            // scaleBias.w = unused
+            ref CameraData cameraData = ref renderingData.cameraData;
+            float flipSign = (cameraData.IsCameraProjectionMatrixFlipped()) ? -1.0f : 1.0f;
+            Vector4 scaleBias = (flipSign < 0.0f) ? new Vector4(flipSign, 1.0f, -1.0f, 1.0f) : new Vector4(flipSign, 0.0f, 1.0f, 1.0f);
+            cmd.SetGlobalVector(m_ScaleBiasId, scaleBias);
+
+            cmd.DrawMesh(RenderingUtils.fullscreenMesh, Matrix4x4.identity, m_CopyDepthMaterial);
             context.ExecuteCommandBuffer(cmd);
             CommandBufferPool.Release(cmd);
         }

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipelineCore.cs
@@ -165,7 +165,7 @@ namespace UnityEngine.Rendering.Universal
         public List<Vector4> bias;
     }
 
-    public static class ShaderPropertyId
+    internal static class ShaderPropertyId
     {
         public static readonly int scaledScreenParams = Shader.PropertyToID("_ScaledScreenParams");
         public static readonly int worldSpaceCameraPos = Shader.PropertyToID("_WorldSpaceCameraPos");

--- a/com.unity.render-pipelines.universal/Shaders/Utils/CopyDepthPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Utils/CopyDepthPass.hlsl
@@ -3,6 +3,16 @@
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 
+#if defined(_DEPTH_MSAA_2)
+    #define MSAA_SAMPLES 2
+#elif defined(_DEPTH_MSAA_4)
+    #define MSAA_SAMPLES 4
+#elif defined(_DEPTH_MSAA_8)
+    #define MSAA_SAMPLES 8
+#else
+    #define MSAA_SAMPLES 1
+#endif
+
 half4 _ScaleBiasRT;
 
 struct Attributes
@@ -57,16 +67,6 @@ Varyings vert(Attributes input)
 #define DEPTH_TEXTURE(name) TEXTURE2D_FLOAT(name)
 #define LOAD(uv, sampleIndex) LOAD_TEXTURE2D_MSAA(_CameraDepthAttachment, uv, sampleIndex)
 #define SAMPLE(uv) SAMPLE_DEPTH_TEXTURE(_CameraDepthAttachment, sampler_CameraDepthAttachment, uv)
-#endif
-
-#if defined(_DEPTH_MSAA_2)
-    #define MSAA_SAMPLES 2
-#elif defined(_DEPTH_MSAA_4)
-    #define MSAA_SAMPLES 4
-#elif defined(_DEPTH_MSAA_8)
-    #define MSAA_SAMPLES 8
-#else
-    #define MSAA_SAMPLES 1
 #endif
 
 #if MSAA_SAMPLES == 1


### PR DESCRIPTION
### Purpose of this PR
 Fix regression that caused the gizmos and grid to now display correctly. [case 1228544](https://issuetracker.unity3d.com/issues/universal-rp-geometry-does-not-properly-obscure-grid-or-gizmos)

---
### Testing status

**Manual Tests**: Tested with the editor camera. Grid and gizmos work correctly.

**Automated Tests**: I'm not sure we can add automation test to scene view.

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

---
### Comments to reviewers

- The regression was introduced in this PR: https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/5913
- The logic to do copy depth changed, in that PR I changed the CopyDepth pass but didn't know there's a specific pass to copy depth for the scene view at the end of the pipeline. We should possibly merge these two passes, but for now just fixing the issue by doing the same changes I did in CopyDepth.cs to the scene view copy depth pass.

-  Changelog is not required as this issue is not in any public package.

-  Made the ShaderProperty API internal, this API is new in 9.0.0, not introduced in any public package.
 This is due to recent dicussion in slack to don't allow shader public API as we want to be able to move them to cbuffer (more efficiency)

