### PR TITLE
[8.x.x][Shader Graph] Backport Deleted Asset Dialogue

### DIFF
--- a/com.unity.shadergraph/CHANGELOG.md
+++ b/com.unity.shadergraph/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added a field to the Master Nodes that overrides the generated shader's ShaderGUI.
+- When a Shader Graph or Sub Graph Asset associated with a open window has been deleted, Unity now displays a dialog that asks whether you would like to save the graph as a new Asset or close the window.
 
 ### Fixed
 - Fixed a bug where any change to the PBR master node settings would lose connection to the normal slot.
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a bug with the `Transform` node where converting from `Absolute World` space in a sub graph causes invalid subscript errors. [1190813](https://issuetracker.unity3d.com/issues/shadergraph-invalid-subscript-errors-are-thrown-when-connecting-a-subgraph-with-transform-node-with-unlit-master-node)
 - Fixed a bug where the `Position` node would change coordinate spaces from `World` to `Absolute World` when shaders recompile. [1184617](https://issuetracker.unity3d.com/product/unity/issues/guid/1184617/)
 - Optimized loading a large Shader Graph. [1209047](https://issuetracker.unity3d.com/issues/shader-graph-unresponsive-editor-when-using-large-graphs)
+- New deleted asset dialogue fixes a bug where deleted assets would throw a missing file exception in the console. [1232246](https://issuetracker.unity3d.com/product/unity/issues/guid/1232246/)
 
 ## [8.0.1] - 2020-05-25
 

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -21,6 +21,10 @@ namespace UnityEditor.ShaderGraph.Drawing
 {
     class MaterialGraphEditWindow : EditorWindow
     {
+        // For conversion to Sub Graph: keys for remembering the user's desired path
+        const string k_PrevSubGraphPathKey = "SHADER_GRAPH_CONVERT_TO_SUB_GRAPH_PATH";
+        const string k_PrevSubGraphPathDefaultValue = "?"; // Special character that NTFS does not allow, so that no directory could match it.
+
         [SerializeField]
         string m_Selected;
 
@@ -42,14 +46,13 @@ namespace UnityEditor.ShaderGraph.Drawing
         [NonSerialized]
         bool m_Deleted;
 
-        GraphEditorView m_GraphEditorView;
-
         MessageManager m_MessageManager;
         MessageManager messageManager
         {
             get { return m_MessageManager ?? (m_MessageManager = new MessageManager()); }
         }
 
+        GraphEditorView m_GraphEditorView;
         GraphEditorView graphEditorView
         {
             get { return m_GraphEditorView; }
@@ -400,12 +403,15 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             if (selectedGuid != null && graphObject != null)
             {
-                var path = AssetDatabase.GUIDToAssetPath(selectedGuid);
-                if (string.IsNullOrEmpty(path) || graphObject == null)
+                var pathAndFile = AssetDatabase.GUIDToAssetPath(selectedGuid);
+                if (string.IsNullOrEmpty(pathAndFile) || graphObject == null)
                     return false;
 
+                // The asset's name needs to be removed from the path, otherwise SaveFilePanel assumes it's a folder
+                string path = Path.GetDirectoryName(pathAndFile);
+
                 var extension = graphObject.graph.isSubGraph ? ShaderSubGraphImporter.Extension : ShaderGraphImporter.Extension;
-                var newPath = EditorUtility.SaveFilePanel("Save Graph As", path, Path.GetFileNameWithoutExtension(path), extension);
+                var newPath = EditorUtility.SaveFilePanelInProject("Save Graph As...", Path.GetFileNameWithoutExtension(pathAndFile), extension, "", path);
                 newPath = newPath.Replace(Application.dataPath, "Assets");
                 if (newPath != path)
                 {
@@ -443,7 +449,16 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             var graphView = graphEditorView.graphView;
 
-            var path = EditorUtility.SaveFilePanelInProject("Save Sub Graph", "New Shader Sub Graph", ShaderSubGraphImporter.Extension, "");
+            string path;
+            string sessionStateResult = SessionState.GetString(k_PrevSubGraphPathKey, k_PrevSubGraphPathDefaultValue);
+            string pathToOriginSG = Path.GetDirectoryName(AssetDatabase.GUIDToAssetPath(selectedGuid));
+
+            if (!sessionStateResult.Equals(k_PrevSubGraphPathDefaultValue))
+                path = sessionStateResult;
+            else
+                path = pathToOriginSG;
+
+            path = EditorUtility.SaveFilePanelInProject("Save Sub Graph", "New Shader Sub Graph", ShaderSubGraphImporter.Extension, "", path);
             path = path.Replace(Application.dataPath, "Assets");
             if (path.Length == 0)
                 return;
@@ -718,8 +733,15 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
             }
 
-            if(FileUtilities.WriteShaderGraphToDisk(path, subGraph))
+            if (FileUtilities.WriteShaderGraphToDisk(path, subGraph))
                 AssetDatabase.ImportAsset(path);
+
+            // Store path for next time
+            if (!pathToOriginSG.Equals(Path.GetDirectoryName(path)))
+                SessionState.SetString(k_PrevSubGraphPathKey, Path.GetDirectoryName(path));
+            else
+                // Or continue to make it so that next time it will open up in the converted-from SG's directory
+                SessionState.EraseString(k_PrevSubGraphPathKey);
 
             var loadedSubGraph = AssetDatabase.LoadAssetAtPath(path, typeof(SubGraphAsset)) as SubGraphAsset;
             if (loadedSubGraph == null)

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphAssetPostProcessor.cs
@@ -43,14 +43,34 @@ namespace UnityEditor.ShaderGraph
             }
         }
 
+        static void DisplayDeletionDialog(string[] deletedAssets)
+        {
+            MaterialGraphEditWindow[] windows = Resources.FindObjectsOfTypeAll<MaterialGraphEditWindow>();
+            foreach (var matGraphEditWindow in windows)
+            {
+                for (int i = 0; i < deletedAssets.Length; ++i)
+                {
+                    if (matGraphEditWindow.selectedGuid == AssetDatabase.AssetPathToGUID(deletedAssets[i]))
+                        matGraphEditWindow.AssetWasDeleted();
+                }
+            }
+        }
+
         static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
         {
             RegisterShaders(importedAssets);
 
-            bool anyShaders = movedAssets.Any(val => val.EndsWith(ShaderGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
-            anyShaders |= movedAssets.Any(val => val.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
-            if (anyShaders)
+            //Moved Assets
+            bool anyMovedShaders = movedAssets.Any(val => val.EndsWith(ShaderGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
+            anyMovedShaders |= movedAssets.Any(val => val.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
+            if (anyMovedShaders)
                 UpdateAfterAssetChange(movedAssets);
+
+            //Deleted Assets
+            bool anyRemovedShaders = deletedAssets.Any(val => val.EndsWith(ShaderGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
+            anyRemovedShaders |= deletedAssets.Any(val => val.EndsWith(ShaderSubGraphImporter.Extension, StringComparison.InvariantCultureIgnoreCase));
+            if (anyRemovedShaders)
+                DisplayDeletionDialog(deletedAssets);
 
             var windows = Resources.FindObjectsOfTypeAll<MaterialGraphEditWindow>();
 


### PR DESCRIPTION
### Purpose of this PR
Why is this PR needed, what hard problem is it solving/fixing? 
Backport #5313 to 8.x.x to resolve a priority 2 regression in the 8.x package [1232246](https://issuetracker.unity3d.com/product/unity/issues/guid/1232246/) [internal link](https://fogbugz.unity3d.com/f/cases/1232246/)

From original PR: 
- Stops users from entering in a still open Shader Graph that is in a buggy soft lock mode; they either ought to close the Shader Graph or last chance to Save As.
- Works with all graphs, allowing users a last chance Save As if they regret the deletion of the Shader Graph
- This popup does not happen until the window has been selected.
- Note that "Save As" is the secondary, not the primary, option. Please feel free to give feedback on that. Although that's abnormal as far as saving stuff goes, I did that because I figured that primary should be the default use case, after all the user will have deleted the file on purpose 96% of the time.


---
### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [x] Built a player
- [x] Checked new UI names with UX convention
- [x] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [x] C# and shader warnings (supress shader cache to see them)
Manually Tested (repeated manual testing from original PR):

- Delete -> Don't Save (Close), Delete -> Save As, Delete -> Save As the same file, many times and ways
- Deleting inside of Unity and outside of Unity via File Explorer
- Shader Graphs and Sub Graphs
- Various window / tab arrangements. The popup (should) only popup once the tab or Shader Graph window has been selected, as opposed to immediately when the file has been deleted.

**Automated Tests**: What did you setup? (Add a screenshot or the reference image of the test please)

**Yamato**: (Select your branch):
https://yamato.prd.cds.internal.unity3d.com/jobs/78-ScriptableRenderPipeline

Any test projects to go with this to help reviewers?

---
### Comments to reviewers
Notes for the reviewers you have assigned.
Should behave the same as master.