### PR TITLE
Added known issues page

### DIFF
--- a/com.unity.render-pipelines.high-definition/Documentation~/Known-Issues.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/Known-Issues.md
@@ -1,0 +1,15 @@
+# Known issues
+
+This page contains information on known about issues you may encounter while using HDRP. Each entry describes the issue and then details the steps to follow in order to resolve the issue.
+
+## Material array size
+
+If you upgrade your HDRP Project to a later version, you may encounter an error message similar to:
+
+```
+Property (_Env2DCaptureForward) exceeds previous array size (48 vs 6). Cap to previous size.
+
+UnityEditor.EditorApplication:Internal_CallGlobalEventHandler()
+```
+
+To fix this issue, restart the Unity editor.

--- a/com.unity.render-pipelines.high-definition/Documentation~/TableOfContents.md
+++ b/com.unity.render-pipelines.high-definition/Documentation~/TableOfContents.md
@@ -155,3 +155,4 @@
   * [Creating a Custom Post-Process Effect](Custom-Post-Process)
   * [Creating a Custom Render Pass](Custom-Pass)
 * [HDRP Glossary](Glossary)
+* [Known Issues and How To Fix Them](Known-Issues)


### PR DESCRIPTION
### Purpose of this PR
Adds known issues page.

The page originally included a description of why the Material array size issue occurs, but I don't think users need to know about this. They just need issue -> how to fix. We should use this minimal formatting when adding other entries to this page.