### PR TITLE
Increase .shadergraph version number when Hybrid Renderer V2 is enabled, to make shader graphs automatically reimport

### DIFF
--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -14,7 +14,16 @@ using Object = System.Object;
 namespace UnityEditor.ShaderGraph
 {
     [ExcludeFromPreset]
+#if ENABLE_HYBRID_RENDERER_V2 && UNITY_2020_1_OR_NEWER
+    // Bump the version number when Hybrid Renderer V2 is enabled, to make
+    // sure that all shader graphs get re-imported. Re-importing is required,
+    // because the shader graph codegen is different for V2.
+    // This ifdef can be removed once V2 is the only option.
+    [ScriptedImporter(100, Extension, 3)]
+#else
     [ScriptedImporter(32, Extension, 3)]
+#endif
+
     class ShaderGraphImporter : ScriptedImporter
     {
         public const string Extension = "shadergraph";


### PR DESCRIPTION
Shader Graph needs to generate different shader code for the Hybrid Renderer, depending on whether Hybrid V1 or V2 is enabled. Hybrid V1 requires codegen that is compatible with Unity's traditional instancing, whereas Hybrid V2 requires the use of new DOTS instancing macros. These two are mutually exclusive.

Currently, this leads to frequent problems when the user switches between V1 and V2, as any shader graphs used by the project will now render incorrectly until they have been reimported, which either needs to be done manually, or by reimporting everything which is extremely time consuming and unnecessary.

This PR changes the `.shadergraph` asset version number when the V2 define is enabled. This should lead to Unity noticing a difference between the already imported shader graphs and the expected version number, and automatically reimporting the shader graphs. Reimporting should now generate the correct shader code, as the preprocessing define has now changed.

---
### Testing status

**Manual Tests**: What did you do?
- [ ] Opened test project + Run graphic tests locally
- [ ] Built a player
- [ ] Checked new UI names with UX convention
- [ ] Tested UI multi-edition + Undo/Redo + Prefab overrides + Alignment in Preset
- [ ] C# and shader warnings (supress shader cache to see them)
- [ ] Checked new resources path for the reloader (in developer mode, you have a button at end of resources that check the paths)
- Other: Tested manually using Hybrid Renderer test projects in the dots repo

HybridHDRPSamples/Assets/SampleScenes/TestShaderGraphOverrides