### PR TITLE
[7.x.x Backport] Changed the diffusion profile warning on the material to an info and changed the message to be more precise.

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add range-based clipping to box lights (case 1178780)
 - Improve area light culling (case 1085873)
 - Light Hierarchy debug mode can now adjust Debug Exposure for visualizing high exposure scenes.
+- Changed the diffusion profile warning on the material to an info and changed the message to be more precise.
 
 ## [7.2.0] - 2020-02-10
 

--- a/com.unity.render-pipelines.high-definition/Editor/Material/DiffusionProfile/DiffusionProfileMaterialUI.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Material/DiffusionProfile/DiffusionProfileMaterialUI.cs
@@ -8,7 +8,7 @@ namespace UnityEditor.Rendering.HighDefinition
 {
     static class DiffusionProfileMaterialUI
     {
-        static GUIContent    diffusionProfileNotInHDRPAsset = new GUIContent("You must add this diffusion profile in the HDRP asset to make it work", EditorGUIUtility.IconContent("console.warnicon").image);
+        static GUIContent    diffusionProfileNotInHDRPAsset = new GUIContent("You must make sure that this diffusion profile is either referenced in the HDRP asset or in the Diffusion Profile Override to make it work.", EditorGUIUtility.IconContent("console.infoicon").image);
 
         public static bool IsSupported(MaterialEditor materialEditor)
         {


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1219352/