### PR TITLE
[8.x.x Backport] Universal/fix dx10 resource

### DIFF
--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where Shader Graph subshaders referenced incorrect asset GUIDs.
 - Fixed issue that caused the QualitySettings anti-aliasing changing without user interaction. [case 1195272](https://issuetracker.unity3d.com/issues/lwrp-the-anti-alias-quality-settings-value-is-changing-without-user-interaction)
 - Fixed a shader issue that caused the Color in Sprite Shape to work improperly.
+- Fixed shader compilation errors when using multiple lights in DX10 level GPU. [case 1222302](https://issuetracker.unity3d.com/issues/urp-no-materials-apart-from-ui-are-rendered-when-using-direct3d11-graphics-api-on-a-dx10-gpu)
 
 ## [8.0.0] - 2020-05-25
 ### Added

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
@@ -48,11 +48,18 @@ half4 _AdditionalLightsCount;
 StructuredBuffer<LightData> _AdditionalLightsBuffer;
 StructuredBuffer<int> _AdditionalLightsIndices;
 #else
+// GLES3 causes a performance regression in some devices when using CBUFFER.
+#ifndef SHADER_API_GLES3
+CBUFFER_START(AdditionalLights)
+#endif
 float4 _AdditionalLightsPosition[MAX_VISIBLE_LIGHTS];
 half4 _AdditionalLightsColor[MAX_VISIBLE_LIGHTS];
 half4 _AdditionalLightsAttenuation[MAX_VISIBLE_LIGHTS];
 half4 _AdditionalLightsSpotDir[MAX_VISIBLE_LIGHTS];
 half4 _AdditionalLightsOcclusionProbes[MAX_VISIBLE_LIGHTS];
+#ifndef SHADER_API_GLES3
+CBUFFER_END
+#endif
 #endif
 
 #define UNITY_MATRIX_M     unity_ObjectToWorld

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl
@@ -35,6 +35,10 @@ SAMPLER_CMP(sampler_MainLightShadowmapTexture);
 TEXTURE2D_SHADOW(_AdditionalLightsShadowmapTexture);
 SAMPLER_CMP(sampler_AdditionalLightsShadowmapTexture);
 
+// GLES3 causes a performance regression in some devices when using CBUFFER.
+#ifndef SHADER_API_GLES3
+CBUFFER_START(MainLightShadows)
+#endif
 // Last cascade is initialized with a no-op matrix. It always transforms
 // shadow coord to half3(0, 0, NEAR_PLANE). We use this trick to avoid
 // branching since ComputeCascadeIndex can return cascade index = MAX_SHADOW_CASCADES
@@ -50,19 +54,34 @@ half4       _MainLightShadowOffset2;
 half4       _MainLightShadowOffset3;
 half4       _MainLightShadowParams;  // (x: shadowStrength, y: 1.0 if soft shadows, 0.0 otherwise)
 float4      _MainLightShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
+#ifndef SHADER_API_GLES3
+CBUFFER_END
+#endif
 
 #if USE_STRUCTURED_BUFFER_FOR_LIGHT_DATA
 StructuredBuffer<ShadowData> _AdditionalShadowsBuffer;
 StructuredBuffer<int> _AdditionalShadowsIndices;
-#else
-float4x4    _AdditionalLightsWorldToShadow[MAX_VISIBLE_LIGHTS];
-half4       _AdditionalShadowParams[MAX_VISIBLE_LIGHTS];
-#endif
 half4       _AdditionalShadowOffset0;
 half4       _AdditionalShadowOffset1;
 half4       _AdditionalShadowOffset2;
 half4       _AdditionalShadowOffset3;
 float4      _AdditionalShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
+#else
+// GLES3 causes a performance regression in some devices when using CBUFFER.
+#ifndef SHADER_API_GLES3
+CBUFFER_START(AdditionalLightShadows)
+#endif
+float4x4    _AdditionalLightsWorldToShadow[MAX_VISIBLE_LIGHTS];
+half4       _AdditionalShadowParams[MAX_VISIBLE_LIGHTS];
+half4       _AdditionalShadowOffset0;
+half4       _AdditionalShadowOffset1;
+half4       _AdditionalShadowOffset2;
+half4       _AdditionalShadowOffset3;
+float4      _AdditionalShadowmapSize; // (xy: 1/width and 1/height, zw: width and height)
+#ifndef SHADER_API_GLES3
+CBUFFER_END
+#endif
+#endif
 
 float4 _ShadowBias; // x: depth bias, y: normal bias
 


### PR DESCRIPTION
### Purpose of this PR
Backport of #6110 
It has already been backported to 7.x.x. (#6505)

---

### Checklist for PR maker
- [x] Have you added a backport label (if needed)? For example, the `need-backport-*` label. After you backport the PR, the label changes to `backported-*`.
- [x] Have you updated the changelog? Each package has a `CHANGELOG.md` file.
- [ ] Have you updated or added the documentation for your PR? When you add a new feature, change a property name, or change the behavior of a feature, it's best practice to include related documentation changes in the same PR.
- [ ] Have you added a graphic test for your PR (if needed)? When you add a new feature, or discover a bug that tests don't cover, please add a graphic test.

---

### Testing status

**Manual Tests**: What did you do?
- [x] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: 
