### PR TITLE
path validation when creating new volume profile (#1229933)

### DIFF
--- a/com.unity.render-pipelines.core/Editor/Volume/VolumeProfileFactory.cs
+++ b/com.unity.render-pipelines.core/Editor/Volume/VolumeProfileFactory.cs
@@ -56,12 +56,22 @@ namespace UnityEditor.Rendering
             {
                 var scenePath = Path.GetDirectoryName(scene.path);
                 var extPath = scene.name;
-                var profilePath = scenePath + "/" + extPath;
+                var profilePath = scenePath + Path.DirectorySeparatorChar + extPath;
 
                 if (!AssetDatabase.IsValidFolder(profilePath))
-                    AssetDatabase.CreateFolder(scenePath, extPath);
+                {
+                    var directories = profilePath.Split(Path.DirectorySeparatorChar);
+                    string rootPath = "";
+                    foreach (var directory in directories)
+                    {
+                        var newPath = rootPath + directory;
+                        if (!AssetDatabase.IsValidFolder(newPath))
+                            AssetDatabase.CreateFolder(rootPath.TrimEnd(Path.DirectorySeparatorChar), directory);
+                        rootPath = newPath + Path.DirectorySeparatorChar;
+                    }
+                }  
 
-                path = profilePath + "/";
+                path = profilePath + Path.DirectorySeparatorChar;
             }
 
             path += targetName + " Profile.asset";

--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -498,6 +498,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue related to the envlightdatasrt not being bound in recursive rendering.
 - Fixed shadow cascade tooltip when using the metric mode (case 1229232)
 - Focus on Decal uses the extends of the projectors
+- Fixed path validation when creating new volume profile (case 1229933)
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled


### PR DESCRIPTION
### Purpose of this PR
https://fogbugz.unity3d.com/f/cases/1229933/

The problem was that some AssetDatabase calls fail when the path does not exist on the disk (which is exactly what happens when you delete the Scene folder). 

The previous code was already checking if the last directory in the path exists (and if not it creates it). After this change we do this for all directories in the path (not only the last one).
