### PR TITLE
World space UI element reflections

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -500,6 +500,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed shadow cascade tooltip when using the metric mode (case 1229232)
 - Fixed how the area light influence volume is computed to match rasterization.
 - Focus on Decal uses the extends of the projectors
+- Fixed reflections of world space UI elements (case 1155022)
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.cs
@@ -2689,8 +2689,8 @@ namespace UnityEngine.Rendering.HighDefinition
         )
         {
 #if UNITY_EDITOR
-            // emit scene view UI
-            if (camera.cameraType == CameraType.SceneView)
+            // emit UI geometry for scene view and reflection cameras
+            if (camera.cameraType == CameraType.SceneView || camera.cameraType == CameraType.Reflection)
             {
                 ScriptableRenderContext.EmitWorldGeometryForSceneView(camera);
             }


### PR DESCRIPTION
### Purpose of this PR
World Space UI was not rendered in realtime reflections
https://fogbugz.unity3d.com/f/cases/1155022/

Before:
![image](https://user-images.githubusercontent.com/15788420/78112586-b7c12f80-73fe-11ea-90c7-c281888603cb.png)

After:
![image](https://user-images.githubusercontent.com/15788420/78112537-a546f600-73fe-11ea-85a4-31d511528967.png)

And here is the test project:
https://drive.google.com/open?id=1Irjd0WGRoii3VAOnlGEJb62ZCBDmD3zS
(slightly modified from the fogbugz, since we have changed the sky system)
