### PR TITLE
Add custom pass msaa rendering info box

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for hair for ray tracing effects.
 - Added support for alpha to coverage for HDRP shaders and shader graph
 - Added support for Quality Levels to Subsurface Scattering.
+- Added an info box to warn about depth test artifacts when rendering object twice in custom passes with MSAA.
 
 ### Fixed
 - Fix when rescale probe all direction below zero (1219246)


### PR DESCRIPTION
### Purpose of this PR
Add an info box to warn about depth test artifacts when rendering object twice in custom passes with MSAA. Note that the issue only happens with Before/After Post Process injection points.

![image](https://user-images.githubusercontent.com/6877923/78060179-64fa6000-738b-11ea-9c6f-bf8c3cffe246.png)

For reference here's the kind of artifacts this is making:
![MSAA](https://user-images.githubusercontent.com/6877923/78060347-ab4fbf00-738b-11ea-8637-0d824c30afc7.gif)


**Manual Tests**: What did you do?
I played a bit with HDRP settings (toggling MSAA) and custom pass injection points to verify that the info only shows up when needed.
