### PR TITLE
Fixed usage of light size data that are not available at runtime.

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -500,6 +500,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed shadow cascade tooltip when using the metric mode (case 1229232)
 - Fixed how the area light influence volume is computed to match rasterization.
 - Focus on Decal uses the extends of the projectors
+- Fixed usage of light size data that are not available at runtime.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightCluster.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Raytracing/HDRaytracingLightCluster.cs
@@ -310,7 +310,7 @@ namespace UnityEngine.Rendering.HighDefinition
                     else
                     {
                         // let's compute the oobb of the light influence volume first
-                        Vector3 oobbDimensions = new Vector3(light.areaSize.x + 2 * lightRange, light.areaSize.y + 2 * lightRange, lightRange); // One-sided
+                        Vector3 oobbDimensions = new Vector3(currentLight.shapeWidth + 2 * lightRange, currentLight.shapeHeight + 2 * lightRange, lightRange); // One-sided
                         Vector3 extents    = 0.5f * oobbDimensions;
                         Vector3 oobbCenter = currentLight.gameObject.transform.position + extents.z * currentLight.gameObject.transform.forward;
 


### PR DESCRIPTION
Regression introduced by this PR when building a player https://github.com/Unity-Technologies/ScriptableRenderPipeline/pull/6454