### PR TITLE
Fix PBR shader gbuffer ztest

### DIFF
--- a/com.unity.render-pipelines.high-definition/CHANGELOG.md
+++ b/com.unity.render-pipelines.high-definition/CHANGELOG.md
@@ -500,6 +500,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed shadow cascade tooltip when using the metric mode (case 1229232)
 - Fixed how the area light influence volume is computed to match rasterization.
 - Focus on Decal uses the extends of the projectors
+- Fixed PBR shader ZTest rendering in deferred.
 
 ### Changed
 - Color buffer pyramid is not allocated anymore if neither refraction nor distortion are enabled

--- a/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDRenderStates.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/ShaderGraph/HDRenderStates.cs
@@ -398,7 +398,8 @@ namespace UnityEditor.Rendering.HighDefinition.ShaderGraph
         public static RenderStateCollection PBRGBuffer = new RenderStateCollection
         {
             { RenderState.Cull(Cull.Off), new FieldCondition(Fields.DoubleSided, true) },
-            { RenderState.ZTest(Uniforms.zTestGBuffer) },
+            { RenderState.ZTest(ZTest.Equal), new FieldCondition(Fields.AlphaClip, true) },
+            { RenderState.ZTest(ZTest.LEqual), new FieldCondition(Fields.AlphaClip, false) },
             { RenderState.Stencil(new StencilDescriptor()
             {
                 WriteMask = $"{ 0 | (int)StencilUsage.RequiresDeferredLighting | (int)StencilUsage.SubsurfaceScattering | (int)StencilUsage.TraceReflectionRay}",


### PR DESCRIPTION
### Purpose of this PR
Fix the PBR shader ZTest in the GBuffer pass, it was using a property that doesn't exists in the shader.
https://fogbugz.unity3d.com/f/cases/1230818/

**Manual Tests**: What did you do?
I Created a new PBR shader graph and then created a material from it (tested both create material from shader and create new material then assign shader workflows).
Then i assigned the material in the scene and verified that the ZTest was correct.
![image](https://user-images.githubusercontent.com/6877923/78149666-89f7dd00-7436-11ea-9de0-b3ad927993e0.png)
